### PR TITLE
Set lock state to unkown on BMW API error

### DIFF
--- a/homeassistant/components/bmw_connected_drive/lock.py
+++ b/homeassistant/components/bmw_connected_drive/lock.py
@@ -56,7 +56,6 @@ class BMWLock(BMWBaseEntity, LockEntity):
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the car."""
         _LOGGER.debug("%s: locking doors", self.vehicle.name)
-        prev_state = self._attr_is_locked
         # Only update the HA state machine if the vehicle reliably reports its lock state
         if self.door_lock_state_available:
             # Optimistic state set here because it takes some time before the
@@ -66,16 +65,17 @@ class BMWLock(BMWBaseEntity, LockEntity):
         try:
             await self.vehicle.remote_services.trigger_remote_door_lock()
         except MyBMWAPIError as ex:
-            self._attr_is_locked = prev_state
+            # Set the state to unknown if the command fails
+            self._attr_is_locked = None
             self.async_write_ha_state()
             raise HomeAssistantError(ex) from ex
-
-        self.coordinator.async_update_listeners()
+        finally:
+            # Always update the listeners to get the latest state
+            self.coordinator.async_update_listeners()
 
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the car."""
         _LOGGER.debug("%s: unlocking doors", self.vehicle.name)
-        prev_state = self._attr_is_locked
         # Only update the HA state machine if the vehicle reliably reports its lock state
         if self.door_lock_state_available:
             # Optimistic state set here because it takes some time before the
@@ -85,11 +85,13 @@ class BMWLock(BMWBaseEntity, LockEntity):
         try:
             await self.vehicle.remote_services.trigger_remote_door_unlock()
         except MyBMWAPIError as ex:
-            self._attr_is_locked = prev_state
+            # Set the state to unknown if the command fails
+            self._attr_is_locked = None
             self.async_write_ha_state()
             raise HomeAssistantError(ex) from ex
-
-        self.coordinator.async_update_listeners()
+        finally:
+            # Always update the listeners to get the latest state
+            self.coordinator.async_update_listeners()
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/homeassistant/components/bmw_connected_drive/lock.py
+++ b/homeassistant/components/bmw_connected_drive/lock.py
@@ -56,6 +56,7 @@ class BMWLock(BMWBaseEntity, LockEntity):
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the car."""
         _LOGGER.debug("%s: locking doors", self.vehicle.name)
+        prev_state = self._attr_is_locked
         # Only update the HA state machine if the vehicle reliably reports its lock state
         if self.door_lock_state_available:
             # Optimistic state set here because it takes some time before the
@@ -65,7 +66,7 @@ class BMWLock(BMWBaseEntity, LockEntity):
         try:
             await self.vehicle.remote_services.trigger_remote_door_lock()
         except MyBMWAPIError as ex:
-            self._attr_is_locked = False
+            self._attr_is_locked = prev_state
             self.async_write_ha_state()
             raise HomeAssistantError(ex) from ex
 
@@ -74,6 +75,7 @@ class BMWLock(BMWBaseEntity, LockEntity):
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the car."""
         _LOGGER.debug("%s: unlocking doors", self.vehicle.name)
+        prev_state = self._attr_is_locked
         # Only update the HA state machine if the vehicle reliably reports its lock state
         if self.door_lock_state_available:
             # Optimistic state set here because it takes some time before the
@@ -83,7 +85,7 @@ class BMWLock(BMWBaseEntity, LockEntity):
         try:
             await self.vehicle.remote_services.trigger_remote_door_unlock()
         except MyBMWAPIError as ex:
-            self._attr_is_locked = True
+            self._attr_is_locked = prev_state
             self.async_write_ha_state()
             raise HomeAssistantError(ex) from ex
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When calling `lock` or `unlock` on BMW vehicles, we now ~~revert to the previous state~~ set it to unknown if an API error occured.
This will be overwritten by the forced refresh from the API afterwards.

Previously, we assumed the counterpart of the action on error.

Tests will be added in https://github.com/home-assistant/core/pull/118436.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
