### PR TITLE
Use external temp if needed in Broadlink

### DIFF
--- a/homeassistant/components/broadlink/climate.py
+++ b/homeassistant/components/broadlink/climate.py
@@ -1,6 +1,6 @@
 """Support for Broadlink climate devices."""
 
-from enum import Enum
+from enum import IntEnum
 from typing import Any
 
 from homeassistant.components.climate import (
@@ -20,7 +20,7 @@ from .device import BroadlinkDevice
 from .entity import BroadlinkEntity
 
 
-class SensorMode(Enum):
+class SensorMode(IntEnum):
     """Thermostat sensor modes."""
 
     INNER_SENSOR_CONTROL = 0
@@ -72,7 +72,7 @@ class BroadlinkThermostat(BroadlinkEntity, ClimateEntity):
     def _update_state(self, data: dict[str, Any]) -> None:
         """Update data."""
         if data.get("sensor") is not None:
-            self.sensor_mode = SensorMode(data.get("sensor"))
+            self.sensor_mode = SensorMode(data["sensor"])
         if data.get("power"):
             if data.get("auto_mode"):
                 self._attr_hvac_mode = HVACMode.AUTO

--- a/homeassistant/components/broadlink/climate.py
+++ b/homeassistant/components/broadlink/climate.py
@@ -71,8 +71,8 @@ class BroadlinkThermostat(BroadlinkEntity, ClimateEntity):
     @callback
     def _update_state(self, data: dict[str, Any]) -> None:
         """Update data."""
-        if data.get("sensor") is not None:
-            self.sensor_mode = SensorMode(data["sensor"])
+        if (sensor := data.get("sensor")) is not None:
+            self.sensor_mode = SensorMode(sensor)
         if data.get("power"):
             if data.get("auto_mode"):
                 self._attr_hvac_mode = HVACMode.AUTO

--- a/homeassistant/components/broadlink/climate.py
+++ b/homeassistant/components/broadlink/climate.py
@@ -86,7 +86,7 @@ class BroadlinkThermostat(BroadlinkEntity, ClimateEntity):
         else:
             self._attr_hvac_mode = HVACMode.OFF
             self._attr_hvac_action = HVACAction.OFF
-        if self.sensor_mode == SensorMode.OUTER_SENSOR_CONTROL:
+        if self.sensor_mode is SensorMode.OUTER_SENSOR_CONTROL:
             self._attr_current_temperature = data.get("external_temp")
         else:
             self._attr_current_temperature = data.get("room_temp")

--- a/homeassistant/components/broadlink/climate.py
+++ b/homeassistant/components/broadlink/climate.py
@@ -71,7 +71,8 @@ class BroadlinkThermostat(BroadlinkEntity, ClimateEntity):
     @callback
     def _update_state(self, data: dict[str, Any]) -> None:
         """Update data."""
-        self.sensor_mode = SensorMode(data.get("sensor"))
+        if data.get("sensor") is not None:
+            self.sensor_mode = SensorMode(data.get("sensor"))
         if data.get("power"):
             if data.get("auto_mode"):
                 self._attr_hvac_mode = HVACMode.AUTO

--- a/tests/components/broadlink/test_climate.py
+++ b/tests/components/broadlink/test_climate.py
@@ -1,5 +1,7 @@
 """Tests for Broadlink climate."""
 
+import pytest
+
 from homeassistant.components.broadlink.climate import SensorMode
 from homeassistant.components.broadlink.const import DOMAIN
 from homeassistant.components.climate import (
@@ -18,19 +20,83 @@ from homeassistant.helpers.entity_component import async_update_entity
 
 from . import get_device
 
+testdata = [
+    (
+        SensorMode.INNER_SENSOR_CONTROL,
+        1,
+        0,
+        1,
+        22,
+        23,
+        30,
+        HVACMode.HEAT,
+        22,
+        23,
+        HVACAction.HEATING,
+    ),
+    (
+        SensorMode.OUTER_SENSOR_CONTROL,
+        1,
+        1,
+        0,
+        22,
+        23,
+        30,
+        HVACMode.AUTO,
+        30,
+        23,
+        HVACAction.IDLE,
+    ),
+    (
+        SensorMode.INNER_SENSOR_CONTROL,
+        0,
+        0,
+        0,
+        22,
+        23,
+        30,
+        HVACMode.OFF,
+        22,
+        23,
+        HVACAction.OFF,
+    ),
+]
 
-async def test_climate_inner_heat_heating(
+
+@pytest.mark.parametrize(
+    (
+        "sensor",
+        "power",
+        "auto_mode",
+        "active",
+        "room_temp",
+        "thermostat_temp",
+        "external_temp",
+        "expected_state",
+        "expected_current_temperature",
+        "expected_temperature",
+        "expected_hvac_action",
+    ),
+    testdata,
+)
+async def test_climate(
+    sensor,
+    power,
+    auto_mode,
+    active,
+    room_temp,
+    thermostat_temp,
+    external_temp,
+    expected_state,
+    expected_current_temperature,
+    expected_temperature,
+    expected_hvac_action,
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test Broadlink climate.
+    """Test Broadlink climate."""
 
-    The test initialized with:
-    - SensorMode.INNER_SENSOR_CONTROL
-    - HVACMode.HEAT
-    - HVACAction.HEATING
-    """
     device = get_device("Guest room")
     mock_setup = await device.setup_entry(hass)
 
@@ -44,22 +110,42 @@ async def test_climate_inner_heat_heating(
     climate = climates[0]
 
     mock_setup.api.get_full_status.return_value = {
-        "sensor": SensorMode.INNER_SENSOR_CONTROL.value,
-        "power": 1,
-        "auto_mode": 0,
-        "active": 1,
-        "room_temp": 22,
-        "thermostat_temp": 23,
-        "external_temp": 30,
+        "sensor": sensor.value,
+        "power": power,
+        "auto_mode": auto_mode,
+        "active": active,
+        "room_temp": room_temp,
+        "thermostat_temp": thermostat_temp,
+        "external_temp": external_temp,
     }
 
     await async_update_entity(hass, climate.entity_id)
     assert mock_setup.api.get_full_status.call_count == 2
     state = hass.states.get(climate.entity_id)
-    assert state.state == HVACMode.HEAT
-    assert state.attributes["current_temperature"] == 22
-    assert state.attributes["temperature"] == 23
-    assert state.attributes["hvac_action"] == HVACAction.HEATING
+    assert state.state == expected_state
+    assert state.attributes["current_temperature"] == expected_current_temperature
+    assert state.attributes["temperature"] == expected_temperature
+    assert state.attributes["hvac_action"] == expected_hvac_action
+
+
+async def test_climate_set_temperature_turn_off_turn_on(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test Broadlink climate."""
+
+    device = get_device("Guest room")
+    mock_setup = await device.setup_entry(hass)
+
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+    )
+    entries = er.async_entries_for_device(entity_registry, device_entry.id)
+    climates = [entry for entry in entries if entry.domain == Platform.CLIMATE]
+    assert len(climates) == 1
+
+    climate = climates[0]
 
     await hass.services.async_call(
         CLIMATE_DOMAIN,
@@ -71,10 +157,6 @@ async def test_climate_inner_heat_heating(
         blocking=True,
     )
     state = hass.states.get(climate.entity_id)
-    assert state.state == HVACMode.HEAT
-    assert state.attributes["current_temperature"] == 22
-    assert state.attributes["temperature"] == 24
-    assert state.attributes["hvac_action"] == HVACAction.HEATING
 
     await hass.services.async_call(
         CLIMATE_DOMAIN,
@@ -87,9 +169,6 @@ async def test_climate_inner_heat_heating(
     state = hass.states.get(climate.entity_id)
 
     assert state.state == HVACMode.OFF
-    assert state.attributes["current_temperature"] == 22
-    assert state.attributes["temperature"] == 24
-    assert state.attributes["hvac_action"] == HVACAction.HEATING
 
     await hass.services.async_call(
         CLIMATE_DOMAIN,
@@ -102,92 +181,3 @@ async def test_climate_inner_heat_heating(
     state = hass.states.get(climate.entity_id)
 
     assert state.state == HVACMode.HEAT
-    assert state.attributes["current_temperature"] == 22
-    assert state.attributes["temperature"] == 24
-    assert state.attributes["hvac_action"] == HVACAction.HEATING
-
-
-async def test_climate_outer_auto_idle(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    entity_registry: er.EntityRegistry,
-) -> None:
-    """Test Broadlink climate.
-
-    The test initialized with:
-    - SensorMode.OUTER_SENSOR_CONTROL
-    - HVACMode.AUTO
-    - HVACAction.IDLE
-    """
-    device = get_device("Guest room")
-    mock_setup = await device.setup_entry(hass)
-
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
-    )
-    entries = er.async_entries_for_device(entity_registry, device_entry.id)
-    climates = [entry for entry in entries if entry.domain == Platform.CLIMATE]
-    assert len(climates) == 1
-
-    climate = climates[0]
-
-    mock_setup.api.get_full_status.return_value = {
-        "sensor": SensorMode.OUTER_SENSOR_CONTROL.value,
-        "power": 1,
-        "auto_mode": 1,
-        "active": 0,
-        "room_temp": 22,
-        "thermostat_temp": 23,
-        "external_temp": 30,
-    }
-
-    await async_update_entity(hass, climate.entity_id)
-    assert mock_setup.api.get_full_status.call_count == 2
-    state = hass.states.get(climate.entity_id)
-    assert state.state == HVACMode.AUTO
-    assert state.attributes["current_temperature"] == 30
-    assert state.attributes["temperature"] == 23
-    assert state.attributes["hvac_action"] == HVACAction.IDLE
-
-
-async def test_climate_inner_off_off(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    entity_registry: er.EntityRegistry,
-) -> None:
-    """Test Broadlink climate.
-
-    The test initialized with:
-    - SensorMode.INNER_SENSOR_CONTROL
-    - HVACMode.OFF
-    - HVACAction.OFF
-    """
-    device = get_device("Guest room")
-    mock_setup = await device.setup_entry(hass)
-
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
-    )
-    entries = er.async_entries_for_device(entity_registry, device_entry.id)
-    climates = [entry for entry in entries if entry.domain == Platform.CLIMATE]
-    assert len(climates) == 1
-
-    climate = climates[0]
-
-    mock_setup.api.get_full_status.return_value = {
-        "sensor": SensorMode.INNER_SENSOR_CONTROL.value,
-        "power": 0,
-        "auto_mode": 0,
-        "active": 0,
-        "room_temp": 22,
-        "thermostat_temp": 23,
-        "external_temp": 30,
-    }
-
-    await async_update_entity(hass, climate.entity_id)
-    assert mock_setup.api.get_full_status.call_count == 2
-    state = hass.states.get(climate.entity_id)
-    assert state.state == HVACMode.OFF
-    assert state.attributes["current_temperature"] == 22
-    assert state.attributes["temperature"] == 23
-    assert state.attributes["hvac_action"] == HVACAction.OFF

--- a/tests/components/broadlink/test_climate.py
+++ b/tests/components/broadlink/test_climate.py
@@ -81,10 +81,10 @@ from . import get_device
 )
 async def test_climate(
     api_return_value: dict[str, Any],
-    expected_state,
-    expected_current_temperature,
-    expected_temperature,
-    expected_hvac_action,
+    expected_state: HVACMode,
+    expected_current_temperature: int,
+    expected_temperature: int,
+    expected_hvac_action: HVACAction,
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,

--- a/tests/components/broadlink/test_climate.py
+++ b/tests/components/broadlink/test_climate.py
@@ -1,0 +1,193 @@
+"""Tests for Broadlink climate."""
+
+from homeassistant.components.broadlink.climate import SensorMode
+from homeassistant.components.broadlink.const import DOMAIN
+from homeassistant.components.climate import (
+    ATTR_TEMPERATURE,
+    DOMAIN as CLIMATE_DOMAIN,
+    SERVICE_SET_TEMPERATURE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    HVACAction,
+    HVACMode,
+)
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.entity_component import async_update_entity
+
+from . import get_device
+
+
+async def test_climate_inner_heat_heating(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test Broadlink climate.
+
+    The test initialized with:
+    - SensorMode.INNER_SENSOR_CONTROL
+    - HVACMode.HEAT
+    - HVACAction.HEATING
+    """
+    device = get_device("Guest room")
+    mock_setup = await device.setup_entry(hass)
+
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+    )
+    entries = er.async_entries_for_device(entity_registry, device_entry.id)
+    climates = [entry for entry in entries if entry.domain == Platform.CLIMATE]
+    assert len(climates) == 1
+
+    climate = climates[0]
+
+    mock_setup.api.get_full_status.return_value = {
+        "sensor": SensorMode.INNER_SENSOR_CONTROL,
+        "power": 1,
+        "auto_mode": 0,
+        "active": 1,
+        "room_temp": 22,
+        "thermostat_temp": 23,
+        "external_temp": 30,
+    }
+
+    await async_update_entity(hass, climate.entity_id)
+    assert mock_setup.api.get_full_status.call_count == 2
+    state = hass.states.get(climate.entity_id)
+    assert state.state == HVACMode.HEAT
+    assert state.attributes["current_temperature"] == 22
+    assert state.attributes["temperature"] == 23
+    assert state.attributes["hvac_action"] == HVACAction.HEATING
+
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_TEMPERATURE,
+        {
+            ATTR_ENTITY_ID: climate.entity_id,
+            ATTR_TEMPERATURE: "24",
+        },
+        blocking=True,
+    )
+    state = hass.states.get(climate.entity_id)
+    assert state.state == HVACMode.HEAT
+    assert state.attributes["current_temperature"] == 22
+    assert state.attributes["temperature"] == 24
+    assert state.attributes["hvac_action"] == HVACAction.HEATING
+
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_TURN_OFF,
+        {
+            ATTR_ENTITY_ID: climate.entity_id,
+        },
+        blocking=True,
+    )
+    state = hass.states.get(climate.entity_id)
+
+    assert state.state == HVACMode.OFF
+    assert state.attributes["current_temperature"] == 22
+    assert state.attributes["temperature"] == 24
+    assert state.attributes["hvac_action"] == HVACAction.HEATING
+
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_TURN_ON,
+        {
+            ATTR_ENTITY_ID: climate.entity_id,
+        },
+        blocking=True,
+    )
+    state = hass.states.get(climate.entity_id)
+
+    assert state.state == HVACMode.HEAT
+    assert state.attributes["current_temperature"] == 22
+    assert state.attributes["temperature"] == 24
+    assert state.attributes["hvac_action"] == HVACAction.HEATING
+
+
+async def test_climate_outer_auto_idle(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test Broadlink climate.
+
+    The test initialized with:
+    - SensorMode.OUTER_SENSOR_CONTROL
+    - HVACMode.AUTO
+    - HVACAction.IDLE
+    """
+    device = get_device("Guest room")
+    mock_setup = await device.setup_entry(hass)
+
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+    )
+    entries = er.async_entries_for_device(entity_registry, device_entry.id)
+    climates = [entry for entry in entries if entry.domain == Platform.CLIMATE]
+    assert len(climates) == 1
+
+    climate = climates[0]
+
+    mock_setup.api.get_full_status.return_value = {
+        "sensor": SensorMode.OUTER_SENSOR_CONTROL,
+        "power": 1,
+        "auto_mode": 1,
+        "active": 0,
+        "room_temp": 22,
+        "thermostat_temp": 23,
+        "external_temp": 30,
+    }
+
+    await async_update_entity(hass, climate.entity_id)
+    assert mock_setup.api.get_full_status.call_count == 2
+    state = hass.states.get(climate.entity_id)
+    assert state.state == HVACMode.AUTO
+    assert state.attributes["current_temperature"] == 30
+    assert state.attributes["temperature"] == 23
+    assert state.attributes["hvac_action"] == HVACAction.IDLE
+
+
+async def test_climate_inner_off_off(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test Broadlink climate.
+
+    The test initialized with:
+    - SensorMode.INNER_SENSOR_CONTROL
+    - HVACMode.OFF
+    - HVACAction.OFF
+    """
+    device = get_device("Guest room")
+    mock_setup = await device.setup_entry(hass)
+
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+    )
+    entries = er.async_entries_for_device(entity_registry, device_entry.id)
+    climates = [entry for entry in entries if entry.domain == Platform.CLIMATE]
+    assert len(climates) == 1
+
+    climate = climates[0]
+
+    mock_setup.api.get_full_status.return_value = {
+        "sensor": SensorMode.INNER_SENSOR_CONTROL,
+        "power": 0,
+        "auto_mode": 0,
+        "active": 0,
+        "room_temp": 22,
+        "thermostat_temp": 23,
+        "external_temp": 30,
+    }
+
+    await async_update_entity(hass, climate.entity_id)
+    assert mock_setup.api.get_full_status.call_count == 2
+    state = hass.states.get(climate.entity_id)
+    assert state.state == HVACMode.OFF
+    assert state.attributes["current_temperature"] == 22
+    assert state.attributes["temperature"] == 23
+    assert state.attributes["hvac_action"] == HVACAction.OFF

--- a/tests/components/broadlink/test_climate.py
+++ b/tests/components/broadlink/test_climate.py
@@ -44,7 +44,7 @@ async def test_climate_inner_heat_heating(
     climate = climates[0]
 
     mock_setup.api.get_full_status.return_value = {
-        "sensor": SensorMode.INNER_SENSOR_CONTROL,
+        "sensor": SensorMode.INNER_SENSOR_CONTROL.value,
         "power": 1,
         "auto_mode": 0,
         "active": 1,
@@ -132,7 +132,7 @@ async def test_climate_outer_auto_idle(
     climate = climates[0]
 
     mock_setup.api.get_full_status.return_value = {
-        "sensor": SensorMode.OUTER_SENSOR_CONTROL,
+        "sensor": SensorMode.OUTER_SENSOR_CONTROL.value,
         "power": 1,
         "auto_mode": 1,
         "active": 0,
@@ -175,7 +175,7 @@ async def test_climate_inner_off_off(
     climate = climates[0]
 
     mock_setup.api.get_full_status.return_value = {
-        "sensor": SensorMode.INNER_SENSOR_CONTROL,
+        "sensor": SensorMode.INNER_SENSOR_CONTROL.value,
         "power": 0,
         "auto_mode": 0,
         "active": 0,

--- a/tests/components/broadlink/test_climate.py
+++ b/tests/components/broadlink/test_climate.py
@@ -158,6 +158,8 @@ async def test_climate_set_temperature_turn_off_turn_on(
     )
     state = hass.states.get(climate.entity_id)
 
+    assert state.attributes["temperature"] == 24
+
     await hass.services.async_call(
         CLIMATE_DOMAIN,
         SERVICE_TURN_OFF,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
Broadlink climate can set to use external temperature sensor instead of the device's sensor. With this PR I store the current state of the sensor in a variable and use to decide which type of temperature should set to the current temperature. Also I don't want to overwrite the sensor with the set_mode, so I must add the current value to the function's parameter.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
With this PR home assistant can't change the current value of the sensor. To do this we should create a switch entity. I set the sensor value with the official application for my tests.
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: https://github.com/home-assistant/core/issues/120887
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
