### PR TITLE
Refactor fixture calling for BMW tests

### DIFF
--- a/tests/components/bmw_connected_drive/test_button.py
+++ b/tests/components/bmw_connected_drive/test_button.py
@@ -14,10 +14,10 @@ from homeassistant.exceptions import HomeAssistantError
 from . import check_remote_service_call, setup_mocked_integration
 
 
+@pytest.mark.usefixtures("bmw_fixture")
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_entity_state_attrs(
     hass: HomeAssistant,
-    bmw_fixture: respx.Router,
-    entity_registry_enabled_by_default: None,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test button options and values."""
@@ -57,9 +57,9 @@ async def test_service_call_success(
     check_remote_service_call(bmw_fixture, remote_service)
 
 
+@pytest.mark.usefixtures("bmw_fixture")
 async def test_service_call_fail(
     hass: HomeAssistant,
-    bmw_fixture: respx.Router,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test failed button press."""

--- a/tests/components/bmw_connected_drive/test_coordinator.py
+++ b/tests/components/bmw_connected_drive/test_coordinator.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 from bimmer_connected.models import MyBMWAPIError, MyBMWAuthError
 from freezegun.api import FrozenDateTimeFactory
-import respx
+import pytest
 
 from homeassistant.components.bmw_connected_drive import DOMAIN as BMW_DOMAIN
 from homeassistant.core import DOMAIN as HA_DOMAIN, HomeAssistant
@@ -18,7 +18,8 @@ from . import FIXTURE_CONFIG_ENTRY
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-async def test_update_success(hass: HomeAssistant, bmw_fixture: respx.Router) -> None:
+@pytest.mark.usefixtures("bmw_fixture")
+async def test_update_success(hass: HomeAssistant) -> None:
     """Test the reauth form."""
     config_entry = MockConfigEntry(**FIXTURE_CONFIG_ENTRY)
     config_entry.add_to_hass(hass)
@@ -32,8 +33,10 @@ async def test_update_success(hass: HomeAssistant, bmw_fixture: respx.Router) ->
     )
 
 
+@pytest.mark.usefixtures("bmw_fixture")
 async def test_update_failed(
-    hass: HomeAssistant, bmw_fixture: respx.Router, freezer: FrozenDateTimeFactory
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test the reauth form."""
     config_entry = MockConfigEntry(**FIXTURE_CONFIG_ENTRY)
@@ -59,8 +62,10 @@ async def test_update_failed(
     assert isinstance(coordinator.last_exception, UpdateFailed) is True
 
 
+@pytest.mark.usefixtures("bmw_fixture")
 async def test_update_reauth(
-    hass: HomeAssistant, bmw_fixture: respx.Router, freezer: FrozenDateTimeFactory
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test the reauth form."""
     config_entry = MockConfigEntry(**FIXTURE_CONFIG_ENTRY)
@@ -96,10 +101,9 @@ async def test_update_reauth(
     assert isinstance(coordinator.last_exception, ConfigEntryAuthFailed) is True
 
 
+@pytest.mark.usefixtures("bmw_fixture")
 async def test_init_reauth(
     hass: HomeAssistant,
-    bmw_fixture: respx.Router,
-    freezer: FrozenDateTimeFactory,
     issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test the reauth form."""

--- a/tests/components/bmw_connected_drive/test_diagnostics.py
+++ b/tests/components/bmw_connected_drive/test_diagnostics.py
@@ -2,7 +2,6 @@
 
 import datetime
 
-from freezegun import freeze_time
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -19,7 +18,7 @@ from tests.components.diagnostics import (
 from tests.typing import ClientSessionGenerator
 
 
-@freeze_time(datetime.datetime(2022, 7, 10, 11, tzinfo=datetime.UTC))
+@pytest.mark.freeze_time(datetime.datetime(2022, 7, 10, 11, tzinfo=datetime.UTC))
 @pytest.mark.usefixtures("bmw_fixture")
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_config_entry_diagnostics(
@@ -38,7 +37,7 @@ async def test_config_entry_diagnostics(
     assert diagnostics == snapshot
 
 
-@freeze_time(datetime.datetime(2022, 7, 10, 11, tzinfo=datetime.UTC))
+@pytest.mark.freeze_time(datetime.datetime(2022, 7, 10, 11, tzinfo=datetime.UTC))
 @pytest.mark.usefixtures("bmw_fixture")
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_device_diagnostics(

--- a/tests/components/bmw_connected_drive/test_diagnostics.py
+++ b/tests/components/bmw_connected_drive/test_diagnostics.py
@@ -2,6 +2,7 @@
 
 import datetime
 
+from freezegun import freeze_time
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -18,12 +19,12 @@ from tests.components.diagnostics import (
 from tests.typing import ClientSessionGenerator
 
 
-@pytest.mark.freeze_time(datetime.datetime(2022, 7, 10, 11, tzinfo=datetime.UTC))
+@freeze_time(datetime.datetime(2022, 7, 10, 11, tzinfo=datetime.UTC))
+@pytest.mark.usefixtures("bmw_fixture")
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_config_entry_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
-    bmw_fixture,
-    entity_registry_enabled_by_default: None,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test config entry diagnostics."""
@@ -37,13 +38,13 @@ async def test_config_entry_diagnostics(
     assert diagnostics == snapshot
 
 
-@pytest.mark.freeze_time(datetime.datetime(2022, 7, 10, 11, tzinfo=datetime.UTC))
+@freeze_time(datetime.datetime(2022, 7, 10, 11, tzinfo=datetime.UTC))
+@pytest.mark.usefixtures("bmw_fixture")
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_device_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     device_registry: dr.DeviceRegistry,
-    bmw_fixture,
-    entity_registry_enabled_by_default: None,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test device diagnostics."""
@@ -63,12 +64,12 @@ async def test_device_diagnostics(
 
 
 @pytest.mark.freeze_time(datetime.datetime(2022, 7, 10, 11, tzinfo=datetime.UTC))
+@pytest.mark.usefixtures("bmw_fixture")
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_device_diagnostics_vehicle_not_found(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     device_registry: dr.DeviceRegistry,
-    bmw_fixture,
-    entity_registry_enabled_by_default: None,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test device diagnostics when the vehicle cannot be found."""

--- a/tests/components/bmw_connected_drive/test_init.py
+++ b/tests/components/bmw_connected_drive/test_init.py
@@ -3,7 +3,6 @@
 from unittest.mock import patch
 
 import pytest
-import respx
 
 from homeassistant.components.bmw_connected_drive.const import DOMAIN as BMW_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
@@ -137,10 +136,10 @@ async def test_dont_migrate_unique_ids(
     assert entity_migrated != entity_not_changed
 
 
+@pytest.mark.usefixtures("bmw_fixture")
 async def test_remove_stale_devices(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
-    bmw_fixture: respx.Router,
 ) -> None:
     """Test remove stale device registry entries."""
     mock_config_entry = MockConfigEntry(**FIXTURE_CONFIG_ENTRY)

--- a/tests/components/bmw_connected_drive/test_number.py
+++ b/tests/components/bmw_connected_drive/test_number.py
@@ -14,10 +14,10 @@ from homeassistant.exceptions import HomeAssistantError
 from . import check_remote_service_call, setup_mocked_integration
 
 
+@pytest.mark.usefixtures("bmw_fixture")
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_entity_state_attrs(
     hass: HomeAssistant,
-    bmw_fixture: respx.Router,
-    entity_registry_enabled_by_default: None,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test number options and values.."""
@@ -62,6 +62,7 @@ async def test_service_call_success(
     assert hass.states.get(entity_id).state == new_value
 
 
+@pytest.mark.usefixtures("bmw_fixture")
 @pytest.mark.parametrize(
     ("entity_id", "value"),
     [
@@ -72,7 +73,6 @@ async def test_service_call_invalid_input(
     hass: HomeAssistant,
     entity_id: str,
     value: str,
-    bmw_fixture: respx.Router,
 ) -> None:
     """Test not allowed values for number inputs."""
 
@@ -92,6 +92,7 @@ async def test_service_call_invalid_input(
     assert hass.states.get(entity_id).state == old_value
 
 
+@pytest.mark.usefixtures("bmw_fixture")
 @pytest.mark.parametrize(
     ("raised", "expected"),
     [
@@ -104,7 +105,6 @@ async def test_service_call_fail(
     hass: HomeAssistant,
     raised: Exception,
     expected: Exception,
-    bmw_fixture: respx.Router,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test exception handling."""

--- a/tests/components/bmw_connected_drive/test_select.py
+++ b/tests/components/bmw_connected_drive/test_select.py
@@ -14,10 +14,10 @@ from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from . import check_remote_service_call, setup_mocked_integration
 
 
+@pytest.mark.usefixtures("bmw_fixture")
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_entity_state_attrs(
     hass: HomeAssistant,
-    bmw_fixture: respx.Router,
-    entity_registry_enabled_by_default: None,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test select options and values.."""
@@ -74,6 +74,7 @@ async def test_service_call_success(
     assert hass.states.get(entity_id).state == new_value
 
 
+@pytest.mark.usefixtures("bmw_fixture")
 @pytest.mark.parametrize(
     ("entity_id", "value"),
     [
@@ -85,7 +86,6 @@ async def test_service_call_invalid_input(
     hass: HomeAssistant,
     entity_id: str,
     value: str,
-    bmw_fixture: respx.Router,
 ) -> None:
     """Test not allowed values for select inputs."""
 
@@ -105,6 +105,7 @@ async def test_service_call_invalid_input(
     assert hass.states.get(entity_id).state == old_value
 
 
+@pytest.mark.usefixtures("bmw_fixture")
 @pytest.mark.parametrize(
     ("raised", "expected"),
     [
@@ -117,7 +118,6 @@ async def test_service_call_fail(
     hass: HomeAssistant,
     raised: Exception,
     expected: Exception,
-    bmw_fixture: respx.Router,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test exception handling."""

--- a/tests/components/bmw_connected_drive/test_sensor.py
+++ b/tests/components/bmw_connected_drive/test_sensor.py
@@ -2,7 +2,6 @@
 
 from freezegun import freeze_time
 import pytest
-import respx
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.core import HomeAssistant
@@ -16,10 +15,10 @@ from . import setup_mocked_integration
 
 
 @freeze_time("2023-06-22 10:30:00+00:00")
+@pytest.mark.usefixtures("bmw_fixture")
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_entity_state_attrs(
     hass: HomeAssistant,
-    bmw_fixture: respx.Router,
-    entity_registry_enabled_by_default: None,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test sensor options and values.."""
@@ -31,6 +30,7 @@ async def test_entity_state_attrs(
     assert hass.states.async_all("sensor") == snapshot
 
 
+@pytest.mark.usefixtures("bmw_fixture")
 @pytest.mark.parametrize(
     ("entity_id", "unit_system", "value", "unit_of_measurement"),
     [
@@ -56,7 +56,6 @@ async def test_unit_conversion(
     unit_system: UnitSystem,
     value: str,
     unit_of_measurement: str,
-    bmw_fixture,
 ) -> None:
     """Test conversion between metric and imperial units for sensors."""
 

--- a/tests/components/bmw_connected_drive/test_sensor.py
+++ b/tests/components/bmw_connected_drive/test_sensor.py
@@ -1,6 +1,5 @@
 """Test BMW sensors."""
 
-from freezegun import freeze_time
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -14,7 +13,7 @@ from homeassistant.util.unit_system import (
 from . import setup_mocked_integration
 
 
-@freeze_time("2023-06-22 10:30:00+00:00")
+@pytest.mark.freeze_time("2023-06-22 10:30:00+00:00")
 @pytest.mark.usefixtures("bmw_fixture")
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_entity_state_attrs(

--- a/tests/components/bmw_connected_drive/test_switch.py
+++ b/tests/components/bmw_connected_drive/test_switch.py
@@ -14,10 +14,9 @@ from homeassistant.exceptions import HomeAssistantError
 from . import check_remote_service_call, setup_mocked_integration
 
 
+@pytest.mark.usefixtures("bmw_fixture")
 async def test_entity_state_attrs(
     hass: HomeAssistant,
-    bmw_fixture: respx.Router,
-    entity_registry_enabled_by_default: None,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test switch options and values.."""
@@ -65,6 +64,7 @@ async def test_service_call_success(
     assert hass.states.get(entity_id).state == new_value
 
 
+@pytest.mark.usefixtures("bmw_fixture")
 @pytest.mark.parametrize(
     ("raised", "expected"),
     [
@@ -77,7 +77,6 @@ async def test_service_call_fail(
     hass: HomeAssistant,
     raised: Exception,
     expected: Exception,
-    bmw_fixture: respx.Router,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test exception handling."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Cleanup use of pytest fixtures for BMW by using `@pytest.mark.usefixtures()` if no access to fixture object is required for tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
