### PR TITLE
Improve type hints for mock_bluetooth/enable_bluetooth

### DIFF
--- a/tests/components/airthings_ble/conftest.py
+++ b/tests/components/airthings_ble/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/aranet/conftest.py
+++ b/tests/components/aranet/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/bluemaestro/conftest.py
+++ b/tests/components/bluemaestro/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/bluetooth_adapters/conftest.py
+++ b/tests/components/bluetooth_adapters/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/bluetooth_le_tracker/conftest.py
+++ b/tests/components/bluetooth_le_tracker/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/bthome/conftest.py
+++ b/tests/components/bthome/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/dormakaba_dkey/conftest.py
+++ b/tests/components/dormakaba_dkey/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/eq3btsmart/conftest.py
+++ b/tests/components/eq3btsmart/conftest.py
@@ -11,7 +11,7 @@ from tests.components.bluetooth import generate_ble_device
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""
 
 

--- a/tests/components/esphome/conftest.py
+++ b/tests/components/esphome/conftest.py
@@ -41,7 +41,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""
 
 

--- a/tests/components/eufylife_ble/conftest.py
+++ b/tests/components/eufylife_ble/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/fjaraskupan/conftest.py
+++ b/tests/components/fjaraskupan/conftest.py
@@ -6,5 +6,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/govee_ble/conftest.py
+++ b/tests/components/govee_ble/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/ibeacon/test_coordinator.py
+++ b/tests/components/ibeacon/test_coordinator.py
@@ -40,7 +40,7 @@ from tests.components.bluetooth import (
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""
 
 

--- a/tests/components/ibeacon/test_device_tracker.py
+++ b/tests/components/ibeacon/test_device_tracker.py
@@ -42,7 +42,7 @@ from tests.components.bluetooth import (
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""
 
 

--- a/tests/components/ibeacon/test_init.py
+++ b/tests/components/ibeacon/test_init.py
@@ -15,7 +15,7 @@ from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""
 
 

--- a/tests/components/ibeacon/test_sensor.py
+++ b/tests/components/ibeacon/test_sensor.py
@@ -34,7 +34,7 @@ from tests.components.bluetooth import (
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""
 
 

--- a/tests/components/idasen_desk/conftest.py
+++ b/tests/components/idasen_desk/conftest.py
@@ -1,6 +1,6 @@
 """IKEA Idasen Desk fixtures."""
 
-from collections.abc import Callable
+from collections.abc import Callable, Generator
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 
@@ -8,12 +8,12 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> Generator[None, None, None]:
     """Auto mock bluetooth."""
     with mock.patch(
         "homeassistant.components.idasen_desk.bluetooth.async_ble_device_from_address"
     ):
-        yield MagicMock()
+        yield
 
 
 @pytest.fixture(autouse=False)

--- a/tests/components/improv_ble/conftest.py
+++ b/tests/components/improv_ble/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/inkbird/conftest.py
+++ b/tests/components/inkbird/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/kegtron/conftest.py
+++ b/tests/components/kegtron/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/keymitt_ble/conftest.py
+++ b/tests/components/keymitt_ble/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/lamarzocco/conftest.py
+++ b/tests/components/lamarzocco/conftest.py
@@ -133,5 +133,5 @@ def remove_local_connection(
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/ld2410_ble/conftest.py
+++ b/tests/components/ld2410_ble/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/leaone/conftest.py
+++ b/tests/components/leaone/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/led_ble/conftest.py
+++ b/tests/components/led_ble/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/medcom_ble/conftest.py
+++ b/tests/components/medcom_ble/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/melnor/conftest.py
+++ b/tests/components/melnor/conftest.py
@@ -57,7 +57,7 @@ FAKE_SERVICE_INFO_2 = BluetoothServiceInfoBleak(
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""
 
 

--- a/tests/components/moat/conftest.py
+++ b/tests/components/moat/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/mopeka/conftest.py
+++ b/tests/components/mopeka/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/oralb/conftest.py
+++ b/tests/components/oralb/conftest.py
@@ -1,5 +1,6 @@
 """OralB session fixtures."""
 
+from collections.abc import Generator
 from unittest import mock
 
 import pytest
@@ -44,7 +45,7 @@ class MockBleakClientBattery49(MockBleakClient):
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> Generator[None, None, None]:
     """Auto mock bluetooth."""
 
     with mock.patch(

--- a/tests/components/qingping/conftest.py
+++ b/tests/components/qingping/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/rapt_ble/conftest.py
+++ b/tests/components/rapt_ble/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/ruuvi_gateway/conftest.py
+++ b/tests/components/ruuvi_gateway/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/ruuvitag_ble/test_config_flow.py
+++ b/tests/components/ruuvitag_ble/test_config_flow.py
@@ -15,7 +15,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Mock bluetooth for all tests in this module."""
 
 

--- a/tests/components/sensirion_ble/test_config_flow.py
+++ b/tests/components/sensirion_ble/test_config_flow.py
@@ -19,7 +19,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Mock bluetooth for all tests in this module."""
 
 

--- a/tests/components/sensorpro/conftest.py
+++ b/tests/components/sensorpro/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/sensorpush/conftest.py
+++ b/tests/components/sensorpush/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -409,5 +409,5 @@ async def mock_rpc_device():
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/snooz/conftest.py
+++ b/tests/components/snooz/conftest.py
@@ -10,7 +10,7 @@ from . import SnoozFixture, create_mock_snooz, create_mock_snooz_config_entry
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""
 
 

--- a/tests/components/switchbot/conftest.py
+++ b/tests/components/switchbot/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/thermobeacon/conftest.py
+++ b/tests/components/thermobeacon/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/thermopro/conftest.py
+++ b/tests/components/thermopro/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/tilt_ble/conftest.py
+++ b/tests/components/tilt_ble/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""

--- a/tests/components/xiaomi_ble/conftest.py
+++ b/tests/components/xiaomi_ble/conftest.py
@@ -1,5 +1,6 @@
 """Session fixtures."""
 
+from collections.abc import Generator
 from unittest import mock
 
 import pytest
@@ -44,7 +45,7 @@ class MockBleakClientBattery5(MockBleakClient):
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> Generator[None, None, None]:
     """Auto mock bluetooth."""
 
     with mock.patch("xiaomi_ble.parser.BleakClient", MockBleakClientBattery5):

--- a/tests/components/yalexs_ble/conftest.py
+++ b/tests/components/yalexs_ble/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth):
+def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, spotted whilst working on #118313

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
