### PR TITLE
Remove legacy list event calendar service

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -38,7 +38,6 @@ from homeassistant.helpers.config_validation import (  # noqa: F401
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.event import async_track_point_in_time
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.template import DATE_STR_FORMAT
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import dt as dt_util
@@ -268,8 +267,6 @@ CALENDAR_EVENT_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
-LEGACY_SERVICE_LIST_EVENTS: Final = "list_events"
-"""Deprecated: please use SERVICE_LIST_EVENTS."""
 SERVICE_GET_EVENTS: Final = "get_events"
 SERVICE_GET_EVENTS_SCHEMA: Final = vol.All(
     cv.has_at_least_one_key(EVENT_END_DATETIME, EVENT_DURATION),
@@ -308,12 +305,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         CREATE_EVENT_SCHEMA,
         async_create_event,
         required_features=[CalendarEntityFeature.CREATE_EVENT],
-    )
-    component.async_register_legacy_entity_service(
-        LEGACY_SERVICE_LIST_EVENTS,
-        SERVICE_GET_EVENTS_SCHEMA,
-        async_list_events_service,
-        supports_response=SupportsResponse.ONLY,
     )
     component.async_register_entity_service(
         SERVICE_GET_EVENTS,
@@ -866,32 +857,6 @@ async def async_create_event(entity: CalendarEntity, call: ServiceCall) -> None:
         EVENT_END: end,
     }
     await entity.async_create_event(**params)
-
-
-async def async_list_events_service(
-    calendar: CalendarEntity, service_call: ServiceCall
-) -> ServiceResponse:
-    """List events on a calendar during a time range.
-
-    Deprecated: please use async_get_events_service.
-    """
-    _LOGGER.warning(
-        "Detected use of service 'calendar.list_events'. "
-        "This is deprecated and will stop working in Home Assistant 2024.6. "
-        "Use 'calendar.get_events' instead which supports multiple entities",
-    )
-    async_create_issue(
-        calendar.hass,
-        DOMAIN,
-        "deprecated_service_calendar_list_events",
-        breaks_in_ha_version="2024.6.0",
-        is_fixable=True,
-        is_persistent=False,
-        issue_domain=calendar.platform.platform_name,
-        severity=IssueSeverity.WARNING,
-        translation_key="deprecated_service_calendar_list_events",
-    )
-    return await async_get_events_service(calendar, service_call)
 
 
 async def async_get_events_service(

--- a/tests/components/calendar/test_init.py
+++ b/tests/components/calendar/test_init.py
@@ -12,17 +12,12 @@ from syrupy.assertion import SnapshotAssertion
 from typing_extensions import Generator
 import voluptuous as vol
 
-from homeassistant.components.calendar import (
-    DOMAIN,
-    LEGACY_SERVICE_LIST_EVENTS,
-    SERVICE_GET_EVENTS,
-)
+from homeassistant.components.calendar import DOMAIN, SERVICE_GET_EVENTS
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import issue_registry as ir
 import homeassistant.util.dt as dt_util
 
-from .conftest import TEST_DOMAIN, MockCalendarEntity, MockConfigEntry
+from .conftest import MockCalendarEntity, MockConfigEntry
 
 from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
@@ -416,20 +411,6 @@ async def test_create_event_service_invalid_params(
     ("service", "expected"),
     [
         (
-            LEGACY_SERVICE_LIST_EVENTS,
-            {
-                "events": [
-                    {
-                        "start": "2023-06-22T05:00:00-06:00",
-                        "end": "2023-06-22T06:00:00-06:00",
-                        "summary": "Future Event",
-                        "description": "Future Description",
-                        "location": "Future Location",
-                    }
-                ]
-            },
-        ),
-        (
             SERVICE_GET_EVENTS,
             {
                 "calendar.calendar_1": {
@@ -486,7 +467,6 @@ async def test_list_events_service(
 @pytest.mark.parametrize(
     ("service"),
     [
-        (LEGACY_SERVICE_LIST_EVENTS),
         SERVICE_GET_EVENTS,
     ],
 )
@@ -568,37 +548,3 @@ async def test_list_events_missing_fields(hass: HomeAssistant) -> None:
             blocking=True,
             return_response=True,
         )
-
-
-async def test_issue_deprecated_service_calendar_list_events(
-    hass: HomeAssistant,
-    issue_registry: ir.IssueRegistry,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test the issue is raised on deprecated service weather.get_forecast."""
-
-    _ = await hass.services.async_call(
-        DOMAIN,
-        LEGACY_SERVICE_LIST_EVENTS,
-        target={"entity_id": ["calendar.calendar_1"]},
-        service_data={
-            "entity_id": "calendar.calendar_1",
-            "duration": "01:00:00",
-        },
-        blocking=True,
-        return_response=True,
-    )
-
-    issue = issue_registry.async_get_issue(
-        "calendar", "deprecated_service_calendar_list_events"
-    )
-    assert issue
-    assert issue.issue_domain == TEST_DOMAIN
-    assert issue.issue_id == "deprecated_service_calendar_list_events"
-    assert issue.translation_key == "deprecated_service_calendar_list_events"
-
-    assert (
-        "Detected use of service 'calendar.list_events'. "
-        "This is deprecated and will stop working in Home Assistant 2024.6. "
-        "Use 'calendar.get_events' instead which supports multiple entities"
-    ) in caplog.text

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -2391,7 +2391,7 @@ async def test_execute_script_complex_response(
             "type": "execute_script",
             "sequence": [
                 {
-                    "service": "calendar.list_events",
+                    "service": "calendar.get_events",
                     "data": {"duration": {"hours": 24, "minutes": 0, "seconds": 0}},
                     "target": {"entity_id": "calendar.calendar_1"},
                     "response_variable": "service_result",
@@ -2405,15 +2405,17 @@ async def test_execute_script_complex_response(
     assert msg_no_var["type"] == const.TYPE_RESULT
     assert msg_no_var["success"]
     assert msg_no_var["result"]["response"] == {
-        "events": [
-            {
-                "start": ANY,
-                "end": ANY,
-                "summary": "Future Event",
-                "description": "Future Description",
-                "location": "Future Location",
-            }
-        ]
+        "calendar.calendar_1": {
+            "events": [
+                {
+                    "start": ANY,
+                    "end": ANY,
+                    "summary": "Future Event",
+                    "description": "Future Description",
+                    "location": "Future Location",
+                }
+            ]
+        }
     }
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Calendar service `list_events` was deprecated in favor of `get_events` in 2023.12 and has now been removed. Use the new `get_events` service

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Removes the deprecated `list_events` service from `calendar`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 