### PR TITLE
Change BMW select and sensor enums to lowercase

### DIFF
--- a/homeassistant/components/bmw_connected_drive/select.py
+++ b/homeassistant/components/bmw_connected_drive/select.py
@@ -52,8 +52,8 @@ SELECT_TYPES: dict[str, BMWSelectEntityDescription] = {
         key="charging_mode",
         translation_key="charging_mode",
         is_available=lambda v: v.is_charging_plan_supported,
-        options=[c.value for c in ChargingMode if c != ChargingMode.UNKNOWN],
-        current_option=lambda v: str(v.charging_profile.charging_mode.value),  # type: ignore[union-attr]
+        options=[c.value.lower() for c in ChargingMode if c != ChargingMode.UNKNOWN],
+        current_option=lambda v: str(v.charging_profile.charging_mode.value).lower(),  # type: ignore[union-attr]
         remote_service=lambda v, o: v.remote_services.trigger_charging_profile_update(
             charging_mode=ChargingMode(o)
         ),

--- a/homeassistant/components/bmw_connected_drive/sensor.py
+++ b/homeassistant/components/bmw_connected_drive/sensor.py
@@ -221,9 +221,5 @@ class BMWSensor(BMWBaseEntity, SensorEntity):
             if state == STATE_UNKNOWN:
                 state = None
 
-            # special handling for charging_status to avoid a breaking change
-            if self.entity_description.key == "charging_status" and state:
-                state = state.upper()
-
         self._attr_native_value = state
         super()._handle_coordinator_update()

--- a/homeassistant/components/bmw_connected_drive/strings.json
+++ b/homeassistant/components/bmw_connected_drive/strings.json
@@ -101,7 +101,21 @@
         "name": "Charging end time"
       },
       "charging_status": {
-        "name": "Charging status"
+        "name": "Charging status",
+        "state": {
+          "default": "Default",
+          "charging": "Charging",
+          "error": "Error",
+          "complete": "Complete",
+          "fully_charged": "Fully charged",
+          "finished_fully_charged": "Finished, fully charged",
+          "finished_not_full": "Finished, not full",
+          "invalid": "Invalid",
+          "not_charging": "Not charging",
+          "plugged_in": "Plugged in",
+          "waiting_for_charging": "Waiting for charging",
+          "target_reached": "Target reached"
+        }
       },
       "charging_target": {
         "name": "Charging target"

--- a/homeassistant/components/bmw_connected_drive/strings.json
+++ b/homeassistant/components/bmw_connected_drive/strings.json
@@ -83,7 +83,11 @@
         "name": "AC Charging Limit"
       },
       "charging_mode": {
-        "name": "Charging Mode"
+        "name": "Charging Mode",
+        "state": {
+          "immediate_charging": "Immediate charging",
+          "delayed_charging": "Delayed charging"
+        }
       }
     },
     "sensor": {

--- a/tests/components/bmw_connected_drive/snapshots/test_select.ambr
+++ b/tests/components/bmw_connected_drive/snapshots/test_select.ambr
@@ -6,8 +6,8 @@
     'area_id': None,
     'capabilities': dict({
       'options': list([
-        'IMMEDIATE_CHARGING',
-        'DELAYED_CHARGING',
+        'immediate_charging',
+        'delayed_charging',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -43,8 +43,8 @@
       'attribution': 'Data provided by MyBMW',
       'friendly_name': 'i3 (+ REX) Charging Mode',
       'options': list([
-        'IMMEDIATE_CHARGING',
-        'DELAYED_CHARGING',
+        'immediate_charging',
+        'delayed_charging',
       ]),
     }),
     'context': <ANY>,
@@ -52,7 +52,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'DELAYED_CHARGING',
+    'state': 'delayed_charging',
   })
 # ---
 # name: test_entity_state_attrs[select.i4_edrive40_ac_charging_limit-entry]
@@ -141,8 +141,8 @@
     'area_id': None,
     'capabilities': dict({
       'options': list([
-        'IMMEDIATE_CHARGING',
-        'DELAYED_CHARGING',
+        'immediate_charging',
+        'delayed_charging',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -178,8 +178,8 @@
       'attribution': 'Data provided by MyBMW',
       'friendly_name': 'i4 eDrive40 Charging Mode',
       'options': list([
-        'IMMEDIATE_CHARGING',
-        'DELAYED_CHARGING',
+        'immediate_charging',
+        'delayed_charging',
       ]),
     }),
     'context': <ANY>,
@@ -187,7 +187,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'IMMEDIATE_CHARGING',
+    'state': 'immediate_charging',
   })
 # ---
 # name: test_entity_state_attrs[select.ix_xdrive50_ac_charging_limit-entry]
@@ -276,8 +276,8 @@
     'area_id': None,
     'capabilities': dict({
       'options': list([
-        'IMMEDIATE_CHARGING',
-        'DELAYED_CHARGING',
+        'immediate_charging',
+        'delayed_charging',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -313,8 +313,8 @@
       'attribution': 'Data provided by MyBMW',
       'friendly_name': 'iX xDrive50 Charging Mode',
       'options': list([
-        'IMMEDIATE_CHARGING',
-        'DELAYED_CHARGING',
+        'immediate_charging',
+        'delayed_charging',
       ]),
     }),
     'context': <ANY>,
@@ -322,6 +322,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'IMMEDIATE_CHARGING',
+    'state': 'immediate_charging',
   })
 # ---

--- a/tests/components/bmw_connected_drive/snapshots/test_sensor.ambr
+++ b/tests/components/bmw_connected_drive/snapshots/test_sensor.ambr
@@ -191,7 +191,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'WAITING_FOR_CHARGING',
+    'state': 'waiting_for_charging',
   })
 # ---
 # name: test_entity_state_attrs[sensor.i3_rex_charging_target-entry]
@@ -822,7 +822,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'NOT_CHARGING',
+    'state': 'not_charging',
   })
 # ---
 # name: test_entity_state_attrs[sensor.i4_edrive40_charging_target-entry]
@@ -1350,7 +1350,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'CHARGING',
+    'state': 'charging',
   })
 # ---
 # name: test_entity_state_attrs[sensor.ix_xdrive50_charging_target-entry]

--- a/tests/components/bmw_connected_drive/test_select.py
+++ b/tests/components/bmw_connected_drive/test_select.py
@@ -42,15 +42,15 @@ async def test_entity_state_attrs(
     [
         (
             "select.i3_rex_charging_mode",
-            "IMMEDIATE_CHARGING",
-            "DELAYED_CHARGING",
+            "immediate_charging",
+            "delayed_charging",
             "charging-profile",
         ),
         ("select.i4_edrive40_ac_charging_limit", "12", "16", "charging-settings"),
         (
             "select.i4_edrive40_charging_mode",
-            "DELAYED_CHARGING",
-            "IMMEDIATE_CHARGING",
+            "delayed_charging",
+            "immediate_charging",
             "charging-profile",
         ),
     ],
@@ -87,7 +87,7 @@ async def test_service_call_success(
     ("entity_id", "value"),
     [
         ("select.i4_edrive40_ac_charging_limit", "17"),
-        ("select.i4_edrive40_charging_mode", "BONKERS_MODE"),
+        ("select.i4_edrive40_charging_mode", "bonkers_mode"),
     ],
 )
 async def test_service_call_invalid_input(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The state of `select.[vehicle]_charging_mode` and `sensor.[vehicle]_charging_status` is now lowercase. Any scripts or automations using this need to be updated accordingly. 

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update `select.[vehicle]_charging_mode` and `sensor.[vehicle]_charging_status` to comply with HA standards (lower-case state + translations).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
