### PR TITLE
Add type hints for Recorder in test fixtures

### DIFF
--- a/tests/components/energy/test_validate.py
+++ b/tests/components/energy/test_validate.py
@@ -5,6 +5,8 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components.energy import async_get_manager, validate
+from homeassistant.components.energy.data import EnergyManager
+from homeassistant.components.recorder import Recorder
 from homeassistant.const import UnitOfEnergy
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.json import JSON_DUMP
@@ -46,7 +48,9 @@ def mock_get_metadata():
 
 
 @pytest.fixture(autouse=True)
-async def mock_energy_manager(recorder_mock, hass):
+async def mock_energy_manager(
+    recorder_mock: Recorder, hass: HomeAssistant
+) -> EnergyManager:
     """Set up energy."""
     assert await async_setup_component(hass, "energy", {"energy": {}})
     manager = await async_get_manager(hass)

--- a/tests/components/energy/test_websocket_api.py
+++ b/tests/components/energy/test_websocket_api.py
@@ -21,13 +21,13 @@ from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture(autouse=True)
-async def setup_integration(recorder_mock, hass):
+async def setup_integration(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Set up the integration."""
     assert await async_setup_component(hass, "energy", {})
 
 
 @pytest.fixture
-def mock_energy_platform(hass):
+def mock_energy_platform(hass: HomeAssistant) -> None:
     """Mock an energy platform."""
     hass.config.components.add("some_domain")
     mock_platform(

--- a/tests/components/recorder/test_filters_with_entityfilter_schema_37.py
+++ b/tests/components/recorder/test_filters_with_entityfilter_schema_37.py
@@ -1,5 +1,6 @@
 """The tests for the recorder filter matching the EntityFilter component."""
 
+from collections.abc import AsyncGenerator
 import json
 from unittest.mock import patch
 
@@ -38,7 +39,9 @@ def db_schema_32():
 
 
 @pytest.fixture(name="legacy_recorder_mock")
-async def legacy_recorder_mock_fixture(recorder_mock):
+async def legacy_recorder_mock_fixture(
+    recorder_mock: Recorder,
+) -> AsyncGenerator[Recorder, None]:
     """Fixture for legacy recorder mock."""
     with patch.object(recorder_mock.states_meta_manager, "active", False):
         yield recorder_mock

--- a/tests/components/recorder/test_migration_from_schema_32.py
+++ b/tests/components/recorder/test_migration_from_schema_32.py
@@ -1,5 +1,6 @@
 """The tests for the recorder filter matching the EntityFilter component."""
 
+from collections.abc import AsyncGenerator
 import datetime
 import importlib
 import sys
@@ -14,7 +15,13 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from homeassistant.components import recorder
-from homeassistant.components.recorder import core, db_schema, migration, statistics
+from homeassistant.components.recorder import (
+    Recorder,
+    core,
+    db_schema,
+    migration,
+    statistics,
+)
 from homeassistant.components.recorder.db_schema import (
     Events,
     EventTypes,
@@ -110,7 +117,9 @@ def db_schema_32():
 
 
 @pytest.fixture(name="legacy_recorder_mock")
-async def legacy_recorder_mock_fixture(recorder_mock):
+async def legacy_recorder_mock_fixture(
+    recorder_mock: Recorder,
+) -> AsyncGenerator[Recorder, None]:
     """Fixture for legacy recorder mock."""
     with patch.object(recorder_mock.states_meta_manager, "active", False):
         yield recorder_mock


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA
https://github.com/home-assistant/core/blob/bb259b607fd963eaed3b916256d86f09810e1a54/pylint/plugins/hass_enforce_type_hints.py#L149

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
