### PR TITLE
Add type hints for requests_mock.Mocker in test fixtures

### DIFF
--- a/tests/components/abode/conftest.py
+++ b/tests/components/abode/conftest.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 
 from jaraco.abode.helpers import urls as URL
 import pytest
+from requests_mock import Mocker
 
 from tests.common import load_fixture
 from tests.components.light.conftest import mock_light_profiles  # noqa: F401
@@ -20,7 +21,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture(autouse=True)
-def requests_mock_fixture(requests_mock) -> None:
+def requests_mock_fixture(requests_mock: Mocker) -> None:
     """Fixture to provide a requests mocker."""
     # Mocks the login response for abodepy.
     requests_mock.post(URL.LOGIN, text=load_fixture("login.json", "abode"))

--- a/tests/components/ecobee/conftest.py
+++ b/tests/components/ecobee/conftest.py
@@ -4,6 +4,7 @@ from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
+from requests_mock import Mocker
 
 from homeassistant.components.ecobee import ECOBEE_API_KEY, ECOBEE_REFRESH_TOKEN
 
@@ -11,7 +12,7 @@ from tests.common import load_fixture, load_json_object_fixture
 
 
 @pytest.fixture(autouse=True)
-def requests_mock_fixture(requests_mock):
+def requests_mock_fixture(requests_mock: Mocker) -> None:
     """Fixture to provide a requests mocker."""
     requests_mock.get(
         "https://api.ecobee.com/1/thermostat",

--- a/tests/components/vultr/conftest.py
+++ b/tests/components/vultr/conftest.py
@@ -4,6 +4,7 @@ import json
 from unittest.mock import patch
 
 import pytest
+from requests_mock import Mocker
 
 from homeassistant.components import vultr
 from homeassistant.core import HomeAssistant
@@ -14,7 +15,7 @@ from tests.common import load_fixture
 
 
 @pytest.fixture(name="valid_config")
-def valid_config(hass: HomeAssistant, requests_mock):
+def valid_config(hass: HomeAssistant, requests_mock: Mocker) -> None:
     """Load a valid config."""
     requests_mock.get(
         "https://api.vultr.com/v1/account/info?api_key=ABCDEFG1234567",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA
https://github.com/home-assistant/core/blob/bb259b607fd963eaed3b916256d86f09810e1a54/pylint/plugins/hass_enforce_type_hints.py#L150

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
