### PR TITLE
Extend Matter sensor discovery schemas for Air Purifier / Air Quality devices

### DIFF
--- a/homeassistant/components/matter/sensor.py
+++ b/homeassistant/components/matter/sensor.py
@@ -310,4 +310,30 @@ DISCOVERY_SCHEMAS = [
             clusters.CarbonMonoxideConcentrationMeasurement.Attributes.MeasuredValue,
         ),
     ),
+    MatterDiscoverySchema(
+        platform=Platform.SENSOR,
+        entity_description=MatterSensorEntityDescription(
+            key="NitrogenDioxideSensor",
+            native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
+            device_class=SensorDeviceClass.NITROGEN_DIOXIDE,
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+        entity_class=MatterSensor,
+        required_attributes=(
+            clusters.NitrogenDioxideConcentrationMeasurement.Attributes.MeasuredValue,
+        ),
+    ),
+    MatterDiscoverySchema(
+        platform=Platform.SENSOR,
+        entity_description=MatterSensorEntityDescription(
+            key="OzoneConcentrationSensor",
+            native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
+            device_class=SensorDeviceClass.OZONE,
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+        entity_class=MatterSensor,
+        required_attributes=(
+            clusters.OzoneConcentrationMeasurement.Attributes.MeasuredValue,
+        ),
+    ),
 ]

--- a/homeassistant/components/matter/sensor.py
+++ b/homeassistant/components/matter/sensor.py
@@ -297,4 +297,17 @@ DISCOVERY_SCHEMAS = [
         entity_class=MatterSensor,
         required_attributes=(clusters.AirQuality.Attributes.AirQuality,),
     ),
+    MatterDiscoverySchema(
+        platform=Platform.SENSOR,
+        entity_description=MatterSensorEntityDescription(
+            key="CarbonMonoxideSensor",
+            native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
+            device_class=SensorDeviceClass.CO,
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+        entity_class=MatterSensor,
+        required_attributes=(
+            clusters.CarbonMonoxideConcentrationMeasurement.Attributes.MeasuredValue,
+        ),
+    ),
 ]

--- a/homeassistant/components/matter/sensor.py
+++ b/homeassistant/components/matter/sensor.py
@@ -349,4 +349,19 @@ DISCOVERY_SCHEMAS = [
         entity_class=MatterSensor,
         required_attributes=(clusters.HepaFilterMonitoring.Attributes.Condition,),
     ),
+    MatterDiscoverySchema(
+        platform=Platform.SENSOR,
+        entity_description=MatterSensorEntityDescription(
+            key="ActivatedCarbonFilterCondition",
+            native_unit_of_measurement=PERCENTAGE,
+            device_class=None,
+            state_class=SensorStateClass.MEASUREMENT,
+            translation_key="activated_carbon_filter_condition",
+            icon="mdi:filter-check",
+        ),
+        entity_class=MatterSensor,
+        required_attributes=(
+            clusters.ActivatedCarbonFilterMonitoring.Attributes.Condition,
+        ),
+    ),
 ]

--- a/homeassistant/components/matter/sensor.py
+++ b/homeassistant/components/matter/sensor.py
@@ -37,6 +37,17 @@ from .entity import MatterEntity, MatterEntityDescription
 from .helpers import get_matter
 from .models import MatterDiscoverySchema
 
+AIR_QUALITY_MAP = {
+    clusters.AirQuality.Enums.AirQualityEnum.kExtremelyPoor: "extremely_poor",
+    clusters.AirQuality.Enums.AirQualityEnum.kVeryPoor: "very_poor",
+    clusters.AirQuality.Enums.AirQualityEnum.kPoor: "poor",
+    clusters.AirQuality.Enums.AirQualityEnum.kFair: "fair",
+    clusters.AirQuality.Enums.AirQualityEnum.kGood: "good",
+    clusters.AirQuality.Enums.AirQualityEnum.kModerate: "moderate",
+    clusters.AirQuality.Enums.AirQualityEnum.kUnknown: "unknown",
+    clusters.AirQuality.Enums.AirQualityEnum.kUnknownEnumValue: "unknown",
+}
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -270,5 +281,20 @@ DISCOVERY_SCHEMAS = [
         required_attributes=(
             clusters.Pm10ConcentrationMeasurement.Attributes.MeasuredValue,
         ),
+    ),
+    MatterDiscoverySchema(
+        platform=Platform.SENSOR,
+        entity_description=MatterSensorEntityDescription(
+            key="AirQuality",
+            translation_key="air_quality",
+            device_class=SensorDeviceClass.ENUM,
+            state_class=None,
+            # convert to set first to remove the duplicate unknown value
+            options=list(set(AIR_QUALITY_MAP.values())),
+            measurement_to_ha=lambda x: AIR_QUALITY_MAP[x],
+            icon="mdi:air-filter",
+        ),
+        entity_class=MatterSensor,
+        required_attributes=(clusters.AirQuality.Attributes.AirQuality,),
     ),
 ]

--- a/homeassistant/components/matter/sensor.py
+++ b/homeassistant/components/matter/sensor.py
@@ -336,4 +336,17 @@ DISCOVERY_SCHEMAS = [
             clusters.OzoneConcentrationMeasurement.Attributes.MeasuredValue,
         ),
     ),
+    MatterDiscoverySchema(
+        platform=Platform.SENSOR,
+        entity_description=MatterSensorEntityDescription(
+            key="HepaFilterCondition",
+            native_unit_of_measurement=PERCENTAGE,
+            device_class=None,
+            state_class=SensorStateClass.MEASUREMENT,
+            translation_key="hepa_filter_condition",
+            icon="mdi:filter-check",
+        ),
+        entity_class=MatterSensor,
+        required_attributes=(clusters.HepaFilterMonitoring.Attributes.Condition,),
+    ),
 ]

--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -98,7 +98,7 @@
         "name": "Flow"
       },
       "hepa_filter_condition": {
-        "name": "Hepa Filter Condition"
+        "name": "Hepa filter condition"
       }
     }
   },

--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -83,7 +83,7 @@
         "name": "Activated carbon filter condition"
       },
       "air_quality": {
-        "name": "Air Quality",
+        "name": "Air quality",
         "state": {
           "extremely_poor": "Extremely poor",
           "very_poor": "Very poor",

--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -81,6 +81,18 @@
     "sensor": {
       "flow": {
         "name": "Flow"
+      },
+      "air_quality": {
+        "name": "Air Quality",
+        "state": {
+          "extremely_poor": "Extremely poor",
+          "very_poor": "Very poor",
+          "poor": "Poor",
+          "fair": "Fair",
+          "good": "Good",
+          "moderate": "Moderate",
+          "unknown": "Unknown"
+        }
       }
     }
   },

--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -79,6 +79,9 @@
       }
     },
     "sensor": {
+      "activated_carbon_filter_condition": {
+        "name": "Activated Carbon Filter Condition"
+      },
       "air_quality": {
         "name": "Air Quality",
         "state": {

--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -79,9 +79,6 @@
       }
     },
     "sensor": {
-      "flow": {
-        "name": "Flow"
-      },
       "air_quality": {
         "name": "Air Quality",
         "state": {
@@ -93,6 +90,12 @@
           "moderate": "Moderate",
           "unknown": "Unknown"
         }
+      },
+      "flow": {
+        "name": "Flow"
+      },
+      "hepa_filter_condition": {
+        "name": "Hepa Filter Condition"
       }
     }
   },

--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -80,7 +80,7 @@
     },
     "sensor": {
       "activated_carbon_filter_condition": {
-        "name": "Activated Carbon Filter Condition"
+        "name": "Activated carbon filter condition"
       },
       "air_quality": {
         "name": "Air Quality",

--- a/tests/components/matter/test_sensor.py
+++ b/tests/components/matter/test_sensor.py
@@ -435,3 +435,11 @@ async def test_air_purifier_sensor(
     assert state.attributes["unit_of_measurement"] == "ppm"
     assert state.attributes["device_class"] == "ozone"
     assert state.attributes["friendly_name"] == "Air Purifier Ozone"
+
+    # Hepa Filter Condition
+    state = hass.states.get("sensor.air_purifier_hepa_filter_condition")
+    assert state
+    assert state.state == "100"
+    assert state.attributes["state_class"] == "measurement"
+    assert state.attributes["unit_of_measurement"] == "%"
+    assert state.attributes["friendly_name"] == "Air Purifier Hepa Filter Condition"

--- a/tests/components/matter/test_sensor.py
+++ b/tests/components/matter/test_sensor.py
@@ -443,3 +443,10 @@ async def test_air_purifier_sensor(
     assert state.attributes["state_class"] == "measurement"
     assert state.attributes["unit_of_measurement"] == "%"
     assert state.attributes["friendly_name"] == "Air Purifier Hepa Filter Condition"
+
+    # Activated Carbon Filter Condition
+    state = hass.states.get("sensor.air_purifier_activated_carbon_filter_condition")
+    assert state
+    assert state.state == "100"
+    assert state.attributes["state_class"] == "measurement"
+    assert state.attributes["unit_of_measurement"] == "%"

--- a/tests/components/matter/test_sensor.py
+++ b/tests/components/matter/test_sensor.py
@@ -442,7 +442,7 @@ async def test_air_purifier_sensor(
     assert state.state == "100"
     assert state.attributes["state_class"] == "measurement"
     assert state.attributes["unit_of_measurement"] == "%"
-    assert state.attributes["friendly_name"] == "Air Purifier Hepa Filter Condition"
+    assert state.attributes["friendly_name"] == "Air Purifier Hepa filter condition"
 
     # Activated Carbon Filter Condition
     state = hass.states.get("sensor.air_purifier_activated_carbon_filter_condition")

--- a/tests/components/matter/test_sensor.py
+++ b/tests/components/matter/test_sensor.py
@@ -391,3 +391,20 @@ async def test_air_purifier_sensor(
     assert state.attributes["unit_of_measurement"] == "ppm"
     assert state.attributes["device_class"] == "volatile_organic_compounds_parts"
     assert state.attributes["friendly_name"] == "Air Purifier VOCs"
+
+    # Air Quality
+    state = hass.states.get("sensor.air_purifier_air_quality")
+    assert state
+    assert state.state == "good"
+    expected_options = [
+        "extremely_poor",
+        "very_poor",
+        "poor",
+        "fair",
+        "good",
+        "moderate",
+        "unknown",
+    ]
+    assert set(state.attributes["options"]) == set(expected_options)
+    assert state.attributes["device_class"] == "enum"
+    assert state.attributes["friendly_name"] == "Air Purifier Air Quality"

--- a/tests/components/matter/test_sensor.py
+++ b/tests/components/matter/test_sensor.py
@@ -413,3 +413,25 @@ async def test_air_purifier_sensor(
     state = hass.states.get("sensor.air_purifier_carbon_monoxide")
     assert state
     assert state.state == "2.0"
+    assert state.attributes["state_class"] == "measurement"
+    assert state.attributes["unit_of_measurement"] == "ppm"
+    assert state.attributes["device_class"] == "carbon_monoxide"
+    assert state.attributes["friendly_name"] == "Air Purifier Carbon monoxide"
+
+    # Nitrogen Dioxide
+    state = hass.states.get("sensor.air_purifier_nitrogen_dioxide")
+    assert state
+    assert state.state == "2.0"
+    assert state.attributes["state_class"] == "measurement"
+    assert state.attributes["unit_of_measurement"] == "ppm"
+    assert state.attributes["device_class"] == "nitrogen_dioxide"
+    assert state.attributes["friendly_name"] == "Air Purifier Nitrogen dioxide"
+
+    # Ozone Concentration
+    state = hass.states.get("sensor.air_purifier_ozone")
+    assert state
+    assert state.state == "2.0"
+    assert state.attributes["state_class"] == "measurement"
+    assert state.attributes["unit_of_measurement"] == "ppm"
+    assert state.attributes["device_class"] == "ozone"
+    assert state.attributes["friendly_name"] == "Air Purifier Ozone"

--- a/tests/components/matter/test_sensor.py
+++ b/tests/components/matter/test_sensor.py
@@ -408,3 +408,8 @@ async def test_air_purifier_sensor(
     assert set(state.attributes["options"]) == set(expected_options)
     assert state.attributes["device_class"] == "enum"
     assert state.attributes["friendly_name"] == "Air Purifier Air Quality"
+
+    # Carbon MonoOxide
+    state = hass.states.get("sensor.air_purifier_carbon_monoxide")
+    assert state
+    assert state.state == "2.0"

--- a/tests/components/matter/test_sensor.py
+++ b/tests/components/matter/test_sensor.py
@@ -407,7 +407,7 @@ async def test_air_purifier_sensor(
     ]
     assert set(state.attributes["options"]) == set(expected_options)
     assert state.attributes["device_class"] == "enum"
-    assert state.attributes["friendly_name"] == "Air Purifier Air Quality"
+    assert state.attributes["friendly_name"] == "Air Purifier Air quality"
 
     # Carbon MonoOxide
     state = hass.states.get("sensor.air_purifier_carbon_monoxide")


### PR DESCRIPTION
## Proposed change
Add the leftover/remaining sensor discovery schemas for Air Purifier (and Air Quality sensor) devices.

I skipped formaldehyde and Radon measurements because we do not (yet) have a device class defined for those and there probably is no device out there yet. These can be added in follow-up PR's once needed.

Apart from the button platform to reset the filter status, the device support for Air Purifier is now complete.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #117022
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
