### PR TITLE
Add ClientSessionGenerator type hints in tests

### DIFF
--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -26,7 +26,7 @@ from tests.common import (
     mock_integration,
     mock_platform,
 )
-from tests.typing import WebSocketGenerator
+from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 
 @pytest.fixture
@@ -43,7 +43,9 @@ def mock_test_component(hass):
 
 
 @pytest.fixture
-async def client(hass, hass_client) -> TestClient:
+async def client(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> TestClient:
     """Fixture that can interact with the config manager API."""
     await async_setup_component(hass, "http", {})
     config_entries.async_setup(hass)

--- a/tests/components/dialogflow/test_init.py
+++ b/tests/components/dialogflow/test_init.py
@@ -13,6 +13,8 @@ from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.setup import async_setup_component
 
+from tests.typing import ClientSessionGenerator
+
 SESSION_ID = "a9b84cec-46b6-484e-8f31-f65dba03ae6d"
 INTENT_ID = "c6a74079-a8f0-46cd-b372-5a934d23591c"
 INTENT_NAME = "tests"
@@ -37,7 +39,7 @@ async def calls(hass: HomeAssistant, fixture) -> list[ServiceCall]:
 
 
 @pytest.fixture
-async def fixture(hass, hass_client_no_auth):
+async def fixture(hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator):
     """Initialize a Home Assistant server for testing this module."""
     await async_setup_component(hass, dialogflow.DOMAIN, {"dialogflow": {}})
     await async_setup_component(

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -8,6 +8,7 @@ import json
 from unittest.mock import patch
 
 from aiohttp.hdrs import CONTENT_TYPE
+from aiohttp.test_utils import TestClient
 import pytest
 
 from homeassistant import const, setup
@@ -243,7 +244,9 @@ def _mock_hue_endpoints(
 
 
 @pytest.fixture
-async def hue_client(hass_hue, hass_client_no_auth):
+async def hue_client(
+    hass_hue, hass_client_no_auth: ClientSessionGenerator
+) -> TestClient:
     """Create web client for emulated hue api."""
     _mock_hue_endpoints(
         hass_hue,

--- a/tests/components/emulated_hue/test_upnp.py
+++ b/tests/components/emulated_hue/test_upnp.py
@@ -1,12 +1,14 @@
 """The tests for the emulated Hue component."""
 
 from asyncio import AbstractEventLoop
+from collections.abc import Generator
 from http import HTTPStatus
 import json
 import unittest
 from unittest.mock import patch
 
 from aiohttp import web
+from aiohttp.test_utils import TestClient
 import defusedxml.ElementTree as ET
 import pytest
 
@@ -45,7 +47,9 @@ def aiohttp_client(
 
 
 @pytest.fixture
-def hue_client(aiohttp_client):
+def hue_client(
+    aiohttp_client: ClientSessionGenerator,
+) -> Generator[TestClient, None, None]:
     """Return a hue API client."""
     app = web.Application()
     with unittest.mock.patch(

--- a/tests/components/file_upload/test_init.py
+++ b/tests/components/file_upload/test_init.py
@@ -16,7 +16,9 @@ from tests.typing import ClientSessionGenerator
 
 
 @pytest.fixture
-async def uploaded_file_dir(hass: HomeAssistant, hass_client) -> Path:
+async def uploaded_file_dir(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> Path:
     """Test uploading and using a file."""
     assert await async_setup_component(hass, "file_upload", {})
     client = await hass_client()

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -6,6 +6,7 @@ import re
 from typing import Any
 from unittest.mock import patch
 
+from aiohttp.test_utils import TestClient
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
@@ -99,13 +100,17 @@ def aiohttp_client(
 
 
 @pytest.fixture
-async def mock_http_client(hass, aiohttp_client, frontend):
+async def mock_http_client(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator, frontend
+) -> TestClient:
     """Start the Home Assistant HTTP component."""
     return await aiohttp_client(hass.http.app)
 
 
 @pytest.fixture
-async def themes_ws_client(hass, hass_ws_client, frontend_themes):
+async def themes_ws_client(
+    hass: HomeAssistant, hass_ws_client: ClientSessionGenerator, frontend_themes
+) -> TestClient:
     """Start the Home Assistant HTTP component."""
     return await hass_ws_client(hass)
 
@@ -117,7 +122,9 @@ async def ws_client(hass, hass_ws_client, frontend):
 
 
 @pytest.fixture
-async def mock_http_client_with_extra_js(hass, aiohttp_client, ignore_frontend_deps):
+async def mock_http_client_with_extra_js(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator, ignore_frontend_deps
+) -> TestClient:
     """Start the Home Assistant HTTP component."""
     assert await async_setup_component(
         hass,

--- a/tests/components/geofency/test_init.py
+++ b/tests/components/geofency/test_init.py
@@ -3,6 +3,7 @@
 from http import HTTPStatus
 from unittest.mock import patch
 
+from aiohttp.test_utils import TestClient
 import pytest
 
 from homeassistant import config_entries
@@ -20,6 +21,8 @@ from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import slugify
+
+from tests.typing import ClientSessionGenerator
 
 HOME_LATITUDE = 37.239622
 HOME_LONGITUDE = -115.815811
@@ -118,7 +121,9 @@ def mock_dev_track(mock_device_tracker_conf):
 
 
 @pytest.fixture
-async def geofency_client(hass, hass_client_no_auth):
+async def geofency_client(
+    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
+) -> TestClient:
     """Geofency mock client (unauthenticated)."""
 
     assert await async_setup_component(

--- a/tests/components/google_mail/test_config_flow.py
+++ b/tests/components/google_mail/test_config_flow.py
@@ -90,9 +90,9 @@ async def test_full_flow(
 )
 async def test_reauth(
     hass: HomeAssistant,
-    hass_client_no_auth,
+    hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
-    current_request_with_host,
+    current_request_with_host: None,
     config_entry: MockConfigEntry,
     fixture: str,
     abort_reason: str,

--- a/tests/components/google_tasks/test_config_flow.py
+++ b/tests/components/google_tasks/test_config_flow.py
@@ -19,6 +19,7 @@ from homeassistant.helpers import config_entry_oauth2_flow
 
 from tests.common import MockConfigEntry, load_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
+from tests.typing import ClientSessionGenerator
 
 CLIENT_ID = "1234"
 CLIENT_SECRET = "5678"
@@ -43,9 +44,9 @@ def setup_userinfo(user_identifier: str) -> Generator[Mock, None, None]:
 
 async def test_full_flow(
     hass: HomeAssistant,
-    hass_client_no_auth,
+    hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
-    current_request_with_host,
+    current_request_with_host: None,
     setup_credentials,
     setup_userinfo,
 ) -> None:
@@ -98,9 +99,9 @@ async def test_full_flow(
 
 async def test_api_not_enabled(
     hass: HomeAssistant,
-    hass_client_no_auth,
+    hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
-    current_request_with_host,
+    current_request_with_host: None,
     setup_credentials,
     setup_userinfo,
 ) -> None:
@@ -159,9 +160,9 @@ async def test_api_not_enabled(
 
 async def test_general_exception(
     hass: HomeAssistant,
-    hass_client_no_auth,
+    hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
-    current_request_with_host,
+    current_request_with_host: None,
     setup_credentials,
     setup_userinfo,
 ) -> None:
@@ -236,9 +237,9 @@ async def test_general_exception(
 )
 async def test_reauth(
     hass: HomeAssistant,
-    hass_client_no_auth,
+    hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
-    current_request_with_host,
+    current_request_with_host: None,
     setup_credentials,
     setup_userinfo,
     user_identifier: str,

--- a/tests/components/gpslogger/test_init.py
+++ b/tests/components/gpslogger/test_init.py
@@ -3,6 +3,7 @@
 from http import HTTPStatus
 from unittest.mock import patch
 
+from aiohttp.test_utils import TestClient
 import pytest
 
 from homeassistant import config_entries
@@ -17,6 +18,8 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import DATA_DISPATCHER
 from homeassistant.setup import async_setup_component
 
+from tests.typing import ClientSessionGenerator
+
 HOME_LATITUDE = 37.239622
 HOME_LONGITUDE = -115.815811
 
@@ -27,7 +30,9 @@ def mock_dev_track(mock_device_tracker_conf):
 
 
 @pytest.fixture
-async def gpslogger_client(hass, hass_client_no_auth):
+async def gpslogger_client(
+    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
+) -> TestClient:
     """Mock client for GPSLogger (unauthenticated)."""
 
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})

--- a/tests/components/hassio/conftest.py
+++ b/tests/components/hassio/conftest.py
@@ -4,6 +4,7 @@ import os
 import re
 from unittest.mock import Mock, patch
 
+from aiohttp.test_utils import TestClient
 import pytest
 
 from homeassistant.components.hassio.handler import HassIO, HassioAPIError
@@ -84,19 +85,25 @@ def hassio_stubs(
 
 
 @pytest.fixture
-def hassio_client(hassio_stubs, hass, hass_client):
+def hassio_client(
+    hassio_stubs, hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> TestClient:
     """Return a Hass.io HTTP client."""
     return hass.loop.run_until_complete(hass_client())
 
 
 @pytest.fixture
-def hassio_noauth_client(hassio_stubs, hass, aiohttp_client):
+def hassio_noauth_client(
+    hassio_stubs, hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> TestClient:
     """Return a Hass.io HTTP client without auth."""
     return hass.loop.run_until_complete(aiohttp_client(hass.http.app))
 
 
 @pytest.fixture
-async def hassio_client_supervisor(hass, aiohttp_client, hassio_stubs):
+async def hassio_client_supervisor(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator, hassio_stubs
+) -> TestClient:
     """Return an authenticated HTTP client."""
     access_token = hass.auth.async_create_access_token(hassio_stubs)
     return await aiohttp_client(

--- a/tests/components/husqvarna_automower/test_config_flow.py
+++ b/tests/components/husqvarna_automower/test_config_flow.py
@@ -32,9 +32,9 @@ from tests.typing import ClientSessionGenerator
 )
 async def test_full_flow(
     hass: HomeAssistant,
-    hass_client_no_auth,
+    hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
-    current_request_with_host,
+    current_request_with_host: None,
     jwt: str,
     new_scope: str,
     amount: int,

--- a/tests/components/locative/test_init.py
+++ b/tests/components/locative/test_init.py
@@ -3,6 +3,7 @@
 from http import HTTPStatus
 from unittest.mock import patch
 
+from aiohttp.test_utils import TestClient
 import pytest
 
 from homeassistant import config_entries
@@ -15,6 +16,8 @@ from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.dispatcher import DATA_DISPATCHER
 from homeassistant.setup import async_setup_component
 
+from tests.typing import ClientSessionGenerator
+
 
 @pytest.fixture(autouse=True)
 def mock_dev_track(mock_device_tracker_conf):
@@ -22,7 +25,9 @@ def mock_dev_track(mock_device_tracker_conf):
 
 
 @pytest.fixture
-async def locative_client(hass, hass_client):
+async def locative_client(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> TestClient:
     """Locative mock client."""
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     await hass.async_block_till_done()

--- a/tests/components/loqed/test_init.py
+++ b/tests/components/loqed/test_init.py
@@ -15,14 +15,15 @@ from homeassistant.helpers.network import get_url
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, load_fixture
+from tests.typing import ClientSessionGenerator
 
 
 async def test_webhook_accepts_valid_message(
     hass: HomeAssistant,
-    hass_client_no_auth,
+    hass_client_no_auth: ClientSessionGenerator,
     integration: MockConfigEntry,
     lock: loqed.Lock,
-):
+) -> None:
     """Test webhook called with valid message."""
     await async_setup_component(hass, "http", {"http": {}})
     client = await hass_client_no_auth()

--- a/tests/components/mailgun/test_init.py
+++ b/tests/components/mailgun/test_init.py
@@ -3,21 +3,26 @@
 import hashlib
 import hmac
 
+from aiohttp.test_utils import TestClient
 import pytest
 
 from homeassistant import config_entries
 from homeassistant.components import mailgun, webhook
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.const import CONF_API_KEY, CONF_DOMAIN
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.setup import async_setup_component
+
+from tests.typing import ClientSessionGenerator
 
 API_KEY = "abc123"
 
 
 @pytest.fixture
-async def http_client(hass, hass_client_no_auth):
+async def http_client(
+    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
+) -> TestClient:
     """Initialize a Home Assistant Server for testing this module."""
     await async_setup_component(hass, webhook.DOMAIN, {})
     return await hass_client_no_auth()

--- a/tests/components/mobile_app/conftest.py
+++ b/tests/components/mobile_app/conftest.py
@@ -2,12 +2,16 @@
 
 from http import HTTPStatus
 
+from aiohttp.test_utils import TestClient
 import pytest
 
 from homeassistant.components.mobile_app.const import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .const import REGISTER, REGISTER_CLEARTEXT
+
+from tests.typing import ClientSessionGenerator
 
 
 @pytest.fixture
@@ -53,7 +57,9 @@ async def push_registration(hass, webhook_client):
 
 
 @pytest.fixture
-async def webhook_client(hass, hass_client):
+async def webhook_client(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> TestClient:
     """Provide an authenticated client for mobile_app to use."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     await hass.async_block_till_done()

--- a/tests/components/nest/conftest.py
+++ b/tests/components/nest/conftest.py
@@ -98,7 +98,7 @@ def aiohttp_client(
 
 
 @pytest.fixture
-async def auth(aiohttp_client):
+async def auth(aiohttp_client: ClientSessionGenerator) -> FakeAuth:
     """Fixture for an AbstractAuth."""
     auth = FakeAuth()
     app = aiohttp.web.Application()

--- a/tests/components/owntracks/test_init.py
+++ b/tests/components/owntracks/test_init.py
@@ -1,11 +1,14 @@
 """Test the owntracks_http platform."""
 
+from aiohttp.test_utils import TestClient
 import pytest
 
 from homeassistant.components import owntracks
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, mock_component
+from tests.typing import ClientSessionGenerator
 
 MINIMAL_LOCATION_MESSAGE = {
     "_type": "location",
@@ -39,7 +42,9 @@ def mock_dev_track(mock_device_tracker_conf):
 
 
 @pytest.fixture
-def mock_client(hass, hass_client_no_auth):
+def mock_client(
+    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
+) -> TestClient:
     """Start the Home Assistant HTTP component."""
     mock_component(hass, "group")
     mock_component(hass, "zone")

--- a/tests/components/rainbird/test_calendar.py
+++ b/tests/components/rainbird/test_calendar.py
@@ -20,6 +20,7 @@ from .conftest import CONFIG_ENTRY_DATA_OLD_FORMAT, mock_response, mock_response
 
 from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMockResponse
+from tests.typing import ClientSessionGenerator
 
 TEST_ENTITY = "calendar.rain_bird_controller"
 type GetEventsFn = Callable[[str, str], Awaitable[dict[str, Any]]]
@@ -237,7 +238,7 @@ async def test_no_schedule(
     hass: HomeAssistant,
     get_events: GetEventsFn,
     responses: list[AiohttpClientMockResponse],
-    hass_client: Callable[..., Awaitable[ClientSession]],
+    hass_client: ClientSessionGenerator,
 ) -> None:
     """Test calendar error when fetching the calendar."""
     responses.extend([mock_response_error(HTTPStatus.BAD_GATEWAY)])  # Arbitrary error

--- a/tests/components/rainforest_raven/test_diagnostics.py
+++ b/tests/components/rainforest_raven/test_diagnostics.py
@@ -13,6 +13,7 @@ from .const import DEMAND, NETWORK_INFO, PRICE_CLUSTER, SUMMATION
 
 from tests.common import patch
 from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
 @pytest.fixture
@@ -47,8 +48,11 @@ async def mock_entry_no_meters(hass: HomeAssistant, mock_device):
 
 
 async def test_entry_diagnostics_no_meters(
-    hass, hass_client, mock_device, mock_entry_no_meters
-):
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_device,
+    mock_entry_no_meters,
+) -> None:
     """Test RAVEn diagnostics before the coordinator has updated."""
     result = await get_diagnostics_for_config_entry(
         hass, hass_client, mock_entry_no_meters
@@ -66,7 +70,9 @@ async def test_entry_diagnostics_no_meters(
     }
 
 
-async def test_entry_diagnostics(hass, hass_client, mock_device, mock_entry):
+async def test_entry_diagnostics(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, mock_device, mock_entry
+) -> None:
     """Test RAVEn diagnostics."""
     result = await get_diagnostics_for_config_entry(hass, hass_client, mock_entry)
 

--- a/tests/components/spaceapi/test_init.py
+++ b/tests/components/spaceapi/test_init.py
@@ -3,12 +3,15 @@
 from http import HTTPStatus
 from unittest.mock import patch
 
+from aiohttp.test_utils import TestClient
 import pytest
 
 from homeassistant.components.spaceapi import DOMAIN, SPACEAPI_VERSION, URL_API_SPACEAPI
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, PERCENTAGE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+
+from tests.typing import ClientSessionGenerator
 
 CONFIG = {
     DOMAIN: {
@@ -80,7 +83,7 @@ SENSOR_OUTPUT = {
 
 
 @pytest.fixture
-def mock_client(hass, hass_client):
+def mock_client(hass: HomeAssistant, hass_client: ClientSessionGenerator) -> TestClient:
     """Start the Home Assistant HTTP component."""
     with patch("homeassistant.components.spaceapi", return_value=True):
         hass.loop.run_until_complete(async_setup_component(hass, "spaceapi", CONFIG))

--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -69,7 +69,7 @@ class HlsClient:
 
 
 @pytest.fixture
-def hls_stream(hass, hass_client):
+def hls_stream(hass: HomeAssistant, hass_client: ClientSessionGenerator):
     """Create test fixture for creating an HLS client for a stream."""
 
     async def create_client_for_stream(stream):

--- a/tests/components/stream/test_ll_hls.py
+++ b/tests/components/stream/test_ll_hls.py
@@ -33,6 +33,8 @@ from .common import (
 )
 from .test_hls import STREAM_SOURCE, HlsClient, make_playlist
 
+from tests.typing import ClientSessionGenerator
+
 SEGMENT_DURATION = 6
 TEST_PART_DURATION = 0.75
 NUM_PART_SEGMENTS = int(-(-SEGMENT_DURATION // TEST_PART_DURATION))
@@ -45,7 +47,7 @@ VERY_LARGE_LAST_BYTE_POS = 9007199254740991
 
 
 @pytest.fixture
-def hls_stream(hass, hass_client):
+def hls_stream(hass: HomeAssistant, hass_client: ClientSessionGenerator):
     """Create test fixture for creating an HLS client for a stream."""
 
     async def create_client_for_stream(stream):

--- a/tests/components/webhook/test_init.py
+++ b/tests/components/webhook/test_init.py
@@ -5,6 +5,7 @@ from ipaddress import ip_address
 from unittest.mock import Mock, patch
 
 from aiohttp import web
+from aiohttp.test_utils import TestClient
 import pytest
 
 from homeassistant.components import webhook
@@ -12,11 +13,11 @@ from homeassistant.config import async_process_ha_core_config
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from tests.typing import WebSocketGenerator
+from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 
 @pytest.fixture
-def mock_client(hass, hass_client):
+def mock_client(hass: HomeAssistant, hass_client: ClientSessionGenerator) -> TestClient:
     """Create http client for webhooks."""
     hass.loop.run_until_complete(async_setup_component(hass, "webhook", {}))
     return hass.loop.run_until_complete(hass_client())

--- a/tests/components/websocket_api/conftest.py
+++ b/tests/components/websocket_api/conftest.py
@@ -1,5 +1,6 @@
 """Fixtures for websocket tests."""
 
+from aiohttp.test_utils import TestClient
 import pytest
 
 from homeassistant.components.websocket_api.auth import TYPE_AUTH_REQUIRED
@@ -7,7 +8,11 @@ from homeassistant.components.websocket_api.http import URL
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from tests.typing import MockHAClientWebSocket, WebSocketGenerator
+from tests.typing import (
+    ClientSessionGenerator,
+    MockHAClientWebSocket,
+    WebSocketGenerator,
+)
 
 
 @pytest.fixture
@@ -19,7 +24,9 @@ async def websocket_client(
 
 
 @pytest.fixture
-async def no_auth_websocket_client(hass, hass_client_no_auth):
+async def no_auth_websocket_client(
+    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
+) -> TestClient:
     """Websocket connection that requires authentication."""
     assert await async_setup_component(hass, "websocket_api", {})
     await hass.async_block_till_done()

--- a/tests/components/youtube/test_config_flow.py
+++ b/tests/components/youtube/test_config_flow.py
@@ -231,9 +231,9 @@ async def test_flow_http_error(
 )
 async def test_reauth(
     hass: HomeAssistant,
-    hass_client_no_auth,
+    hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
-    current_request_with_host,
+    current_request_with_host: None,
     config_entry: MockConfigEntry,
     fixture: str,
     abort_reason: str,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
