### PR TITLE
Add config flow to One-Time Password (OTP) integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -987,7 +987,6 @@ omit =
     homeassistant/components/osoenergy/sensor.py
     homeassistant/components/osoenergy/water_heater.py
     homeassistant/components/osramlightify/light.py
-    homeassistant/components/otp/__init__.py
     homeassistant/components/otp/sensor.py
     homeassistant/components/overkiz/__init__.py
     homeassistant/components/overkiz/alarm_control_panel.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -987,6 +987,7 @@ omit =
     homeassistant/components/osoenergy/sensor.py
     homeassistant/components/osoenergy/water_heater.py
     homeassistant/components/osramlightify/light.py
+    homeassistant/components/otp/__init__.py
     homeassistant/components/otp/sensor.py
     homeassistant/components/overkiz/__init__.py
     homeassistant/components/overkiz/alarm_control_panel.py

--- a/homeassistant/components/otp/__init__.py
+++ b/homeassistant/components/otp/__init__.py
@@ -1,1 +1,22 @@
-"""The otp component."""
+"""The One-Time Password (OTP) integration."""
+
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up One-Time Password (OTP) from a config entry."""
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/otp/config_flow.py
+++ b/homeassistant/components/otp/config_flow.py
@@ -10,7 +10,7 @@ import pyotp
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_CODE, CONF_NAME, CONF_TOKEN
+from homeassistant.const import CONF_NAME, CONF_TOKEN
 
 from .const import DEFAULT_NAME, DOMAIN
 
@@ -22,8 +22,6 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Required(CONF_NAME, default=DEFAULT_NAME): str,
     }
 )
-
-STEP_CONFIRM_DATA_SCHEMA = vol.Schema({vol.Required(CONF_CODE): str})
 
 
 class TOTPConfigFlow(ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/otp/config_flow.py
+++ b/homeassistant/components/otp/config_flow.py
@@ -99,3 +99,14 @@ class TOTPConfigFlow(ConfigFlow, domain=DOMAIN):
             },
             errors=errors,
         )
+
+    async def async_step_import(self, import_info: dict[str, Any]) -> ConfigFlowResult:
+        """Import config from yaml."""
+
+        await self.async_set_unique_id(import_info[CONF_TOKEN])
+        self._abort_if_unique_id_configured()
+
+        return self.async_create_entry(
+            title=import_info.get(CONF_NAME, DEFAULT_NAME),
+            data=import_info,
+        )

--- a/homeassistant/components/otp/config_flow.py
+++ b/homeassistant/components/otp/config_flow.py
@@ -1,0 +1,101 @@
+"""Config flow for One-Time Password (OTP) integration."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pyotp
+import voluptuous as vol
+
+from homeassistant.auth.mfa_modules.totp import _generate_qr_code
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_CODE, CONF_NAME, CONF_TOKEN
+
+from .const import DEFAULT_NAME, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_TOKEN): str,
+        vol.Required(CONF_NAME, default=DEFAULT_NAME): str,
+    }
+)
+
+STEP_CONFIRM_DATA_SCHEMA = vol.Schema({vol.Required(CONF_CODE): str})
+
+
+class TOTPConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for One-Time Password (OTP)."""
+
+    VERSION = 1
+    user_input: dict[str, Any]
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            # generate new token if empty
+            if not user_input.get(CONF_TOKEN):
+                user_input[CONF_TOKEN] = await self.hass.async_add_executor_job(
+                    pyotp.random_base32
+                )
+
+            await self.async_set_unique_id(user_input[CONF_TOKEN])
+            self._abort_if_unique_id_configured()
+
+            self.user_input = user_input
+            return await self.async_step_confirm()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=self.add_suggested_values_to_schema(
+                data_schema=STEP_USER_DATA_SCHEMA, suggested_values=user_input
+            ),
+            errors=errors,
+            last_step=False,
+        )
+
+    async def async_step_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the confirmation step."""
+
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                if await self.hass.async_add_executor_job(
+                    pyotp.TOTP(self.user_input[CONF_TOKEN]).verify, user_input["code"]
+                ):
+                    return self.async_create_entry(
+                        title=self.user_input[CONF_NAME],
+                        data={CONF_TOKEN: self.user_input[CONF_TOKEN]},
+                    )
+
+                errors["base"] = "invalid_code"
+
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+
+        url = await self.hass.async_add_executor_job(
+            pyotp.TOTP(self.user_input[CONF_TOKEN]).provisioning_uri,
+            self.user_input[CONF_NAME],
+            "Home Assistant",
+        )
+        qr_code = await self.hass.async_add_executor_job(_generate_qr_code, url)
+
+        return self.async_show_form(
+            step_id="confirm",
+            data_schema=STEP_CONFIRM_DATA_SCHEMA,
+            description_placeholders={
+                "code": self.user_input[CONF_TOKEN],
+                "url": url,
+                "qr_code": qr_code,
+            },
+            errors=errors,
+        )

--- a/homeassistant/components/otp/config_flow.py
+++ b/homeassistant/components/otp/config_flow.py
@@ -18,7 +18,7 @@ _LOGGER = logging.getLogger(__name__)
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_TOKEN): str,
+        vol.Required(CONF_TOKEN): str,
         vol.Required(CONF_NAME, default=DEFAULT_NAME): str,
     }
 )

--- a/homeassistant/components/otp/config_flow.py
+++ b/homeassistant/components/otp/config_flow.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import binascii
 import logging
 from typing import Any
 
+import pyotp
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
@@ -36,13 +38,23 @@ class TOTPConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         errors: dict[str, str] = {}
         if user_input is not None:
-            await self.async_set_unique_id(user_input[CONF_TOKEN])
-            self._abort_if_unique_id_configured()
+            try:
+                await self.hass.async_add_executor_job(
+                    pyotp.TOTP(user_input[CONF_TOKEN]).now
+                )
+            except binascii.Error:
+                errors["base"] = "invalid_code"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                await self.async_set_unique_id(user_input[CONF_TOKEN])
+                self._abort_if_unique_id_configured()
 
-            return self.async_create_entry(
-                title=user_input[CONF_NAME],
-                data=user_input,
-            )
+                return self.async_create_entry(
+                    title=user_input[CONF_NAME],
+                    data=user_input,
+                )
 
         return self.async_show_form(
             step_id="user",

--- a/homeassistant/components/otp/const.py
+++ b/homeassistant/components/otp/const.py
@@ -1,0 +1,4 @@
+"""Constants for the One-Time Password (OTP) integration."""
+
+DOMAIN = "otp"
+DEFAULT_NAME = "OTP Sensor"

--- a/homeassistant/components/otp/manifest.json
+++ b/homeassistant/components/otp/manifest.json
@@ -2,6 +2,7 @@
   "domain": "otp",
   "name": "One-Time Password (OTP)",
   "codeowners": [],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/otp",
   "iot_class": "local_polling",
   "loggers": ["pyotp"],

--- a/homeassistant/components/otp/sensor.py
+++ b/homeassistant/components/otp/sensor.py
@@ -41,7 +41,7 @@ async def async_setup_platform(
         HOMEASSISTANT_DOMAIN,
         f"deprecated_yaml_{DOMAIN}",
         is_fixable=False,
-        breaks_in_ha_version="2025.01.0",
+        breaks_in_ha_version="2025.1.0",
         severity=IssueSeverity.WARNING,
         translation_key="deprecated_yaml",
         translation_placeholders={

--- a/homeassistant/components/otp/sensor.py
+++ b/homeassistant/components/otp/sensor.py
@@ -8,13 +8,14 @@ import pyotp
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME, CONF_TOKEN
 from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, StateType
 
-DEFAULT_NAME = "OTP Sensor"
+from .const import DEFAULT_NAME
 
 TIME_STEP = 30  # Default time step assumed by Google Authenticator
 
@@ -38,6 +39,14 @@ async def async_setup_platform(
     token = config[CONF_TOKEN]
 
     async_add_entities([TOTPSensor(name, token)], True)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the OTP sensor."""
+
+    async_add_entities([TOTPSensor(entry.title, entry.data[CONF_TOKEN])], True)
 
 
 # Only TOTP supported at the moment, HOTP might be added later

--- a/homeassistant/components/otp/sensor.py
+++ b/homeassistant/components/otp/sensor.py
@@ -8,14 +8,15 @@ import pyotp
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_NAME, CONF_TOKEN
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, StateType
 
-from .const import DEFAULT_NAME
+from .const import DEFAULT_NAME, DOMAIN
 
 TIME_STEP = 30  # Default time step assumed by Google Authenticator
 
@@ -35,10 +36,22 @@ async def async_setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the OTP sensor."""
-    name = config[CONF_NAME]
-    token = config[CONF_TOKEN]
-
-    async_add_entities([TOTPSensor(name, token)], True)
+    async_create_issue(
+        hass,
+        HOMEASSISTANT_DOMAIN,
+        f"deprecated_yaml_{DOMAIN}",
+        is_fixable=False,
+        breaks_in_ha_version="2025.01.0",
+        severity=IssueSeverity.WARNING,
+        translation_key="deprecated_yaml",
+        translation_placeholders={
+            "domain": DOMAIN,
+            "integration_title": "One-Time Password (OTP)",
+        },
+    )
+    await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=config
+    )
 
 
 async def async_setup_entry(

--- a/homeassistant/components/otp/sensor.py
+++ b/homeassistant/components/otp/sensor.py
@@ -59,7 +59,9 @@ async def async_setup_entry(
 ) -> None:
     """Set up the OTP sensor."""
 
-    async_add_entities([TOTPSensor(entry.title, entry.data[CONF_TOKEN])], True)
+    async_add_entities(
+        [TOTPSensor(entry.data[CONF_NAME], entry.data[CONF_TOKEN])], True
+    )
 
 
 # Only TOTP supported at the moment, HOTP might be added later

--- a/homeassistant/components/otp/strings.json
+++ b/homeassistant/components/otp/strings.json
@@ -9,7 +9,8 @@
       }
     },
     "error": {
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "invalid_token": "Invalid Token"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"

--- a/homeassistant/components/otp/strings.json
+++ b/homeassistant/components/otp/strings.json
@@ -2,23 +2,17 @@
   "config": {
     "step": {
       "user": {
-        "description": "Leave `authenticator token` empty to generate a new random token.",
         "data": {
-          "name": "[%key:common::config_flow::data::name%]",
-          "token": "Authenticator token (OTP)"
-        }
-      },
-      "confirm": {
-        "title": "Verify One-Time Password (OTP)",
-        "description": "Before completing setup of One-Time Password (OTP), verify with a verification code. Scan the QR code with your authentication app. If you don't have one, we recommend either [Google Authenticator](https://support.google.com/accounts/answer/1066447) or [Authy](https://authy.com/).\n\n{qr_code}\n\nAfter scanning the code, enter the six digit code from your app to verify the setup. If you have problems scanning the QR code, do a manual setup with code **`{code}`**.",
-        "data": {
-          "code": "Verification code (OTP)"
+          "host": "[%key:common::config_flow::data::host%]",
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
         }
       }
     },
     "error": {
-      "unknown": "[%key:common::config_flow::error::unknown%]",
-      "invalid_code": "Invalid code, please try again. If you get this error consistently, please make sure the clock of your Home Assistant system is accurate."
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"

--- a/homeassistant/components/otp/strings.json
+++ b/homeassistant/components/otp/strings.json
@@ -10,7 +10,7 @@
     },
     "error": {
       "unknown": "[%key:common::config_flow::error::unknown%]",
-      "invalid_token": "Invalid Token"
+      "invalid_token": "Invalid token"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"

--- a/homeassistant/components/otp/strings.json
+++ b/homeassistant/components/otp/strings.json
@@ -3,15 +3,12 @@
     "step": {
       "user": {
         "data": {
-          "host": "[%key:common::config_flow::data::host%]",
-          "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]"
+          "name": "[%key:common::config_flow::data::name%]",
+          "token": "Authenticator token (OTP)"
         }
       }
     },
     "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {

--- a/homeassistant/components/otp/strings.json
+++ b/homeassistant/components/otp/strings.json
@@ -1,0 +1,27 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "description": "Leave `authenticator token` empty to generate a new random token.",
+        "data": {
+          "name": "[%key:common::config_flow::data::name%]",
+          "token": "Authenticator token (OTP)"
+        }
+      },
+      "confirm": {
+        "title": "Verify One-Time Password (OTP)",
+        "description": "Before completing setup of One-Time Password (OTP), verify with a verification code. Scan the QR code with your authentication app. If you don't have one, we recommend either [Google Authenticator](https://support.google.com/accounts/answer/1066447) or [Authy](https://authy.com/).\n\n{qr_code}\n\nAfter scanning the code, enter the six digit code from your app to verify the setup. If you have problems scanning the QR code, do a manual setup with code **`{code}`**.",
+        "data": {
+          "code": "Verification code (OTP)"
+        }
+      }
+    },
+    "error": {
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "invalid_code": "Invalid code, please try again. If you get this error consistently, please make sure the clock of your Home Assistant system is accurate."
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -397,6 +397,7 @@ FLOWS = {
         "oralb",
         "osoenergy",
         "otbr",
+        "otp",
         "ourgroceries",
         "overkiz",
         "ovo_energy",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -4415,7 +4415,7 @@
     "otp": {
       "name": "One-Time Password (OTP)",
       "integration_type": "hub",
-      "config_flow": false,
+      "config_flow": true,
       "iot_class": "local_polling"
     },
     "ourgroceries": {

--- a/tests/components/otp/__init__.py
+++ b/tests/components/otp/__init__.py
@@ -1,0 +1,1 @@
+"""Test the One-Time Password (OTP) config flow."""

--- a/tests/components/otp/__init__.py
+++ b/tests/components/otp/__init__.py
@@ -1,1 +1,1 @@
-"""Test the One-Time Password (OTP) config flow."""
+"""Test the One-Time Password (OTP)."""

--- a/tests/components/otp/conftest.py
+++ b/tests/components/otp/conftest.py
@@ -5,6 +5,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from homeassistant.components.otp.const import DOMAIN
+from homeassistant.components.sensor.const import DOMAIN as SENSOR_DOMAIN
+from homeassistant.const import CONF_NAME, CONF_PLATFORM, CONF_TOKEN
+from homeassistant.helpers.typing import ConfigType
+
+from tests.common import MockConfigEntry
+
 
 @pytest.fixture
 def mock_setup_entry() -> Generator[AsyncMock, None, None]:
@@ -41,3 +48,15 @@ def mock_otp_config_entry() -> MockConfigEntry:
         },
         unique_id="2FX5FBSYRE6VEC2FSHBQCRKO2GNDVZ52",
     )
+
+
+@pytest.fixture(name="otp_yaml_config")
+def mock_otp_yaml_config() -> ConfigType:
+    """Mock otp configuration entry."""
+    return {
+        SENSOR_DOMAIN: {
+            CONF_PLATFORM: "otp",
+            CONF_TOKEN: "2FX5FBSYRE6VEC2FSHBQCRKO2GNDVZ52",
+            CONF_NAME: "OTP Sensor",
+        }
+    }

--- a/tests/components/otp/conftest.py
+++ b/tests/components/otp/conftest.py
@@ -1,7 +1,7 @@
 """Common fixtures for the One-Time Password (OTP) tests."""
 
 from collections.abc import Generator
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -13,3 +13,17 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
         "homeassistant.components.otp.async_setup_entry", return_value=True
     ) as mock_setup_entry:
         yield mock_setup_entry
+
+
+@pytest.fixture
+def mock_pyotp() -> Generator[MagicMock, None, None]:
+    """Mock a pyotp."""
+    with (
+        patch(
+            "homeassistant.components.otp.config_flow.pyotp",
+        ) as mock_client,
+    ):
+        mock_totp = MagicMock()
+        mock_totp.now.return_value = True
+        mock_client.TOTP.return_value = mock_totp
+        yield mock_client

--- a/tests/components/otp/conftest.py
+++ b/tests/components/otp/conftest.py
@@ -1,7 +1,7 @@
 """Common fixtures for the One-Time Password (OTP) tests."""
 
 from collections.abc import Generator
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -13,33 +13,3 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
         "homeassistant.components.otp.async_setup_entry", return_value=True
     ) as mock_setup_entry:
         yield mock_setup_entry
-
-
-@pytest.fixture
-def mock_pyotp() -> Generator[MagicMock, None, None]:
-    """Mock a pyotp."""
-    with (
-        patch(
-            "homeassistant.components.otp.config_flow.pyotp",
-        ) as mock_client,
-    ):
-        mock_client.random_base32.return_value = "TOKEN_B"
-        mock_totp = MagicMock()
-        mock_totp.verify.return_value = True
-        mock_totp.provisioning_uri.return_value = "test-uri"
-
-        mock_client.TOTP.return_value = mock_totp
-
-        yield mock_client
-
-
-@pytest.fixture
-def mock_qr() -> Generator[MagicMock, None, None]:
-    """Mock a pyotp."""
-    with (
-        patch(
-            "homeassistant.components.otp.config_flow._generate_qr_code",
-            return_value="qr-code",
-        ) as mock_client,
-    ):
-        yield mock_client.return_value

--- a/tests/components/otp/conftest.py
+++ b/tests/components/otp/conftest.py
@@ -1,0 +1,45 @@
+"""Common fixtures for the One-Time Password (OTP) tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.otp.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry
+
+
+@pytest.fixture
+def mock_pyotp() -> Generator[MagicMock, None, None]:
+    """Mock a pyotp."""
+    with (
+        patch(
+            "homeassistant.components.otp.config_flow.pyotp",
+        ) as mock_client,
+    ):
+        mock_client.random_base32.return_value = "TOKEN_B"
+        mock_totp = MagicMock()
+        mock_totp.verify.return_value = True
+        mock_totp.provisioning_uri.return_value = "test-uri"
+
+        mock_client.TOTP.return_value = mock_totp
+
+        yield mock_client
+
+
+@pytest.fixture
+def mock_qr() -> Generator[MagicMock, None, None]:
+    """Mock a pyotp."""
+    with (
+        patch(
+            "homeassistant.components.otp.config_flow._generate_qr_code",
+            return_value="qr-code",
+        ) as mock_client,
+    ):
+        yield mock_client.return_value

--- a/tests/components/otp/conftest.py
+++ b/tests/components/otp/conftest.py
@@ -22,8 +22,22 @@ def mock_pyotp() -> Generator[MagicMock, None, None]:
         patch(
             "homeassistant.components.otp.config_flow.pyotp",
         ) as mock_client,
+        patch("homeassistant.components.otp.sensor.pyotp", new=mock_client),
     ):
         mock_totp = MagicMock()
-        mock_totp.now.return_value = True
+        mock_totp.now.return_value = 123456
         mock_client.TOTP.return_value = mock_totp
         yield mock_client
+
+
+@pytest.fixture(name="otp_config_entry")
+def mock_otp_config_entry() -> MockConfigEntry:
+    """Mock otp configuration entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_NAME: "OTP Sensor",
+            CONF_TOKEN: "2FX5FBSYRE6VEC2FSHBQCRKO2GNDVZ52",
+        },
+        unique_id="2FX5FBSYRE6VEC2FSHBQCRKO2GNDVZ52",
+    )

--- a/tests/components/otp/snapshots/test_sensor.ambr
+++ b/tests/components/otp/snapshots/test_sensor.ambr
@@ -1,0 +1,15 @@
+# serializer version: 1
+# name: test_setup
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'OTP Sensor',
+      'icon': 'mdi:update',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.otp_sensor',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '123456',
+  })
+# ---

--- a/tests/components/otp/test_config_flow.py
+++ b/tests/components/otp/test_config_flow.py
@@ -1,0 +1,126 @@
+"""Test the One-Time Password (OTP) config flow."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components.otp.const import DOMAIN
+from homeassistant.const import CONF_CODE, CONF_NAME, CONF_TOKEN
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+TEST_DATA = {
+    CONF_NAME: "OTP Sensor",
+    CONF_TOKEN: "TOKEN_A",
+}
+
+TEST_DATA_2 = {
+    CONF_NAME: "OTP Sensor",
+    CONF_TOKEN: "",
+}
+
+
+@pytest.mark.parametrize(
+    ("expected_token", "test_user_input"),
+    [
+        ("TOKEN_A", TEST_DATA),
+        ("TOKEN_B", TEST_DATA_2),
+    ],
+)
+async def test_form(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_pyotp: MagicMock,
+    mock_qr: MagicMock,
+    expected_token: str,
+    test_user_input: dict[str, str],
+) -> None:
+    """Test we get the form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        test_user_input,
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "confirm"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_CODE: "123456"},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "OTP Sensor"
+    assert result["data"] == {CONF_TOKEN: expected_token}
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_errors_and_recover(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_pyotp: MagicMock,
+    mock_qr: MagicMock,
+) -> None:
+    """Test errors and recover."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        TEST_DATA,
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "confirm"
+    assert result["errors"] == {}
+
+    mock_pyotp.TOTP().verify.return_value = False
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_CODE: "000000"},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "confirm"
+    assert result["errors"] == {"base": "invalid_code"}
+
+    mock_pyotp.TOTP().verify.side_effect = ValueError
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_CODE: "000000"},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "confirm"
+    assert result["errors"] == {"base": "unknown"}
+
+    mock_pyotp.TOTP().verify.return_value = True
+    mock_pyotp.TOTP().verify.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_CODE: "123456"},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "OTP Sensor"
+    assert result["data"] == {CONF_TOKEN: "TOKEN_A"}
+    assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/otp/test_config_flow.py
+++ b/tests/components/otp/test_config_flow.py
@@ -1,6 +1,9 @@
 """Test the One-Time Password (OTP) config flow."""
 
-from unittest.mock import AsyncMock
+import binascii
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.otp.const import DOMAIN
@@ -8,10 +11,16 @@ from homeassistant.const import CONF_NAME, CONF_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
+TEST_DATA = {
+    CONF_NAME: "OTP Sensor",
+    CONF_TOKEN: "TOKEN_A",
+}
+
 
 async def test_form(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
+    mock_pyotp: MagicMock,
 ) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
@@ -23,17 +32,56 @@ async def test_form(
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {
-            CONF_NAME: "OTP Sensor",
-            CONF_TOKEN: "TOKEN_A",
-        },
+        TEST_DATA,
     )
     await hass.async_block_till_done()
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == "OTP Sensor"
-    assert result["data"] == {
-        CONF_NAME: "OTP Sensor",
-        CONF_TOKEN: "TOKEN_A",
-    }
+    assert result["data"] == TEST_DATA
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("exception", "error"),
+    [
+        (binascii.Error, "invalid_code"),
+        (IndexError, "unknown"),
+    ],
+)
+async def test_errors_and_recover(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_pyotp: MagicMock,
+    exception: Exception,
+    error: str,
+) -> None:
+    """Test errors and recover."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {}
+
+    mock_pyotp.TOTP().now.side_effect = exception
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input=TEST_DATA,
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": error}
+
+    mock_pyotp.TOTP().now.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input=TEST_DATA,
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "OTP Sensor"
+    assert result["data"] == TEST_DATA
     assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/otp/test_config_flow.py
+++ b/tests/components/otp/test_config_flow.py
@@ -85,3 +85,20 @@ async def test_errors_and_recover(
     assert result["title"] == "OTP Sensor"
     assert result["data"] == TEST_DATA
     assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_flow_import(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_pyotp: MagicMock
+) -> None:
+    """Test that we can import a YAML config."""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_IMPORT},
+        data=TEST_DATA,
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "OTP Sensor"
+    assert result["data"] == TEST_DATA

--- a/tests/components/otp/test_config_flow.py
+++ b/tests/components/otp/test_config_flow.py
@@ -1,40 +1,17 @@
 """Test the One-Time Password (OTP) config flow."""
 
-from unittest.mock import AsyncMock, MagicMock
-
-import pytest
+from unittest.mock import AsyncMock
 
 from homeassistant import config_entries
 from homeassistant.components.otp.const import DOMAIN
-from homeassistant.const import CONF_CODE, CONF_NAME, CONF_TOKEN
+from homeassistant.const import CONF_NAME, CONF_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-TEST_DATA = {
-    CONF_NAME: "OTP Sensor",
-    CONF_TOKEN: "TOKEN_A",
-}
 
-TEST_DATA_2 = {
-    CONF_NAME: "OTP Sensor",
-    CONF_TOKEN: "",
-}
-
-
-@pytest.mark.parametrize(
-    ("expected_token", "test_user_input"),
-    [
-        ("TOKEN_A", TEST_DATA),
-        ("TOKEN_B", TEST_DATA_2),
-    ],
-)
 async def test_form(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
-    mock_pyotp: MagicMock,
-    mock_qr: MagicMock,
-    expected_token: str,
-    test_user_input: dict[str, str],
 ) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
@@ -46,81 +23,17 @@ async def test_form(
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        test_user_input,
-    )
-    await hass.async_block_till_done()
-
-    assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "confirm"
-    assert result["errors"] == {}
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input={CONF_CODE: "123456"},
+        {
+            CONF_NAME: "OTP Sensor",
+            CONF_TOKEN: "TOKEN_A",
+        },
     )
     await hass.async_block_till_done()
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == "OTP Sensor"
-    assert result["data"] == {CONF_TOKEN: expected_token}
-    assert len(mock_setup_entry.mock_calls) == 1
-
-
-async def test_errors_and_recover(
-    hass: HomeAssistant,
-    mock_setup_entry: AsyncMock,
-    mock_pyotp: MagicMock,
-    mock_qr: MagicMock,
-) -> None:
-    """Test errors and recover."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    assert result["type"] == FlowResultType.FORM
-    assert result["errors"] == {}
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        TEST_DATA,
-    )
-    await hass.async_block_till_done()
-
-    assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "confirm"
-    assert result["errors"] == {}
-
-    mock_pyotp.TOTP().verify.return_value = False
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input={CONF_CODE: "000000"},
-    )
-    await hass.async_block_till_done()
-
-    assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "confirm"
-    assert result["errors"] == {"base": "invalid_code"}
-
-    mock_pyotp.TOTP().verify.side_effect = ValueError
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input={CONF_CODE: "000000"},
-    )
-    await hass.async_block_till_done()
-
-    assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "confirm"
-    assert result["errors"] == {"base": "unknown"}
-
-    mock_pyotp.TOTP().verify.return_value = True
-    mock_pyotp.TOTP().verify.side_effect = None
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input={CONF_CODE: "123456"},
-    )
-    await hass.async_block_till_done()
-
-    assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["title"] == "OTP Sensor"
-    assert result["data"] == {CONF_TOKEN: "TOKEN_A"}
+    assert result["data"] == {
+        CONF_NAME: "OTP Sensor",
+        CONF_TOKEN: "TOKEN_A",
+    }
     assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/otp/test_init.py
+++ b/tests/components/otp/test_init.py
@@ -1,0 +1,23 @@
+"""Test the One-Time Password (OTP) init."""
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_entry_setup_unload(
+    hass: HomeAssistant, otp_config_entry: MockConfigEntry
+) -> None:
+    """Test integration setup and unload."""
+
+    otp_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(otp_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert otp_config_entry.state is ConfigEntryState.LOADED
+
+    await hass.config_entries.async_unload(otp_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert otp_config_entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/otp/test_sensor.py
+++ b/tests/components/otp/test_sensor.py
@@ -1,19 +1,22 @@
 """Tests for the One-Time Password (OTP) Sensors."""
 
-from unittest.mock import MagicMock
-
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.config_entries import ConfigEntryState
-from homeassistant.core import HomeAssistant
+from homeassistant.components.otp.const import DOMAIN
+from homeassistant.components.sensor.const import DOMAIN as SENSOR_DOMAIN
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.typing import ConfigType
+from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
 
+@pytest.mark.usefixtures("mock_pyotp")
 async def test_setup(
     hass: HomeAssistant,
     otp_config_entry: MockConfigEntry,
-    mock_pyotp: MagicMock,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test setup of ista EcoTrend sensor platform."""
@@ -22,6 +25,17 @@ async def test_setup(
     await hass.config_entries.async_setup(otp_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert otp_config_entry.state is ConfigEntryState.LOADED
-
     assert hass.states.get("sensor.otp_sensor") == snapshot
+
+
+async def test_deprecated_yaml_issue(
+    hass: HomeAssistant, issue_registry: ir.IssueRegistry, otp_yaml_config: ConfigType
+) -> None:
+    """Test an issue is created when attempting setup from yaml config."""
+
+    assert await async_setup_component(hass, SENSOR_DOMAIN, otp_yaml_config)
+    await hass.async_block_till_done()
+
+    assert issue_registry.async_get_issue(
+        domain=HOMEASSISTANT_DOMAIN, issue_id=f"deprecated_yaml_{DOMAIN}"
+    )

--- a/tests/components/otp/test_sensor.py
+++ b/tests/components/otp/test_sensor.py
@@ -1,0 +1,27 @@
+"""Tests for the One-Time Password (OTP) Sensors."""
+
+from unittest.mock import MagicMock
+
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_setup(
+    hass: HomeAssistant,
+    otp_config_entry: MockConfigEntry,
+    mock_pyotp: MagicMock,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test setup of ista EcoTrend sensor platform."""
+
+    otp_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(otp_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert otp_config_entry.state is ConfigEntryState.LOADED
+
+    assert hass.states.get("sensor.otp_sensor") == snapshot


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds config flow to the One-Time Password (OTP) integration.

Migration process from yaml config and deprecation notice is still missing, will be added soon.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33031

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
