### PR TITLE
Add AiohttpClientMocker type hints in tests

### DIFF
--- a/tests/components/android_ip_webcam/conftest.py
+++ b/tests/components/android_ip_webcam/conftest.py
@@ -7,10 +7,11 @@ import pytest
 from homeassistant.const import CONTENT_TYPE_JSON
 
 from tests.common import load_fixture
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 @pytest.fixture
-def aioclient_mock_fixture(aioclient_mock) -> None:
+def aioclient_mock_fixture(aioclient_mock: AiohttpClientMocker) -> None:
     """Fixture to provide a aioclient mocker."""
     aioclient_mock.get(
         "http://1.1.1.1:8080/status.json?show_avail=1",

--- a/tests/components/application_credentials/test_init.py
+++ b/tests/components/application_credentials/test_init.py
@@ -175,7 +175,7 @@ class OAuthFixture:
 async def oauth_fixture(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,
-    aioclient_mock: Any,
+    aioclient_mock: AiohttpClientMocker,
 ) -> OAuthFixture:
     """Fixture for testing the OAuth flow."""
     return OAuthFixture(hass, hass_client_no_auth, aioclient_mock)

--- a/tests/components/duckdns/test_init.py
+++ b/tests/components/duckdns/test_init.py
@@ -33,7 +33,7 @@ async def async_set_txt(hass, txt):
 
 
 @pytest.fixture
-def setup_duckdns(hass, aioclient_mock):
+def setup_duckdns(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) -> None:
     """Fixture that sets up DuckDNS."""
     aioclient_mock.get(
         duckdns.UPDATE_URL, params={"domains": DOMAIN, "token": TOKEN}, text="OK"

--- a/tests/components/flo/conftest.py
+++ b/tests/components/flo/conftest.py
@@ -12,6 +12,7 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, CONTENT_TYPE_JSON
 from .common import TEST_EMAIL_ADDRESS, TEST_PASSWORD, TEST_TOKEN, TEST_USER_ID
 
 from tests.common import MockConfigEntry, load_fixture
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 @pytest.fixture
@@ -25,7 +26,7 @@ def config_entry(hass):
 
 
 @pytest.fixture
-def aioclient_mock_fixture(aioclient_mock):
+def aioclient_mock_fixture(aioclient_mock: AiohttpClientMocker) -> None:
     """Fixture to provide a aioclient mocker."""
     now = round(time.time())
     # Mocks the login response for flo.

--- a/tests/components/freedns/test_init.py
+++ b/tests/components/freedns/test_init.py
@@ -16,7 +16,7 @@ UPDATE_URL = freedns.UPDATE_URL
 
 
 @pytest.fixture
-def setup_freedns(hass, aioclient_mock):
+def setup_freedns(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) -> None:
     """Fixture that sets up FreeDNS."""
     params = {}
     params[ACCESS_TOKEN] = ""

--- a/tests/components/google_domains/test_init.py
+++ b/tests/components/google_domains/test_init.py
@@ -20,7 +20,9 @@ UPDATE_URL = f"https://{USERNAME}:{PASSWORD}@domains.google.com/nic/update"
 
 
 @pytest.fixture
-def setup_google_domains(hass, aioclient_mock):
+def setup_google_domains(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Fixture that sets up NamecheapDNS."""
     aioclient_mock.get(UPDATE_URL, params={"hostname": DOMAIN}, text="ok 0.0.0.0")
 

--- a/tests/components/habitica/test_init.py
+++ b/tests/components/habitica/test_init.py
@@ -17,6 +17,7 @@ from homeassistant.const import ATTR_NAME
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, async_capture_events
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 TEST_API_CALL_ARGS = {"text": "Use API from Home Assistant", "type": "todo"}
 TEST_USER_NAME = "test_user"
@@ -45,7 +46,7 @@ def habitica_entry(hass):
 
 
 @pytest.fixture
-def common_requests(aioclient_mock):
+def common_requests(aioclient_mock: AiohttpClientMocker) -> AiohttpClientMocker:
     """Register requests for the tests."""
     aioclient_mock.get(
         "https://habitica.com/api/v3/user",

--- a/tests/components/hassio/conftest.py
+++ b/tests/components/hassio/conftest.py
@@ -7,13 +7,14 @@ from unittest.mock import Mock, patch
 import pytest
 
 from homeassistant.components.hassio.handler import HassIO, HassioAPIError
-from homeassistant.core import CoreState
+from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.setup import async_setup_component
 
 from . import SUPERVISOR_TOKEN
 
 from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import ClientSessionGenerator
 
 
 @pytest.fixture(autouse=True)
@@ -45,7 +46,12 @@ def hassio_env():
 
 
 @pytest.fixture
-def hassio_stubs(hassio_env, hass, hass_client, aioclient_mock):
+def hassio_stubs(
+    hassio_env,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+):
     """Create mock hassio http client."""
     with (
         patch(
@@ -100,7 +106,7 @@ async def hassio_client_supervisor(hass, aiohttp_client, hassio_stubs):
 
 
 @pytest.fixture
-async def hassio_handler(hass, aioclient_mock):
+async def hassio_handler(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker):
     """Create mock hassio handler."""
     with patch.dict(os.environ, {"SUPERVISOR_TOKEN": SUPERVISOR_TOKEN}):
         yield HassIO(hass.loop, async_get_clientsession(hass), "127.0.0.1")
@@ -109,7 +115,7 @@ async def hassio_handler(hass, aioclient_mock):
 @pytest.fixture
 def all_setup_requests(
     aioclient_mock: AiohttpClientMocker, request: pytest.FixtureRequest
-):
+) -> None:
     """Mock all setup requests."""
     include_addons = hasattr(request, "param") and request.param.get(
         "include_addons", False

--- a/tests/components/mobile_app/test_notify.py
+++ b/tests/components/mobile_app/test_notify.py
@@ -10,13 +10,15 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, MockUser
 from tests.test_util.aiohttp import AiohttpClientMocker
 from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture
-async def setup_push_receiver(hass, aioclient_mock, hass_admin_user):
+async def setup_push_receiver(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, hass_admin_user: MockUser
+) -> None:
     """Fixture that sets up a mocked push receiver."""
     push_url = "https://mobile-push.home-assistant.dev/push"
 

--- a/tests/components/myuplink/test_config_flow.py
+++ b/tests/components/myuplink/test_config_flow.py
@@ -24,9 +24,9 @@ CURRENT_SCOPE = "WRITESYSTEM READSYSTEM offline_access"
 
 async def test_full_flow(
     hass: HomeAssistant,
-    hass_client_no_auth,
-    aioclient_mock,
-    current_request_with_host,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
     setup_credentials,
 ) -> None:
     """Check full flow."""

--- a/tests/components/namecheapdns/test_init.py
+++ b/tests/components/namecheapdns/test_init.py
@@ -18,7 +18,9 @@ PASSWORD = "abcdefgh"
 
 
 @pytest.fixture
-def setup_namecheapdns(hass, aioclient_mock):
+def setup_namecheapdns(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Fixture that sets up NamecheapDNS."""
     aioclient_mock.get(
         namecheapdns.UPDATE_URL,

--- a/tests/components/nest/test_config_flow.py
+++ b/tests/components/nest/test_config_flow.py
@@ -35,6 +35,8 @@ from .common import (
 )
 
 from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import ClientSessionGenerator
 
 WEB_REDIRECT_URL = "https://example.com/auth/external/callback"
 APP_REDIRECT_URL = "urn:ietf:wg:oauth:2.0:oob"
@@ -189,7 +191,12 @@ class OAuthFixture:
 
 
 @pytest.fixture
-async def oauth(hass, hass_client_no_auth, aioclient_mock, current_request_with_host):
+async def oauth(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    current_request_with_host: None,
+) -> OAuthFixture:
     """Create the simulated oauth flow."""
     return OAuthFixture(hass, hass_client_no_auth, aioclient_mock)
 

--- a/tests/components/no_ip/test_init.py
+++ b/tests/components/no_ip/test_init.py
@@ -22,7 +22,7 @@ USERNAME = "abc@123.com"
 
 
 @pytest.fixture
-def setup_no_ip(hass, aioclient_mock):
+def setup_no_ip(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) -> None:
     """Fixture that sets up NO-IP."""
     aioclient_mock.get(UPDATE_URL, params={"hostname": DOMAIN}, text="good 0.0.0.0")
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
