### PR TITLE
Improve UniFi config flow tests

### DIFF
--- a/tests/components/unifi/conftest.py
+++ b/tests/components/unifi/conftest.py
@@ -87,7 +87,6 @@ def config_entry_fixture(
         unique_id="1",
         data=config_entry_data,
         options=config_entry_options,
-        version=1,
     )
     config_entry.add_to_hass(hass)
     return config_entry

--- a/tests/components/unifi/conftest.py
+++ b/tests/components/unifi/conftest.py
@@ -127,7 +127,9 @@ def default_request_fixture(
 ) -> Callable[[str], None]:
     """Mock default UniFi requests responses."""
 
-    def __mock_default_requests(host: str, site_id: str) -> None:
+    def __mock_default_requests(
+        host: str = DEFAULT_HOST, site_id: str = DEFAULT_SITE
+    ) -> None:
         url = f"https://{host}:{DEFAULT_PORT}"
 
         def mock_get_request(path: str, payload: list[dict[str, Any]]) -> None:
@@ -229,12 +231,20 @@ def wlan_data_fixture() -> list[dict[str, Any]]:
     return []
 
 
-@pytest.fixture(name="setup_default_unifi_requests")
-def default_vapix_requests_fixture(
-    config_entry: ConfigEntry,
+@pytest.fixture(name="mock_default_unifi_requests")
+def mock_default_unifi_requests_fixture(
     mock_unifi_requests: Callable[[str, str], None],
 ) -> None:
     """Mock default UniFi requests responses."""
+    mock_unifi_requests(DEFAULT_HOST, DEFAULT_SITE)
+
+
+@pytest.fixture(name="setup_default_unifi_requests")
+def default_unifi_requests_fixture(
+    config_entry: ConfigEntry,
+    mock_unifi_requests: Callable[[str, str], None],
+) -> None:
+    """Mock config entry and default UniFi requests responses."""
     mock_unifi_requests(config_entry.data[CONF_HOST], config_entry.data[CONF_SITE_ID])
 
 

--- a/tests/components/unifi/test_button.py
+++ b/tests/components/unifi/test_button.py
@@ -83,11 +83,11 @@ async def test_restart_device_button(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     aioclient_mock: AiohttpClientMocker,
-    setup_config_entry,
+    config_entry_setup,
     websocket_mock,
 ) -> None:
     """Test restarting device button."""
-    config_entry = setup_config_entry
+    config_entry = config_entry_setup
     assert len(hass.states.async_entity_ids(BUTTON_DOMAIN)) == 1
 
     ent_reg_entry = entity_registry.async_get("button.switch_restart")
@@ -169,11 +169,11 @@ async def test_power_cycle_poe(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     aioclient_mock: AiohttpClientMocker,
-    setup_config_entry,
+    config_entry_setup,
     websocket_mock,
 ) -> None:
     """Test restarting device button."""
-    config_entry = setup_config_entry
+    config_entry = config_entry_setup
     assert len(hass.states.async_entity_ids(BUTTON_DOMAIN)) == 2
 
     ent_reg_entry = entity_registry.async_get("button.switch_port_1_power_cycle")
@@ -225,11 +225,11 @@ async def test_wlan_regenerate_password(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     aioclient_mock: AiohttpClientMocker,
-    setup_config_entry,
+    config_entry_setup,
     websocket_mock,
 ) -> None:
     """Test WLAN regenerate password button."""
-    config_entry = setup_config_entry
+    config_entry = config_entry_setup
     assert len(hass.states.async_entity_ids(BUTTON_DOMAIN)) == 0
 
     button_regenerate_password = "button.ssid_1_regenerate_password"

--- a/tests/components/unifi/test_config_flow.py
+++ b/tests/components/unifi/test_config_flow.py
@@ -96,7 +96,7 @@ DPI_GROUPS = [
 
 
 async def test_flow_works(
-    hass: HomeAssistant, mock_discovery, mock_default_unifi_requests: None
+    hass: HomeAssistant, mock_discovery, mock_default_requests: None
 ) -> None:
     """Test config flow."""
     mock_discovery.return_value = "1"
@@ -166,7 +166,7 @@ async def test_flow_works_negative_discovery(
     ],
 )
 async def test_flow_multiple_sites(
-    hass: HomeAssistant, mock_default_unifi_requests: None
+    hass: HomeAssistant, mock_default_requests: None
 ) -> None:
     """Test config flow works when finding multiple sites."""
     result = await hass.config_entries.flow.async_init(
@@ -194,7 +194,7 @@ async def test_flow_multiple_sites(
 
 
 async def test_flow_raise_already_configured(
-    hass: HomeAssistant, setup_config_entry: ConfigEntry
+    hass: HomeAssistant, config_entry_setup: ConfigEntry
 ) -> None:
     """Test config flow aborts since a connected config entry already exists."""
     result = await hass.config_entries.flow.async_init(
@@ -220,7 +220,7 @@ async def test_flow_raise_already_configured(
 
 
 async def test_flow_aborts_configuration_updated(
-    hass: HomeAssistant, setup_config_entry: ConfigEntry
+    hass: HomeAssistant, config_entry_setup: ConfigEntry
 ) -> None:
     """Test config flow aborts since a connected config entry already exists."""
     result = await hass.config_entries.flow.async_init(
@@ -250,7 +250,7 @@ async def test_flow_aborts_configuration_updated(
 
 
 async def test_flow_fails_user_credentials_faulty(
-    hass: HomeAssistant, mock_default_unifi_requests: None
+    hass: HomeAssistant, mock_default_requests: None
 ) -> None:
     """Test config flow."""
     result = await hass.config_entries.flow.async_init(
@@ -277,7 +277,7 @@ async def test_flow_fails_user_credentials_faulty(
 
 
 async def test_flow_fails_hub_unavailable(
-    hass: HomeAssistant, mock_default_unifi_requests: None
+    hass: HomeAssistant, mock_default_requests: None
 ) -> None:
     """Test config flow."""
     result = await hass.config_entries.flow.async_init(
@@ -304,10 +304,10 @@ async def test_flow_fails_hub_unavailable(
 
 
 async def test_reauth_flow_update_configuration(
-    hass: HomeAssistant, setup_config_entry: ConfigEntry
+    hass: HomeAssistant, config_entry_setup: ConfigEntry
 ) -> None:
     """Verify reauth flow can update hub configuration."""
-    config_entry = setup_config_entry
+    config_entry = config_entry_setup
 
     result = await hass.config_entries.flow.async_init(
         UNIFI_DOMAIN,
@@ -349,10 +349,10 @@ async def test_reauth_flow_update_configuration(
 @pytest.mark.parametrize("wlan_payload", [WLANS])
 @pytest.mark.parametrize("dpi_group_payload", [DPI_GROUPS])
 async def test_advanced_option_flow(
-    hass: HomeAssistant, setup_config_entry: ConfigEntry
+    hass: HomeAssistant, config_entry_setup: ConfigEntry
 ) -> None:
     """Test advanced config flow options."""
-    config_entry = setup_config_entry
+    config_entry = config_entry_setup
 
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id, context={"show_advanced_options": True}
@@ -433,10 +433,10 @@ async def test_advanced_option_flow(
 
 @pytest.mark.parametrize("client_payload", [CLIENTS])
 async def test_simple_option_flow(
-    hass: HomeAssistant, setup_config_entry: ConfigEntry
+    hass: HomeAssistant, config_entry_setup: ConfigEntry
 ) -> None:
     """Test simple config flow options."""
-    config_entry = setup_config_entry
+    config_entry = config_entry_setup
 
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id, context={"show_advanced_options": False}

--- a/tests/components/unifi/test_config_flow.py
+++ b/tests/components/unifi/test_config_flow.py
@@ -550,7 +550,7 @@ async def test_form_ssdp_aborts_if_serial_already_exists(
 
 
 async def test_form_ssdp_gets_form_with_ignored_entry(hass: HomeAssistant) -> None:
-    """Test we can still setup if there is an ignored entry."""
+    """Test we can still setup if there is an ignored never configured entry."""
 
     entry = MockConfigEntry(
         domain=UNIFI_DOMAIN,
@@ -564,11 +564,11 @@ async def test_form_ssdp_gets_form_with_ignored_entry(hass: HomeAssistant) -> No
         data=ssdp.SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
-            ssdp_location="http://1.2.3.4:41417/rootDesc.xml",
+            ssdp_location="http://1.2.3.4:1234/rootDesc.xml",
             upnp={
                 "friendlyName": "UniFi Dream Machine New",
                 "modelDescription": "UniFi Dream Machine Pro",
-                "serialNumber": "e0:63:da:20:14:a9",
+                "serialNumber": "1",
             },
         ),
     )

--- a/tests/components/unifi/test_config_flow.py
+++ b/tests/components/unifi/test_config_flow.py
@@ -4,6 +4,7 @@ import socket
 from unittest.mock import PropertyMock, patch
 
 import aiounifi
+import pytest
 
 from homeassistant import config_entries
 from homeassistant.components import ssdp
@@ -30,12 +31,9 @@ from homeassistant.const import (
     CONF_PORT,
     CONF_USERNAME,
     CONF_VERIFY_SSL,
-    CONTENT_TYPE_JSON,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-
-from .test_hub import setup_unifi_integration
 
 from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMocker
@@ -98,7 +96,7 @@ DPI_GROUPS = [
 
 
 async def test_flow_works(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_discovery
+    hass: HomeAssistant, mock_discovery, mock_default_unifi_requests: None
 ) -> None:
     """Test config flow."""
     mock_discovery.return_value = "1"
@@ -115,25 +113,6 @@ async def test_flow_works(
         CONF_PORT: 443,
         CONF_VERIFY_SSL: False,
     }
-
-    aioclient_mock.get("https://1.2.3.4:1234", status=302)
-
-    aioclient_mock.post(
-        "https://1.2.3.4:1234/api/login",
-        json={"data": "login successful", "meta": {"rc": "ok"}},
-        headers={"content-type": CONTENT_TYPE_JSON},
-    )
-
-    aioclient_mock.get(
-        "https://1.2.3.4:1234/api/self/sites",
-        json={
-            "data": [
-                {"desc": "Site name", "name": "site_id", "role": "admin", "_id": "1"}
-            ],
-            "meta": {"rc": "ok"},
-        },
-        headers={"content-type": CONTENT_TYPE_JSON},
-    )
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -159,7 +138,7 @@ async def test_flow_works(
 
 
 async def test_flow_works_negative_discovery(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_discovery
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test config flow with a negative outcome of async_discovery_unifi."""
     result = await hass.config_entries.flow.async_init(
@@ -177,8 +156,17 @@ async def test_flow_works_negative_discovery(
     }
 
 
+@pytest.mark.parametrize(
+    "site_payload",
+    [
+        [
+            {"name": "default", "role": "admin", "desc": "site name", "_id": "1"},
+            {"name": "site2", "role": "admin", "desc": "site2 name", "_id": "2"},
+        ]
+    ],
+)
 async def test_flow_multiple_sites(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, mock_default_unifi_requests: None
 ) -> None:
     """Test config flow works when finding multiple sites."""
     result = await hass.config_entries.flow.async_init(
@@ -187,26 +175,6 @@ async def test_flow_multiple_sites(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
-
-    aioclient_mock.get("https://1.2.3.4:1234", status=302)
-
-    aioclient_mock.post(
-        "https://1.2.3.4:1234/api/login",
-        json={"data": "login successful", "meta": {"rc": "ok"}},
-        headers={"content-type": CONTENT_TYPE_JSON},
-    )
-
-    aioclient_mock.get(
-        "https://1.2.3.4:1234/api/self/sites",
-        json={
-            "data": [
-                {"name": "default", "role": "admin", "desc": "site name", "_id": "1"},
-                {"name": "site2", "role": "admin", "desc": "site2 name", "_id": "2"},
-            ],
-            "meta": {"rc": "ok"},
-        },
-        headers={"content-type": CONTENT_TYPE_JSON},
-    )
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -226,9 +194,7 @@ async def test_flow_multiple_sites(
 
 
 async def test_flow_raise_already_configured(
-    hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
-    setup_config_entry: ConfigEntry,
+    hass: HomeAssistant, setup_config_entry: ConfigEntry
 ) -> None:
     """Test config flow aborts since a connected config entry already exists."""
     result = await hass.config_entries.flow.async_init(
@@ -254,9 +220,7 @@ async def test_flow_raise_already_configured(
 
 
 async def test_flow_aborts_configuration_updated(
-    hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
-    setup_config_entry: ConfigEntry,
+    hass: HomeAssistant, setup_config_entry: ConfigEntry
 ) -> None:
     """Test config flow aborts since a connected config entry already exists."""
     result = await hass.config_entries.flow.async_init(
@@ -265,25 +229,6 @@ async def test_flow_aborts_configuration_updated(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
-
-    aioclient_mock.get("https://1.2.3.4:1234", status=302)
-
-    aioclient_mock.post(
-        "https://1.2.3.4:1234/api/login",
-        json={"data": "login successful", "meta": {"rc": "ok"}},
-        headers={"content-type": CONTENT_TYPE_JSON},
-    )
-
-    aioclient_mock.get(
-        "https://1.2.3.4:1234/api/self/sites",
-        json={
-            "data": [
-                {"desc": "Site name", "name": "site_id", "role": "admin", "_id": "1"}
-            ],
-            "meta": {"rc": "ok"},
-        },
-        headers={"content-type": CONTENT_TYPE_JSON},
-    )
 
     with patch("homeassistant.components.unifi.async_setup_entry") and patch(
         "homeassistant.components.unifi.UnifiHub.available", new_callable=PropertyMock
@@ -305,7 +250,7 @@ async def test_flow_aborts_configuration_updated(
 
 
 async def test_flow_fails_user_credentials_faulty(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, mock_default_unifi_requests: None
 ) -> None:
     """Test config flow."""
     result = await hass.config_entries.flow.async_init(
@@ -314,8 +259,6 @@ async def test_flow_fails_user_credentials_faulty(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
-
-    aioclient_mock.get("https://1.2.3.4:1234", status=302)
 
     with patch("aiounifi.Controller.login", side_effect=aiounifi.errors.Unauthorized):
         result = await hass.config_entries.flow.async_configure(
@@ -334,7 +277,7 @@ async def test_flow_fails_user_credentials_faulty(
 
 
 async def test_flow_fails_hub_unavailable(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, mock_default_unifi_requests: None
 ) -> None:
     """Test config flow."""
     result = await hass.config_entries.flow.async_init(
@@ -343,8 +286,6 @@ async def test_flow_fails_hub_unavailable(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
-
-    aioclient_mock.get("https://1.2.3.4:1234", status=302)
 
     with patch("aiounifi.Controller.login", side_effect=aiounifi.errors.RequestError):
         result = await hass.config_entries.flow.async_configure(
@@ -363,9 +304,7 @@ async def test_flow_fails_hub_unavailable(
 
 
 async def test_reauth_flow_update_configuration(
-    hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
-    setup_config_entry: ConfigEntry,
+    hass: HomeAssistant, setup_config_entry: ConfigEntry
 ) -> None:
     """Verify reauth flow can update hub configuration."""
     config_entry = setup_config_entry
@@ -405,19 +344,15 @@ async def test_reauth_flow_update_configuration(
     assert config_entry.data[CONF_PASSWORD] == "new_pass"
 
 
+@pytest.mark.parametrize("client_payload", [CLIENTS])
+@pytest.mark.parametrize("device_payload", [DEVICES])
+@pytest.mark.parametrize("wlan_payload", [WLANS])
+@pytest.mark.parametrize("dpi_group_payload", [DPI_GROUPS])
 async def test_advanced_option_flow(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, setup_config_entry: ConfigEntry
 ) -> None:
     """Test advanced config flow options."""
-    config_entry = await setup_unifi_integration(
-        hass,
-        aioclient_mock,
-        clients_response=CLIENTS,
-        devices_response=DEVICES,
-        wlans_response=WLANS,
-        dpigroup_response=DPI_GROUPS,
-        dpiapp_response=[],
-    )
+    config_entry = setup_config_entry
 
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id, context={"show_advanced_options": True}
@@ -496,13 +431,12 @@ async def test_advanced_option_flow(
     }
 
 
+@pytest.mark.parametrize("client_payload", [CLIENTS])
 async def test_simple_option_flow(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, setup_config_entry: ConfigEntry
 ) -> None:
     """Test simple config flow options."""
-    config_entry = await setup_unifi_integration(
-        hass, aioclient_mock, clients_response=CLIENTS
-    )
+    config_entry = setup_config_entry
 
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id, context={"show_advanced_options": False}
@@ -569,21 +503,18 @@ async def test_form_ssdp(hass: HomeAssistant) -> None:
     }
 
 
-async def test_form_ssdp_aborts_if_host_already_exists(hass: HomeAssistant) -> None:
+async def test_form_ssdp_aborts_if_host_already_exists(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> None:
     """Test we abort if the host is already configured."""
 
-    entry = MockConfigEntry(
-        domain=UNIFI_DOMAIN,
-        data={"host": "192.168.208.1", "site": "site_id"},
-    )
-    entry.add_to_hass(hass)
     result = await hass.config_entries.flow.async_init(
         UNIFI_DOMAIN,
         context={"source": config_entries.SOURCE_SSDP},
         data=ssdp.SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
-            ssdp_location="http://192.168.208.1:41417/rootDesc.xml",
+            ssdp_location="http://1.2.3.4:1234/rootDesc.xml",
             upnp={
                 "friendlyName": "UniFi Dream Machine",
                 "modelDescription": "UniFi Dream Machine Pro",
@@ -595,26 +526,22 @@ async def test_form_ssdp_aborts_if_host_already_exists(hass: HomeAssistant) -> N
     assert result["reason"] == "already_configured"
 
 
-async def test_form_ssdp_aborts_if_serial_already_exists(hass: HomeAssistant) -> None:
+async def test_form_ssdp_aborts_if_serial_already_exists(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> None:
     """Test we abort if the serial is already configured."""
 
-    entry = MockConfigEntry(
-        domain=UNIFI_DOMAIN,
-        data={"controller": {"host": "1.2.3.4", "site": "site_id"}},
-        unique_id="e0:63:da:20:14:a9",
-    )
-    entry.add_to_hass(hass)
     result = await hass.config_entries.flow.async_init(
         UNIFI_DOMAIN,
         context={"source": config_entries.SOURCE_SSDP},
         data=ssdp.SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
-            ssdp_location="http://192.168.208.1:41417/rootDesc.xml",
+            ssdp_location="http://1.2.3.4:1234/rootDesc.xml",
             upnp={
                 "friendlyName": "UniFi Dream Machine",
                 "modelDescription": "UniFi Dream Machine Pro",
-                "serialNumber": "e0:63:da:20:14:a9",
+                "serialNumber": "1",
             },
         ),
     )

--- a/tests/components/unifi/test_hub.py
+++ b/tests/components/unifi/test_hub.py
@@ -239,14 +239,14 @@ async def setup_unifi_integration(
 
 async def test_hub_setup(
     device_registry: dr.DeviceRegistry,
-    prepare_config_entry: Callable[[], ConfigEntry],
+    config_entry_factory: Callable[[], ConfigEntry],
 ) -> None:
     """Successful setup."""
     with patch(
         "homeassistant.config_entries.ConfigEntries.async_forward_entry_setups",
         return_value=True,
     ) as forward_entry_setup:
-        config_entry = await prepare_config_entry()
+        config_entry = await config_entry_factory()
         hub = config_entry.runtime_data
 
     entry = hub.config.entry
@@ -288,10 +288,10 @@ async def test_hub_setup(
 
 
 async def test_reset_after_successful_setup(
-    hass: HomeAssistant, setup_config_entry: ConfigEntry
+    hass: HomeAssistant, config_entry_setup: ConfigEntry
 ) -> None:
     """Calling reset when the entry has been setup."""
-    config_entry = setup_config_entry
+    config_entry = config_entry_setup
     assert config_entry.state is ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(config_entry.entry_id)
@@ -299,10 +299,10 @@ async def test_reset_after_successful_setup(
 
 
 async def test_reset_fails(
-    hass: HomeAssistant, setup_config_entry: ConfigEntry
+    hass: HomeAssistant, config_entry_setup: ConfigEntry
 ) -> None:
     """Calling reset when the entry has been setup can return false."""
-    config_entry = setup_config_entry
+    config_entry = config_entry_setup
     assert config_entry.state is ConfigEntryState.LOADED
 
     with patch(
@@ -330,7 +330,7 @@ async def test_reset_fails(
 async def test_connection_state_signalling(
     hass: HomeAssistant,
     mock_device_registry,
-    setup_config_entry: ConfigEntry,
+    config_entry_setup: ConfigEntry,
     websocket_mock,
 ) -> None:
     """Verify connection statesignalling and connection state are working."""
@@ -349,7 +349,7 @@ async def test_connection_state_signalling(
 async def test_reconnect_mechanism(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    setup_config_entry: ConfigEntry,
+    config_entry_setup: ConfigEntry,
     websocket_mock,
 ) -> None:
     """Verify reconnect prints only on first reconnection try."""
@@ -378,7 +378,7 @@ async def test_reconnect_mechanism(
 async def test_reconnect_mechanism_exceptions(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    setup_config_entry: ConfigEntry,
+    config_entry_setup: ConfigEntry,
     websocket_mock,
     exception,
 ) -> None:

--- a/tests/components/unifi/test_init.py
+++ b/tests/components/unifi/test_init.py
@@ -35,20 +35,20 @@ async def test_setup_with_no_config(hass: HomeAssistant) -> None:
 
 
 async def test_setup_entry_fails_config_entry_not_ready(
-    hass: HomeAssistant, prepare_config_entry: Callable[[], ConfigEntry]
+    hass: HomeAssistant, config_entry_factory: Callable[[], ConfigEntry]
 ) -> None:
     """Failed authentication trigger a reauthentication flow."""
     with patch(
         "homeassistant.components.unifi.get_unifi_api",
         side_effect=CannotConnect,
     ):
-        config_entry = await prepare_config_entry()
+        config_entry = await config_entry_factory()
 
     assert config_entry.state == ConfigEntryState.SETUP_RETRY
 
 
 async def test_setup_entry_fails_trigger_reauth_flow(
-    hass: HomeAssistant, prepare_config_entry: Callable[[], ConfigEntry]
+    hass: HomeAssistant, config_entry_factory: Callable[[], ConfigEntry]
 ) -> None:
     """Failed authentication trigger a reauthentication flow."""
     with (
@@ -58,7 +58,7 @@ async def test_setup_entry_fails_trigger_reauth_flow(
         ),
         patch.object(hass.config_entries.flow, "async_init") as mock_flow_init,
     ):
-        config_entry = await prepare_config_entry()
+        config_entry = await config_entry_factory()
         mock_flow_init.assert_called_once()
 
     assert config_entry.state == ConfigEntryState.SETUP_ERROR
@@ -86,7 +86,7 @@ async def test_setup_entry_fails_trigger_reauth_flow(
 async def test_wireless_clients(
     hass: HomeAssistant,
     hass_storage: dict[str, Any],
-    prepare_config_entry: Callable[[], ConfigEntry],
+    config_entry_factory: Callable[[], ConfigEntry],
 ) -> None:
     """Verify wireless clients class."""
     hass_storage[unifi.STORAGE_KEY] = {
@@ -98,7 +98,7 @@ async def test_wireless_clients(
         },
     }
 
-    await prepare_config_entry()
+    await config_entry_factory()
     await flush_store(hass.data[unifi.UNIFI_WIRELESS_CLIENTS]._store)
 
     assert sorted(hass_storage[unifi.STORAGE_KEY]["data"]["wireless_clients"]) == [
@@ -173,14 +173,14 @@ async def test_remove_config_entry_device(
     hass_storage: dict[str, Any],
     aioclient_mock: AiohttpClientMocker,
     device_registry: dr.DeviceRegistry,
-    prepare_config_entry: Callable[[], ConfigEntry],
+    config_entry_factory: Callable[[], ConfigEntry],
     client_payload: list[dict[str, Any]],
     device_payload: list[dict[str, Any]],
     mock_unifi_websocket,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Verify removing a device manually."""
-    config_entry = await prepare_config_entry()
+    config_entry = await config_entry_factory()
 
     assert await async_setup_component(hass, "config", {})
     ws_client = await hass_ws_client(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow up PR to https://github.com/home-assistant/core/pull/118126
Make more use of fixtures
Do not use runtime_data
Try better naming of fixtures

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
