### PR TITLE
Fix incorrect `patch` type hint in main conftest

### DIFF
--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -137,7 +137,7 @@ _TEST_FIXTURES: dict[str, list[str] | str] = {
     "mock_bluetooth": "None",
     "mock_bluetooth_adapters": "None",
     "mock_device_tracker_conf": "list[Device]",
-    "mock_get_source_ip": "None",
+    "mock_get_source_ip": "Patcher",
     "mock_hass_config": "None",
     "mock_hass_config_yaml": "None",
     "mock_zeroconf": "None",

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -137,7 +137,7 @@ _TEST_FIXTURES: dict[str, list[str] | str] = {
     "mock_bluetooth": "None",
     "mock_bluetooth_adapters": "None",
     "mock_device_tracker_conf": "list[Device]",
-    "mock_get_source_ip": "Patcher",
+    "mock_get_source_ip": "_patch",
     "mock_hass_config": "None",
     "mock_hass_config_yaml": "None",
     "mock_zeroconf": "None",

--- a/tests/components/network/conftest.py
+++ b/tests/components/network/conftest.py
@@ -1,10 +1,9 @@
 """Tests for the Network Configuration integration."""
 
 from collections.abc import Generator
+from unittest.mock import _patch
 
 import pytest
-
-from tests.typing import Patcher
 
 
 @pytest.fixture(autouse=True)
@@ -14,7 +13,7 @@ def mock_network():
 
 @pytest.fixture(autouse=True)
 def override_mock_get_source_ip(
-    mock_get_source_ip: Patcher,
+    mock_get_source_ip: _patch,
 ) -> Generator[None, None, None]:
     """Override mock of network util's async_get_source_ip."""
     mock_get_source_ip.stop()

--- a/tests/components/network/conftest.py
+++ b/tests/components/network/conftest.py
@@ -1,6 +1,10 @@
 """Tests for the Network Configuration integration."""
 
+from collections.abc import Generator
+
 import pytest
+
+from tests.typing import Patcher
 
 
 @pytest.fixture(autouse=True)
@@ -9,7 +13,9 @@ def mock_network():
 
 
 @pytest.fixture(autouse=True)
-def override_mock_get_source_ip(mock_get_source_ip):
+def override_mock_get_source_ip(
+    mock_get_source_ip: Patcher,
+) -> Generator[None, None, None]:
     """Override mock of network util's async_get_source_ip."""
     mock_get_source_ip.stop()
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,6 +77,7 @@ from .typing import (
     MqttMockHAClient,
     MqttMockHAClientGenerator,
     MqttMockPahoClient,
+    Patcher,
     RecorderInstanceGenerator,
     WebSocketGenerator,
 )
@@ -1151,7 +1152,7 @@ def mock_network() -> Generator[None, None, None]:
 
 
 @pytest.fixture(autouse=True, scope="session")
-def mock_get_source_ip() -> Generator[patch, None, None]:
+def mock_get_source_ip() -> Generator[Patcher, None, None]:
     """Mock network util's async_get_source_ip."""
     patcher = patch(
         "homeassistant.components.network.util.async_get_source_ip",
@@ -1165,7 +1166,7 @@ def mock_get_source_ip() -> Generator[patch, None, None]:
 
 
 @pytest.fixture(autouse=True, scope="session")
-def translations_once() -> Generator[patch, None, None]:
+def translations_once() -> Generator[Patcher, None, None]:
     """Only load translations once per session."""
     from homeassistant.helpers.translation import _TranslationsCacheData
 
@@ -1182,7 +1183,9 @@ def translations_once() -> Generator[patch, None, None]:
 
 
 @pytest.fixture
-def disable_translations_once(translations_once):
+def disable_translations_once(
+    translations_once: Patcher,
+) -> Generator[None, None, None]:
     """Override loading translations once."""
     translations_once.stop()
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ import sqlite3
 import ssl
 import threading
 from typing import TYPE_CHECKING, Any, cast
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, _patch, patch
 
 from aiohttp import client
 from aiohttp.test_utils import (
@@ -77,7 +77,6 @@ from .typing import (
     MqttMockHAClient,
     MqttMockHAClientGenerator,
     MqttMockPahoClient,
-    Patcher,
     RecorderInstanceGenerator,
     WebSocketGenerator,
 )
@@ -1152,7 +1151,7 @@ def mock_network() -> Generator[None, None, None]:
 
 
 @pytest.fixture(autouse=True, scope="session")
-def mock_get_source_ip() -> Generator[Patcher, None, None]:
+def mock_get_source_ip() -> Generator[_patch, None, None]:
     """Mock network util's async_get_source_ip."""
     patcher = patch(
         "homeassistant.components.network.util.async_get_source_ip",
@@ -1166,7 +1165,7 @@ def mock_get_source_ip() -> Generator[Patcher, None, None]:
 
 
 @pytest.fixture(autouse=True, scope="session")
-def translations_once() -> Generator[Patcher, None, None]:
+def translations_once() -> Generator[_patch, None, None]:
     """Only load translations once per session."""
     from homeassistant.helpers.translation import _TranslationsCacheData
 
@@ -1184,7 +1183,7 @@ def translations_once() -> Generator[Patcher, None, None]:
 
 @pytest.fixture
 def disable_translations_once(
-    translations_once: Patcher,
+    translations_once: _patch,
 ) -> Generator[None, None, None]:
     """Override loading translations once."""
     translations_once.stop()

--- a/tests/helpers/test_translation.py
+++ b/tests/helpers/test_translation.py
@@ -15,7 +15,7 @@ from homeassistant.setup import async_setup_component
 
 
 @pytest.fixture(autouse=True)
-def _disable_translations_once(disable_translations_once):
+def _disable_translations_once(disable_translations_once: None) -> None:
     """Override loading translations once."""
 
 

--- a/tests/typing.py
+++ b/tests/typing.py
@@ -38,4 +38,4 @@ type RecorderInstanceGenerator = Callable[..., Coroutine[Any, Any, Recorder]]
 type WebSocketGenerator = Callable[..., Coroutine[Any, Any, MockHAClientWebSocket]]
 
 type Patcher = _patch_default_new
-"""Type alias for unittest.mock._patcher."""
+"""Type alias for unittest.mock._patch_default_new."""

--- a/tests/typing.py
+++ b/tests/typing.py
@@ -10,9 +10,6 @@ from aiohttp import ClientWebSocketResponse
 from aiohttp.test_utils import TestClient
 
 if TYPE_CHECKING:
-    # _patch_default_new is not available at runtime
-    from unittest.mock import _patch_default_new
-
     # Local import to avoid processing recorder module when running a
     # testcase which does not use the recorder.
     from homeassistant.components.recorder import Recorder
@@ -36,6 +33,3 @@ type MqttMockHAClientGenerator = Callable[..., Coroutine[Any, Any, MqttMockHACli
 type RecorderInstanceGenerator = Callable[..., Coroutine[Any, Any, Recorder]]
 """Instance generator for `homeassistant.components.recorder.Recorder`."""
 type WebSocketGenerator = Callable[..., Coroutine[Any, Any, MockHAClientWebSocket]]
-
-type Patcher = _patch_default_new
-"""Type alias for unittest.mock._patch_default_new."""

--- a/tests/typing.py
+++ b/tests/typing.py
@@ -10,6 +10,9 @@ from aiohttp import ClientWebSocketResponse
 from aiohttp.test_utils import TestClient
 
 if TYPE_CHECKING:
+    # _patcher is not available at runtime
+    from unittest.mock import _patch_default_new
+
     # Local import to avoid processing recorder module when running a
     # testcase which does not use the recorder.
     from homeassistant.components.recorder import Recorder
@@ -33,3 +36,6 @@ type MqttMockHAClientGenerator = Callable[..., Coroutine[Any, Any, MqttMockHACli
 type RecorderInstanceGenerator = Callable[..., Coroutine[Any, Any, Recorder]]
 """Instance generator for `homeassistant.components.recorder.Recorder`."""
 type WebSocketGenerator = Callable[..., Coroutine[Any, Any, MockHAClientWebSocket]]
+
+type Patcher = _patch_default_new
+"""Type alias for unittest.mock._patcher."""

--- a/tests/typing.py
+++ b/tests/typing.py
@@ -10,7 +10,7 @@ from aiohttp import ClientWebSocketResponse
 from aiohttp.test_utils import TestClient
 
 if TYPE_CHECKING:
-    # _patcher is not available at runtime
+    # _patch_default_new is not available at runtime
     from unittest.mock import _patch_default_new
 
     # Local import to avoid processing recorder module when running a


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The incorrect type hint was introduced in #117096 and #117118

`patch` is a callable that returns a `_patch_default_new` class, but this class is not available at runtime so we need to create an alias.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
