### PR TITLE
Fix incorrect type hint in dremel_3d_printer tests

### DIFF
--- a/tests/components/dremel_3d_printer/test_binary_sensor.py
+++ b/tests/components/dremel_3d_printer/test_binary_sensor.py
@@ -1,6 +1,6 @@
 """Binary sensor tests for the Dremel 3D Printer integration."""
 
-from unittest.mock import AsyncMock
+import pytest
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.dremel_3d_printer.const import DOMAIN
@@ -11,11 +11,9 @@ from homeassistant.setup import async_setup_component
 from tests.common import MockConfigEntry
 
 
+@pytest.mark.usefixtures("connection", "entity_registry_enabled_by_default")
 async def test_binary_sensors(
-    hass: HomeAssistant,
-    connection,
-    config_entry: MockConfigEntry,
-    entity_registry_enabled_by_default: AsyncMock,
+    hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:
     """Test we get binary sensor data."""
     await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/components/dremel_3d_printer/test_button.py
+++ b/tests/components/dremel_3d_printer/test_button.py
@@ -1,6 +1,6 @@
 """Button tests for the Dremel 3D Printer integration."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -22,11 +22,10 @@ from tests.common import MockConfigEntry
         ("resume", "resume"),
     ],
 )
+@pytest.mark.usefixtures("connection", "entity_registry_enabled_by_default")
 async def test_buttons(
     hass: HomeAssistant,
-    connection: None,
     config_entry: MockConfigEntry,
-    entity_registry_enabled_by_default: AsyncMock,
     button: str,
     function: str,
 ) -> None:

--- a/tests/components/dremel_3d_printer/test_sensor.py
+++ b/tests/components/dremel_3d_printer/test_sensor.py
@@ -1,9 +1,9 @@
 """Sensor tests for the Dremel 3D Printer integration."""
 
 from datetime import datetime
-from unittest.mock import AsyncMock
 
 from freezegun.api import FrozenDateTimeFactory
+import pytest
 
 from homeassistant.components.dremel_3d_printer.const import DOMAIN
 from homeassistant.components.sensor import (
@@ -26,11 +26,10 @@ from homeassistant.util.dt import UTC
 from tests.common import MockConfigEntry
 
 
+@pytest.mark.usefixtures("connection", "entity_registry_enabled_by_default")
 async def test_sensors(
     hass: HomeAssistant,
-    connection,
     config_entry: MockConfigEntry,
-    entity_registry_enabled_by_default: AsyncMock,
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test we get sensor data."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA
Take the opportunity to move to `pytest.mark.usefixtures`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
