### PR TITLE
Fix updating options in Jewish Calendar

### DIFF
--- a/homeassistant/components/jewish_calendar/__init__.py
+++ b/homeassistant/components/jewish_calendar/__init__.py
@@ -154,6 +154,11 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         async_update_unique_ids(ent_reg, config_entry.entry_id, old_prefix)
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
+
+    async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+        await hass.config_entries.async_reload(entry.entry_id)
+
+    config_entry.async_on_unload(config_entry.add_update_listener(update_listener))
     return True
 
 

--- a/homeassistant/components/jewish_calendar/__init__.py
+++ b/homeassistant/components/jewish_calendar/__init__.py
@@ -119,10 +119,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     """Set up a configuration entry for Jewish calendar."""
     language = config_entry.data.get(CONF_LANGUAGE, DEFAULT_LANGUAGE)
     diaspora = config_entry.data.get(CONF_DIASPORA, DEFAULT_DIASPORA)
-    candle_lighting_offset = config_entry.data.get(
+    candle_lighting_offset = config_entry.options.get(
         CONF_CANDLE_LIGHT_MINUTES, DEFAULT_CANDLE_LIGHT
     )
-    havdalah_offset = config_entry.data.get(
+    havdalah_offset = config_entry.options.get(
         CONF_HAVDALAH_OFFSET_MINUTES, DEFAULT_HAVDALAH_OFFSET_MINUTES
     )
 
@@ -156,7 +156,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
     async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
-        await hass.config_entries.async_reload(entry.entry_id)
+        # Trigger update of states for all platforms
+        await hass.config_entries.async_reload(config_entry.entry_id)
 
     config_entry.async_on_unload(config_entry.add_update_listener(update_listener))
     return True

--- a/homeassistant/components/jewish_calendar/config_flow.py
+++ b/homeassistant/components/jewish_calendar/config_flow.py
@@ -100,10 +100,23 @@ class JewishCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle the initial step."""
         if user_input is not None:
+            _options = {}
+            if CONF_CANDLE_LIGHT_MINUTES in user_input:
+                _options[CONF_CANDLE_LIGHT_MINUTES] = user_input[
+                    CONF_CANDLE_LIGHT_MINUTES
+                ]
+                del user_input[CONF_CANDLE_LIGHT_MINUTES]
+            if CONF_HAVDALAH_OFFSET_MINUTES in user_input:
+                _options[CONF_HAVDALAH_OFFSET_MINUTES] = user_input[
+                    CONF_HAVDALAH_OFFSET_MINUTES
+                ]
+                del user_input[CONF_HAVDALAH_OFFSET_MINUTES]
             if CONF_LOCATION in user_input:
                 user_input[CONF_LATITUDE] = user_input[CONF_LOCATION][CONF_LATITUDE]
                 user_input[CONF_LONGITUDE] = user_input[CONF_LOCATION][CONF_LONGITUDE]
-            return self.async_create_entry(title=DEFAULT_NAME, data=user_input)
+            return self.async_create_entry(
+                title=DEFAULT_NAME, data=user_input, options=_options
+            )
 
         return self.async_show_form(
             step_id="user",

--- a/tests/components/jewish_calendar/test_config_flow.py
+++ b/tests/components/jewish_calendar/test_config_flow.py
@@ -1,5 +1,6 @@
 """Test the Jewish calendar config flow."""
 
+from datetime import timedelta
 from unittest.mock import AsyncMock
 
 import pytest
@@ -27,8 +28,9 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.setup import async_setup_component
+import homeassistant.util.dt as dt_util
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 async def test_step_user(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
@@ -137,3 +139,44 @@ async def test_options(hass: HomeAssistant, mock_config_entry: MockConfigEntry) 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_CANDLE_LIGHT_MINUTES] == 25
     assert result["data"][CONF_HAVDALAH_OFFSET_MINUTES] == 34
+
+
+async def test_options_updates_sensors(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test that updating the options of the Jewish Calendar integration triggers a value update."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    future = dt_util.utcnow() + timedelta(seconds=30)
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    # Get the value of the "upcoming_shabbat_candle_lighting" sensor
+    initial_sensor_value = hass.states.get(
+        "sensor.jewish_calendar_upcoming_shabbat_candle_lighting"
+    ).state
+    initial_sensor_value = dt_util.parse_datetime(initial_sensor_value)
+
+    # Update the CONF_CANDLE_LIGHT_MINUTES option to a new value
+    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_CANDLE_LIGHT_MINUTES: DEFAULT_CANDLE_LIGHT + 1,
+        },
+    )
+
+    future = dt_util.utcnow() + timedelta(seconds=30)
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    # The sensor value should have changed to be one minute later
+    new_sensor_value = hass.states.get(
+        "sensor.jewish_calendar_upcoming_shabbat_candle_lighting"
+    ).state
+    new_sensor_value = dt_util.parse_datetime(new_sensor_value)
+
+    # Verify that the new sensor value is one minute later
+    assert new_sensor_value - initial_sensor_value == timedelta(minutes=1)

--- a/tests/components/jewish_calendar/test_config_flow.py
+++ b/tests/components/jewish_calendar/test_config_flow.py
@@ -179,4 +179,4 @@ async def test_options_updates_sensors(
     new_sensor_value = dt_util.parse_datetime(new_sensor_value)
 
     # Verify that the new sensor value is one minute later
-    assert new_sensor_value - initial_sensor_value == timedelta(minutes=1)
+    assert abs(new_sensor_value - initial_sensor_value) == timedelta(minutes=1)

--- a/tests/components/jewish_calendar/test_config_flow.py
+++ b/tests/components/jewish_calendar/test_config_flow.py
@@ -12,7 +12,6 @@ from homeassistant.components.jewish_calendar.const import (
     CONF_HAVDALAH_OFFSET_MINUTES,
     DEFAULT_CANDLE_LIGHT,
     DEFAULT_DIASPORA,
-    DEFAULT_HAVDALAH_OFFSET_MINUTES,
     DEFAULT_LANGUAGE,
     DOMAIN,
 )
@@ -75,10 +74,8 @@ async def test_import_no_options(hass: HomeAssistant, language, diaspora) -> Non
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
-    assert entries[0].data == conf[DOMAIN] | {
-        CONF_CANDLE_LIGHT_MINUTES: DEFAULT_CANDLE_LIGHT,
-        CONF_HAVDALAH_OFFSET_MINUTES: DEFAULT_HAVDALAH_OFFSET_MINUTES,
-    }
+    for entry_key, entry_val in entries[0].data.items():
+        assert entry_val == conf[DOMAIN][entry_key]
 
 
 async def test_import_with_options(hass: HomeAssistant) -> None:
@@ -101,7 +98,10 @@ async def test_import_with_options(hass: HomeAssistant) -> None:
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
-    assert entries[0].data == conf[DOMAIN]
+    for entry_key, entry_val in entries[0].data.items():
+        assert entry_val == conf[DOMAIN][entry_key]
+    for entry_key, entry_val in entries[0].options.items():
+        assert entry_val == conf[DOMAIN][entry_key]
 
 
 async def test_single_instance_allowed(
@@ -137,11 +137,13 @@ async def test_options(hass: HomeAssistant, mock_config_entry: MockConfigEntry) 
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["data"][CONF_CANDLE_LIGHT_MINUTES] == 25
-    assert result["data"][CONF_HAVDALAH_OFFSET_MINUTES] == 34
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].options[CONF_CANDLE_LIGHT_MINUTES] == 25
+    assert entries[0].options[CONF_HAVDALAH_OFFSET_MINUTES] == 34
 
 
-async def test_options_updates_sensors(
+async def test_options_reconfigure(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
     """Test that updating the options of the Jewish Calendar integration triggers a value update."""

--- a/tests/components/jewish_calendar/test_config_flow.py
+++ b/tests/components/jewish_calendar/test_config_flow.py
@@ -1,6 +1,5 @@
 """Test the Jewish calendar config flow."""
 
-from datetime import timedelta
 from unittest.mock import AsyncMock
 
 import pytest
@@ -10,7 +9,6 @@ from homeassistant.components.jewish_calendar.const import (
     CONF_CANDLE_LIGHT_MINUTES,
     CONF_DIASPORA,
     CONF_HAVDALAH_OFFSET_MINUTES,
-    DEFAULT_CANDLE_LIGHT,
     DEFAULT_DIASPORA,
     DEFAULT_LANGUAGE,
     DOMAIN,
@@ -27,9 +25,8 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.setup import async_setup_component
-import homeassistant.util.dt as dt_util
 
-from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.common import MockConfigEntry
 
 
 async def test_step_user(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
@@ -141,44 +138,3 @@ async def test_options(hass: HomeAssistant, mock_config_entry: MockConfigEntry) 
     assert len(entries) == 1
     assert entries[0].options[CONF_CANDLE_LIGHT_MINUTES] == 25
     assert entries[0].options[CONF_HAVDALAH_OFFSET_MINUTES] == 34
-
-
-async def test_options_reconfigure(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry
-) -> None:
-    """Test that updating the options of the Jewish Calendar integration triggers a value update."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    future = dt_util.utcnow() + timedelta(seconds=30)
-    async_fire_time_changed(hass, future)
-    await hass.async_block_till_done()
-
-    # Get the value of the "upcoming_shabbat_candle_lighting" sensor
-    initial_sensor_value = hass.states.get(
-        "sensor.jewish_calendar_upcoming_shabbat_candle_lighting"
-    ).state
-    initial_sensor_value = dt_util.parse_datetime(initial_sensor_value)
-
-    # Update the CONF_CANDLE_LIGHT_MINUTES option to a new value
-    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        user_input={
-            CONF_CANDLE_LIGHT_MINUTES: DEFAULT_CANDLE_LIGHT + 1,
-        },
-    )
-
-    future = dt_util.utcnow() + timedelta(seconds=30)
-    async_fire_time_changed(hass, future)
-    await hass.async_block_till_done()
-
-    # The sensor value should have changed to be one minute later
-    new_sensor_value = hass.states.get(
-        "sensor.jewish_calendar_upcoming_shabbat_candle_lighting"
-    ).state
-    new_sensor_value = dt_util.parse_datetime(new_sensor_value)
-
-    # Verify that the new sensor value is one minute later
-    assert abs(new_sensor_value - initial_sensor_value) == timedelta(minutes=1)

--- a/tests/components/jewish_calendar/test_init.py
+++ b/tests/components/jewish_calendar/test_init.py
@@ -58,7 +58,10 @@ async def test_import_unique_id_migration(hass: HomeAssistant) -> None:
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
-    assert entries[0].data == yaml_conf[DOMAIN]
+    for entry_key, entry_val in entries[0].data.items():
+        assert entry_val == yaml_conf[DOMAIN][entry_key]
+    for entry_key, entry_val in entries[0].options.items():
+        assert entry_val == yaml_conf[DOMAIN][entry_key]
 
     # Assert that the unique_id was updated
     new_unique_id = ent_reg.async_get(sample_entity.entity_id).unique_id

--- a/tests/components/jewish_calendar/test_sensor.py
+++ b/tests/components/jewish_calendar/test_sensor.py
@@ -519,6 +519,8 @@ async def test_shabbat_times_sensor(
             data={
                 CONF_LANGUAGE: language,
                 CONF_DIASPORA: diaspora,
+            },
+            options={
                 CONF_CANDLE_LIGHT_MINUTES: candle_lighting,
                 CONF_HAVDALAH_OFFSET_MINUTES: havdalah,
             },


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This should go into 2024.6

With the config flow it seems we forgot to support triggering the update of the sensor states after changing the options value

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
