### PR TITLE
Fix group platform dependencies

### DIFF
--- a/homeassistant/components/group/manifest.json
+++ b/homeassistant/components/group/manifest.json
@@ -1,6 +1,15 @@
 {
   "domain": "group",
   "name": "Group",
+  "after_dependencies": [
+    "alarm_control_panel",
+    "climate",
+    "device_tracker",
+    "person",
+    "plant",
+    "vacuum",
+    "water_heater"
+  ],
   "codeowners": ["@home-assistant/core"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/group",

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -1487,28 +1487,67 @@ async def test_group_vacuum_on(hass: HomeAssistant) -> None:
     assert hass.states.get("group.group_zero").state == STATE_ON
 
 
-async def test_device_tracker_not_home(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    ("entity_state_list", "group_state"),
+    [
+        (
+            {
+                "device_tracker.one": "not_home",
+                "device_tracker.two": "not_home",
+                "device_tracker.three": "not_home",
+            },
+            "not_home",
+        ),
+        (
+            {
+                "device_tracker.one": "home",
+                "device_tracker.two": "not_home",
+                "device_tracker.three": "not_home",
+            },
+            "home",
+        ),
+        (
+            {
+                "device_tracker.one": "home",
+                "device_tracker.two": "elsewhere",
+                "device_tracker.three": "not_home",
+            },
+            "home",
+        ),
+        (
+            {
+                "device_tracker.one": "not_home",
+                "device_tracker.two": "elsewhere",
+                "device_tracker.three": "not_home",
+            },
+            "not_home",
+        ),
+    ],
+)
+async def test_device_tracker_or_person_not_home(
+    hass: HomeAssistant,
+    entity_state_list: dict[str, str],
+    group_state: str,
+) -> None:
     """Test group of device_tracker not_home."""
     await async_setup_component(hass, "device_tracker", {})
+    await async_setup_component(hass, "person", {})
     await hass.async_block_till_done()
-    hass.states.async_set("device_tracker.one", "not_home")
-    hass.states.async_set("device_tracker.two", "not_home")
-    hass.states.async_set("device_tracker.three", "not_home")
+    for entity_id, state in entity_state_list.items():
+        hass.states.async_set(entity_id, state)
 
     assert await async_setup_component(
         hass,
         "group",
         {
             "group": {
-                "group_zero": {
-                    "entities": "device_tracker.one, device_tracker.two, device_tracker.three"
-                },
+                "group_zero": {"entities": ", ".join(entity_state_list)},
             }
         },
     )
     await hass.async_block_till_done()
 
-    assert hass.states.get("group.group_zero").state == "not_home"
+    assert hass.states.get("group.group_zero").state == group_state
 
 
 async def test_light_removed(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If the `group` integration is set up, the platforms of the entities set up are not having a default `on`/ `off` group state, and the platforms are not native platforms of `group`, then we should ensure these platforms are set up before the `group` integration is set up. The platforms are:
-   "alarm_control_panel",
-   "climate",
-   "device_tracker",
-   "person",
-   "plant",
-   "vacuum",
-   "water_heater"



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #118423
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
