### PR TITLE
Adjust "hass" type hint for test fixtures in pylint plugin

### DIFF
--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -113,6 +113,7 @@ _TEST_FIXTURES: dict[str, list[str] | str] = {
     "entity_registry_enabled_by_default": "None",
     "event_loop": "AbstractEventLoop",
     "freezer": "FrozenDateTimeFactory",
+    "hass": "HomeAssistant",
     "hass_access_token": "str",
     "hass_admin_credential": "Credentials",
     "hass_admin_user": "MockUser",
@@ -3218,16 +3219,6 @@ class HassTypeHintChecker(BaseChecker):
         if self._ignore_function(node, annotations):
             return
 
-        # Check that common arguments are correctly typed.
-        for arg_name, expected_type in _COMMON_ARGUMENTS.items():
-            arg_node, annotation = _get_named_annotation(node, arg_name)
-            if arg_node and not _is_valid_type(expected_type, annotation):
-                self.add_message(
-                    "hass-argument-type",
-                    node=arg_node,
-                    args=(arg_name, expected_type, node.name),
-                )
-
         # Check method or function matchers.
         if node.is_method():
             matchers = _METHOD_MATCH
@@ -3245,6 +3236,16 @@ class HassTypeHintChecker(BaseChecker):
                     self._check_test_function(node, True)
                     return
             matchers = self._function_matchers
+
+        # Check that common arguments are correctly typed.
+        for arg_name, expected_type in _COMMON_ARGUMENTS.items():
+            arg_node, annotation = _get_named_annotation(node, arg_name)
+            if arg_node and not _is_valid_type(expected_type, annotation):
+                self.add_message(
+                    "hass-argument-type",
+                    node=arg_node,
+                    args=(arg_name, expected_type, node.name),
+                )
 
         for match in matchers:
             if not match.need_to_check_function(node):

--- a/tests/pylint/test_enforce_type_hints.py
+++ b/tests/pylint/test_enforce_type_hints.py
@@ -1175,15 +1175,6 @@ def test_pytest_invalid_function(
     with assert_adds_messages(
         linter,
         pylint.testutils.MessageTest(
-            msg_id="hass-argument-type",
-            node=hass_node,
-            args=("hass", ["HomeAssistant", "HomeAssistant | None"], "test_sample"),
-            line=3,
-            col_offset=4,
-            end_line=3,
-            end_col_offset=19,
-        ),
-        pylint.testutils.MessageTest(
             msg_id="hass-return-type",
             node=func_node,
             args=("None", "test_sample"),
@@ -1227,6 +1218,15 @@ def test_pytest_invalid_function(
             col_offset=4,
             end_line=6,
             end_col_offset=36,
+        ),
+        pylint.testutils.MessageTest(
+            msg_id="hass-argument-type",
+            node=hass_node,
+            args=("hass", "HomeAssistant", "test_sample"),
+            line=3,
+            col_offset=4,
+            end_line=3,
+            end_col_offset=19,
         ),
     ):
         type_hint_checker.visit_asyncfunctiondef(func_node)
@@ -1283,15 +1283,6 @@ def test_pytest_invalid_fixture(
         linter,
         pylint.testutils.MessageTest(
             msg_id="hass-argument-type",
-            node=hass_node,
-            args=("hass", ["HomeAssistant", "HomeAssistant | None"], "sample_fixture"),
-            line=6,
-            col_offset=4,
-            end_line=6,
-            end_col_offset=19,
-        ),
-        pylint.testutils.MessageTest(
-            msg_id="hass-argument-type",
             node=caplog_node,
             args=("caplog", "pytest.LogCaptureFixture", "sample_fixture"),
             line=7,
@@ -1307,6 +1298,15 @@ def test_pytest_invalid_fixture(
             col_offset=4,
             end_line=8,
             end_col_offset=29,
+        ),
+        pylint.testutils.MessageTest(
+            msg_id="hass-argument-type",
+            node=hass_node,
+            args=("hass", "HomeAssistant", "sample_fixture"),
+            line=6,
+            col_offset=4,
+            end_line=6,
+            end_col_offset=19,
         ),
     ):
         type_hint_checker.visit_asyncfunctiondef(func_node)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In test fixtures, we know `hass` should be `HomeAssistant` and never `HomeAssistant | None`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
