### PR TITLE
Remove useless threading locks in mqtt

### DIFF
--- a/homeassistant/components/mqtt/async_client.py
+++ b/homeassistant/components/mqtt/async_client.py
@@ -2,19 +2,24 @@
 
 from __future__ import annotations
 
+from functools import lru_cache
 from types import TracebackType
 from typing import Self
 
 from paho.mqtt.client import Client as MQTTClient
 
+_MQTT_LOCK_COUNT = 7
+
 
 class NullLock:
     """Null lock."""
 
+    @lru_cache(maxsize=_MQTT_LOCK_COUNT)
     def __enter__(self) -> Self:
         """Enter the lock."""
         return self
 
+    @lru_cache(maxsize=_MQTT_LOCK_COUNT)
     def __exit__(
         self,
         exc_type: type[BaseException] | None,
@@ -23,9 +28,11 @@ class NullLock:
     ) -> None:
         """Exit the lock."""
 
-    def acquire(self) -> None:
+    @lru_cache(maxsize=_MQTT_LOCK_COUNT)
+    def acquire(self, blocking: bool = False, timeout: int = -1) -> None:
         """Acquire the lock."""
 
+    @lru_cache(maxsize=_MQTT_LOCK_COUNT)
     def release(self) -> None:
         """Release the lock."""
 

--- a/homeassistant/components/mqtt/async_client.py
+++ b/homeassistant/components/mqtt/async_client.py
@@ -1,0 +1,53 @@
+"""Async wrappings for mqtt client."""
+
+from __future__ import annotations
+
+from types import TracebackType
+from typing import Self
+
+from paho.mqtt.client import Client as MQTTClient
+
+
+class NullLock:
+    """Null lock."""
+
+    def __enter__(self) -> Self:
+        """Enter the lock."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Exit the lock."""
+
+    def acquire(self) -> None:
+        """Acquire the lock."""
+
+    def release(self) -> None:
+        """Release the lock."""
+
+
+class AsyncMQTTClient(MQTTClient):
+    """Async MQTT Client.
+
+    Wrapper around paho.mqtt.client.Client to remove the locking
+    that is not needed since we are running in an async event loop.
+    """
+
+    def async_setup(self) -> None:
+        """Set up the client.
+
+        All the threading locks are replaced with NullLock
+        since the client is running in an async event loop
+        and will never run in multiple threads.
+        """
+        self._in_callback_mutex = NullLock()
+        self._callback_mutex = NullLock()
+        self._msgtime_mutex = NullLock()
+        self._out_message_mutex = NullLock()
+        self._in_message_mutex = NullLock()
+        self._reconnect_delay_mutex = NullLock()
+        self._mid_generate_mutex = NullLock()

--- a/tests/components/mqtt/test_config_flow.py
+++ b/tests/components/mqtt/test_config_flow.py
@@ -121,7 +121,9 @@ def mock_try_connection_success() -> Generator[MqttMockPahoClient, None, None]:
         mock_client().on_unsubscribe(mock_client, 0, mid)
         return (0, mid)
 
-    with patch("paho.mqtt.client.Client") as mock_client:
+    with patch(
+        "homeassistant.components.mqtt.async_client.AsyncMQTTClient"
+    ) as mock_client:
         mock_client().loop_start = loop_start
         mock_client().subscribe = _subscribe
         mock_client().unsubscribe = _unsubscribe
@@ -135,7 +137,9 @@ def mock_try_connection_time_out() -> Generator[MagicMock, None, None]:
 
     # Patch prevent waiting 5 sec for a timeout
     with (
-        patch("paho.mqtt.client.Client") as mock_client,
+        patch(
+            "homeassistant.components.mqtt.async_client.AsyncMQTTClient"
+        ) as mock_client,
         patch("homeassistant.components.mqtt.config_flow.MQTT_TIMEOUT", 0),
     ):
         mock_client().loop_start = lambda *args: 1

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -180,7 +180,9 @@ async def test_mqtt_await_ack_at_disconnect(
         mid = 100
         rc = 0
 
-    with patch("paho.mqtt.client.Client") as mock_client:
+    with patch(
+        "homeassistant.components.mqtt.async_client.AsyncMQTTClient"
+    ) as mock_client:
         mqtt_client = mock_client.return_value
         mqtt_client.connect = MagicMock(
             return_value=0,
@@ -2219,7 +2221,9 @@ async def test_publish_error(
     entry.add_to_hass(hass)
 
     # simulate an Out of memory error
-    with patch("paho.mqtt.client.Client") as mock_client:
+    with patch(
+        "homeassistant.components.mqtt.async_client.AsyncMQTTClient"
+    ) as mock_client:
         mock_client().connect = lambda *args: 1
         mock_client().publish().rc = 1
         assert await hass.config_entries.async_setup(entry.entry_id)
@@ -2354,7 +2358,9 @@ async def test_setup_mqtt_client_protocol(
     protocol: int,
 ) -> None:
     """Test MQTT client protocol setup."""
-    with patch("paho.mqtt.client.Client") as mock_client:
+    with patch(
+        "homeassistant.components.mqtt.async_client.AsyncMQTTClient"
+    ) as mock_client:
         await mqtt_mock_entry()
 
     # check if protocol setup was correctly
@@ -2374,7 +2380,9 @@ async def test_handle_mqtt_timeout_on_callback(
         mid = 100
         rc = 0
 
-    with patch("paho.mqtt.client.Client") as mock_client:
+    with patch(
+        "homeassistant.components.mqtt.async_client.AsyncMQTTClient"
+    ) as mock_client:
 
         def _mock_ack(topic: str, qos: int = 0) -> tuple[int, int]:
             # Handle ACK for subscribe normally
@@ -2419,7 +2427,9 @@ async def test_setup_raises_config_entry_not_ready_if_no_connect_broker(
     entry = MockConfigEntry(domain=mqtt.DOMAIN, data={mqtt.CONF_BROKER: "test-broker"})
     entry.add_to_hass(hass)
 
-    with patch("paho.mqtt.client.Client") as mock_client:
+    with patch(
+        "homeassistant.components.mqtt.async_client.AsyncMQTTClient"
+    ) as mock_client:
         mock_client().connect = MagicMock(side_effect=OSError("Connection error"))
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -2454,7 +2464,9 @@ async def test_setup_uses_certificate_on_certificate_set_to_auto_and_insecure(
     def mock_tls_insecure_set(insecure_param) -> None:
         insecure_check["insecure"] = insecure_param
 
-    with patch("paho.mqtt.client.Client") as mock_client:
+    with patch(
+        "homeassistant.components.mqtt.async_client.AsyncMQTTClient"
+    ) as mock_client:
         mock_client().tls_set = mock_tls_set
         mock_client().tls_insecure_set = mock_tls_insecure_set
         await mqtt_mock_entry()
@@ -4021,7 +4033,7 @@ async def test_link_config_entry(
     assert _check_entities() == 2
 
     # reload entry and assert again
-    with patch("paho.mqtt.client.Client"):
+    with patch("homeassistant.components.mqtt.async_client.AsyncMQTTClient"):
         await hass.config_entries.async_reload(mqtt_config_entry.entry_id)
         await hass.async_block_till_done()
 

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -193,10 +193,15 @@ async def test_mqtt_await_ack_at_disconnect(
         mqtt_client.publish = MagicMock(return_value=FakeInfo())
         entry = MockConfigEntry(
             domain=mqtt.DOMAIN,
-            data={"certificate": "auto", mqtt.CONF_BROKER: "test-broker"},
+            data={
+                "certificate": "auto",
+                mqtt.CONF_BROKER: "test-broker",
+                mqtt.CONF_DISCOVERY: False,
+            },
         )
         entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(entry.entry_id)
+
         mqtt_client = mock_client.return_value
 
         # publish from MQTT client without awaiting

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -920,7 +920,9 @@ def mqtt_client_mock(hass: HomeAssistant) -> Generator[MqttMockPahoClient, None,
             self.mid = mid
             self.rc = 0
 
-    with patch("paho.mqtt.client.Client") as mock_client:
+    with patch(
+        "homeassistant.components.mqtt.async_client.AsyncMQTTClient"
+    ) as mock_client:
         # The below use a call_soon for the on_publish/on_subscribe/on_unsubscribe
         # callbacks to simulate the behavior of the real MQTT client which will
         # not be synchronous.


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Since everything happens in the main thread, the threading locks used by the paho mqtt client are useless overhead. The one exception is where we connect the client in the executor, but since the executor job is awaited and the client will not run in the main thread until the executor job is done, there is no need to lock there either.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
