### PR TITLE
Bump reolink-aio to 0.9.1

### DIFF
--- a/homeassistant/components/reolink/entity.py
+++ b/homeassistant/components/reolink/entity.py
@@ -91,18 +91,14 @@ class ReolinkHostCoordinatorEntity(ReolinkBaseCoordinatorEntity[None]):
         await super().async_added_to_hass()
         cmd_key = self.entity_description.cmd_key
         if cmd_key is not None:
-            self._host.update_cmd_list_count[cmd_key].setdefault("host", 0)
-            self._host.update_cmd_list_count[cmd_key]["host"] += 1
-            self._host.update_cmd_list.setdefault(cmd_key, [])
+            self._host.async_register_update_cmd(cmd_key)
 
     async def async_will_remove_from_hass(self) -> None:
         """Entity removed."""
         cmd_key = self.entity_description.cmd_key
         if cmd_key is not None:
-            self._host.update_cmd_list_count[cmd_key]["host"] -= 1
-            if self._host.update_cmd_list_count[cmd_key]["host"] <= 0:
-                self._host.update_cmd_list_count.pop(cmd_key)
-                self._host.update_cmd_list.pop(cmd_key)
+            self._host.async_unregister_update_cmd(cmd_key)
+
         await super().async_will_remove_from_hass()
 
 
@@ -144,17 +140,12 @@ class ReolinkChannelCoordinatorEntity(ReolinkHostCoordinatorEntity):
         await super().async_added_to_hass()
         cmd_key = self.entity_description.cmd_key
         if cmd_key is not None:
-            self._host.update_cmd_list_count[cmd_key].setdefault(self._channel, 0)
-            self._host.update_cmd_list_count[cmd_key][self._channel] += 1
-            if self._channel not in self._host.update_cmd_list[cmd_key]:
-                self._host.update_cmd_list[cmd_key].append(self._channel)
+            self._host.async_register_update_cmd(cmd_key, self._channel)
 
     async def async_will_remove_from_hass(self) -> None:
         """Entity removed."""
         cmd_key = self.entity_description.cmd_key
         if cmd_key is not None:
-            self._host.update_cmd_list_count[cmd_key][self._channel] -= 1
-            if self._host.update_cmd_list_count[cmd_key][self._channel] <= 0:
-                self._host.update_cmd_list_count[cmd_key].pop(self._channel)
-                self._host.update_cmd_list[cmd_key].remove(self._channel)
+            self._host.async_unregister_update_cmd(cmd_key, self._channel)
+
         await super().async_will_remove_from_hass()

--- a/homeassistant/components/reolink/entity.py
+++ b/homeassistant/components/reolink/entity.py
@@ -100,10 +100,11 @@ class ReolinkHostCoordinatorEntity(ReolinkBaseCoordinatorEntity[None]):
     async def async_will_remove_from_hass(self) -> None:
         """Entity removed."""
         cmd_key = self.entity_description.cmd_key
-        self._update_cmd_list_count[cmd_key]["host"] -= 1
-        if self._update_cmd_list_count[cmd_key]["host"] <= 0:
-            self._update_cmd_list_count.pop(cmd_key)
-            self._host.update_cmd_list.pop(cmd_key)
+        if cmd_key is not None:
+            self._update_cmd_list_count[cmd_key]["host"] -= 1
+            if self._update_cmd_list_count[cmd_key]["host"] <= 0:
+                self._update_cmd_list_count.pop(cmd_key)
+                self._host.update_cmd_list.pop(cmd_key)
         await super().async_will_remove_from_hass()
 
 
@@ -153,8 +154,9 @@ class ReolinkChannelCoordinatorEntity(ReolinkHostCoordinatorEntity):
     async def async_will_remove_from_hass(self) -> None:
         """Entity removed."""
         cmd_key = self.entity_description.cmd_key
-        self._update_cmd_list_count[cmd_key][self._channel] -= 1
-        if self._update_cmd_list_count[cmd_key][self._channel] <= 0:
-            self._update_cmd_list_count[cmd_key].pop(self._channel)
-            self._host.update_cmd_list[cmd_key].remove(self._channel)
+        if cmd_key is not None:
+            self._update_cmd_list_count[cmd_key][self._channel] -= 1
+            if self._update_cmd_list_count[cmd_key][self._channel] <= 0:
+                self._update_cmd_list_count[cmd_key].pop(self._channel)
+                self._host.update_cmd_list[cmd_key].remove(self._channel)
         await super().async_will_remove_from_hass()

--- a/homeassistant/components/reolink/entity.py
+++ b/homeassistant/components/reolink/entity.py
@@ -85,15 +85,26 @@ class ReolinkHostCoordinatorEntity(ReolinkBaseCoordinatorEntity[None]):
         super().__init__(reolink_data, reolink_data.device_coordinator)
 
         self._attr_unique_id = f"{self._host.unique_id}_{self.entity_description.key}"
+        self._update_cmd_list_count: dict[str, dict[int, int]] = {}
 
     async def async_added_to_hass(self) -> None:
         """Entity created."""
         await super().async_added_to_hass()
-        if (
-            self.entity_description.cmd_key is not None
-            and self.entity_description.cmd_key not in self._host.update_cmd_list
-        ):
-            self._host.update_cmd_list[self.entity_description.cmd_key] = []
+        cmd_key = self.entity_description.cmd_key
+        if cmd_key is not None:
+            self._update_cmd_list_count.setdefault(cmd_key, {})
+            self._update_cmd_list_count[cmd_key].setdefault(-1, 0)
+            self._update_cmd_list_count[cmd_key][-1] += 1
+            self._host.update_cmd_list.setdefault(cmd_key, [])
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Entity removed."""
+        cmd_key = self.entity_description.cmd_key
+        self._update_cmd_list_count[cmd_key][-1] -= 1
+        if self._update_cmd_list_count[cmd_key][-1] <= 0:
+            self._update_cmd_list_count.pop(cmd_key)
+            self._host.update_cmd_list.pop(cmd_key)
+        await super().async_will_remove_from_hass()
 
 
 class ReolinkChannelCoordinatorEntity(ReolinkHostCoordinatorEntity):
@@ -133,8 +144,17 @@ class ReolinkChannelCoordinatorEntity(ReolinkHostCoordinatorEntity):
         """Entity created."""
         await super().async_added_to_hass()
         cmd_key = self.entity_description.cmd_key
-        if (
-            cmd_key is not None
-            and self._channel not in self._host.update_cmd_list[cmd_key]
-        ):
-            self._host.update_cmd_list[cmd_key].append(self._channel)
+        if cmd_key is not None:
+            self._update_cmd_list_count[cmd_key].setdefault(self._channel, 0)
+            self._update_cmd_list_count[cmd_key][self._channel] += 1
+            if self._channel not in self._host.update_cmd_list[cmd_key]:
+                self._host.update_cmd_list[cmd_key].append(self._channel)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Entity removed."""
+        cmd_key = self.entity_description.cmd_key
+        self._update_cmd_list_count[cmd_key][self._channel] -= 1
+        if self._update_cmd_list_count[cmd_key][self._channel] <= 0:
+            self._update_cmd_list_count[cmd_key].pop(self._channel)
+            self._host.update_cmd_list[cmd_key].remove(self._channel)
+        await super().async_will_remove_from_hass()

--- a/homeassistant/components/reolink/entity.py
+++ b/homeassistant/components/reolink/entity.py
@@ -85,7 +85,7 @@ class ReolinkHostCoordinatorEntity(ReolinkBaseCoordinatorEntity[None]):
         super().__init__(reolink_data, reolink_data.device_coordinator)
 
         self._attr_unique_id = f"{self._host.unique_id}_{self.entity_description.key}"
-        self._update_cmd_list_count: dict[str, dict[int, int]] = {}
+        self._update_cmd_list_count: dict[str, dict[int | str, int]] = {}
 
     async def async_added_to_hass(self) -> None:
         """Entity created."""
@@ -93,15 +93,15 @@ class ReolinkHostCoordinatorEntity(ReolinkBaseCoordinatorEntity[None]):
         cmd_key = self.entity_description.cmd_key
         if cmd_key is not None:
             self._update_cmd_list_count.setdefault(cmd_key, {})
-            self._update_cmd_list_count[cmd_key].setdefault(-1, 0)
-            self._update_cmd_list_count[cmd_key][-1] += 1
+            self._update_cmd_list_count[cmd_key].setdefault("host", 0)
+            self._update_cmd_list_count[cmd_key]["host"] += 1
             self._host.update_cmd_list.setdefault(cmd_key, [])
 
     async def async_will_remove_from_hass(self) -> None:
         """Entity removed."""
         cmd_key = self.entity_description.cmd_key
-        self._update_cmd_list_count[cmd_key][-1] -= 1
-        if self._update_cmd_list_count[cmd_key][-1] <= 0:
+        self._update_cmd_list_count[cmd_key]["host"] -= 1
+        if self._update_cmd_list_count[cmd_key]["host"] <= 0:
             self._update_cmd_list_count.pop(cmd_key)
             self._host.update_cmd_list.pop(cmd_key)
         await super().async_will_remove_from_hass()

--- a/homeassistant/components/reolink/entity.py
+++ b/homeassistant/components/reolink/entity.py
@@ -93,7 +93,7 @@ class ReolinkHostCoordinatorEntity(ReolinkBaseCoordinatorEntity[None]):
             self.entity_description.cmd_key is not None
             and self.entity_description.cmd_key not in self._host.update_cmd_list
         ):
-            self._host.update_cmd_list.append(self.entity_description.cmd_key)
+            self._host.update_cmd_list[self.entity_description.cmd_key] = []
 
 
 class ReolinkChannelCoordinatorEntity(ReolinkHostCoordinatorEntity):
@@ -128,3 +128,13 @@ class ReolinkChannelCoordinatorEntity(ReolinkHostCoordinatorEntity):
                 sw_version=self._host.api.camera_sw_version(dev_ch),
                 configuration_url=self._conf_url,
             )
+
+    async def async_added_to_hass(self) -> None:
+        """Entity created."""
+        await super().async_added_to_hass()
+        cmd_key = self.entity_description.cmd_key
+        if (
+            cmd_key is not None
+            and self._channel not in self._host.update_cmd_list[cmd_key]
+        ):
+            self._host.update_cmd_list[cmd_key].append(self._channel)

--- a/homeassistant/components/reolink/entity.py
+++ b/homeassistant/components/reolink/entity.py
@@ -85,25 +85,24 @@ class ReolinkHostCoordinatorEntity(ReolinkBaseCoordinatorEntity[None]):
         super().__init__(reolink_data, reolink_data.device_coordinator)
 
         self._attr_unique_id = f"{self._host.unique_id}_{self.entity_description.key}"
-        self._update_cmd_list_count: dict[str, dict[int | str, int]] = {}
 
     async def async_added_to_hass(self) -> None:
         """Entity created."""
         await super().async_added_to_hass()
         cmd_key = self.entity_description.cmd_key
         if cmd_key is not None:
-            self._update_cmd_list_count.setdefault(cmd_key, {})
-            self._update_cmd_list_count[cmd_key].setdefault("host", 0)
-            self._update_cmd_list_count[cmd_key]["host"] += 1
+            self._host.update_cmd_list_count.setdefault(cmd_key, {})
+            self._host.update_cmd_list_count[cmd_key].setdefault("host", 0)
+            self._host.update_cmd_list_count[cmd_key]["host"] += 1
             self._host.update_cmd_list.setdefault(cmd_key, [])
 
     async def async_will_remove_from_hass(self) -> None:
         """Entity removed."""
         cmd_key = self.entity_description.cmd_key
         if cmd_key is not None:
-            self._update_cmd_list_count[cmd_key]["host"] -= 1
-            if self._update_cmd_list_count[cmd_key]["host"] <= 0:
-                self._update_cmd_list_count.pop(cmd_key)
+            self._host.update_cmd_list_count[cmd_key]["host"] -= 1
+            if self._host.update_cmd_list_count[cmd_key]["host"] <= 0:
+                self._host.update_cmd_list_count.pop(cmd_key)
                 self._host.update_cmd_list.pop(cmd_key)
         await super().async_will_remove_from_hass()
 
@@ -146,8 +145,8 @@ class ReolinkChannelCoordinatorEntity(ReolinkHostCoordinatorEntity):
         await super().async_added_to_hass()
         cmd_key = self.entity_description.cmd_key
         if cmd_key is not None:
-            self._update_cmd_list_count[cmd_key].setdefault(self._channel, 0)
-            self._update_cmd_list_count[cmd_key][self._channel] += 1
+            self._host.update_cmd_list_count[cmd_key].setdefault(self._channel, 0)
+            self._host.update_cmd_list_count[cmd_key][self._channel] += 1
             if self._channel not in self._host.update_cmd_list[cmd_key]:
                 self._host.update_cmd_list[cmd_key].append(self._channel)
 
@@ -155,8 +154,8 @@ class ReolinkChannelCoordinatorEntity(ReolinkHostCoordinatorEntity):
         """Entity removed."""
         cmd_key = self.entity_description.cmd_key
         if cmd_key is not None:
-            self._update_cmd_list_count[cmd_key][self._channel] -= 1
-            if self._update_cmd_list_count[cmd_key][self._channel] <= 0:
-                self._update_cmd_list_count[cmd_key].pop(self._channel)
+            self._host.update_cmd_list_count[cmd_key][self._channel] -= 1
+            if self._host.update_cmd_list_count[cmd_key][self._channel] <= 0:
+                self._host.update_cmd_list_count[cmd_key].pop(self._channel)
                 self._host.update_cmd_list[cmd_key].remove(self._channel)
         await super().async_will_remove_from_hass()

--- a/homeassistant/components/reolink/entity.py
+++ b/homeassistant/components/reolink/entity.py
@@ -91,7 +91,6 @@ class ReolinkHostCoordinatorEntity(ReolinkBaseCoordinatorEntity[None]):
         await super().async_added_to_hass()
         cmd_key = self.entity_description.cmd_key
         if cmd_key is not None:
-            self._host.update_cmd_list_count.setdefault(cmd_key, {})
             self._host.update_cmd_list_count[cmd_key].setdefault("host", 0)
             self._host.update_cmd_list_count[cmd_key]["host"] += 1
             self._host.update_cmd_list.setdefault(cmd_key, [])

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -67,7 +67,7 @@ class ReolinkHost:
             timeout=DEFAULT_TIMEOUT,
         )
 
-        self.update_cmd_list: dict[str : list[int]] = {}
+        self.update_cmd_list: dict[str, list[int]] = {}
 
         self.webhook_id: str | None = None
         self._onvif_push_supported: bool = True

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -22,7 +22,7 @@ from homeassistant.const import (
     CONF_PROTOCOL,
     CONF_USERNAME,
 )
-from homeassistant.core import CALLBACK_TYPE, HassJob, HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HassJob, HomeAssistant, callback
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -68,9 +68,8 @@ class ReolinkHost:
             timeout=DEFAULT_TIMEOUT,
         )
 
-        self.update_cmd_list: dict[str, list[int]] = {}
-        self.update_cmd_list_count: defaultdict[str, dict[int | str, int]] = (
-            defaultdict(dict)
+        self._update_cmd: defaultdict[str, defaultdict[int | None, int]] = defaultdict(
+            lambda: defaultdict(int)
         )
 
         self.webhook_id: str | None = None
@@ -87,6 +86,20 @@ class ReolinkHost:
         self._poll_job = HassJob(self._async_poll_all_motion, cancel_on_shutdown=True)
         self._long_poll_task: asyncio.Task | None = None
         self._lost_subscription: bool = False
+
+    @callback
+    def async_register_update_cmd(self, cmd: str, channel: int | None = None) -> None:
+        """Register the command to update the state."""
+        self._update_cmd[cmd][channel] += 1
+
+    @callback
+    def async_unregister_update_cmd(self, cmd: str, channel: int | None = None) -> None:
+        """Unregister the command to update the state."""
+        self._update_cmd[cmd][channel] -= 1
+        if self._update_cmd[cmd][channel] <= 0:
+            del self._update_cmd[cmd][channel]
+        if not self._update_cmd[cmd]:
+            del self._update_cmd[cmd]
 
     @property
     def unique_id(self) -> str:
@@ -324,7 +337,7 @@ class ReolinkHost:
 
     async def update_states(self) -> None:
         """Call the API of the camera device to update the internal states."""
-        await self._api.get_states(cmd_list=self.update_cmd_list)
+        await self._api.get_states(cmd_list=self._update_cmd)
 
     async def disconnect(self) -> None:
         """Disconnect from the API, so the connection will be released."""

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -68,6 +68,7 @@ class ReolinkHost:
         )
 
         self.update_cmd_list: dict[str, list[int]] = {}
+        self.update_cmd_list_count: dict[str, dict[int | str, int]] = {}
 
         self.webhook_id: str | None = None
         self._onvif_push_supported: bool = True

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections import defaultdict
 from collections.abc import Mapping
 import logging
 from typing import Any, Literal
@@ -68,7 +69,9 @@ class ReolinkHost:
         )
 
         self.update_cmd_list: dict[str, list[int]] = {}
-        self.update_cmd_list_count: dict[str, dict[int | str, int]] = {}
+        self.update_cmd_list_count: defaultdict[str, dict[int | str, int]] = (
+            defaultdict(dict)
+        )
 
         self.webhook_id: str | None = None
         self._onvif_push_supported: bool = True

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -96,7 +96,7 @@ class ReolinkHost:
     def async_unregister_update_cmd(self, cmd: str, channel: int | None = None) -> None:
         """Unregister the command to update the state."""
         self._update_cmd[cmd][channel] -= 1
-        if self._update_cmd[cmd][channel] <= 0:
+        if not self._update_cmd[cmd][channel]:
             del self._update_cmd[cmd][channel]
         if not self._update_cmd[cmd]:
             del self._update_cmd[cmd]

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -67,7 +67,7 @@ class ReolinkHost:
             timeout=DEFAULT_TIMEOUT,
         )
 
-        self.update_cmd_list: list[str] = []
+        self.update_cmd_list: dict[str : list[int]] = {}
 
         self.webhook_id: str | None = None
         self._onvif_push_supported: bool = True

--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -18,5 +18,5 @@
   "documentation": "https://www.home-assistant.io/integrations/reolink",
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
-  "requirements": ["reolink-aio==0.8.11"]
+  "requirements": ["reolink-aio==0.9.0"]
 }

--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -18,5 +18,5 @@
   "documentation": "https://www.home-assistant.io/integrations/reolink",
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
-  "requirements": ["reolink-aio==0.9.0"]
+  "requirements": ["reolink-aio==0.9.1"]
 }

--- a/homeassistant/components/reolink/select.py
+++ b/homeassistant/components/reolink/select.py
@@ -109,12 +109,14 @@ SELECT_ENTITIES = (
     ReolinkSelectEntityDescription(
         key="status_led",
         cmd_key="GetPowerLed",
-        translation_key="status_led",
+        translation_key="doorbell_led",
         entity_category=EntityCategory.CONFIG,
-        get_options=[state.name for state in StatusLedEnum],
+        get_options=lambda api, ch: api.doorbell_led_list(ch),
         supported=lambda api, ch: api.supported(ch, "doorbell_led"),
         value=lambda api, ch: StatusLedEnum(api.doorbell_led(ch)).name,
-        method=lambda api, ch, name: api.set_status_led(ch, StatusLedEnum[name].value),
+        method=lambda api, ch, name: (
+            api.set_status_led(ch, StatusLedEnum[name].value, doorbell=True)
+        ),
     ),
 )
 

--- a/homeassistant/components/reolink/strings.json
+++ b/homeassistant/components/reolink/strings.json
@@ -463,8 +463,8 @@
           "pantiltfirst": "Pan/tilt first"
         }
       },
-      "status_led": {
-        "name": "Status LED",
+      "doorbell_led": {
+        "name": "Doorbell LED",
         "state": {
           "stayoff": "Stay off",
           "auto": "Auto",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2454,7 +2454,7 @@ renault-api==0.2.2
 renson-endura-delta==1.7.1
 
 # homeassistant.components.reolink
-reolink-aio==0.9.0
+reolink-aio==0.9.1
 
 # homeassistant.components.idteck_prox
 rfk101py==0.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2454,7 +2454,7 @@ renault-api==0.2.2
 renson-endura-delta==1.7.1
 
 # homeassistant.components.reolink
-reolink-aio==0.8.11
+reolink-aio==0.9.0
 
 # homeassistant.components.idteck_prox
 rfk101py==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1912,7 +1912,7 @@ renault-api==0.2.2
 renson-endura-delta==1.7.1
 
 # homeassistant.components.reolink
-reolink-aio==0.9.0
+reolink-aio==0.9.1
 
 # homeassistant.components.rflink
 rflink==0.0.66

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1912,7 +1912,7 @@ renault-api==0.2.2
 renson-endura-delta==1.7.1
 
 # homeassistant.components.reolink
-reolink-aio==0.8.11
+reolink-aio==0.9.0
 
 # homeassistant.components.rflink
 rflink==0.0.66


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
**Breaking changes:**
- [get_states cmd_list now a dict[str, list[int]] and added wake boolean](https://github.com/starkillerOG/reolink_aio/commit/9ffadcf9b40e6d4489fc06104477329cc12315a7)
- [allow control off both Doorbell LEDs](https://github.com/starkillerOG/reolink_aio/commit/de293cf52de7b114de88621feb67b65d14286852)

**Additions:**
- [Add manual recording capability](https://github.com/starkillerOG/reolink_aio/commit/49dda81efdea7bc0168602f10168654d40fb3090)
- [Add doorbell_led_list](https://github.com/starkillerOG/reolink_aio/commit/1479a14de13984999a5686e5ef04fc25ea3f9c17)
- [Add sleep status support](https://github.com/starkillerOG/reolink_aio/commit/c9c305062660372004b9178c0424f0468e913205)
- [Add channel_for_uid method](https://github.com/starkillerOG/reolink_aio/commit/ea88734513c6114ae46d939c1c7114fb8b556b14)

**Bug fixes:**
- [Add width and height to snapshot sub resolution request](https://github.com/starkillerOG/reolink_aio/commit/d8f6263641c6e2d330fadaaa789274e635d494e9)
- [get_state only get channels that support that feature](https://github.com/starkillerOG/reolink_aio/commit/0e0405c3ff14835a1351807c5bc6735ea3e14db9)
- [Do not request GetAiAlarm for "other" type](https://github.com/starkillerOG/reolink_aio/commit/82b410ca8df2a18417f1c7013676a671b77117dd)
- [Implement GetPushCfg for host level push enabled status](https://github.com/starkillerOG/reolink_aio/commit/c49aa6c167af4c4c9d1f8daa673173e56e2481ef)

**Optimizations:**
- [Add debug log about checking RTSP urls](https://github.com/starkillerOG/reolink_aio/commit/119fa7fe0c35d10e8526d518495feccbf5d58c29)
- [Ensure channel UIDs are unique](https://github.com/starkillerOG/reolink_aio/commit/c901194f9c8010bec2c57c9759564e0c46ab6f84)
- [fix camera_uid](https://github.com/starkillerOG/reolink_aio/commit/29b410cdfac7e90bf85e1859f4772d654faf137b)
- [Allow cmd_list type DefaultDict[str, DefaultDict[int | None, int]]](https://github.com/starkillerOG/reolink_aio/commit/d64d7ad4ca152dcfa752ba450a89fa9bc0193f3b)
- [Drop python 3.9 support](https://github.com/starkillerOG/reolink_aio/commit/7161184ef9a0f6fd6a0f5c1a9463b9e218c388fc)

**Full Changelog**: https://github.com/starkillerOG/reolink_aio/compare/0.8.11...0.9.1

Due to a breaking change in reolink-aio regarding the structure of the cmd_list and the doorbell LED, some small adjustments are needed in the bump PR. The rest of the changes will be done in split out PRs to make Battery cameras fully compatible (and not drain their batteries).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33045

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
