### PR TITLE
Bump ZHA dependencies

### DIFF
--- a/homeassistant/components/zha/backup.py
+++ b/homeassistant/components/zha/backup.py
@@ -13,7 +13,13 @@ async def async_pre_backup(hass: HomeAssistant) -> None:
     """Perform operations before a backup starts."""
     _LOGGER.debug("Performing coordinator backup")
 
-    zha_gateway = get_zha_gateway(hass)
+    try:
+        zha_gateway = get_zha_gateway(hass)
+    except ValueError:
+        # If ZHA config is in `configuration.yaml` and ZHA is not set up, do nothing
+        _LOGGER.warning("No ZHA gateway exists, skipping coordinator backup")
+        return
+
     await zha_gateway.application_controller.backups.create_backup(load_devices=True)
 
 

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -29,7 +29,7 @@
     "zigpy-xbee==0.20.1",
     "zigpy-zigate==0.12.0",
     "zigpy-znp==0.12.1",
-    "universal-silabs-flasher==0.0.18",
+    "universal-silabs-flasher==0.0.20",
     "pyserial-asyncio-fast==0.11"
   ],
   "usb": [

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -21,7 +21,7 @@
     "universal_silabs_flasher"
   ],
   "requirements": [
-    "bellows==0.38.4",
+    "bellows==0.39.0",
     "pyserial==3.5",
     "zha-quirks==0.0.116",
     "zigpy-deconz==0.23.1",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -547,7 +547,7 @@ beautifulsoup4==4.12.3
 # beewi-smartclim==0.0.10
 
 # homeassistant.components.zha
-bellows==0.38.4
+bellows==0.39.0
 
 # homeassistant.components.bmw_connected_drive
 bimmer-connected[china]==0.15.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2794,7 +2794,7 @@ unifi_ap==0.0.1
 unifiled==0.11
 
 # homeassistant.components.zha
-universal-silabs-flasher==0.0.18
+universal-silabs-flasher==0.0.20
 
 # homeassistant.components.upb
 upb-lib==0.5.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -472,7 +472,7 @@ base36==0.1.1
 beautifulsoup4==4.12.3
 
 # homeassistant.components.zha
-bellows==0.38.4
+bellows==0.39.0
 
 # homeassistant.components.bmw_connected_drive
 bimmer-connected[china]==0.15.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2162,7 +2162,7 @@ ultraheat-api==0.5.7
 unifi-discovery==1.1.8
 
 # homeassistant.components.zha
-universal-silabs-flasher==0.0.18
+universal-silabs-flasher==0.0.20
 
 # homeassistant.components.upb
 upb-lib==0.5.6

--- a/tests/components/zha/test_backup.py
+++ b/tests/components/zha/test_backup.py
@@ -1,6 +1,6 @@
 """Unit tests for ZHA backup platform."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 from zigpy.application import ControllerApplication
 
@@ -20,6 +20,13 @@ async def test_pre_backup(
     zigpy_app_controller.backups.create_backup.assert_called_once_with(
         load_devices=True
     )
+
+
+@patch("homeassistant.components.zha.backup.get_zha_gateway", side_effect=ValueError())
+async def test_pre_backup_no_gateway(hass: HomeAssistant, setup_zha) -> None:
+    """Test graceful backup failure when no gateway exists."""
+    await setup_zha()
+    await async_pre_backup(hass)
 
 
 async def test_post_backup(hass: HomeAssistant, setup_zha) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bumps ZHA dependencies:

- bellows to [0.39.0](https://github.com/zigpy/bellows/releases/tag/0.39.0)
- universal-silabs-flasher to [0.20.0](https://github.com/NabuCasa/universal-silabs-flasher/releases/tag/v0.0.20)

We recently made the EZSP protocol parsing a little stricter and there are still some commands that were being parsed improperly. One of these is preventing backups from being created when certain firmware versions are installed.

The flasher is bumped as well because it loosely pins bellows to a specific minor version.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #117859
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
