### PR TITLE
Make preset list indicate whether the current mount position matches a preset in Vogel's Motionmount

### DIFF
--- a/homeassistant/components/motionmount/select.py
+++ b/homeassistant/components/motionmount/select.py
@@ -65,6 +65,7 @@ class MotionMountPresets(MotionMountEntity, SelectEntity):
                     and preset.turn == self.mm.turn
                 ):
                     self._attr_current_option = f"{preset.index}: {preset.name}"
+                    break
 
         return self._attr_current_option
 

--- a/homeassistant/components/motionmount/select.py
+++ b/homeassistant/components/motionmount/select.py
@@ -54,7 +54,7 @@ class MotionMountPresets(MotionMountEntity, SelectEntity):
         if self.mm.is_moving:
             return self._attr_current_option
 
-        # When the mount doesn't move we select the option that matches the current position
+        # When the mount isn't moving we select the option that matches the current position
         self._attr_current_option = None
         if self.mm.extension == 0 and self.mm.turn == 0:
             self._attr_current_option = self._attr_options[0]  # Select Wall preset

--- a/homeassistant/components/motionmount/select.py
+++ b/homeassistant/components/motionmount/select.py
@@ -25,6 +25,7 @@ class MotionMountPresets(MotionMountEntity, SelectEntity):
 
     _attr_translation_key = "motionmount_preset"
     _attr_current_option: str | None = None
+    _presets: list[motionmount.Preset] = []
 
     def __init__(
         self,
@@ -44,11 +45,29 @@ class MotionMountPresets(MotionMountEntity, SelectEntity):
 
     async def async_update(self) -> None:
         """Get latest state from MotionMount."""
-        presets = await self.mm.get_presets()
-        self._update_options(presets)
+        self._presets = await self.mm.get_presets()
+        self._update_options(self._presets)
 
-        if self._attr_current_option is None:
-            self._attr_current_option = self._attr_options[0]
+    @property
+    def current_option(self) -> str | None:
+        """Get the current option."""
+        # When the mount is moving we return the currently selected option
+        if self.mm.is_moving:
+            return self._attr_current_option
+
+        # When the mount doesn't move we select the option that matches the current position
+        self._attr_current_option = None
+        if self.mm.extension == 0 and self.mm.turn == 0:
+            self._attr_current_option = self._attr_options[0]  # Select Wall preset
+        else:
+            for preset in self._presets:
+                if (
+                    preset.extension == self.mm.extension
+                    and preset.turn == self.mm.turn
+                ):
+                    self._attr_current_option = f"{preset.index}: {preset.name}"
+
+        return self._attr_current_option
 
     async def async_select_option(self, option: str) -> None:
         """Set the new option."""

--- a/homeassistant/components/motionmount/select.py
+++ b/homeassistant/components/motionmount/select.py
@@ -24,8 +24,6 @@ class MotionMountPresets(MotionMountEntity, SelectEntity):
     """The presets of a MotionMount."""
 
     _attr_translation_key = "motionmount_preset"
-    _attr_current_option: str | None = None
-    _presets: list[motionmount.Preset] = []
 
     def __init__(
         self,
@@ -35,6 +33,7 @@ class MotionMountPresets(MotionMountEntity, SelectEntity):
         """Initialize Preset selector."""
         super().__init__(mm, config_entry)
         self._attr_unique_id = f"{self._base_unique_id}-preset"
+        self._presets: list[motionmount.Preset] = []
 
     def _update_options(self, presets: list[motionmount.Preset]) -> None:
         """Convert presets to select options."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
This PR updates the presets list logic such that it shows the preset that matches the current position or no preset if there is no match.
This also makes it easier for user to select a preset if the list happens to have a preset selected while the mount isn't there. In such case the user action would not result in a preset command to be send.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
