### PR TITLE
Refactor Zeversolar init tests

### DIFF
--- a/tests/components/zeversolar/conftest.py
+++ b/tests/components/zeversolar/conftest.py
@@ -1,0 +1,47 @@
+"""Define mocks and test objects."""
+
+import pytest
+from zeversolar import StatusEnum, ZeverSolarData
+
+from homeassistant.components.zeversolar.const import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_PORT
+
+from tests.common import MockConfigEntry
+
+MOCK_HOST_ZEVERSOLAR = "zeversolar-fake-host"
+MOCK_PORT_ZEVERSOLAR = 10200
+
+
+@pytest.fixture
+def config_entry() -> MockConfigEntry:
+    """Create a mock config entry."""
+
+    return MockConfigEntry(
+        data={
+            CONF_HOST: MOCK_HOST_ZEVERSOLAR,
+            CONF_PORT: MOCK_PORT_ZEVERSOLAR,
+        },
+        domain=DOMAIN,
+        unique_id="my_id_2",
+    )
+
+
+@pytest.fixture
+def zeversolar_data() -> ZeverSolarData:
+    """Create a ZeverSolarData structure for tests."""
+
+    return ZeverSolarData(
+        wifi_enabled=False,
+        serial_or_registry_id="1223",
+        registry_key="A-2",
+        hardware_version="M10",
+        software_version="123-23",
+        reported_datetime="19900101 23:00",
+        communication_status=StatusEnum.OK,
+        num_inverters=1,
+        serial_number="123456778",
+        pac=1234,
+        energy_today=123,
+        status=StatusEnum.OK,
+        meter_status=StatusEnum.OK,
+    )

--- a/tests/components/zeversolar/test_init.py
+++ b/tests/components/zeversolar/test_init.py
@@ -1,32 +1,96 @@
 """Test the init file code."""
 
+from unittest.mock import patch
+
 import pytest
+from zeversolar import StatusEnum, ZeverSolarData
+from zeversolar.exceptions import ZeverSolarTimeout
 
 import homeassistant.components.zeversolar.__init__ as init
 from homeassistant.components.zeversolar.const import DOMAIN
-from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_HOST, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from tests.common import MockConfigEntry, MockModule, mock_integration
+from tests.common import MockConfigEntry
 
 MOCK_HOST_ZEVERSOLAR = "zeversolar-fake-host"
 MOCK_PORT_ZEVERSOLAR = 10200
 
+MOCK_DATA = ZeverSolarData(
+    wifi_enabled=False,
+    serial_or_registry_id="1223",
+    registry_key="A-2",
+    hardware_version="M10",
+    software_version="123-23",
+    reported_datetime="19900101 23:00",
+    communication_status=StatusEnum.OK,
+    num_inverters=1,
+    serial_number="123456778",
+    pac=1234,
+    energy_today=123,
+    status=StatusEnum.OK,
+    meter_status=StatusEnum.OK,
+)
 
-async def test_async_setup_entry_fails(hass: HomeAssistant) -> None:
-    """Test the sensor setup."""
-    mock_integration(hass, MockModule(DOMAIN))
 
-    config = MockConfigEntry(
+def create_config_mock():
+    """Create a mock config entry."""
+
+    return MockConfigEntry(
         data={
             CONF_HOST: MOCK_HOST_ZEVERSOLAR,
             CONF_PORT: MOCK_PORT_ZEVERSOLAR,
         },
         domain=DOMAIN,
+        unique_id="my_id_2",
     )
 
+
+async def test_async_setup_entry(hass: HomeAssistant) -> None:
+    """Test async_setup_entry."""
+
+    config = create_config_mock()
     config.add_to_hass(hass)
 
-    with pytest.raises(ConfigEntryNotReady):
+    with (
+        patch("zeversolar.ZeverSolarClient.get_data", return_value=MOCK_DATA),
+    ):
+        result = await init.async_setup_entry(hass, config)
+        await hass.async_block_till_done()
+
+        assert result is True
+
+
+async def test_async_setup_entry_fails(hass: HomeAssistant) -> None:
+    """Test to start the integration when inverter is offline (e.g. at night)."""
+
+    config = create_config_mock()
+    config.add_to_hass(hass)
+
+    with (
+        patch(
+            "zeversolar.ZeverSolarClient.get_data",
+            side_effect=ZeverSolarTimeout,
+        ),
+        pytest.raises(ConfigEntryNotReady),
+    ):
         await init.async_setup_entry(hass, config)
+
+
+async def test_load_entry(
+    hass: HomeAssistant,
+) -> None:
+    """Test loading the entry."""
+
+    with (
+        patch("homeassistant.components.zeversolar.PLATFORMS", [Platform.SENSOR]),
+        patch("zeversolar.ZeverSolarClient.get_data", return_value=MOCK_DATA),
+    ):
+        entry = create_config_mock()
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert entry.state is ConfigEntryState.LOADED

--- a/tests/components/zeversolar/test_init.py
+++ b/tests/components/zeversolar/test_init.py
@@ -51,8 +51,7 @@ def create_config_mock():
 async def test_async_setup_entry(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
     """Test async_setup_entry."""
 
-    config = create_config_mock()
-    config.add_to_hass(hass)
+    config_entry.add_to_hass(hass)
 
     with (
         patch("zeversolar.ZeverSolarClient.get_data", return_value=MOCK_DATA),

--- a/tests/components/zeversolar/test_init.py
+++ b/tests/components/zeversolar/test_init.py
@@ -14,7 +14,7 @@ from tests.common import MockConfigEntry
 async def test_async_setup_entry_fails(
     hass: HomeAssistant, config_entry: MockConfigEntry, zeversolar_data: ZeverSolarData
 ) -> None:
-    """Test to start the integration when inverter is offline (e.g. at night). Must raise a ConfigEntryNotReady error."""
+    """Test to load/unload the integration."""
 
     config_entry.add_to_hass(hass)
 
@@ -29,7 +29,7 @@ async def test_async_setup_entry_fails(
         patch("zeversolar.ZeverSolarClient.get_data", return_value=zeversolar_data),
     ):
         hass.config_entries.async_schedule_reload(config_entry.entry_id)
-        assert config_entry.state is ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     with (
         patch("homeassistant.components.zeversolar.PLATFORMS", []),

--- a/tests/components/zeversolar/test_init.py
+++ b/tests/components/zeversolar/test_init.py
@@ -16,7 +16,7 @@ from tests.common import MockConfigEntry
 
 
 async def test_async_setup_entry_fails(
-    hass: HomeAssistant, config_entry: MockConfigEntry
+    hass: HomeAssistant, config_entry: MockConfigEntry, zeversolar_data: ZeverSolarData
 ) -> None:
     """Test to start the integration when inverter is offline (e.g. at night). Must raise a ConfigEntryNotReady error."""
 
@@ -29,13 +29,8 @@ async def test_async_setup_entry_fails(
         await init.async_setup_entry(hass, config_entry)
 
 
-async def test_load_entry(
-    hass: HomeAssistant, config_entry: MockConfigEntry, zeversolar_data: ZeverSolarData
-) -> None:
-    """Test loading the entry."""
-
     with (
-        patch("homeassistant.components.zeversolar.PLATFORMS", [Platform.SENSOR]),
+        patch("homeassistant.components.zeversolar.PLATFORMS", []),
         patch("zeversolar.ZeverSolarClient.get_data", return_value=zeversolar_data),
     ):
         config_entry.add_to_hass(hass)

--- a/tests/components/zeversolar/test_init.py
+++ b/tests/components/zeversolar/test_init.py
@@ -8,7 +8,6 @@ from zeversolar.exceptions import ZeverSolarTimeout
 
 import homeassistant.components.zeversolar.__init__ as init
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
@@ -27,34 +26,21 @@ async def test_async_setup_entry_fails(
         pytest.raises(ConfigEntryNotReady),
     ):
         await init.async_setup_entry(hass, config_entry)
-
+        assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
     with (
         patch("homeassistant.components.zeversolar.PLATFORMS", []),
         patch("zeversolar.ZeverSolarClient.get_data", return_value=zeversolar_data),
     ):
-        config_entry.add_to_hass(hass)
-
         result = await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
         assert result is True
         assert config_entry.state is ConfigEntryState.LOADED
 
-
-async def test_load_entry_fails(
-    hass: HomeAssistant, config_entry: MockConfigEntry
-) -> None:
-    """Test to start the integration when inverter is offline (e.g. at night)."""
-
     with (
-        patch("homeassistant.components.zeversolar.PLATFORMS", [Platform.SENSOR]),
-        patch("zeversolar.ZeverSolarClient.get_data", side_effect=ZeverSolarTimeout),
+        patch("homeassistant.components.zeversolar.PLATFORMS", []),
     ):
-        config_entry.add_to_hass(hass)
-
-        result = await hass.config_entries.async_setup(config_entry.entry_id)
+        result = await init.async_unload_entry(hass, config_entry)
         await hass.async_block_till_done()
-
-        assert result is False
-        assert config_entry.state is ConfigEntryState.SETUP_RETRY
+        assert result is True

--- a/tests/components/zeversolar/test_init.py
+++ b/tests/components/zeversolar/test_init.py
@@ -48,7 +48,7 @@ def create_config_mock():
     )
 
 
-async def test_async_setup_entry(hass: HomeAssistant) -> None:
+async def test_async_setup_entry(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
     """Test async_setup_entry."""
 
     config = create_config_mock()

--- a/tests/components/zeversolar/test_init.py
+++ b/tests/components/zeversolar/test_init.py
@@ -57,7 +57,7 @@ async def test_async_setup_entry(hass: HomeAssistant) -> None:
     with (
         patch("zeversolar.ZeverSolarClient.get_data", return_value=MOCK_DATA),
     ):
-        result = await init.async_setup_entry(hass, config)
+        result = await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
         assert result is True

--- a/tests/components/zeversolar/test_init.py
+++ b/tests/components/zeversolar/test_init.py
@@ -35,7 +35,8 @@ MOCK_DATA = ZeverSolarData(
 )
 
 
-def create_config_mock():
+@pytest.fixture
+def config_entry() -> MockConfigEntry:
     """Create a mock config entry."""
 
     return MockConfigEntry(

--- a/tests/components/zeversolar/test_init.py
+++ b/tests/components/zeversolar/test_init.py
@@ -26,7 +26,7 @@ async def test_async_setup_entry_fails(
         pytest.raises(ConfigEntryNotReady),
     ):
         await init.async_setup_entry(hass, config_entry)
-        assert config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
     with (
         patch("homeassistant.components.zeversolar.PLATFORMS", []),
@@ -41,6 +41,6 @@ async def test_async_setup_entry_fails(
     with (
         patch("homeassistant.components.zeversolar.PLATFORMS", []),
     ):
-        result = await init.async_unload_entry(hass, config_entry)
-        await hass.async_block_till_done()
-        assert result is True
+        result = await hass.config_entries.async_unload(config_entry.entry_id)
+    assert result is True
+    assert config_entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/zeversolar/test_init.py
+++ b/tests/components/zeversolar/test_init.py
@@ -3,94 +3,63 @@
 from unittest.mock import patch
 
 import pytest
-from zeversolar import StatusEnum, ZeverSolarData
+from zeversolar import ZeverSolarData
 from zeversolar.exceptions import ZeverSolarTimeout
 
 import homeassistant.components.zeversolar.__init__ as init
-from homeassistant.components.zeversolar.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_HOST, CONF_PORT, Platform
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
 from tests.common import MockConfigEntry
 
-MOCK_HOST_ZEVERSOLAR = "zeversolar-fake-host"
-MOCK_PORT_ZEVERSOLAR = 10200
 
-MOCK_DATA = ZeverSolarData(
-    wifi_enabled=False,
-    serial_or_registry_id="1223",
-    registry_key="A-2",
-    hardware_version="M10",
-    software_version="123-23",
-    reported_datetime="19900101 23:00",
-    communication_status=StatusEnum.OK,
-    num_inverters=1,
-    serial_number="123456778",
-    pac=1234,
-    energy_today=123,
-    status=StatusEnum.OK,
-    meter_status=StatusEnum.OK,
-)
-
-
-@pytest.fixture
-def config_entry() -> MockConfigEntry:
-    """Create a mock config entry."""
-
-    return MockConfigEntry(
-        data={
-            CONF_HOST: MOCK_HOST_ZEVERSOLAR,
-            CONF_PORT: MOCK_PORT_ZEVERSOLAR,
-        },
-        domain=DOMAIN,
-        unique_id="my_id_2",
-    )
-
-
-async def test_async_setup_entry(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
-    """Test async_setup_entry."""
+async def test_async_setup_entry_fails(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test to start the integration when inverter is offline (e.g. at night). Must raise a ConfigEntryNotReady error."""
 
     config_entry.add_to_hass(hass)
 
     with (
-        patch("zeversolar.ZeverSolarClient.get_data", return_value=MOCK_DATA),
-    ):
-        result = await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-
-        assert result is True
-
-
-async def test_async_setup_entry_fails(hass: HomeAssistant) -> None:
-    """Test to start the integration when inverter is offline (e.g. at night)."""
-
-    config = create_config_mock()
-    config.add_to_hass(hass)
-
-    with (
-        patch(
-            "zeversolar.ZeverSolarClient.get_data",
-            side_effect=ZeverSolarTimeout,
-        ),
+        patch("zeversolar.ZeverSolarClient.get_data", side_effect=ZeverSolarTimeout),
         pytest.raises(ConfigEntryNotReady),
     ):
-        await init.async_setup_entry(hass, config)
+        await init.async_setup_entry(hass, config_entry)
 
 
 async def test_load_entry(
-    hass: HomeAssistant,
+    hass: HomeAssistant, config_entry: MockConfigEntry, zeversolar_data: ZeverSolarData
 ) -> None:
     """Test loading the entry."""
 
     with (
         patch("homeassistant.components.zeversolar.PLATFORMS", [Platform.SENSOR]),
-        patch("zeversolar.ZeverSolarClient.get_data", return_value=MOCK_DATA),
+        patch("zeversolar.ZeverSolarClient.get_data", return_value=zeversolar_data),
     ):
-        entry = create_config_mock()
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
+        config_entry.add_to_hass(hass)
+
+        result = await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-        assert entry.state is ConfigEntryState.LOADED
+        assert result is True
+        assert config_entry.state is ConfigEntryState.LOADED
+
+
+async def test_load_entry_fails(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test to start the integration when inverter is offline (e.g. at night)."""
+
+    with (
+        patch("homeassistant.components.zeversolar.PLATFORMS", [Platform.SENSOR]),
+        patch("zeversolar.ZeverSolarClient.get_data", side_effect=ZeverSolarTimeout),
+    ):
+        config_entry.add_to_hass(hass)
+
+        result = await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert result is False
+        assert config_entry.state is ConfigEntryState.SETUP_RETRY


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Modify some tests in the Zeversolar integration.
This is a follow-up PR of #117928 suggested by @MartinHjelmare

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #117928
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
