### PR TITLE
Improve LLM prompt

### DIFF
--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -250,7 +250,8 @@ class AssistAPI(API):
         prompt = [
             (
                 "Call the intent tools to control Home Assistant. "
-                "None of their parameters take a list. "
+                "Their domain parameter does not take a list. "
+                "When controlling a device, prefer passing just its name."
                 "When controlling an area, prefer passing just area name and domain."
             )
         ]

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -250,7 +250,8 @@ class AssistAPI(API):
         prompt = [
             (
                 "Call the intent tools to control Home Assistant. "
-                "When controlling an area, prefer passing area name and domain."
+                "None of their parameters take a list. "
+                "When controlling an area, prefer passing just area name and domain."
             )
         ]
         area: ar.AreaEntry | None = None

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -250,9 +250,9 @@ class AssistAPI(API):
         prompt = [
             (
                 "Call the intent tools to control Home Assistant. "
-                "Their domain parameter does not take a list. "
-                "When controlling a device, prefer passing just its name."
-                "When controlling an area, prefer passing just area name and domain."
+                "When controlling a device, prefer passing just its name and its domain "
+                "(what comes before the dot in its entity id). "
+                "When controlling an area, prefer passing just area name and a single domain."
             )
         ]
         area: ar.AreaEntry | None = None

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -423,9 +423,9 @@ async def test_assist_api_prompt(
     )
     first_part_prompt = (
         "Call the intent tools to control Home Assistant. "
-        "Their domain parameter does not take a list. "
-        "When controlling a device, prefer passing just its name."
-        "When controlling an area, prefer passing just area name and domain."
+        "When controlling a device, prefer passing just its name and its domain "
+        "(what comes before the dot in its entity id). "
+        "When controlling an area, prefer passing just area name and a single domain."
     )
     no_timer_prompt = "This device does not support timers."
 

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -423,7 +423,8 @@ async def test_assist_api_prompt(
     )
     first_part_prompt = (
         "Call the intent tools to control Home Assistant. "
-        "When controlling an area, prefer passing area name and domain."
+        "None of their parameters take a list. "
+        "When controlling an area, prefer passing just area name and domain."
     )
     no_timer_prompt = "This device does not support timers."
 

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -423,7 +423,8 @@ async def test_assist_api_prompt(
     )
     first_part_prompt = (
         "Call the intent tools to control Home Assistant. "
-        "None of their parameters take a list. "
+        "Their domain parameter does not take a list. "
+        "When controlling a device, prefer passing just its name."
         "When controlling an area, prefer passing just area name and domain."
     )
     no_timer_prompt = "This device does not support timers."


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve LLM prompt.
- Before LLM would pass a list to the domain which is invalid:
`Tool call: HassTurnOn({'domain': ['light'], 'area': 'Bedroom 1'})`
Or when controlling a single device it would also pass domain as a list.
- When controlling a single device ask LLM to pass the domain since it's needed for opening and closing covers.
But now that results to passing the wrong domain in some cases. e.g. I have "input_boolean.desk_light" and ask it turn on the desk light it will pass domain=light instead of input_boolean. Tell LLM the domain is what comes before the dot in entity id.
- Gemini 1.5 flash when controlling lights in an area would always pass area and name while Gemini 1.5 pro would pass area and domain. Now they both pass area and domain.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #118440
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
