### PR TITLE
Cleanup mock_get_source_ip from tests

### DIFF
--- a/tests/components/default_config/test_init.py
+++ b/tests/components/default_config/test_init.py
@@ -34,7 +34,7 @@ def recorder_url_mock():
 
 
 async def test_setup(
-    hass: HomeAssistant, mock_zeroconf: None, mock_get_source_ip, mock_bluetooth: None
+    hass: HomeAssistant, mock_zeroconf: None, mock_bluetooth: None
 ) -> None:
     """Test setup."""
     recorder_helper.async_initialize_recorder(hass)

--- a/tests/components/dlna_dmr/conftest.py
+++ b/tests/components/dlna_dmr/conftest.py
@@ -158,8 +158,3 @@ def async_get_local_ip_mock() -> Iterable[Mock]:
     ) as func:
         func.return_value = AddressFamily.AF_INET, LOCAL_IP
         yield func
-
-
-@pytest.fixture(autouse=True)
-def dlna_dmr_mock_get_source_ip(mock_get_source_ip):
-    """Mock network util's async_get_source_ip."""

--- a/tests/components/emulated_roku/test_config_flow.py
+++ b/tests/components/emulated_roku/test_config_flow.py
@@ -8,7 +8,7 @@ from homeassistant.data_entry_flow import FlowResultType
 from tests.common import MockConfigEntry
 
 
-async def test_flow_works(hass: HomeAssistant, mock_get_source_ip) -> None:
+async def test_flow_works(hass: HomeAssistant) -> None:
     """Test that config flow works."""
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
@@ -21,9 +21,7 @@ async def test_flow_works(hass: HomeAssistant, mock_get_source_ip) -> None:
     assert result["data"] == {"name": "Emulated Roku Test", "listen_port": 8060}
 
 
-async def test_flow_already_registered_entry(
-    hass: HomeAssistant, mock_get_source_ip
-) -> None:
+async def test_flow_already_registered_entry(hass: HomeAssistant) -> None:
     """Test that config flow doesn't allow existing names."""
     MockConfigEntry(
         domain="emulated_roku", data={"name": "Emulated Roku Test", "listen_port": 8062}

--- a/tests/components/emulated_roku/test_init.py
+++ b/tests/components/emulated_roku/test_init.py
@@ -7,7 +7,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
-async def test_config_required_fields(hass: HomeAssistant, mock_get_source_ip) -> None:
+async def test_config_required_fields(hass: HomeAssistant) -> None:
     """Test that configuration is successful with required fields."""
     with (
         patch.object(emulated_roku, "configured_servers", return_value=[]),
@@ -35,9 +35,7 @@ async def test_config_required_fields(hass: HomeAssistant, mock_get_source_ip) -
         )
 
 
-async def test_config_already_registered_not_configured(
-    hass: HomeAssistant, mock_get_source_ip
-) -> None:
+async def test_config_already_registered_not_configured(hass: HomeAssistant) -> None:
     """Test that an already registered name causes the entry to be ignored."""
     with (
         patch(

--- a/tests/components/fritz/test_config_flow.py
+++ b/tests/components/fritz/test_config_flow.py
@@ -93,7 +93,6 @@ from tests.common import MockConfigEntry
 async def test_user(
     hass: HomeAssistant,
     fc_class_mock,
-    mock_get_source_ip,
     show_advanced_options: bool,
     user_input: dict,
     expected_config: dict,
@@ -156,7 +155,6 @@ async def test_user(
 async def test_user_already_configured(
     hass: HomeAssistant,
     fc_class_mock,
-    mock_get_source_ip,
     show_advanced_options: bool,
     user_input,
 ) -> None:
@@ -218,7 +216,6 @@ async def test_user_already_configured(
 )
 async def test_exception_security(
     hass: HomeAssistant,
-    mock_get_source_ip,
     error,
     show_advanced_options: bool,
     user_input,
@@ -251,7 +248,6 @@ async def test_exception_security(
 )
 async def test_exception_connection(
     hass: HomeAssistant,
-    mock_get_source_ip,
     show_advanced_options: bool,
     user_input,
 ) -> None:
@@ -282,7 +278,7 @@ async def test_exception_connection(
     [(True, MOCK_USER_INPUT_ADVANCED), (False, MOCK_USER_INPUT_SIMPLE)],
 )
 async def test_exception_unknown(
-    hass: HomeAssistant, mock_get_source_ip, show_advanced_options: bool, user_input
+    hass: HomeAssistant, show_advanced_options: bool, user_input
 ) -> None:
     """Test starting a flow by user with an unknown exception."""
 
@@ -309,7 +305,6 @@ async def test_exception_unknown(
 async def test_reauth_successful(
     hass: HomeAssistant,
     fc_class_mock,
-    mock_get_source_ip,
 ) -> None:
     """Test starting a reauthentication flow."""
 
@@ -374,7 +369,6 @@ async def test_reauth_successful(
 async def test_reauth_not_successful(
     hass: HomeAssistant,
     fc_class_mock,
-    mock_get_source_ip,
     side_effect,
     error,
 ) -> None:
@@ -442,7 +436,6 @@ async def test_reauth_not_successful(
 async def test_reconfigure_successful(
     hass: HomeAssistant,
     fc_class_mock,
-    mock_get_source_ip,
     show_advanced_options: bool,
     user_input: dict,
     expected_config: dict,
@@ -508,7 +501,6 @@ async def test_reconfigure_successful(
 async def test_reconfigure_not_successful(
     hass: HomeAssistant,
     fc_class_mock,
-    mock_get_source_ip,
 ) -> None:
     """Test starting a reconfigure flow but no connection found."""
 
@@ -579,9 +571,7 @@ async def test_reconfigure_not_successful(
         }
 
 
-async def test_ssdp_already_configured(
-    hass: HomeAssistant, fc_class_mock, mock_get_source_ip
-) -> None:
+async def test_ssdp_already_configured(hass: HomeAssistant, fc_class_mock) -> None:
     """Test starting a flow from discovery with an already configured device."""
 
     mock_config = MockConfigEntry(
@@ -608,9 +598,7 @@ async def test_ssdp_already_configured(
         assert result["reason"] == "already_configured"
 
 
-async def test_ssdp_already_configured_host(
-    hass: HomeAssistant, fc_class_mock, mock_get_source_ip
-) -> None:
+async def test_ssdp_already_configured_host(hass: HomeAssistant, fc_class_mock) -> None:
     """Test starting a flow from discovery with an already configured host."""
 
     mock_config = MockConfigEntry(
@@ -638,7 +626,7 @@ async def test_ssdp_already_configured_host(
 
 
 async def test_ssdp_already_configured_host_uuid(
-    hass: HomeAssistant, fc_class_mock, mock_get_source_ip
+    hass: HomeAssistant, fc_class_mock
 ) -> None:
     """Test starting a flow from discovery with an already configured uuid."""
 
@@ -667,7 +655,7 @@ async def test_ssdp_already_configured_host_uuid(
 
 
 async def test_ssdp_already_in_progress_host(
-    hass: HomeAssistant, fc_class_mock, mock_get_source_ip
+    hass: HomeAssistant, fc_class_mock
 ) -> None:
     """Test starting a flow from discovery twice."""
     with patch(
@@ -690,7 +678,7 @@ async def test_ssdp_already_in_progress_host(
         assert result["reason"] == "already_in_progress"
 
 
-async def test_ssdp(hass: HomeAssistant, fc_class_mock, mock_get_source_ip) -> None:
+async def test_ssdp(hass: HomeAssistant, fc_class_mock) -> None:
     """Test starting a flow from discovery."""
     with (
         patch(
@@ -732,7 +720,7 @@ async def test_ssdp(hass: HomeAssistant, fc_class_mock, mock_get_source_ip) -> N
     assert mock_setup_entry.called
 
 
-async def test_ssdp_exception(hass: HomeAssistant, mock_get_source_ip) -> None:
+async def test_ssdp_exception(hass: HomeAssistant) -> None:
     """Test starting a flow from discovery but no device found."""
     with patch(
         "homeassistant.components.fritz.config_flow.FritzConnection",

--- a/tests/components/homekit/test_config_flow.py
+++ b/tests/components/homekit/test_config_flow.py
@@ -45,7 +45,7 @@ def _mock_config_entry_with_options_populated():
     )
 
 
-async def test_setup_in_bridge_mode(hass: HomeAssistant, mock_get_source_ip) -> None:
+async def test_setup_in_bridge_mode(hass: HomeAssistant) -> None:
     """Test we can setup a new instance in bridge mode."""
 
     result = await hass.config_entries.flow.async_init(
@@ -99,9 +99,7 @@ async def test_setup_in_bridge_mode(hass: HomeAssistant, mock_get_source_ip) -> 
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_setup_in_bridge_mode_name_taken(
-    hass: HomeAssistant, mock_get_source_ip
-) -> None:
+async def test_setup_in_bridge_mode_name_taken(hass: HomeAssistant) -> None:
     """Test we can setup a new instance in bridge mode when the name is taken."""
 
     entry = MockConfigEntry(
@@ -163,7 +161,7 @@ async def test_setup_in_bridge_mode_name_taken(
 
 
 async def test_setup_creates_entries_for_accessory_mode_devices(
-    hass: HomeAssistant, mock_get_source_ip
+    hass: HomeAssistant,
 ) -> None:
     """Test we can setup a new instance and we create entries for accessory mode devices."""
     hass.states.async_set("camera.one", "on")
@@ -257,7 +255,7 @@ async def test_setup_creates_entries_for_accessory_mode_devices(
     assert len(mock_setup_entry.mock_calls) == 7
 
 
-async def test_import(hass: HomeAssistant, mock_get_source_ip) -> None:
+async def test_import(hass: HomeAssistant) -> None:
     """Test we can import instance."""
 
     ignored_entry = MockConfigEntry(domain=DOMAIN, data={}, source=SOURCE_IGNORE)
@@ -302,9 +300,7 @@ async def test_import(hass: HomeAssistant, mock_get_source_ip) -> None:
     assert len(mock_setup_entry.mock_calls) == 2
 
 
-async def test_options_flow_exclude_mode_advanced(
-    hass: HomeAssistant, mock_get_source_ip
-) -> None:
+async def test_options_flow_exclude_mode_advanced(hass: HomeAssistant) -> None:
     """Test config flow options in exclude mode with advanced options."""
 
     config_entry = _mock_config_entry_with_options_populated()
@@ -357,9 +353,7 @@ async def test_options_flow_exclude_mode_advanced(
     }
 
 
-async def test_options_flow_exclude_mode_basic(
-    hass: HomeAssistant, mock_get_source_ip
-) -> None:
+async def test_options_flow_exclude_mode_basic(hass: HomeAssistant) -> None:
     """Test config flow options in exclude mode."""
 
     config_entry = _mock_config_entry_with_options_populated()
@@ -417,7 +411,6 @@ async def test_options_flow_devices(
     demo_cleanup,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    mock_get_source_ip,
     mock_async_zeroconf: None,
 ) -> None:
     """Test devices can be bridged."""
@@ -510,7 +503,7 @@ async def test_options_flow_devices(
 
 @patch(f"{PATH_HOMEKIT}.async_port_is_available", return_value=True)
 async def test_options_flow_devices_preserved_when_advanced_off(
-    port_mock, hass: HomeAssistant, mock_get_source_ip, mock_async_zeroconf: None
+    port_mock, hass: HomeAssistant, mock_async_zeroconf: None
 ) -> None:
     """Test devices are preserved if they were added in advanced mode but it was turned off."""
     config_entry = MockConfigEntry(
@@ -586,7 +579,7 @@ async def test_options_flow_devices_preserved_when_advanced_off(
 
 
 async def test_options_flow_include_mode_with_non_existant_entity(
-    hass: HomeAssistant, mock_get_source_ip
+    hass: HomeAssistant,
 ) -> None:
     """Test config flow options in include mode with a non-existent entity."""
     config_entry = MockConfigEntry(
@@ -646,7 +639,7 @@ async def test_options_flow_include_mode_with_non_existant_entity(
 
 
 async def test_options_flow_exclude_mode_with_non_existant_entity(
-    hass: HomeAssistant, mock_get_source_ip
+    hass: HomeAssistant,
 ) -> None:
     """Test config flow options in exclude mode with a non-existent entity."""
     config_entry = MockConfigEntry(
@@ -706,9 +699,7 @@ async def test_options_flow_exclude_mode_with_non_existant_entity(
     await hass.config_entries.async_unload(config_entry.entry_id)
 
 
-async def test_options_flow_include_mode_basic(
-    hass: HomeAssistant, mock_get_source_ip
-) -> None:
+async def test_options_flow_include_mode_basic(hass: HomeAssistant) -> None:
     """Test config flow options in include mode."""
 
     config_entry = _mock_config_entry_with_options_populated()
@@ -754,9 +745,7 @@ async def test_options_flow_include_mode_basic(
     await hass.config_entries.async_unload(config_entry.entry_id)
 
 
-async def test_options_flow_exclude_mode_with_cameras(
-    hass: HomeAssistant, mock_get_source_ip
-) -> None:
+async def test_options_flow_exclude_mode_with_cameras(hass: HomeAssistant) -> None:
     """Test config flow options in exclude mode with cameras."""
 
     config_entry = _mock_config_entry_with_options_populated()
@@ -863,9 +852,7 @@ async def test_options_flow_exclude_mode_with_cameras(
     await hass.config_entries.async_unload(config_entry.entry_id)
 
 
-async def test_options_flow_include_mode_with_cameras(
-    hass: HomeAssistant, mock_get_source_ip
-) -> None:
+async def test_options_flow_include_mode_with_cameras(hass: HomeAssistant) -> None:
     """Test config flow options in include mode with cameras."""
 
     config_entry = _mock_config_entry_with_options_populated()
@@ -999,9 +986,7 @@ async def test_options_flow_include_mode_with_cameras(
     await hass.config_entries.async_unload(config_entry.entry_id)
 
 
-async def test_options_flow_with_camera_audio(
-    hass: HomeAssistant, mock_get_source_ip
-) -> None:
+async def test_options_flow_with_camera_audio(hass: HomeAssistant) -> None:
     """Test config flow options with cameras that support audio."""
 
     config_entry = _mock_config_entry_with_options_populated()
@@ -1135,9 +1120,7 @@ async def test_options_flow_with_camera_audio(
     await hass.config_entries.async_unload(config_entry.entry_id)
 
 
-async def test_options_flow_blocked_when_from_yaml(
-    hass: HomeAssistant, mock_get_source_ip
-) -> None:
+async def test_options_flow_blocked_when_from_yaml(hass: HomeAssistant) -> None:
     """Test config flow options."""
 
     config_entry = MockConfigEntry(
@@ -1181,7 +1164,6 @@ async def test_options_flow_blocked_when_from_yaml(
 async def test_options_flow_include_mode_basic_accessory(
     port_mock,
     hass: HomeAssistant,
-    mock_get_source_ip,
     hk_driver,
     mock_async_zeroconf: None,
 ) -> None:
@@ -1283,7 +1265,7 @@ async def test_options_flow_include_mode_basic_accessory(
 
 
 async def test_converting_bridge_to_accessory_mode(
-    hass: HomeAssistant, hk_driver, mock_get_source_ip
+    hass: HomeAssistant, hk_driver
 ) -> None:
     """Test we can convert a bridge to accessory mode."""
 
@@ -1408,7 +1390,6 @@ def _get_schema_default(schema, key_name):
 async def test_options_flow_exclude_mode_skips_category_entities(
     port_mock,
     hass: HomeAssistant,
-    mock_get_source_ip,
     hk_driver,
     mock_async_zeroconf: None,
     entity_registry: er.EntityRegistry,
@@ -1513,7 +1494,6 @@ async def test_options_flow_exclude_mode_skips_category_entities(
 async def test_options_flow_exclude_mode_skips_hidden_entities(
     port_mock,
     hass: HomeAssistant,
-    mock_get_source_ip,
     hk_driver,
     mock_async_zeroconf: None,
     entity_registry: er.EntityRegistry,
@@ -1598,7 +1578,6 @@ async def test_options_flow_exclude_mode_skips_hidden_entities(
 async def test_options_flow_include_mode_allows_hidden_entities(
     port_mock,
     hass: HomeAssistant,
-    mock_get_source_ip,
     hk_driver,
     mock_async_zeroconf: None,
     entity_registry: er.EntityRegistry,

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -111,7 +111,7 @@ def always_patch_driver(hk_driver):
 
 
 @pytest.fixture(autouse=True)
-def patch_source_ip(mock_get_source_ip):
+def patch_source_ip():
     """Patch homeassistant and pyhap functions for getting local address."""
     with patch("pyhap.util.get_local_address", return_value="10.10.10.10"):
         yield

--- a/tests/components/homekit/test_init.py
+++ b/tests/components/homekit/test_init.py
@@ -26,9 +26,7 @@ from tests.common import MockConfigEntry
 from tests.components.logbook.common import MockRow, mock_humanify
 
 
-async def test_humanify_homekit_changed_event(
-    hass: HomeAssistant, hk_driver, mock_get_source_ip
-) -> None:
+async def test_humanify_homekit_changed_event(hass: HomeAssistant, hk_driver) -> None:
     """Test humanifying HomeKit changed event."""
     hass.config.components.add("recorder")
     with patch("homeassistant.components.homekit.HomeKit") as mock_homekit:

--- a/tests/components/homekit/test_util.py
+++ b/tests/components/homekit/test_util.py
@@ -241,9 +241,7 @@ def test_density_to_air_quality() -> None:
     assert density_to_air_quality(200) == 5
 
 
-async def test_async_show_setup_msg(
-    hass: HomeAssistant, hk_driver, mock_get_source_ip
-) -> None:
+async def test_async_show_setup_msg(hass: HomeAssistant, hk_driver) -> None:
     """Test show setup message as persistence notification."""
     pincode = b"123-45-678"
 

--- a/tests/components/lifx/conftest.py
+++ b/tests/components/lifx/conftest.py
@@ -42,11 +42,6 @@ def mock_effect_conductor():
 
 
 @pytest.fixture(autouse=True)
-def lifx_mock_get_source_ip(mock_get_source_ip):
-    """Mock network util's async_get_source_ip."""
-
-
-@pytest.fixture(autouse=True)
 def lifx_no_wait_for_timeouts():
     """Avoid waiting for timeouts in tests."""
     with (

--- a/tests/components/local_ip/test_config_flow.py
+++ b/tests/components/local_ip/test_config_flow.py
@@ -10,7 +10,7 @@ from homeassistant.data_entry_flow import FlowResultType
 from tests.common import MockConfigEntry
 
 
-async def test_config_flow(hass: HomeAssistant, mock_get_source_ip) -> None:
+async def test_config_flow(hass: HomeAssistant) -> None:
     """Test we can finish a config flow."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -25,7 +25,7 @@ async def test_config_flow(hass: HomeAssistant, mock_get_source_ip) -> None:
     assert state
 
 
-async def test_already_setup(hass: HomeAssistant, mock_get_source_ip) -> None:
+async def test_already_setup(hass: HomeAssistant) -> None:
     """Test we abort if already setup."""
     MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/local_ip/test_init.py
+++ b/tests/components/local_ip/test_init.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from tests.common import MockConfigEntry
 
 
-async def test_basic_setup(hass: HomeAssistant, mock_get_source_ip) -> None:
+async def test_basic_setup(hass: HomeAssistant) -> None:
     """Test component setup creates entry from config."""
     entry = MockConfigEntry(domain=DOMAIN, data={})
     entry.add_to_hass(hass)

--- a/tests/components/motion_blinds/test_config_flow.py
+++ b/tests/components/motion_blinds/test_config_flow.py
@@ -72,7 +72,7 @@ TEST_INTERFACES = [
 
 
 @pytest.fixture(name="motion_blinds_connect", autouse=True)
-def motion_blinds_connect_fixture(mock_get_source_ip):
+def motion_blinds_connect_fixture():
     """Mock Motionblinds connection and entry setup."""
     with (
         patch(

--- a/tests/components/nmap_tracker/test_config_flow.py
+++ b/tests/components/nmap_tracker/test_config_flow.py
@@ -25,7 +25,7 @@ from tests.common import MockConfigEntry
 @pytest.mark.parametrize(
     "hosts", ["1.1.1.1", "192.168.1.0/24", "192.168.1.0/24,192.168.2.0/24"]
 )
-async def test_form(hass: HomeAssistant, hosts: str, mock_get_source_ip) -> None:
+async def test_form(hass: HomeAssistant, hosts: str) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -64,7 +64,7 @@ async def test_form(hass: HomeAssistant, hosts: str, mock_get_source_ip) -> None
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_range(hass: HomeAssistant, mock_get_source_ip) -> None:
+async def test_form_range(hass: HomeAssistant) -> None:
     """Test we get the form and can take an ip range."""
 
     result = await hass.config_entries.flow.async_init(
@@ -100,7 +100,7 @@ async def test_form_range(hass: HomeAssistant, mock_get_source_ip) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_invalid_hosts(hass: HomeAssistant, mock_get_source_ip) -> None:
+async def test_form_invalid_hosts(hass: HomeAssistant) -> None:
     """Test invalid hosts passed in."""
 
     result = await hass.config_entries.flow.async_init(
@@ -124,7 +124,7 @@ async def test_form_invalid_hosts(hass: HomeAssistant, mock_get_source_ip) -> No
     assert result2["errors"] == {CONF_HOSTS: "invalid_hosts"}
 
 
-async def test_form_already_configured(hass: HomeAssistant, mock_get_source_ip) -> None:
+async def test_form_already_configured(hass: HomeAssistant) -> None:
     """Test duplicate host list."""
 
     config_entry = MockConfigEntry(
@@ -159,7 +159,7 @@ async def test_form_already_configured(hass: HomeAssistant, mock_get_source_ip) 
     assert result2["reason"] == "already_configured"
 
 
-async def test_form_invalid_excludes(hass: HomeAssistant, mock_get_source_ip) -> None:
+async def test_form_invalid_excludes(hass: HomeAssistant) -> None:
     """Test invalid excludes passed in."""
 
     result = await hass.config_entries.flow.async_init(
@@ -183,7 +183,7 @@ async def test_form_invalid_excludes(hass: HomeAssistant, mock_get_source_ip) ->
     assert result2["errors"] == {CONF_EXCLUDE: "invalid_hosts"}
 
 
-async def test_options_flow(hass: HomeAssistant, mock_get_source_ip) -> None:
+async def test_options_flow(hass: HomeAssistant) -> None:
     """Test we can edit options."""
 
     config_entry = MockConfigEntry(

--- a/tests/components/qnap/conftest.py
+++ b/tests/components/qnap/conftest.py
@@ -24,7 +24,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def qnap_connect(mock_get_source_ip: None) -> Generator[MagicMock, None, None]:
+def qnap_connect() -> Generator[MagicMock, None, None]:
     """Mock qnap connection."""
     with patch(
         "homeassistant.components.qnap.config_flow.QNAPStats", autospec=True

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -47,9 +47,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def reolink_connect_class(
-    mock_get_source_ip: None,
-) -> Generator[MagicMock, None, None]:
+def reolink_connect_class() -> Generator[MagicMock, None, None]:
     """Mock reolink connection and return both the host_mock and host_mock_class."""
     with (
         patch(
@@ -112,7 +110,7 @@ def reolink_connect(
 
 
 @pytest.fixture
-def reolink_platforms(mock_get_source_ip: None) -> Generator[None, None, None]:
+def reolink_platforms() -> Generator[None, None, None]:
     """Mock reolink entry setup."""
     with patch("homeassistant.components.reolink.PLATFORMS", return_value=[]):
         yield

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -56,11 +56,6 @@ async def silent_ssdp_scanner(hass):
 
 
 @pytest.fixture(autouse=True)
-def samsungtv_mock_get_source_ip(mock_get_source_ip):
-    """Mock network util's async_get_source_ip."""
-
-
-@pytest.fixture(autouse=True)
 def samsungtv_mock_async_get_local_ip():
     """Mock upnp util's async_get_local_ip."""
     with patch(

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -627,12 +627,6 @@ def tv_event_fixture(soco):
     return SonosMockEvent(soco, soco.avTransport, variables)
 
 
-@pytest.fixture(autouse=True)
-def mock_get_source_ip(mock_get_source_ip):
-    """Mock network util's async_get_source_ip in all sonos tests."""
-    return mock_get_source_ip
-
-
 @pytest.fixture(name="zgs_discovery", scope="package")
 def zgs_discovery_fixture():
     """Load ZoneGroupState discovery payload and return it."""

--- a/tests/components/ssdp/test_init.py
+++ b/tests/components/ssdp/test_init.py
@@ -42,7 +42,6 @@ async def init_ssdp_component(hass: HomeAssistant) -> SsdpListener:
     "homeassistant.components.ssdp.async_get_ssdp",
     return_value={"mock-domain": [{"st": "mock-st"}]},
 )
-@pytest.mark.usefixtures("mock_get_source_ip")
 async def test_ssdp_flow_dispatched_on_st(
     mock_get_ssdp, hass: HomeAssistant, caplog: pytest.LogCaptureFixture, mock_flow_init
 ) -> None:
@@ -85,7 +84,6 @@ async def test_ssdp_flow_dispatched_on_st(
     "homeassistant.components.ssdp.async_get_ssdp",
     return_value={"mock-domain": [{"manufacturerURL": "mock-url"}]},
 )
-@pytest.mark.usefixtures("mock_get_source_ip")
 async def test_ssdp_flow_dispatched_on_manufacturer_url(
     mock_get_ssdp, hass: HomeAssistant, caplog: pytest.LogCaptureFixture, mock_flow_init
 ) -> None:
@@ -125,7 +123,6 @@ async def test_ssdp_flow_dispatched_on_manufacturer_url(
     assert "Failed to fetch ssdp data" not in caplog.text
 
 
-@pytest.mark.usefixtures("mock_get_source_ip")
 @patch(
     "homeassistant.components.ssdp.async_get_ssdp",
     return_value={"mock-domain": [{"manufacturer": "Paulus"}]},
@@ -170,7 +167,6 @@ async def test_scan_match_upnp_devicedesc_manufacturer(
     }
 
 
-@pytest.mark.usefixtures("mock_get_source_ip")
 @patch(
     "homeassistant.components.ssdp.async_get_ssdp",
     return_value={"mock-domain": [{"deviceType": "Paulus"}]},
@@ -216,7 +212,6 @@ async def test_scan_match_upnp_devicedesc_devicetype(
     }
 
 
-@pytest.mark.usefixtures("mock_get_source_ip")
 @patch(
     "homeassistant.components.ssdp.async_get_ssdp",
     return_value={
@@ -260,7 +255,6 @@ async def test_scan_not_all_present(
     assert not mock_flow_init.mock_calls
 
 
-@pytest.mark.usefixtures("mock_get_source_ip")
 @patch(
     "homeassistant.components.ssdp.async_get_ssdp",
     return_value={
@@ -307,7 +301,6 @@ async def test_scan_not_all_match(
     assert not mock_flow_init.mock_calls
 
 
-@pytest.mark.usefixtures("mock_get_source_ip")
 @patch(
     "homeassistant.components.ssdp.async_get_ssdp",
     return_value={"mock-domain": [{"deviceType": "Paulus"}]},
@@ -383,7 +376,6 @@ async def test_flow_start_only_alive(
     )
 
 
-@pytest.mark.usefixtures("mock_get_source_ip")
 @patch(
     "homeassistant.components.ssdp.async_get_ssdp",
     return_value={},
@@ -441,7 +433,6 @@ async def test_discovery_from_advertisement_sets_ssdp_st(
     "homeassistant.components.ssdp.async_build_source_set",
     return_value={IPv4Address("192.168.1.1")},
 )
-@pytest.mark.usefixtures("mock_get_source_ip")
 async def test_start_stop_scanner(mock_source_set, hass: HomeAssistant) -> None:
     """Test we start and stop the scanner."""
     ssdp_listener = await init_ssdp_component(hass)
@@ -463,7 +454,6 @@ async def test_start_stop_scanner(mock_source_set, hass: HomeAssistant) -> None:
     assert ssdp_listener.async_stop.call_count == 1
 
 
-@pytest.mark.usefixtures("mock_get_source_ip")
 @pytest.mark.no_fail_on_log_exception
 @patch("homeassistant.components.ssdp.async_get_ssdp", return_value={})
 async def test_scan_with_registered_callback(
@@ -559,7 +549,6 @@ async def test_scan_with_registered_callback(
     assert async_integration_callback_from_cache.call_count == 1
 
 
-@pytest.mark.usefixtures("mock_get_source_ip")
 @patch(
     "homeassistant.components.ssdp.async_get_ssdp",
     return_value={"mock-domain": [{"st": "mock-st"}]},
@@ -688,7 +677,6 @@ _ADAPTERS_WITH_MANUAL_CONFIG = [
 ]
 
 
-@pytest.mark.usefixtures("mock_get_source_ip")
 @patch(
     "homeassistant.components.ssdp.async_get_ssdp",
     return_value={
@@ -714,7 +702,6 @@ async def test_async_detect_interfaces_setting_empty_route(
     assert sources == {("2001:db8::", 0, 0, 1), ("192.168.1.5", 0)}
 
 
-@pytest.mark.usefixtures("mock_get_source_ip")
 @patch(
     "homeassistant.components.ssdp.async_get_ssdp",
     return_value={
@@ -764,7 +751,6 @@ async def test_bind_failure_skips_adapter(
     assert sources == {("192.168.1.5", 0)}  # Note no UpnpServer for IPv6 address.
 
 
-@pytest.mark.usefixtures("mock_get_source_ip")
 @patch(
     "homeassistant.components.ssdp.async_get_ssdp",
     return_value={
@@ -800,7 +786,6 @@ async def test_ipv4_does_additional_search_for_sonos(
     assert ssdp_listener.async_search.call_args[1] == {}
 
 
-@pytest.mark.usefixtures("mock_get_source_ip")
 @patch(
     "homeassistant.components.ssdp.async_get_ssdp",
     return_value={"mock-domain": [{"deviceType": "Paulus"}]},

--- a/tests/components/tplink/conftest.py
+++ b/tests/components/tplink/conftest.py
@@ -84,11 +84,6 @@ def entity_reg_fixture(hass):
     return mock_registry(hass)
 
 
-@pytest.fixture(autouse=True)
-def tplink_mock_get_source_ip(mock_get_source_ip):
-    """Mock network util's async_get_source_ip."""
-
-
 @pytest.fixture
 def mock_setup_entry() -> Generator[AsyncMock, None, None]:
     """Override async_setup_entry."""

--- a/tests/components/upnp/conftest.py
+++ b/tests/components/upnp/conftest.py
@@ -228,7 +228,6 @@ async def ssdp_no_discovery():
 @pytest.fixture
 async def mock_config_entry(
     hass: HomeAssistant,
-    mock_get_source_ip,
     ssdp_instant_discovery,
     mock_igd_device: IgdDevice,
     mock_mac_address_from_host,

--- a/tests/components/upnp/test_config_flow.py
+++ b/tests/components/upnp/test_config_flow.py
@@ -38,7 +38,6 @@ from tests.common import MockConfigEntry
 @pytest.mark.usefixtures(
     "ssdp_instant_discovery",
     "mock_setup_entry",
-    "mock_get_source_ip",
     "mock_mac_address_from_host",
 )
 async def test_flow_ssdp(hass: HomeAssistant) -> None:
@@ -72,7 +71,6 @@ async def test_flow_ssdp(hass: HomeAssistant) -> None:
 @pytest.mark.usefixtures(
     "ssdp_instant_discovery",
     "mock_setup_entry",
-    "mock_get_source_ip",
     "mock_mac_address_from_host",
 )
 async def test_flow_ssdp_ignore(hass: HomeAssistant) -> None:
@@ -104,7 +102,6 @@ async def test_flow_ssdp_ignore(hass: HomeAssistant) -> None:
     }
 
 
-@pytest.mark.usefixtures("mock_get_source_ip")
 async def test_flow_ssdp_incomplete_discovery(hass: HomeAssistant) -> None:
     """Test config flow: incomplete discovery through ssdp."""
     # Discovered via step ssdp.
@@ -126,7 +123,6 @@ async def test_flow_ssdp_incomplete_discovery(hass: HomeAssistant) -> None:
     assert result["reason"] == "incomplete_discovery"
 
 
-@pytest.mark.usefixtures("mock_get_source_ip")
 async def test_flow_ssdp_non_igd_device(hass: HomeAssistant) -> None:
     """Test config flow: incomplete discovery through ssdp."""
     # Discovered via step ssdp.
@@ -151,7 +147,6 @@ async def test_flow_ssdp_non_igd_device(hass: HomeAssistant) -> None:
 @pytest.mark.usefixtures(
     "ssdp_instant_discovery",
     "mock_setup_entry",
-    "mock_get_source_ip",
     "mock_no_mac_address_from_host",
 )
 async def test_flow_ssdp_no_mac_address(hass: HomeAssistant) -> None:
@@ -249,7 +244,6 @@ async def test_flow_ssdp_discovery_changed_udn_match_host(hass: HomeAssistant) -
 @pytest.mark.usefixtures(
     "ssdp_instant_discovery",
     "mock_setup_entry",
-    "mock_get_source_ip",
 )
 async def test_flow_ssdp_discovery_changed_udn_but_st_differs(
     hass: HomeAssistant,
@@ -403,7 +397,6 @@ async def test_flow_ssdp_discovery_changed_udn_ignored_entry(
 @pytest.mark.usefixtures(
     "ssdp_instant_discovery",
     "mock_setup_entry",
-    "mock_get_source_ip",
     "mock_mac_address_from_host",
 )
 async def test_flow_user(hass: HomeAssistant) -> None:
@@ -435,7 +428,6 @@ async def test_flow_user(hass: HomeAssistant) -> None:
 @pytest.mark.usefixtures(
     "ssdp_no_discovery",
     "mock_setup_entry",
-    "mock_get_source_ip",
     "mock_mac_address_from_host",
 )
 async def test_flow_user_no_discovery(hass: HomeAssistant) -> None:
@@ -450,7 +442,6 @@ async def test_flow_user_no_discovery(hass: HomeAssistant) -> None:
 @pytest.mark.usefixtures(
     "ssdp_instant_discovery",
     "mock_setup_entry",
-    "mock_get_source_ip",
     "mock_mac_address_from_host",
 )
 async def test_flow_ssdp_with_mismatched_udn(hass: HomeAssistant) -> None:

--- a/tests/components/upnp/test_init.py
+++ b/tests/components/upnp/test_init.py
@@ -30,9 +30,7 @@ from .conftest import (
 from tests.common import MockConfigEntry
 
 
-@pytest.mark.usefixtures(
-    "ssdp_instant_discovery", "mock_get_source_ip", "mock_mac_address_from_host"
-)
+@pytest.mark.usefixtures("ssdp_instant_discovery", "mock_mac_address_from_host")
 async def test_async_setup_entry_default(hass: HomeAssistant) -> None:
     """Test async_setup_entry."""
     entry = MockConfigEntry(
@@ -52,9 +50,7 @@ async def test_async_setup_entry_default(hass: HomeAssistant) -> None:
     assert await hass.config_entries.async_setup(entry.entry_id) is True
 
 
-@pytest.mark.usefixtures(
-    "ssdp_instant_discovery", "mock_get_source_ip", "mock_no_mac_address_from_host"
-)
+@pytest.mark.usefixtures("ssdp_instant_discovery", "mock_no_mac_address_from_host")
 async def test_async_setup_entry_default_no_mac_address(hass: HomeAssistant) -> None:
     """Test async_setup_entry."""
     entry = MockConfigEntry(
@@ -76,7 +72,6 @@ async def test_async_setup_entry_default_no_mac_address(hass: HomeAssistant) -> 
 
 @pytest.mark.usefixtures(
     "ssdp_instant_discovery_multi_location",
-    "mock_get_source_ip",
     "mock_mac_address_from_host",
 )
 async def test_async_setup_entry_multi_location(
@@ -106,7 +101,7 @@ async def test_async_setup_entry_multi_location(
     mock_async_create_device.assert_called_once_with(TEST_LOCATION)
 
 
-@pytest.mark.usefixtures("mock_get_source_ip", "mock_mac_address_from_host")
+@pytest.mark.usefixtures("mock_mac_address_from_host")
 async def test_async_setup_udn_mismatch(
     hass: HomeAssistant, mock_async_create_device: AsyncMock
 ) -> None:

--- a/tests/components/yamaha_musiccast/test_config_flow.py
+++ b/tests/components/yamaha_musiccast/test_config_flow.py
@@ -129,7 +129,7 @@ def mock_empty_discovery_information():
 
 
 async def test_user_input_device_not_found(
-    hass: HomeAssistant, mock_get_device_info_mc_exception, mock_get_source_ip
+    hass: HomeAssistant, mock_get_device_info_mc_exception
 ) -> None:
     """Test when user specifies a non-existing device."""
     result = await hass.config_entries.flow.async_init(
@@ -147,7 +147,7 @@ async def test_user_input_device_not_found(
 
 
 async def test_user_input_non_yamaha_device_found(
-    hass: HomeAssistant, mock_get_device_info_invalid, mock_get_source_ip
+    hass: HomeAssistant, mock_get_device_info_invalid
 ) -> None:
     """Test when user specifies an existing device, which does not provide the musiccast API."""
     result = await hass.config_entries.flow.async_init(
@@ -165,7 +165,7 @@ async def test_user_input_non_yamaha_device_found(
 
 
 async def test_user_input_device_already_existing(
-    hass: HomeAssistant, mock_get_device_info_valid, mock_get_source_ip
+    hass: HomeAssistant, mock_get_device_info_valid
 ) -> None:
     """Test when user specifies an existing device."""
     mock_entry = MockConfigEntry(
@@ -189,7 +189,7 @@ async def test_user_input_device_already_existing(
 
 
 async def test_user_input_unknown_error(
-    hass: HomeAssistant, mock_get_device_info_exception, mock_get_source_ip
+    hass: HomeAssistant, mock_get_device_info_exception
 ) -> None:
     """Test when user specifies an existing device, which does not provide the musiccast API."""
     result = await hass.config_entries.flow.async_init(
@@ -210,7 +210,6 @@ async def test_user_input_device_found(
     hass: HomeAssistant,
     mock_get_device_info_valid,
     mock_valid_discovery_information,
-    mock_get_source_ip,
 ) -> None:
     """Test when user specifies an existing device."""
     result = await hass.config_entries.flow.async_init(
@@ -236,7 +235,6 @@ async def test_user_input_device_found_no_ssdp(
     hass: HomeAssistant,
     mock_get_device_info_valid,
     mock_empty_discovery_information,
-    mock_get_source_ip,
 ) -> None:
     """Test when user specifies an existing device, which no discovery data are present for."""
     result = await hass.config_entries.flow.async_init(
@@ -261,9 +259,7 @@ async def test_user_input_device_found_no_ssdp(
 # SSDP Flows
 
 
-async def test_ssdp_discovery_failed(
-    hass: HomeAssistant, mock_ssdp_no_yamaha, mock_get_source_ip
-) -> None:
+async def test_ssdp_discovery_failed(hass: HomeAssistant, mock_ssdp_no_yamaha) -> None:
     """Test when an SSDP discovered device is not a musiccast device."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -284,7 +280,7 @@ async def test_ssdp_discovery_failed(
 
 
 async def test_ssdp_discovery_successful_add_device(
-    hass: HomeAssistant, mock_ssdp_yamaha, mock_get_source_ip
+    hass: HomeAssistant, mock_ssdp_yamaha
 ) -> None:
     """Test when the SSDP discovered device is a musiccast device and the user confirms it."""
     result = await hass.config_entries.flow.async_init(
@@ -320,7 +316,7 @@ async def test_ssdp_discovery_successful_add_device(
 
 
 async def test_ssdp_discovery_existing_device_update(
-    hass: HomeAssistant, mock_ssdp_yamaha, mock_get_source_ip
+    hass: HomeAssistant, mock_ssdp_yamaha
 ) -> None:
     """Test when the SSDP discovered device is a musiccast device, but it already exists with another IP."""
     mock_entry = MockConfigEntry(

--- a/tests/components/yeelight/conftest.py
+++ b/tests/components/yeelight/conftest.py
@@ -1,10 +1,3 @@
 """yeelight conftest."""
 
-import pytest
-
 from tests.components.light.conftest import mock_light_profiles  # noqa: F401
-
-
-@pytest.fixture(autouse=True)
-def yeelight_mock_get_source_ip(mock_get_source_ip):
-    """Mock network util's async_get_source_ip."""

--- a/tests/components/zeroconf/conftest.py
+++ b/tests/components/zeroconf/conftest.py
@@ -1,9 +1,1 @@
 """Tests for the Zeroconf component."""
-
-import pytest
-
-
-@pytest.fixture(autouse=True)
-def zc_mock_get_source_ip(mock_get_source_ip):
-    """Enable the mock_get_source_ip fixture for all zeroconf tests."""
-    return mock_get_source_ip


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
While investigating type hints, I found that `mock_get_source_ip` was made autouse in #58669


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
