### PR TITLE
Migrate Intergas InComfort/Intouch Lan2RF gateway  YAML to config flow

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -599,6 +599,8 @@ omit =
     homeassistant/components/incomfort/__init__.py
     homeassistant/components/incomfort/binary_sensor.py
     homeassistant/components/incomfort/climate.py
+    homeassistant/components/incomfort/errors.py
+    homeassistant/components/incomfort/models.py
     homeassistant/components/incomfort/sensor.py
     homeassistant/components/incomfort/water_heater.py
     homeassistant/components/insteon/binary_sensor.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -596,7 +596,11 @@ omit =
     homeassistant/components/ifttt/alarm_control_panel.py
     homeassistant/components/iglo/light.py
     homeassistant/components/ihc/*
-    homeassistant/components/incomfort/*
+    homeassistant/components/incomfort/__init__.py
+    homeassistant/components/incomfort/binary_sensor.py
+    homeassistant/components/incomfort/climate.py
+    homeassistant/components/incomfort/sensor.py
+    homeassistant/components/incomfort/water_heater.py
     homeassistant/components/insteon/binary_sensor.py
     homeassistant/components/insteon/climate.py
     homeassistant/components/insteon/cover.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -659,6 +659,7 @@ build.json @home-assistant/supervisor
 /homeassistant/components/improv_ble/ @emontnemery
 /tests/components/improv_ble/ @emontnemery
 /homeassistant/components/incomfort/ @zxdavb
+/tests/components/incomfort/ @zxdavb
 /homeassistant/components/influxdb/ @mdegat01
 /tests/components/influxdb/ @mdegat01
 /homeassistant/components/inkbird/ @bdraco

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -659,6 +659,7 @@ build.json @home-assistant/supervisor
 /homeassistant/components/improv_ble/ @emontnemery
 /tests/components/improv_ble/ @emontnemery
 /homeassistant/components/incomfort/ @jbouwh
+/tests/components/incomfort/ @jbouwh
 /homeassistant/components/influxdb/ @mdegat01
 /tests/components/influxdb/ @mdegat01
 /homeassistant/components/inkbird/ @bdraco

--- a/homeassistant/components/incomfort/__init__.py
+++ b/homeassistant/components/incomfort/__init__.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import logging
-
 from aiohttp import ClientResponseError
 from incomfortclient import IncomfortError, InvalidHeaterList
 import voluptuous as vol
@@ -11,6 +9,7 @@ import voluptuous as vol
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant, callback
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import config_validation as cv, issue_registry as ir
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -20,8 +19,6 @@ from homeassistant.helpers.typing import ConfigType
 from .const import DOMAIN
 from .errors import InConfortTimeout, InConfortUnknownError, NoHeaters, NotFound
 from .models import DATA_INCOMFORT, async_connect_gateway
-
-_LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -43,36 +40,53 @@ PLATFORMS = (
     Platform.CLIMATE,
 )
 
+INTEGRATION_TITLE = "Intergas InComfort/Intouch Lan2RF gateway"
+
+
+async def _async_import(hass: HomeAssistant, config: ConfigType) -> None:
+    """Import config entry from configuration.yaml."""
+    if not hass.config_entries.async_entries(DOMAIN):
+        # Start import flow
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=config
+        )
+        if result["type"] == FlowResultType.ABORT:
+            ir.async_create_issue(
+                hass,
+                DOMAIN,
+                f"deprecated_yaml_import_issue_{result['reason']}",
+                breaks_in_ha_version="2025.1.0",
+                is_fixable=False,
+                issue_domain=DOMAIN,
+                severity=ir.IssueSeverity.WARNING,
+                translation_key=f"deprecated_yaml_import_issue_{result['reason']}",
+                translation_placeholders={
+                    "domain": DOMAIN,
+                    "integration_title": INTEGRATION_TITLE,
+                },
+            )
+            return
+
+    ir.async_create_issue(
+        hass,
+        HOMEASSISTANT_DOMAIN,
+        f"deprecated_yaml_{DOMAIN}",
+        breaks_in_ha_version="2025.1.0",
+        is_fixable=False,
+        issue_domain=DOMAIN,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="deprecated_yaml",
+        translation_placeholders={
+            "domain": DOMAIN,
+            "integration_title": INTEGRATION_TITLE,
+        },
+    )
+
 
 async def async_setup(hass: HomeAssistant, hass_config: ConfigType) -> bool:
     """Create an Intergas InComfort/Intouch system."""
-
     if config := hass_config.get(DOMAIN):
-        ir.async_create_issue(
-            hass,
-            HOMEASSISTANT_DOMAIN,
-            f"deprecated_yaml_{DOMAIN}",
-            breaks_in_ha_version="2025.1.0",
-            is_fixable=False,
-            issue_domain=DOMAIN,
-            severity=ir.IssueSeverity.WARNING,
-            translation_key="deprecated_yaml",
-            translation_placeholders={
-                "domain": DOMAIN,
-                "integration_title": "Intergas InComfort/Intouch Lan2RF gateway",
-            },
-        )
-
-    if hass.config_entries.async_entries(DOMAIN):
-        return True
-    # Start import flow
-    if config:
-        hass.async_create_task(
-            hass.config_entries.flow.async_init(
-                DOMAIN, context={"source": SOURCE_IMPORT}, data=config
-            )
-        )
-
+        hass.async_create_task(_async_import(hass, config))
     return True
 
 

--- a/homeassistant/components/incomfort/__init__.py
+++ b/homeassistant/components/incomfort/__init__.py
@@ -107,8 +107,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise InConfortUnknownError from exc
     except TimeoutError as exc:
         raise InConfortTimeout from exc
-    except Exception as exc:  # noqa: BLE001
-        raise InConfortUnknownError from exc
 
     hass.data.setdefault(DATA_INCOMFORT, {entry.entry_id: data})
 

--- a/homeassistant/components/incomfort/__init__.py
+++ b/homeassistant/components/incomfort/__init__.py
@@ -127,7 +127,6 @@ class IncomfortEntity(Entity):
     """Base class for all InComfort entities."""
 
     _attr_should_poll = False
-    _attr_has_entity_name = True
 
     async def async_added_to_hass(self) -> None:
         """Set up a listener when this entity is added to HA."""

--- a/homeassistant/components/incomfort/__init__.py
+++ b/homeassistant/components/incomfort/__init__.py
@@ -101,6 +101,7 @@ class IncomfortEntity(Entity):
     """Base class for all InComfort entities."""
 
     _attr_should_poll = False
+    _attr_has_entity_name = True
 
     async def async_added_to_hass(self) -> None:
         """Set up a listener when this entity is added to HA."""

--- a/homeassistant/components/incomfort/__init__.py
+++ b/homeassistant/components/incomfort/__init__.py
@@ -105,7 +105,11 @@ class IncomfortEntity(Entity):
 
     async def async_added_to_hass(self) -> None:
         """Set up a listener when this entity is added to HA."""
-        self.async_on_remove(async_dispatcher_connect(self.hass, DOMAIN, self._refresh))
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, f"{DOMAIN}_{self.unique_id}", self._refresh
+            )
+        )
 
     @callback
     def _refresh(self) -> None:

--- a/homeassistant/components/incomfort/__init__.py
+++ b/homeassistant/components/incomfort/__init__.py
@@ -80,6 +80,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a config entry."""
     try:
         data = await async_connect_gateway(hass, dict(entry.data))
+        for heater in data.heaters:
+            await heater.update()
     except InvalidHeaterList as exc:
         raise NoHeaters from exc
     except IncomfortError as exc:
@@ -95,8 +97,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise InConfortUnknownError from exc
 
     hass.data.setdefault(DATA_INCOMFORT, {entry.entry_id: data})
-    for heater in data.heaters:
-        await heater.update()
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True

--- a/homeassistant/components/incomfort/binary_sensor.py
+++ b/homeassistant/components/incomfort/binary_sensor.py
@@ -7,6 +7,7 @@ from typing import Any
 from incomfortclient import Gateway as InComfortGateway, Heater as InComfortHeater
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback

--- a/homeassistant/components/incomfort/binary_sensor.py
+++ b/homeassistant/components/incomfort/binary_sensor.py
@@ -9,10 +9,9 @@ from incomfortclient import Gateway as InComfortGateway, Heater as InComfortHeat
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import DATA_INCOMFORT, DOMAIN, IncomfortEntity
+from . import DATA_INCOMFORT, IncomfortEntity
 
 
 async def async_setup_entry(

--- a/homeassistant/components/incomfort/binary_sensor.py
+++ b/homeassistant/components/incomfort/binary_sensor.py
@@ -38,6 +38,7 @@ class IncomfortFailed(IncomfortEntity, BinarySensorEntity):
 
         self._client = client
         self._heater = heater
+
         self._attr_unique_id = f"{heater.serial_no}_failed"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, heater.serial_no)},

--- a/homeassistant/components/incomfort/binary_sensor.py
+++ b/homeassistant/components/incomfort/binary_sensor.py
@@ -38,11 +38,10 @@ class IncomfortFailed(IncomfortEntity, BinarySensorEntity):
 
         self._client = client
         self._heater = heater
+        self._attr_unique_id = f"{heater.serial_no}_failed"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, heater.serial_no)},
         )
-
-        self._attr_unique_id = f"{heater.serial_no}_failed"
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/incomfort/binary_sensor.py
+++ b/homeassistant/components/incomfort/binary_sensor.py
@@ -40,9 +40,6 @@ class IncomfortFailed(IncomfortEntity, BinarySensorEntity):
         self._heater = heater
 
         self._attr_unique_id = f"{heater.serial_no}_failed"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, heater.serial_no)},
-        )
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/incomfort/climate.py
+++ b/homeassistant/components/incomfort/climate.py
@@ -58,14 +58,13 @@ class InComfortClimate(IncomfortEntity, ClimateEntity):
         self._client = client
         self._room = room
         self._attr_name = None
+        self._attr_unique_id = f"{heater.serial_no}_{room.room_no}"
+        self._attr_name = f"Thermostat {room.room_no}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._attr_unique_id)},
             manufacturer="Intergas",
-            name=f"Thermostat {room.room_no} ({heater.serial_no})",
+            name=f"Thermostat {room.room_no}",
         )
-
-        self._attr_unique_id = f"{heater.serial_no}_{room.room_no}"
-        self._attr_name = f"Thermostat {room.room_no}"
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/homeassistant/components/incomfort/climate.py
+++ b/homeassistant/components/incomfort/climate.py
@@ -18,10 +18,9 @@ from homeassistant.components.climate import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import DATA_INCOMFORT, DOMAIN, IncomfortEntity
+from . import DATA_INCOMFORT, IncomfortEntity
 
 
 async def async_setup_entry(

--- a/homeassistant/components/incomfort/climate.py
+++ b/homeassistant/components/incomfort/climate.py
@@ -60,6 +60,7 @@ class InComfortClimate(IncomfortEntity, ClimateEntity):
         self._attr_name = None
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._attr_unique_id)},
+            manufacturer="Intergas",
             name=f"Thermostat {room.room_no} ({heater.serial_no})",
         )
 

--- a/homeassistant/components/incomfort/climate.py
+++ b/homeassistant/components/incomfort/climate.py
@@ -58,14 +58,8 @@ class InComfortClimate(IncomfortEntity, ClimateEntity):
         self._client = client
         self._room = room
 
-        self._attr_name = None
         self._attr_unique_id = f"{heater.serial_no}_{room.room_no}"
         self._attr_name = f"Thermostat {room.room_no}"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self._attr_unique_id)},
-            manufacturer="Intergas",
-            name=f"Thermostat {room.room_no}",
-        )
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/homeassistant/components/incomfort/climate.py
+++ b/homeassistant/components/incomfort/climate.py
@@ -58,7 +58,6 @@ class InComfortClimate(IncomfortEntity, ClimateEntity):
         self._client = client
         self._room = room
         self._attr_name = None
-        self._attr_has_entity_name = True
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._attr_unique_id)},
             name=f"Thermostat {room.room_no} ({heater.serial_no})",

--- a/homeassistant/components/incomfort/climate.py
+++ b/homeassistant/components/incomfort/climate.py
@@ -57,6 +57,7 @@ class InComfortClimate(IncomfortEntity, ClimateEntity):
 
         self._client = client
         self._room = room
+
         self._attr_name = None
         self._attr_unique_id = f"{heater.serial_no}_{room.room_no}"
         self._attr_name = f"Thermostat {room.room_no}"

--- a/homeassistant/components/incomfort/config_flow.py
+++ b/homeassistant/components/incomfort/config_flow.py
@@ -2,10 +2,13 @@
 
 from typing import Any
 
+from aiohttp import ClientResponseError
+from incomfortclient import IncomfortError, InvalidHeaterList
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.selector import (
     TextSelector,
     TextSelectorConfig,
@@ -31,6 +34,39 @@ CONFIG_SCHEMA = vol.Schema(
     }
 )
 
+ERROR_STATUS_MAPPING: dict[int, tuple[str, str]] = {
+    401: (CONF_PASSWORD, "auth_error"),
+    404: ("base", "not_found"),
+}
+
+
+async def async_try_connect_gateway(
+    hass: HomeAssistant, config: dict[str, Any], errors: dict[str, str]
+) -> bool:
+    """Try to connect to the Lan2RF gateway."""
+    try:
+        await async_connect_gateway(hass, config)
+    except InvalidHeaterList:
+        errors["base"] = "no_heaters"
+        return False
+    except IncomfortError as exc:
+        if isinstance(exc.message, ClientResponseError):
+            scope, error = ERROR_STATUS_MAPPING.get(
+                exc.message.status, ("base", "unknown_error")
+            )
+            errors[scope] = error
+            return False
+        errors["base"] = "unknown_error"
+        return False
+    except TimeoutError:
+        errors["base"] = "timeout_error"
+        return False
+    except Exception:  # noqa: BLE001
+        errors["base"] = "unknown_error"
+        return False
+
+    return True
+
 
 class InComfortConfigFlow(ConfigFlow, domain=DOMAIN):
     """Config flow to set up an Intergas InComfort boyler and thermostats."""
@@ -42,7 +78,7 @@ class InComfortConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         if user_input is not None:
             self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
-            if await async_connect_gateway(self.hass, user_input, errors):
+            if await async_try_connect_gateway(self.hass, user_input, errors):
                 return self.async_create_entry(title=TITLE, data=user_input)
 
         return self.async_show_form(

--- a/homeassistant/components/incomfort/config_flow.py
+++ b/homeassistant/components/incomfort/config_flow.py
@@ -57,6 +57,8 @@ async def async_try_connect_gateway(
         return {"base": "unknown"}
     except TimeoutError:
         return {"base": "timeout_error"}
+    except Exception:  # noqa: BLE001
+        return {"base": "unknown"}
 
     return None
 

--- a/homeassistant/components/incomfort/config_flow.py
+++ b/homeassistant/components/incomfort/config_flow.py
@@ -87,4 +87,8 @@ class InComfortConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(self, import_data: dict[str, Any]) -> ConfigFlowResult:
         """Import `incomfort` config entry from configuration.yaml."""
-        return self.async_create_entry(title=TITLE, data=import_data)
+        errors: dict[str, str] = {}
+        if await async_try_connect_gateway(self.hass, import_data, errors):
+            return self.async_create_entry(title=TITLE, data=import_data)
+        reason = next(iter(errors.items()))[1]
+        return self.async_abort(reason=reason)

--- a/homeassistant/components/incomfort/config_flow.py
+++ b/homeassistant/components/incomfort/config_flow.py
@@ -1,0 +1,53 @@
+"""Config flow support for Intergas InComfort integration."""
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers.selector import (
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+)
+
+from .const import DOMAIN
+from .models import async_connect_gateway
+
+TITLE = "Intergas InComfort/Intouch Lan2RF gateway"
+
+
+class InComfortConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Config flow to set up an Intergas InComfort boyler and thermostats."""
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+        data_schema = {
+            vol.Required(CONF_HOST): TextSelector(
+                TextSelectorConfig(type=TextSelectorType.TEXT)
+            ),
+            vol.Optional(CONF_USERNAME): TextSelector(
+                TextSelectorConfig(type=TextSelectorType.TEXT, autocomplete="admin")
+            ),
+            vol.Optional(CONF_PASSWORD): TextSelector(
+                TextSelectorConfig(type=TextSelectorType.PASSWORD)
+            ),
+        }
+        if (
+            user_input is not None
+            and await async_connect_gateway(self.hass, user_input, errors) is not None
+        ):
+            self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
+            return self.async_create_entry(title=TITLE, data=user_input)
+
+        return self.async_show_form(
+            step_id="user", data_schema=vol.Schema(data_schema), errors=errors
+        )
+
+    async def async_step_import(self, import_data: dict[str, Any]) -> ConfigFlowResult:
+        """Import `incomfort` config entry from configuration.yaml."""
+        return self.async_create_entry(title=TITLE, data=import_data)

--- a/homeassistant/components/incomfort/config_flow.py
+++ b/homeassistant/components/incomfort/config_flow.py
@@ -17,6 +17,20 @@ from .models import async_connect_gateway
 
 TITLE = "Intergas InComfort/Intouch Lan2RF gateway"
 
+CONFIG_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): TextSelector(
+            TextSelectorConfig(type=TextSelectorType.TEXT)
+        ),
+        vol.Optional(CONF_USERNAME): TextSelector(
+            TextSelectorConfig(type=TextSelectorType.TEXT, autocomplete="admin")
+        ),
+        vol.Optional(CONF_PASSWORD): TextSelector(
+            TextSelectorConfig(type=TextSelectorType.PASSWORD)
+        ),
+    }
+)
+
 
 class InComfortConfigFlow(ConfigFlow, domain=DOMAIN):
     """Config flow to set up an Intergas InComfort boyler and thermostats."""
@@ -26,24 +40,13 @@ class InComfortConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle the initial step."""
         errors: dict[str, str] = {}
-        data_schema = {
-            vol.Required(CONF_HOST): TextSelector(
-                TextSelectorConfig(type=TextSelectorType.TEXT)
-            ),
-            vol.Optional(CONF_USERNAME): TextSelector(
-                TextSelectorConfig(type=TextSelectorType.TEXT, autocomplete="admin")
-            ),
-            vol.Optional(CONF_PASSWORD): TextSelector(
-                TextSelectorConfig(type=TextSelectorType.PASSWORD)
-            ),
-        }
         if user_input is not None:
             self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
             if await async_connect_gateway(self.hass, user_input, errors):
                 return self.async_create_entry(title=TITLE, data=user_input)
 
         return self.async_show_form(
-            step_id="user", data_schema=vol.Schema(data_schema), errors=errors
+            step_id="user", data_schema=CONFIG_SCHEMA, errors=errors
         )
 
     async def async_step_import(self, import_data: dict[str, Any]) -> ConfigFlowResult:

--- a/homeassistant/components/incomfort/config_flow.py
+++ b/homeassistant/components/incomfort/config_flow.py
@@ -37,12 +37,10 @@ class InComfortConfigFlow(ConfigFlow, domain=DOMAIN):
                 TextSelectorConfig(type=TextSelectorType.PASSWORD)
             ),
         }
-        if (
-            user_input is not None
-            and await async_connect_gateway(self.hass, user_input, errors) is not None
-        ):
+        if user_input is not None:
             self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
-            return self.async_create_entry(title=TITLE, data=user_input)
+            if await async_connect_gateway(self.hass, user_input, errors):
+                return self.async_create_entry(title=TITLE, data=user_input)
 
         return self.async_show_form(
             step_id="user", data_schema=vol.Schema(data_schema), errors=errors

--- a/homeassistant/components/incomfort/const.py
+++ b/homeassistant/components/incomfort/const.py
@@ -1,3 +1,3 @@
-"""Constants for `InComfort` integration."""
+"""Constants for Intergas InComfort integration."""
 
 DOMAIN = "incomfort"

--- a/homeassistant/components/incomfort/const.py
+++ b/homeassistant/components/incomfort/const.py
@@ -1,0 +1,3 @@
+"""Constants for `InComfort` integration."""
+
+DOMAIN = "incomfort"

--- a/homeassistant/components/incomfort/errors.py
+++ b/homeassistant/components/incomfort/errors.py
@@ -29,4 +29,4 @@ class InConfortUnknownError(ConfigEntryNotReady):
     """Raise exception if no heaters are found."""
 
     translation_domain = DOMAIN
-    translation_key = "unknown_error"
+    translation_key = "unknown"

--- a/homeassistant/components/incomfort/errors.py
+++ b/homeassistant/components/incomfort/errors.py
@@ -1,11 +1,7 @@
 """Exceptions raised by Intergas InComfort integration."""
 
 from homeassistant.core import DOMAIN
-from homeassistant.exceptions import (
-    ConfigEntryAuthFailed,
-    ConfigEntryNotReady,
-    HomeAssistantError,
-)
+from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 
 
 class NotFound(HomeAssistantError):
@@ -34,17 +30,3 @@ class InConfortUnknownError(ConfigEntryNotReady):
 
     translation_domain = DOMAIN
     translation_key = "unknown_error"
-
-
-def raise_from_error_code(errors: dict[str, str]) -> None:
-    """Raise an error by error code."""
-    code = next(iter(errors.items()))[1]
-    if code == "auth_error":
-        raise ConfigEntryAuthFailed("Incorrect credentials")
-    if code == "not_found":
-        raise NotFound
-    if code == "no_heaters":
-        raise NoHeaters
-    if code == "timeout_error":
-        raise InConfortTimeout
-    raise InConfortUnknownError

--- a/homeassistant/components/incomfort/errors.py
+++ b/homeassistant/components/incomfort/errors.py
@@ -1,0 +1,50 @@
+"""Exceptions raised by `InComfort` integration."""
+
+from homeassistant.core import DOMAIN
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryNotReady,
+    HomeAssistantError,
+)
+
+
+class NotFound(HomeAssistantError):
+    """Raise exception if no Lan2RF Gateway was found."""
+
+    translation_domain = DOMAIN
+    translation_key = "not_found"
+
+
+class NoHeaters(ConfigEntryNotReady):
+    """Raise exception if no heaters are found."""
+
+    translation_domain = DOMAIN
+    translation_key = "no_heaters"
+
+
+class InConfortTimeout(ConfigEntryNotReady):
+    """Raise exception if no heaters are found."""
+
+    translation_domain = DOMAIN
+    translation_key = "timeout_error"
+
+
+class InConfortUnknownError(ConfigEntryNotReady):
+    """Raise exception if no heaters are found."""
+
+    translation_domain = DOMAIN
+    translation_key = "unknown_error"
+
+
+def raise_from_error_code(errors: dict[str, str]) -> None:
+    """Raise an error by error code."""
+    code = next(iter(errors.items()))[1]
+    if code == "auth_error":
+        raise ConfigEntryAuthFailed("Incorrect credentials")
+    if code == "not_found":
+        raise NotFound
+    if code == "no_heaters":
+        raise NoHeaters
+    if code == "timeout_error":
+        raise InConfortTimeout
+    raise InConfortUnknownError

--- a/homeassistant/components/incomfort/errors.py
+++ b/homeassistant/components/incomfort/errors.py
@@ -1,4 +1,4 @@
-"""Exceptions raised by `InComfort` integration."""
+"""Exceptions raised by Intergas InComfort integration."""
 
 from homeassistant.core import DOMAIN
 from homeassistant.exceptions import (

--- a/homeassistant/components/incomfort/manifest.json
+++ b/homeassistant/components/incomfort/manifest.json
@@ -2,6 +2,7 @@
   "domain": "incomfort",
   "name": "Intergas InComfort/Intouch Lan2RF gateway",
   "codeowners": ["@zxdavb"],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/incomfort",
   "iot_class": "local_polling",
   "loggers": ["incomfortclient"],

--- a/homeassistant/components/incomfort/models.py
+++ b/homeassistant/components/incomfort/models.py
@@ -1,0 +1,72 @@
+"""Models for Intergas InComfort integration."""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from aiohttp import ClientResponseError
+from incomfortclient import (
+    Gateway as InComfortGateway,
+    Heater as InComfortHeater,
+    IncomfortError,
+    InvalidHeaterList,
+)
+
+from homeassistant.const import CONF_HOST, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.util.hass_dict import HassKey
+
+from .const import DOMAIN
+
+
+@dataclass
+class InComfortData:
+    """Keep the Intergas InComfort entry data."""
+
+    client: InComfortGateway
+    heaters: list[InComfortHeater] = field(default_factory=list)
+
+
+DATA_INCOMFORT: HassKey[dict[str, InComfortData]] = HassKey(DOMAIN)
+
+
+ERROR_STATUS_MAPPING: dict[int, tuple[str, str]] = {
+    401: (CONF_PASSWORD, "auth_error"),
+    404: ("base", "not_found"),
+}
+
+
+async def async_connect_gateway(
+    hass: HomeAssistant,
+    entry_data: dict[str, Any],
+    errors: dict[str, str],
+) -> InComfortData | None:
+    """Validate the configuration."""
+    credentials = dict(entry_data)
+    hostname = credentials.pop(CONF_HOST)
+
+    client = InComfortGateway(
+        hostname, **credentials, session=async_get_clientsession(hass)
+    )
+    try:
+        heaters = await client.heaters()
+    except InvalidHeaterList:
+        errors["base"] = "no_heaters"
+        return None
+    except IncomfortError as exc:
+        if isinstance(exc.message, ClientResponseError):
+            scope, error = ERROR_STATUS_MAPPING.get(
+                exc.message.status, ("base", "unknown_error")
+            )
+            errors[scope] = error
+            return None
+        errors["base"] = "unknown_error"
+        return None
+    except TimeoutError:
+        errors["base"] = "timeout_error"
+        return None
+    except Exception:  # noqa: BLE001
+        errors["base"] = "unknown_error"
+        return None
+
+    return InComfortData(client=client, heaters=heaters)

--- a/homeassistant/components/incomfort/models.py
+++ b/homeassistant/components/incomfort/models.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from incomfortclient import Gateway as InComfortGateway, Heater as InComfortHeater
 
-from homeassistant.const import CONF_HOST, CONF_PASSWORD
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util.hass_dict import HassKey
@@ -22,12 +22,6 @@ class InComfortData:
 
 
 DATA_INCOMFORT: HassKey[dict[str, InComfortData]] = HassKey(DOMAIN)
-
-
-ERROR_STATUS_MAPPING: dict[int, tuple[str, str]] = {
-    401: (CONF_PASSWORD, "auth_error"),
-    404: ("base", "not_found"),
-}
 
 
 async def async_connect_gateway(

--- a/homeassistant/components/incomfort/sensor.py
+++ b/homeassistant/components/incomfort/sensor.py
@@ -12,13 +12,14 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfPressure, UnitOfTemperature
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import slugify
 
-from . import DOMAIN, IncomfortEntity
+from . import DATA_INCOMFORT, DOMAIN, IncomfortEntity
 
 INCOMFORT_HEATER_TEMP = "CV Temp"
 INCOMFORT_PRESSURE = "CV Pressure"
@@ -59,26 +60,18 @@ SENSOR_TYPES: tuple[IncomfortSensorEntityDescription, ...] = (
 )
 
 
-async def async_setup_platform(
+async def async_setup_entry(
     hass: HomeAssistant,
-    config: ConfigType,
+    entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
-    """Set up an InComfort/InTouch sensor device."""
-    if discovery_info is None:
-        return
-
-    client = hass.data[DOMAIN]["client"]
-    heaters = hass.data[DOMAIN]["heaters"]
-
-    entities = [
-        IncomfortSensor(client, heater, description)
-        for heater in heaters
+    """Set up InComfort/InTouch sensor entities."""
+    incomfort_data = hass.data[DATA_INCOMFORT][entry.entry_id]
+    async_add_entities(
+        IncomfortSensor(incomfort_data.client, heater, description)
+        for heater in incomfort_data.heaters
         for description in SENSOR_TYPES
-    ]
-
-    async_add_entities(entities)
+    )
 
 
 class IncomfortSensor(IncomfortEntity, SensorEntity):
@@ -100,6 +93,10 @@ class IncomfortSensor(IncomfortEntity, SensorEntity):
         self._heater = heater
 
         self._attr_unique_id = f"{heater.serial_no}_{slugify(description.name)}"
+        self._attr_has_entity_name = True
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, heater.serial_no)},
+        )
 
     @property
     def native_value(self) -> str | None:

--- a/homeassistant/components/incomfort/sensor.py
+++ b/homeassistant/components/incomfort/sensor.py
@@ -93,7 +93,6 @@ class IncomfortSensor(IncomfortEntity, SensorEntity):
         self._heater = heater
 
         self._attr_unique_id = f"{heater.serial_no}_{slugify(description.name)}"
-        self._attr_has_entity_name = True
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, heater.serial_no)},
         )

--- a/homeassistant/components/incomfort/sensor.py
+++ b/homeassistant/components/incomfort/sensor.py
@@ -15,11 +15,10 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfPressure, UnitOfTemperature
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import slugify
 
-from . import DATA_INCOMFORT, DOMAIN, IncomfortEntity
+from . import DATA_INCOMFORT, IncomfortEntity
 
 INCOMFORT_HEATER_TEMP = "CV Temp"
 INCOMFORT_PRESSURE = "CV Pressure"

--- a/homeassistant/components/incomfort/sensor.py
+++ b/homeassistant/components/incomfort/sensor.py
@@ -93,9 +93,6 @@ class IncomfortSensor(IncomfortEntity, SensorEntity):
         self._heater = heater
 
         self._attr_unique_id = f"{heater.serial_no}_{slugify(description.name)}"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, heater.serial_no)},
-        )
 
     @property
     def native_value(self) -> str | None:

--- a/homeassistant/components/incomfort/strings.json
+++ b/homeassistant/components/incomfort/strings.json
@@ -14,6 +14,21 @@
           "password": "The password to log into the gateway, is printed at the bottom of the Lan2RF Gateway or is `intergas` for some older devices."
         }
       }
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
+      "auth_error": "Invalid credentials.",
+      "no_heaters": "No heaters found.",
+      "not_found": "No Lan2RF gateway found.",
+      "timeout_error": "Time out when connection to Lan2RF gateway.",
+      "unknown_error": "Unknown error when connection to Lan2RF gateway."
+    },
+    "error": {
+      "auth_error": "[%key:component::incomfort::config::abort::auth_error%]",
+      "no_heaters": "[%key:component::incomfort::config::abort::no_heaters%]",
+      "not_found": "[%key:component::incomfort::config::abort::not_found%]",
+      "timeout_error": "[%key:component::incomfort::config::abort::timeout_error%]",
+      "unknown_error": "[%key:component::incomfort::config::abort::unknown_error%]"
     }
   }
 }

--- a/homeassistant/components/incomfort/strings.json
+++ b/homeassistant/components/incomfort/strings.json
@@ -1,0 +1,19 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "description": "Set up new Intergas InComfort Lan2RF Gateway, some older systems might not need credentials to be set up. For newer devices authentication is required.",
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        },
+        "data_description": {
+          "host": "Hostname or IP-address of the Intergas InComfort Lan2RF Gateway.",
+          "username": "The username to log into the gateway. This is `admin` in most cases.",
+          "password": "The password to log into the gateway, is printed at the bottom of the Lan2RF Gateway or is `intergas` for some older devices."
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/incomfort/strings.json
+++ b/homeassistant/components/incomfort/strings.json
@@ -21,18 +21,18 @@
       "no_heaters": "No heaters found.",
       "not_found": "No Lan2RF gateway found.",
       "timeout_error": "Time out when connection to Lan2RF gateway.",
-      "unknown_error": "Unknown error when connection to Lan2RF gateway."
+      "unknown": "Unknown error when connection to Lan2RF gateway."
     },
     "error": {
       "auth_error": "[%key:component::incomfort::config::abort::auth_error%]",
       "no_heaters": "[%key:component::incomfort::config::abort::no_heaters%]",
       "not_found": "[%key:component::incomfort::config::abort::not_found%]",
       "timeout_error": "[%key:component::incomfort::config::abort::timeout_error%]",
-      "unknown_error": "[%key:component::incomfort::config::abort::unknown_error%]"
+      "unknown": "[%key:component::incomfort::config::abort::unknown%]"
     }
   },
   "issues": {
-    "deprecated_yaml_import_issue_unknown_error": {
+    "deprecated_yaml_import_issue_unknown": {
       "title": "YAML import failed with unknown error",
       "description": "Configuring {integration_title} using YAML is being removed but there was an unknown error while importing your existing configuration.\nSetup will not proceed.\n\nVerify that your {integration_title} is operating correctly and restart Home Assistant to attempt the import again.\n\nAlternatively, you may remove the `{domain}` configuration from your configuration.yaml entirely, restart Home Assistant, and add the {integration_title} integration manually."
     },

--- a/homeassistant/components/incomfort/strings.json
+++ b/homeassistant/components/incomfort/strings.json
@@ -30,5 +30,27 @@
       "timeout_error": "[%key:component::incomfort::config::abort::timeout_error%]",
       "unknown_error": "[%key:component::incomfort::config::abort::unknown_error%]"
     }
+  },
+  "issues": {
+    "deprecated_yaml_import_issue_unknown_error": {
+      "title": "YAML import failed with unknown error",
+      "description": "Configuring {integration_title} using YAML is being removed but there was an unknown error while importing your existing configuration.\nSetup will not proceed.\n\nVerify that your {integration_title} is operating correctly and restart Home Assistant to attempt the import again.\n\nAlternatively, you may remove the `{domain}` configuration from your configuration.yaml entirely, restart Home Assistant, and add the {integration_title} integration manually."
+    },
+    "deprecated_yaml_import_issue_auth_error": {
+      "title": "YAML import failed due to an authentication error",
+      "description": "Configuring {integration_title} using YAML is being removed but there was an authentication error while importing your existing configuration.\nSetup will not proceed.\n\nVerify that your {integration_title} is operating correctly and restart Home Assistant to attempt the import again.\n\nAlternatively, you may remove the `{domain}` configuration from your configuration.yaml entirely, restart Home Assistant, and add the {integration_title} integration manually."
+    },
+    "deprecated_yaml_import_issue_no_heaters": {
+      "title": "YAML import failed because no heaters were found",
+      "description": "Configuring {integration_title} using YAML is being removed but no heaters were found while importing your existing configuration.\nSetup will not proceed.\n\nVerify that your {integration_title} is operating correctly and restart Home Assistant to attempt the import again.\n\nAlternatively, you may remove the `{domain}` configuration from your configuration.yaml entirely, restart Home Assistant, and add the {integration_title} integration manually."
+    },
+    "deprecated_yaml_import_issue_not_found": {
+      "title": "YAML import failed because no gateway was found",
+      "description": "Configuring {integration_title} using YAML is being removed but no Lan2RF gateway was found while importing your existing configuration.\nSetup will not proceed.\n\nVerify that your {integration_title} is operating correctly and restart Home Assistant to attempt the import again.\n\nAlternatively, you may remove the `{domain}` configuration from your configuration.yaml entirely, restart Home Assistant, and add the {integration_title} integration manually."
+    },
+    "deprecated_yaml_import_issue_timeout_error": {
+      "title": "YAML import failed because of timeout issues",
+      "description": "Configuring {integration_title} using YAML is being removed but there was a timeout while connecting to your {integration_title} while importing your existing configuration.\nSetup will not proceed.\n\nVerify that your {integration_title} is operating correctly and restart Home Assistant to attempt the import again.\n\nAlternatively, you may remove the `{domain}` configuration from your configuration.yaml entirely, restart Home Assistant, and add the {integration_title} integration manually."
+    }
   }
 }

--- a/homeassistant/components/incomfort/water_heater.py
+++ b/homeassistant/components/incomfort/water_heater.py
@@ -52,11 +52,6 @@ class IncomfortWaterHeater(IncomfortEntity, WaterHeaterEntity):
         self._heater = heater
 
         self._attr_unique_id = heater.serial_no
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, heater.serial_no)},
-            manufacturer="Intergas",
-            name="Boiler",
-        )
 
     @property
     def icon(self) -> str:

--- a/homeassistant/components/incomfort/water_heater.py
+++ b/homeassistant/components/incomfort/water_heater.py
@@ -114,4 +114,4 @@ class IncomfortWaterHeater(IncomfortEntity, WaterHeaterEntity):
             _LOGGER.warning("Update failed, message is: %s", err)
 
         else:
-            async_dispatcher_send(self.hass, DOMAIN)
+            async_dispatcher_send(self.hass, f"{DOMAIN}_{self.unique_id}")

--- a/homeassistant/components/incomfort/water_heater.py
+++ b/homeassistant/components/incomfort/water_heater.py
@@ -51,15 +51,11 @@ class IncomfortWaterHeater(IncomfortEntity, WaterHeaterEntity):
         self._client = client
         self._heater = heater
         self._attr_unique_id = heater.serial_no
-        self._attr_name = "Boiler"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, heater.serial_no)},
             manufacturer="Intergas",
             name="Boiler",
         )
-        self._attr_should_poll = True
-
-        self._attr_unique_id = heater.serial_no
 
     @property
     def icon(self) -> str:

--- a/homeassistant/components/incomfort/water_heater.py
+++ b/homeassistant/components/incomfort/water_heater.py
@@ -68,14 +68,13 @@ class IncomfortWaterHeater(IncomfortEntity, WaterHeaterEntity):
         self._client = client
         self._heater = heater
         self._attr_unique_id = heater.serial_no
-        self._attr_name = None
-        self._attr_has_entity_name = True
+        self._attr_name = "Boiler"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, heater.serial_no)},
             manufacturer="Intergas",
             name="Boiler",
         )
-        _attr_should_poll = True
+        self._attr_should_poll = True
 
         self._attr_unique_id = heater.serial_no
 

--- a/homeassistant/components/incomfort/water_heater.py
+++ b/homeassistant/components/incomfort/water_heater.py
@@ -50,6 +50,7 @@ class IncomfortWaterHeater(IncomfortEntity, WaterHeaterEntity):
 
         self._client = client
         self._heater = heater
+
         self._attr_unique_id = heater.serial_no
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, heater.serial_no)},

--- a/homeassistant/components/incomfort/water_heater.py
+++ b/homeassistant/components/incomfort/water_heater.py
@@ -15,29 +15,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import DATA_INCOMFORT, DOMAIN, IncomfortEntity
 
 _LOGGER = logging.getLogger(__name__)
 
 HEATER_ATTRS = ["display_code", "display_text", "is_burning"]
-
-
-async def async_setup_platform(
-    hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
-) -> None:
-    """Set up an InComfort/Intouch water_heater device."""
-    if discovery_info is None:
-        return
-
-    client = hass.data[DATA_INCOMFORT][DOMAIN].client
-    heaters = hass.data[DATA_INCOMFORT][DOMAIN].heaters
-
-    async_add_entities([IncomfortWaterHeater(client, h) for h in heaters])
 
 
 async def async_setup_entry(

--- a/homeassistant/components/incomfort/water_heater.py
+++ b/homeassistant/components/incomfort/water_heater.py
@@ -12,7 +12,6 @@ from homeassistant.components.water_heater import WaterHeaterEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -256,6 +256,7 @@ FLOWS = {
         "imap",
         "imgw_pib",
         "improv_ble",
+        "incomfort",
         "inkbird",
         "insteon",
         "intellifire",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -2809,7 +2809,7 @@
     "incomfort": {
       "name": "Intergas InComfort/Intouch Lan2RF gateway",
       "integration_type": "hub",
-      "config_flow": false,
+      "config_flow": true,
       "iot_class": "local_polling"
     },
     "indianamichiganpower": {

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -935,6 +935,9 @@ ifaddr==0.2.0
 # homeassistant.components.imgw_pib
 imgw_pib==1.0.1
 
+# homeassistant.components.incomfort
+incomfort-client==0.5.0
+
 # homeassistant.components.influxdb
 influxdb-client==1.24.0
 

--- a/tests/components/incomfort/__init__.py
+++ b/tests/components/incomfort/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the `InComfort` integration."""

--- a/tests/components/incomfort/__init__.py
+++ b/tests/components/incomfort/__init__.py
@@ -1,1 +1,1 @@
-"""Tests for the `InComfort` integration."""
+"""Tests for the Intergas InComfort integration."""

--- a/tests/components/incomfort/conftest.py
+++ b/tests/components/incomfort/conftest.py
@@ -1,0 +1,94 @@
+"""Fixtures for `InComfort` integration."""
+
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.incomfort.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        yield mock_setup_entry
+
+
+@pytest.fixture
+def mock_heater_status() -> dict[str, Any]:
+    """Mock heater status."""
+    return {
+        "display_code": 126,
+        "display_text": "standby",
+        "fault_code": None,
+        "is_burning": False,
+        "is_failed": False,
+        "is_pumping": False,
+        "is_tapping": False,
+        "heater_temp": 35.34,
+        "tap_temp": 30.21,
+        "pressure": 1.86,
+        "serial_no": "2404c08648",
+        "nodenr": 249,
+        "rf_message_rssi": 30,
+        "rfstatus_cntr": 0,
+    }
+
+
+@pytest.fixture
+def mock_room_status() -> dict[str, Any]:
+    """Mock room status."""
+    return {"room_temp": 21.42, "setpoint": 18.0, "override": 18.0}
+
+
+@pytest.fixture
+def mock_incomfort(
+    hass: HomeAssistant,
+    mock_heater_status: dict[str, Any],
+    mock_room_status: dict[str, Any],
+) -> Generator[MagicMock, None]:
+    """Mock the InComfort gateway client."""
+
+    class MockRoom:
+        """Mocked InComfort room class."""
+
+        override: float
+        room_no: int
+        room_temp: float
+        setpoint: float
+        status: dict[str, Any]
+
+        def __init__(self) -> None:
+            """Initialize mocked room."""
+            self.override = mock_room_status["override"]
+            self.room_no = 1
+            self.room_temp = mock_room_status["room_temp"]
+            self.setpoint = mock_room_status["setpoint"]
+            self.status = mock_room_status
+
+    class MockHeater:
+        """Mocked InComfort heater class."""
+
+        serial_no: str
+        status: dict[str, Any]
+        rooms: list[MockRoom]
+
+        def __init__(self) -> None:
+            """Initialize mocked heater."""
+            self.serial_no = "c0ffeec0ffee"
+
+        async def update(self) -> None:
+            self.status = mock_heater_status
+            self.rooms = [MockRoom]
+
+    with patch(
+        "homeassistant.components.incomfort.models.InComfortGateway", MagicMock()
+    ) as patch_gateway:
+        patch_gateway().heaters = AsyncMock()
+        patch_gateway().heaters.return_value = [MockHeater()]
+        yield patch_gateway

--- a/tests/components/incomfort/conftest.py
+++ b/tests/components/incomfort/conftest.py
@@ -1,4 +1,4 @@
-"""Fixtures for `InComfort` integration."""
+"""Fixtures for Intergas InComfort integration."""
 
 from collections.abc import Generator
 from typing import Any

--- a/tests/components/incomfort/test_config_flow.py
+++ b/tests/components/incomfort/test_config_flow.py
@@ -1,4 +1,4 @@
-"""Tests for the `InComfort` config flow."""
+"""Tests for the Intergas InComfort config flow."""
 
 from unittest.mock import AsyncMock, MagicMock
 

--- a/tests/components/incomfort/test_config_flow.py
+++ b/tests/components/incomfort/test_config_flow.py
@@ -1,0 +1,132 @@
+"""Tests for the `InComfort` config flow."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from aiohttp import ClientResponseError
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components.incomfort import DOMAIN
+from homeassistant.const import CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
+
+MOCK_CONFIG = {
+    "host": "192.168.1.12",
+    "username": "admin",
+    "password": "verysecret",
+}
+
+
+async def test_form(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_incomfort: MagicMock
+) -> None:
+    """Test we get the form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {}
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], MOCK_CONFIG
+    )
+    await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "Intergas InComfort/Intouch Lan2RF gateway"
+    assert result2["data"] == MOCK_CONFIG
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_import(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_incomfort: MagicMock
+) -> None:
+    """Test we get the form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=MOCK_CONFIG
+    )
+    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Intergas InComfort/Intouch Lan2RF gateway"
+    assert result["data"] == MOCK_CONFIG
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_entry_already_configured(hass: HomeAssistant) -> None:
+    """Test aborting if the entry is already configured."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG)
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "host": MOCK_CONFIG["host"],
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.ABORT
+    assert result2["reason"] == "already_configured"
+
+
+@pytest.mark.parametrize(
+    ("status", "error", "base"),
+    [
+        (401, "auth_error", CONF_PASSWORD),
+        (404, "not_found", "base"),
+        (500, "unknown_error", "base"),
+    ],
+)
+async def test_form_invalid_auth(
+    hass: HomeAssistant, mock_incomfort: MagicMock, status: int, error: str, base: str
+) -> None:
+    """Test we handle client response errors correctly."""
+    # pylint: disable-next=import-outside-toplevel
+    from incomfortclient import IncomfortError
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    mock_incomfort().heaters.side_effect = IncomfortError(
+        ClientResponseError(None, None, status=status)
+    )
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], MOCK_CONFIG
+    )
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["errors"] == {
+        base: error,
+    }
+
+
+@pytest.mark.parametrize(
+    ("exc", "error"),
+    [
+        (TimeoutError, "timeout_error"),
+        (ValueError("some value error"), "unknown_error"),
+    ],
+)
+async def test_form_cannot_connect(
+    hass: HomeAssistant, mock_incomfort: MagicMock, exc: Exception, error: str
+) -> None:
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    mock_incomfort().heaters.side_effect = exc
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], MOCK_CONFIG
+    )
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["errors"] == {"base": error}

--- a/tests/components/incomfort/test_config_flow.py
+++ b/tests/components/incomfort/test_config_flow.py
@@ -3,11 +3,12 @@
 from unittest.mock import AsyncMock, MagicMock
 
 from aiohttp import ClientResponseError
+from incomfortclient import IncomfortError
 import pytest
 
-from homeassistant import config_entries
 from homeassistant.components.incomfort import DOMAIN
-from homeassistant.const import CONF_PASSWORD
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.const import CONF_HOST, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -23,12 +24,12 @@ MOCK_CONFIG = {
 async def test_form(
     hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_incomfort: MagicMock
 ) -> None:
-    """Test we get the form."""
+    """Test we get the full form."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": SOURCE_USER}
     )
     assert result["type"] is FlowResultType.FORM
-    assert result["errors"] == {}
+    assert result["errors"] is None
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"], MOCK_CONFIG
@@ -44,9 +45,9 @@ async def test_form(
 async def test_import(
     hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_incomfort: MagicMock
 ) -> None:
-    """Test we get the form."""
+    """Test we van import from YAML."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=MOCK_CONFIG
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=MOCK_CONFIG
     )
     await hass.async_block_till_done()
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -56,54 +57,25 @@ async def test_import(
 
 
 @pytest.mark.parametrize(
-    ("status_code", "abort_reason"),
-    [
-        (401, "auth_error"),
-        (404, "not_found"),
-        (500, "unknown_error"),
-    ],
-)
-async def test_import_client_response_fails(
-    hass: HomeAssistant,
-    mock_setup_entry: AsyncMock,
-    mock_incomfort: MagicMock,
-    status_code: str,
-    abort_reason: str,
-) -> None:
-    """Test we get the form."""
-    # pylint: disable-next=import-outside-toplevel
-    from incomfortclient import IncomfortError
-
-    mock_incomfort().heaters.side_effect = IncomfortError(
-        ClientResponseError(None, None, status=status_code)
-    )
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=MOCK_CONFIG
-    )
-    await hass.async_block_till_done()
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == abort_reason
-    assert len(mock_setup_entry.mock_calls) == 0
-
-
-@pytest.mark.parametrize(
     ("exc", "abort_reason"),
     [
+        (IncomfortError(ClientResponseError(None, None, status=401)), "auth_error"),
+        (IncomfortError(ClientResponseError(None, None, status=404)), "not_found"),
+        (IncomfortError(ClientResponseError(None, None, status=500)), "unknown"),
         (TimeoutError, "timeout_error"),
-        (ValueError("some value error"), "unknown_error"),
     ],
 )
-async def test_import_data_fails(
+async def test_import_fails(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
     mock_incomfort: MagicMock,
     exc: Exception,
     abort_reason: str,
 ) -> None:
-    """Test we get the form."""
+    """Test YAML import fails."""
     mock_incomfort().heaters.side_effect = exc
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=MOCK_CONFIG
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=MOCK_CONFIG
     )
     await hass.async_block_till_done()
     assert result["type"] is FlowResultType.ABORT
@@ -117,14 +89,14 @@ async def test_entry_already_configured(hass: HomeAssistant) -> None:
     entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": SOURCE_USER}
     )
     assert result["type"] is FlowResultType.FORM
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            "host": MOCK_CONFIG["host"],
+            CONF_HOST: MOCK_CONFIG[CONF_HOST],
         },
     )
     await hass.async_block_till_done()
@@ -134,27 +106,40 @@ async def test_entry_already_configured(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    ("status", "error", "base"),
+    ("exc", "error", "base"),
     [
-        (401, "auth_error", CONF_PASSWORD),
-        (404, "not_found", "base"),
-        (500, "unknown_error", "base"),
+        (
+            IncomfortError(ClientResponseError(None, None, status=401)),
+            "auth_error",
+            CONF_PASSWORD,
+        ),
+        (
+            IncomfortError(ClientResponseError(None, None, status=404)),
+            "not_found",
+            "base",
+        ),
+        (
+            IncomfortError(ClientResponseError(None, None, status=500)),
+            "unknown",
+            "base",
+        ),
+        (TimeoutError, "timeout_error", "base"),
     ],
 )
-async def test_form_invalid_auth(
-    hass: HomeAssistant, mock_incomfort: MagicMock, status: int, error: str, base: str
+async def test_form_validation(
+    hass: HomeAssistant,
+    mock_incomfort: MagicMock,
+    exc: Exception,
+    error: str,
+    base: str,
 ) -> None:
-    """Test we handle client response errors correctly."""
-    # pylint: disable-next=import-outside-toplevel
-    from incomfortclient import IncomfortError
-
+    """Test form validation."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": SOURCE_USER}
     )
 
-    mock_incomfort().heaters.side_effect = IncomfortError(
-        ClientResponseError(None, None, status=status)
-    )
+    # Simulate issue and retry
+    mock_incomfort().heaters.side_effect = exc
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"], MOCK_CONFIG
     )
@@ -163,26 +148,10 @@ async def test_form_invalid_auth(
         base: error,
     }
 
-
-@pytest.mark.parametrize(
-    ("exc", "error"),
-    [
-        (TimeoutError, "timeout_error"),
-        (ValueError("some value error"), "unknown_error"),
-    ],
-)
-async def test_form_cannot_connect(
-    hass: HomeAssistant, mock_incomfort: MagicMock, exc: Exception, error: str
-) -> None:
-    """Test we handle cannot connect error."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    mock_incomfort().heaters.side_effect = exc
+    # Fix the issue and retry
+    mock_incomfort().heaters.side_effect = None
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"], MOCK_CONFIG
     )
-
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["errors"] == {"base": error}
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert "errors" not in result2

--- a/tests/components/incomfort/test_config_flow.py
+++ b/tests/components/incomfort/test_config_flow.py
@@ -62,6 +62,7 @@ async def test_import(
         (IncomfortError(ClientResponseError(None, None, status=401)), "auth_error"),
         (IncomfortError(ClientResponseError(None, None, status=404)), "not_found"),
         (IncomfortError(ClientResponseError(None, None, status=500)), "unknown"),
+        (ValueError, "unknown"),
         (TimeoutError, "timeout_error"),
     ],
 )
@@ -123,6 +124,7 @@ async def test_entry_already_configured(hass: HomeAssistant) -> None:
             "unknown",
             "base",
         ),
+        (ValueError, "unknown", "base"),
         (TimeoutError, "timeout_error", "base"),
     ],
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrates the YAML config of the `incomfort` integration to a config flow setup. The existing config is automatically imported and an issue is registered to ask users to remove the old YAML config.
The unique ID's of the platform entities do not change.

For future PR's:
- New devices to be created for each thermostat and each heater. The (binary)sensor entities, and water_heater entity will be bound to the heater device. The thermostat will be bound to a climate device.
- Implement DataCoordinator
- Icons file
- Platform tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33040

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
