### PR TITLE
Add service "history.retrieve" to query historic entity state

### DIFF
--- a/homeassistant/components/history/icons.json
+++ b/homeassistant/components/history/icons.json
@@ -1,0 +1,5 @@
+{
+  "services": {
+    "retrieve": "mdi:history"
+  }
+}

--- a/homeassistant/components/history/services.yaml
+++ b/homeassistant/components/history/services.yaml
@@ -1,0 +1,13 @@
+retrieve:
+  fields:
+    entity_ids:
+      required: true
+      selector:
+        entity:
+          multiple: true
+    start_time:
+      selector:
+        datetime:
+    end_time:
+      selector:
+        datetime:

--- a/homeassistant/components/history/strings.json
+++ b/homeassistant/components/history/strings.json
@@ -1,0 +1,22 @@
+{
+  "services": {
+    "retrieve": {
+      "name": "Retrieve History",
+      "description": "Get history for an entity",
+      "fields": {
+        "entity_ids": {
+          "name": "Entities",
+          "description": "The entities to get historic data for."
+        },
+        "start_time": {
+          "name": "Start time",
+          "description": "Start of the historic period to retrieve. Defaults to one day before end time."
+        },
+        "end_time": {
+          "name": "End time",
+          "description": "End of the historic period to retrieve. Defaults to now."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I found myself trying to access historic state information for entities a few times. For example to compare a current value with a previous value. 
For now, there are limit ways to access historic information. For some use cases you can use a bunch of helper items that you then have to manage. Or you can use the API, or even a 3rd party database, both of which feel cumbersome to query inside a script.
Now that we have the ability to return data from service calls, i figured i would extend the history integration with a service to access historic information.
One fun automation i implemented using this is querying my energy meter history and just feeding it to an LLM using conversation.process, asking it to give a snarky comment of my power usage of the previous day, compared to the week so far, as a motivation to me and my family to be more energy conscious.

For now, i decided to keep the PR simple and not add a bunch of features. 
You give call the service with a list of entities. Optionally you can add a start/end timestamp, both of which have dynamic defaults.
```yaml
service: history.retrieve
data:
  entity_ids:
    - sensor.sun_next_rising
  start_time: "2024-06-09 06:45:12"
  end_time: "2024-06-19 08:11:42"
```
The response is the exact same that the API provides, which is a `dict[str,list[state]]`
```yaml
sensor.sun_next_rising:
  - entity_id: sensor.sun_next_rising
    state: "2024-05-29T03:20:53+00:00"
    attributes: {}
    last_changed: "2024-06-01T17:43:22.710122+00:00"
    last_reported: "2024-06-01T17:43:22.710122+00:00"
    last_updated: "2024-06-01T17:43:22.710122+00:00"
    context:
      id: 01HZD0PZ5X1M6J8048BFB8CVCN
      parent_id: null
      user_id: null
  - state: "2024-06-03T03:16:48+00:00"
    last_changed: "2024-06-02T15:30:36.071566+00:00"
```

After a short discussion in the discord, i decided to not add any more features. I initially had parameters to aggregate the data, but decided to remove these, since its easy enough to aggregate yourself using templating.
The function i use to access historic data (`get_significant_states_with_session`) has a lot more paramaters, for which i decided to put a bunch of defaults that seemed reasonable to me.

I am in no way a python dev, nor do i know much about home assistant development. So any input on this is very welcome.
I have not added any tests yet, i will have to check into how to do that. As a strong proponent of test-driven development myself, i apologize for this ;)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: `will add once i'm done with it`

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository] `will add once i'm done with it`

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository. `I am not sure i am qualified to do this, but i will have a look`

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
