### PR TITLE
Fix incorrect `zeroconf` type hint in tests

### DIFF
--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -140,7 +140,7 @@ _TEST_FIXTURES: dict[str, list[str] | str] = {
     "mock_get_source_ip": "None",
     "mock_hass_config": "None",
     "mock_hass_config_yaml": "None",
-    "mock_zeroconf": "None",
+    "mock_zeroconf": "MagicMock",
     "mqtt_client_mock": "MqttMockPahoClient",
     "mqtt_mock": "MqttMockHAClient",
     "mqtt_mock_entry": "MqttMockHAClientGenerator",

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -132,7 +132,7 @@ _TEST_FIXTURES: dict[str, list[str] | str] = {
     "issue_registry": "IssueRegistry",
     "legacy_auth": "LegacyApiPasswordAuthProvider",
     "local_auth": "HassAuthProvider",
-    "mock_async_zeroconf": "None",
+    "mock_async_zeroconf": "MagicMock",
     "mock_bleak_scanner_start": "MagicMock",
     "mock_bluetooth": "None",
     "mock_bluetooth_adapters": "None",

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -297,7 +297,7 @@ async def test_homekit_setup(
 
 
 async def test_homekit_setup_ip_address(
-    hass: HomeAssistant, hk_driver, mock_async_zeroconf: None
+    hass: HomeAssistant, hk_driver, mock_async_zeroconf: MagicMock
 ) -> None:
     """Test setup with given IP address."""
     entry = MockConfigEntry(
@@ -344,7 +344,7 @@ async def test_homekit_setup_ip_address(
 async def test_homekit_with_single_advertise_ips(
     hass: HomeAssistant,
     hk_driver,
-    mock_async_zeroconf: None,
+    mock_async_zeroconf: MagicMock,
     hass_storage: dict[str, Any],
 ) -> None:
     """Test setup with a single advertise ips."""
@@ -379,7 +379,7 @@ async def test_homekit_with_single_advertise_ips(
 async def test_homekit_with_many_advertise_ips(
     hass: HomeAssistant,
     hk_driver,
-    mock_async_zeroconf: None,
+    mock_async_zeroconf: MagicMock,
     hass_storage: dict[str, Any],
 ) -> None:
     """Test setup with many advertise ips."""

--- a/tests/components/otbr/test_init.py
+++ b/tests/components/otbr/test_init.py
@@ -41,7 +41,9 @@ DATASET_NO_CHANNEL = bytes.fromhex(
 
 
 async def test_import_dataset(
-    hass: HomeAssistant, mock_async_zeroconf: None, issue_registry: ir.IssueRegistry
+    hass: HomeAssistant,
+    mock_async_zeroconf: MagicMock,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test the active dataset is imported at setup."""
     add_service_listener_called = asyncio.Event()

--- a/tests/components/thread/test_dataset_store.py
+++ b/tests/components/thread/test_dataset_store.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from typing import Any
-from unittest.mock import ANY, AsyncMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 from python_otbr_api.tlv_parser import TLVError
@@ -710,7 +710,7 @@ async def test_set_preferred_extended_address(hass: HomeAssistant) -> None:
 
 
 async def test_automatically_set_preferred_dataset(
-    hass: HomeAssistant, mock_async_zeroconf: None
+    hass: HomeAssistant, mock_async_zeroconf: MagicMock
 ) -> None:
     """Test automatically setting the first dataset as the preferred dataset."""
     add_service_listener_called = asyncio.Event()
@@ -775,7 +775,7 @@ async def test_automatically_set_preferred_dataset(
 
 
 async def test_automatically_set_preferred_dataset_own_and_other_router(
-    hass: HomeAssistant, mock_async_zeroconf: None
+    hass: HomeAssistant, mock_async_zeroconf: MagicMock
 ) -> None:
     """Test automatically setting the first dataset as the preferred dataset.
 
@@ -854,7 +854,7 @@ async def test_automatically_set_preferred_dataset_own_and_other_router(
 
 
 async def test_automatically_set_preferred_dataset_other_router(
-    hass: HomeAssistant, mock_async_zeroconf: None
+    hass: HomeAssistant, mock_async_zeroconf: MagicMock
 ) -> None:
     """Test automatically setting the first dataset as the preferred dataset.
 
@@ -922,7 +922,7 @@ async def test_automatically_set_preferred_dataset_other_router(
 
 
 async def test_automatically_set_preferred_dataset_no_router(
-    hass: HomeAssistant, mock_async_zeroconf: None
+    hass: HomeAssistant, mock_async_zeroconf: MagicMock
 ) -> None:
     """Test automatically setting the first dataset as the preferred dataset.
 

--- a/tests/components/thread/test_diagnostics.py
+++ b/tests/components/thread/test_diagnostics.py
@@ -1,7 +1,7 @@
 """Test the thread websocket API."""
 
 import dataclasses
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -182,7 +182,7 @@ def ndb() -> Mock:
 
 async def test_diagnostics(
     hass: HomeAssistant,
-    mock_async_zeroconf: None,
+    mock_async_zeroconf: MagicMock,
     ndb: Mock,
     hass_client: ClientSessionGenerator,
     snapshot: SnapshotAssertion,

--- a/tests/components/thread/test_discovery.py
+++ b/tests/components/thread/test_discovery.py
@@ -1,6 +1,6 @@
 """Test the thread websocket API."""
 
-from unittest.mock import ANY, AsyncMock, Mock
+from unittest.mock import ANY, AsyncMock, MagicMock, Mock
 
 import pytest
 from zeroconf.asyncio import AsyncServiceInfo
@@ -24,7 +24,9 @@ from . import (
 )
 
 
-async def test_discover_routers(hass: HomeAssistant, mock_async_zeroconf: None) -> None:
+async def test_discover_routers(
+    hass: HomeAssistant, mock_async_zeroconf: MagicMock
+) -> None:
     """Test discovering thread routers."""
     mock_async_zeroconf.async_add_service_listener = AsyncMock()
     mock_async_zeroconf.async_remove_service_listener = AsyncMock()

--- a/tests/components/thread/test_discovery.py
+++ b/tests/components/thread/test_discovery.py
@@ -153,7 +153,7 @@ async def test_discover_routers(
     ],
 )
 async def test_discover_routers_unconfigured(
-    hass: HomeAssistant, mock_async_zeroconf: None, data, unconfigured
+    hass: HomeAssistant, mock_async_zeroconf: MagicMock, data, unconfigured
 ) -> None:
     """Test discovering thread routers and setting the unconfigured flag."""
     mock_async_zeroconf.async_add_service_listener = AsyncMock()
@@ -199,7 +199,7 @@ async def test_discover_routers_unconfigured(
     "data", [ROUTER_DISCOVERY_HASS_BAD_DATA, ROUTER_DISCOVERY_HASS_MISSING_DATA]
 )
 async def test_discover_routers_bad_or_missing_optional_data(
-    hass: HomeAssistant, mock_async_zeroconf: None, data
+    hass: HomeAssistant, mock_async_zeroconf: MagicMock, data
 ) -> None:
     """Test discovering thread routers with bad or missing vendor mDNS data."""
     mock_async_zeroconf.async_add_service_listener = AsyncMock()
@@ -249,7 +249,7 @@ async def test_discover_routers_bad_or_missing_optional_data(
     ],
 )
 async def test_discover_routers_bad_or_missing_mandatory_data(
-    hass: HomeAssistant, mock_async_zeroconf: None, service
+    hass: HomeAssistant, mock_async_zeroconf: MagicMock, service
 ) -> None:
     """Test discovering thread routers with missing mandatory mDNS data."""
     mock_async_zeroconf.async_add_service_listener = AsyncMock()
@@ -283,7 +283,7 @@ async def test_discover_routers_bad_or_missing_mandatory_data(
 
 
 async def test_discover_routers_get_service_info_fails(
-    hass: HomeAssistant, mock_async_zeroconf: None
+    hass: HomeAssistant, mock_async_zeroconf: MagicMock
 ) -> None:
     """Test discovering thread routers with invalid mDNS data."""
     mock_async_zeroconf.async_add_service_listener = AsyncMock()
@@ -313,7 +313,7 @@ async def test_discover_routers_get_service_info_fails(
 
 
 async def test_discover_routers_update_unchanged(
-    hass: HomeAssistant, mock_async_zeroconf: None
+    hass: HomeAssistant, mock_async_zeroconf: MagicMock
 ) -> None:
     """Test discovering thread routers with identical mDNS data in update."""
     mock_async_zeroconf.async_add_service_listener = AsyncMock()
@@ -355,7 +355,7 @@ async def test_discover_routers_update_unchanged(
 
 
 async def test_discover_routers_stop_twice(
-    hass: HomeAssistant, mock_async_zeroconf: None
+    hass: HomeAssistant, mock_async_zeroconf: MagicMock
 ) -> None:
     """Test discovering thread routers stopping discovery twice."""
     mock_async_zeroconf.async_add_service_listener = AsyncMock()

--- a/tests/components/thread/test_websocket_api.py
+++ b/tests/components/thread/test_websocket_api.py
@@ -1,6 +1,6 @@
 """Test the thread websocket API."""
 
-from unittest.mock import ANY, AsyncMock
+from unittest.mock import ANY, AsyncMock, MagicMock
 
 from zeroconf.asyncio import AsyncServiceInfo
 
@@ -315,7 +315,9 @@ async def test_set_preferred_dataset_wrong_id(
 
 
 async def test_discover_routers(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, mock_async_zeroconf: None
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    mock_async_zeroconf: MagicMock,
 ) -> None:
     """Test discovering thread routers."""
     mock_async_zeroconf.async_add_service_listener = AsyncMock()

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -1,7 +1,7 @@
 """Test Zeroconf component setup process."""
 
 from typing import Any
-from unittest.mock import call, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from zeroconf import (
@@ -1285,7 +1285,7 @@ async def test_async_detect_interfaces_explicitly_set_ipv6_freebsd(
     )
 
 
-async def test_no_name(hass: HomeAssistant, mock_async_zeroconf: None) -> None:
+async def test_no_name(hass: HomeAssistant, mock_async_zeroconf: MagicMock) -> None:
     """Test fallback to Home for mDNS announcement if the name is missing."""
     hass.config.location_name = ""
     with patch("homeassistant.components.zeroconf.HaZeroconf"):
@@ -1299,7 +1299,7 @@ async def test_no_name(hass: HomeAssistant, mock_async_zeroconf: None) -> None:
 
 
 async def test_setup_with_disallowed_characters_in_local_name(
-    hass: HomeAssistant, mock_async_zeroconf: None, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant, mock_async_zeroconf: MagicMock
 ) -> None:
     """Test we still setup with disallowed characters in the location name."""
     with (
@@ -1323,7 +1323,7 @@ async def test_setup_with_disallowed_characters_in_local_name(
 
 
 async def test_start_with_frontend(
-    hass: HomeAssistant, mock_async_zeroconf: None
+    hass: HomeAssistant, mock_async_zeroconf: MagicMock
 ) -> None:
     """Test we start with the frontend."""
     with patch("homeassistant.components.zeroconf.HaZeroconf"):

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -148,7 +148,7 @@ def get_zeroconf_info_mock_model(model):
     return mock_zc_info
 
 
-async def test_setup(hass: HomeAssistant, mock_async_zeroconf: None) -> None:
+async def test_setup(hass: HomeAssistant, mock_async_zeroconf: MagicMock) -> None:
     """Test configured options for a device are loaded via config entry."""
     mock_zc = {
         "_http._tcp.local.": [
@@ -994,7 +994,9 @@ async def test_info_from_service_can_return_ipv6(hass: HomeAssistant) -> None:
     assert info.host == "fd11:1111:1111:0:1234:1234:1234:1234"
 
 
-async def test_get_instance(hass: HomeAssistant, mock_async_zeroconf: None) -> None:
+async def test_get_instance(
+    hass: HomeAssistant, mock_async_zeroconf: MagicMock
+) -> None:
     """Test we get an instance."""
     assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
     assert await zeroconf.async_get_async_instance(hass) is mock_async_zeroconf

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -238,7 +238,7 @@ async def test_setup_with_overly_long_url_and_name(
 
 
 async def test_setup_with_defaults(
-    hass: HomeAssistant, mock_zeroconf: None, mock_async_zeroconf: None
+    hass: HomeAssistant, mock_zeroconf: MagicMock, mock_async_zeroconf: None
 ) -> None:
     """Test default interface config."""
     with (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1206,7 +1206,7 @@ def mock_zeroconf() -> Generator[MagicMock, None, None]:
 
 
 @pytest.fixture
-def mock_async_zeroconf(mock_zeroconf: None) -> Generator[MagicMock, None, None]:
+def mock_async_zeroconf(mock_zeroconf: MagicMock) -> Generator[MagicMock, None, None]:
     """Mock AsyncZeroconf."""
     from zeroconf import DNSCache, Zeroconf  # pylint: disable=import-outside-toplevel
     from zeroconf.asyncio import (  # pylint: disable=import-outside-toplevel

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1190,7 +1190,7 @@ def disable_translations_once(translations_once):
 
 
 @pytest.fixture
-def mock_zeroconf() -> Generator[None, None, None]:
+def mock_zeroconf() -> Generator[MagicMock, None, None]:
     """Mock zeroconf."""
     from zeroconf import DNSCache  # pylint: disable=import-outside-toplevel
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1206,7 +1206,7 @@ def mock_zeroconf() -> Generator[None, None, None]:
 
 
 @pytest.fixture
-def mock_async_zeroconf(mock_zeroconf: None) -> Generator[None, None, None]:
+def mock_async_zeroconf(mock_zeroconf: None) -> Generator[MagicMock, None, None]:
     """Mock AsyncZeroconf."""
     from zeroconf import DNSCache, Zeroconf  # pylint: disable=import-outside-toplevel
     from zeroconf.asyncio import (  # pylint: disable=import-outside-toplevel


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`mock_async_zeroconf` was incorrectly marked as `None` in #87842
`mock_zeroconf` was amended in #96957

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
