### PR TITLE
Add type hints for FixtureRequest in tests

### DIFF
--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -152,6 +152,7 @@ _TEST_FIXTURES: dict[str, list[str] | str] = {
     "mqtt_mock_entry": "MqttMockHAClientGenerator",
     "recorder_db_url": "str",
     "recorder_mock": "Recorder",
+    "request": "pytest.FixtureRequest",
     "requests_mock": "Mocker",
     "snapshot": "SnapshotAssertion",
     "socket_enabled": "None",

--- a/tests/components/ambient_network/conftest.py
+++ b/tests/components/ambient_network/conftest.py
@@ -66,7 +66,7 @@ async def mock_aioambient(open_api: OpenAPI):
 
 
 @pytest.fixture(name="config_entry")
-def config_entry_fixture(request) -> MockConfigEntry:
+def config_entry_fixture(request: pytest.FixtureRequest) -> MockConfigEntry:
     """Mock config entry."""
     return MockConfigEntry(
         domain=ambient_network.DOMAIN,

--- a/tests/components/blebox/conftest.py
+++ b/tests/components/blebox/conftest.py
@@ -1,5 +1,6 @@
 """PyTest fixtures and test helpers."""
 
+from typing import Any
 from unittest import mock
 from unittest.mock import AsyncMock, PropertyMock, patch
 
@@ -71,7 +72,7 @@ def config_fixture():
 
 
 @pytest.fixture(name="feature")
-def feature_fixture(request):
+def feature_fixture(request: pytest.FixtureRequest) -> Any:
     """Return an entity wrapper from given fixture name."""
     return request.getfixturevalue(request.param)
 

--- a/tests/components/blueprint/test_models.py
+++ b/tests/components/blueprint/test_models.py
@@ -27,7 +27,7 @@ def blueprint_1():
 
 
 @pytest.fixture(params=[False, True])
-def blueprint_2(request):
+def blueprint_2(request: pytest.FixtureRequest) -> models.Blueprint:
     """Blueprint fixture with default inputs."""
     blueprint = {
         "blueprint": {

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -81,7 +81,7 @@ def assert_state(actual: State | None, expected: State | None) -> None:
 )
 def add_event_call_service(
     hass: HomeAssistant,
-    request: Any,
+    request: pytest.FixtureRequest,
 ) -> Callable[dict[str, Any], Awaitable[None]]:
     """Fixture for calling the add or create event service."""
     (domain, service_call, data, target) = request.param

--- a/tests/components/hdmi_cec/test_media_player.py
+++ b/tests/components/hdmi_cec/test_media_player.py
@@ -70,7 +70,7 @@ from . import MockHDMIDevice, assert_key_press_release
     ],
     ids=["skip_assert_state", "run_assert_state"],
 )
-def assert_state_fixture(hass, request):
+def assert_state_fixture(request: pytest.FixtureRequest):
     """Allow for skipping the assert state changes.
 
     This is broken in this entity, but we still want to test that

--- a/tests/components/home_connect/conftest.py
+++ b/tests/components/home_connect/conftest.py
@@ -131,7 +131,7 @@ def mock_get_appliances() -> Generator[None, Any, None]:
 
 
 @pytest.fixture(name="appliance")
-def mock_appliance(request) -> Mock:
+def mock_appliance(request: pytest.FixtureRequest) -> MagicMock:
     """Fixture to mock Appliance."""
     app = "Washer"
     if hasattr(request, "param") and request.param:

--- a/tests/components/influxdb/test_init.py
+++ b/tests/components/influxdb/test_init.py
@@ -1,5 +1,6 @@
 """The tests for the InfluxDB component."""
 
+from collections.abc import Generator
 from dataclasses import dataclass
 import datetime
 from http import HTTPStatus
@@ -51,7 +52,9 @@ def mock_batch_timeout(hass, monkeypatch):
 
 
 @pytest.fixture(name="mock_client")
-def mock_client_fixture(request):
+def mock_client_fixture(
+    request: pytest.FixtureRequest,
+) -> Generator[MagicMock, None, None]:
     """Patch the InfluxDBClient object with mock for version under test."""
     if request.param == influxdb.API_VERSION_2:
         client_target = f"{INFLUX_CLIENT_PATH}V2"
@@ -63,7 +66,7 @@ def mock_client_fixture(request):
 
 
 @pytest.fixture(name="get_mock_call")
-def get_mock_call_fixture(request):
+def get_mock_call_fixture(request: pytest.FixtureRequest):
     """Get version specific lambda to make write API call mock."""
 
     def v2_call(body, precision):

--- a/tests/components/influxdb/test_sensor.py
+++ b/tests/components/influxdb/test_sensor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from dataclasses import dataclass
 from datetime import timedelta
 from http import HTTPStatus
@@ -79,7 +80,9 @@ class Table:
 
 
 @pytest.fixture(name="mock_client")
-def mock_client_fixture(request):
+def mock_client_fixture(
+    request: pytest.FixtureRequest,
+) -> Generator[MagicMock, None, None]:
     """Patch the InfluxDBClient object with mock for version under test."""
     if request.param == API_VERSION_2:
         client_target = f"{INFLUXDB_CLIENT_PATH}V2"

--- a/tests/components/jvc_projector/conftest.py
+++ b/tests/components/jvc_projector/conftest.py
@@ -1,7 +1,7 @@
 """Fixtures for JVC Projector integration."""
 
 from collections.abc import Generator
-from unittest.mock import AsyncMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -15,7 +15,9 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture(name="mock_device")
-def fixture_mock_device(request) -> Generator[None, AsyncMock, None]:
+def fixture_mock_device(
+    request: pytest.FixtureRequest,
+) -> Generator[MagicMock, None, None]:
     """Return a mocked JVC Projector device."""
     target = "homeassistant.components.jvc_projector.JvcProjector"
     if hasattr(request, "param"):

--- a/tests/components/media_player/test_async_helpers.py
+++ b/tests/components/media_player/test_async_helpers.py
@@ -111,7 +111,7 @@ class DescrMediaPlayer(SimpleMediaPlayer):
 
 
 @pytest.fixture(params=[ExtendedMediaPlayer, SimpleMediaPlayer])
-def player(hass, request):
+def player(hass: HomeAssistant, request: pytest.FixtureRequest) -> mp.MediaPlayerEntity:
     """Return a media player."""
     return request.param(hass)
 

--- a/tests/components/met/test_config_flow.py
+++ b/tests/components/met/test_config_flow.py
@@ -1,5 +1,7 @@
 """Tests for Met.no config flow."""
 
+from collections.abc import Generator
+from typing import Any
 from unittest.mock import ANY, patch
 
 import pytest
@@ -17,7 +19,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture(name="met_setup", autouse=True)
-def met_setup_fixture(request):
+def met_setup_fixture(request: pytest.FixtureRequest) -> Generator[Any]:
     """Patch met setup entry."""
     if "disable_autouse_fixture" in request.keywords:
         yield

--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -4,6 +4,7 @@ import copy
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
+from typing import Any
 from unittest import mock
 
 from freezegun.api import FrozenDateTimeFactory
@@ -182,7 +183,9 @@ async def do_next_cycle(
 
 
 @pytest.fixture(name="mock_test_state")
-async def mock_test_state_fixture(hass, request):
+async def mock_test_state_fixture(
+    hass: HomeAssistant, request: pytest.FixtureRequest
+) -> Any:
     """Mock restore cache."""
     mock_restore_cache(hass, request.param)
     return request.param

--- a/tests/components/prosegur/test_alarm_control_panel.py
+++ b/tests/components/prosegur/test_alarm_control_panel.py
@@ -1,5 +1,6 @@
 """Tests for the Prosegur alarm control panel device."""
 
+from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 from pyprosegur.installation import Status
@@ -35,7 +36,7 @@ def mock_auth():
 
 
 @pytest.fixture(params=list(Status))
-def mock_status(request):
+def mock_status(request: pytest.FixtureRequest) -> Generator[None, None, None]:
     """Mock the status of the alarm."""
 
     install = AsyncMock()

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -1,5 +1,6 @@
 """Test data purging."""
 
+from collections.abc import Generator
 from datetime import datetime, timedelta
 import json
 import sqlite3
@@ -58,7 +59,7 @@ TEST_EVENT_TYPES = (
 
 
 @pytest.fixture(name="use_sqlite")
-def mock_use_sqlite(request):
+def mock_use_sqlite(request: pytest.FixtureRequest) -> Generator[None, None, None]:
     """Pytest fixture to switch purge method."""
     with patch(
         "homeassistant.components.recorder.core.Recorder.dialect_name",

--- a/tests/components/recorder/test_purge_v32_schema.py
+++ b/tests/components/recorder/test_purge_v32_schema.py
@@ -1,5 +1,6 @@
 """Test data purging."""
 
+from collections.abc import Generator
 from datetime import datetime, timedelta
 import json
 import sqlite3
@@ -54,7 +55,7 @@ def db_schema_32():
 
 
 @pytest.fixture(name="use_sqlite")
-def mock_use_sqlite(request):
+def mock_use_sqlite(request: pytest.FixtureRequest) -> Generator[None, None, None]:
     """Pytest fixture to switch purge method."""
     with patch(
         "homeassistant.components.recorder.core.Recorder.dialect_name",

--- a/tests/components/renault/test_init.py
+++ b/tests/components/renault/test_init.py
@@ -25,7 +25,7 @@ def override_platforms() -> Generator[None, None, None]:
 
 
 @pytest.fixture(autouse=True, name="vehicle_type", params=["zoe_40"])
-def override_vehicle_type(request) -> str:
+def override_vehicle_type(request: pytest.FixtureRequest) -> str:
     """Parametrize vehicle type."""
     return request.param
 

--- a/tests/components/renault/test_services.py
+++ b/tests/components/renault/test_services.py
@@ -46,7 +46,7 @@ def override_platforms() -> Generator[None, None, None]:
 
 
 @pytest.fixture(autouse=True, name="vehicle_type", params=["zoe_40"])
-def override_vehicle_type(request) -> str:
+def override_vehicle_type(request: pytest.FixtureRequest) -> str:
     """Parametrize vehicle type."""
     return request.param
 

--- a/tests/components/screenlogic/test_services.py
+++ b/tests/components/screenlogic/test_services.py
@@ -1,5 +1,6 @@
 """Tests for ScreenLogic integration service calls."""
 
+from collections.abc import AsyncGenerator
 from typing import Any
 from unittest.mock import DEFAULT, AsyncMock, patch
 
@@ -49,10 +50,10 @@ def dataset_fixture():
 @pytest.fixture(name="service_fixture")
 async def setup_screenlogic_services_fixture(
     hass: HomeAssistant,
-    request,
+    request: pytest.FixtureRequest,
     device_registry: dr.DeviceRegistry,
     mock_config_entry: MockConfigEntry,
-):
+) -> AsyncGenerator[dict[str, Any], None]:
     """Define the setup for a patched screenlogic integration."""
     data = (
         marker.args[0]

--- a/tests/components/switcher_kis/conftest.py
+++ b/tests/components/switcher_kis/conftest.py
@@ -1,7 +1,7 @@
 """Common fixtures and objects for the Switcher integration tests."""
 
 from collections.abc import Generator
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -16,7 +16,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_bridge(request):
+def mock_bridge(request: pytest.FixtureRequest) -> Generator[MagicMock, None, None]:
     """Return a mocked SwitcherBridge."""
     with (
         patch(

--- a/tests/components/tami4/conftest.py
+++ b/tests/components/tami4/conftest.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Generator
 from datetime import datetime
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from Tami4EdgeAPI.device import Device
@@ -37,7 +37,7 @@ def mock_api(mock__get_devices, mock_get_water_quality):
 
 
 @pytest.fixture
-def mock__get_devices(request):
+def mock__get_devices(request: pytest.FixtureRequest) -> Generator[None, None, None]:
     """Fixture to mock _get_devices which makes a call to the API."""
 
     side_effect = getattr(request, "param", None)
@@ -60,7 +60,9 @@ def mock__get_devices(request):
 
 
 @pytest.fixture
-def mock_get_water_quality(request):
+def mock_get_water_quality(
+    request: pytest.FixtureRequest,
+) -> Generator[None, None, None]:
     """Fixture to mock get_water_quality which makes a call to the API."""
 
     side_effect = getattr(request, "param", None)
@@ -98,7 +100,9 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_request_otp(request):
+def mock_request_otp(
+    request: pytest.FixtureRequest,
+) -> Generator[MagicMock, None, None]:
     """Mock request_otp."""
 
     side_effect = getattr(request, "param", None)
@@ -112,7 +116,7 @@ def mock_request_otp(request):
 
 
 @pytest.fixture
-def mock_submit_otp(request):
+def mock_submit_otp(request: pytest.FixtureRequest) -> Generator[MagicMock, None, None]:
     """Mock submit_otp."""
 
     side_effect = getattr(request, "param", None)

--- a/tests/components/vallox/test_sensor.py
+++ b/tests/components/vallox/test_sensor.py
@@ -1,6 +1,7 @@
 """Tests for Vallox sensor platform."""
 
 from datetime import datetime, timedelta, tzinfo
+from typing import Any
 
 import pytest
 from vallox_websocket_api import MetricData
@@ -12,7 +13,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def set_tz(request):
+def set_tz(request: pytest.FixtureRequest) -> Any:
     """Set the default TZ to the one requested."""
     request.getfixturevalue(request.param)
 

--- a/tests/components/weatherflow_cloud/test_config_flow.py
+++ b/tests/components/weatherflow_cloud/test_config_flow.py
@@ -56,14 +56,18 @@ async def test_config_flow_abort(hass: HomeAssistant, mock_get_stations) -> None
 
 
 @pytest.mark.parametrize(
-    "mock_fixture, expected_error",  # noqa: PT006
+    ("mock_fixture", "expected_error"),
     [
         ("mock_get_stations_500_error", "cannot_connect"),
         ("mock_get_stations_401_error", "invalid_api_key"),
     ],
 )
 async def test_config_errors(
-    hass: HomeAssistant, request, expected_error, mock_fixture, mock_get_stations
+    hass: HomeAssistant,
+    request: pytest.FixtureRequest,
+    expected_error: str,
+    mock_fixture: str,
+    mock_get_stations,
 ) -> None:
     """Test the config flow for various error scenarios."""
     mock_get_stations_bad = request.getfixturevalue(mock_fixture)

--- a/tests/components/whirlpool/conftest.py
+++ b/tests/components/whirlpool/conftest.py
@@ -18,7 +18,7 @@ MOCK_SAID4 = "said4"
     name="region",
     params=[("EU", Region.EU), ("US", Region.US)],
 )
-def fixture_region(request):
+def fixture_region(request: pytest.FixtureRequest) -> tuple[str, Region]:
     """Return a region for input."""
     return request.param
 
@@ -31,7 +31,7 @@ def fixture_region(request):
         ("Maytag", Brand.Maytag),
     ],
 )
-def fixture_brand(request):
+def fixture_brand(request: pytest.FixtureRequest) -> tuple[str, Brand]:
     """Return a brand for input."""
     return request.param
 

--- a/tests/components/xiaomi_miio/test_vacuum.py
+++ b/tests/components/xiaomi_miio/test_vacuum.py
@@ -1,5 +1,6 @@
 """The tests for the Xiaomi vacuum platform."""
 
+from collections.abc import Generator
 from datetime import datetime, time, timedelta
 from unittest import mock
 from unittest.mock import MagicMock, patch
@@ -140,7 +141,9 @@ new_fanspeeds = {
 
 
 @pytest.fixture(name="mock_mirobo_fanspeeds", params=[old_fanspeeds, new_fanspeeds])
-def mirobo_old_speeds_fixture(request):
+def mirobo_old_speeds_fixture(
+    request: pytest.FixtureRequest,
+) -> Generator[MagicMock, None, None]:
     """Fixture for testing both types of fanspeeds."""
     mock_vacuum = MagicMock()
     mock_vacuum.status().battery = 32

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -385,7 +385,7 @@ def zha_device_restored(hass, zigpy_app_controller, setup_zha):
 
 
 @pytest.fixture(params=["zha_device_joined", "zha_device_restored"])
-def zha_device_joined_restored(request):
+def zha_device_joined_restored(request: pytest.FixtureRequest):
     """Join or restore ZHA device."""
     named_method = request.getfixturevalue(request.param)
     named_method.name = request.param

--- a/tests/components/zha/test_device.py
+++ b/tests/components/zha/test_device.py
@@ -309,7 +309,7 @@ async def test_ota_sw_version(
 )
 async def test_device_restore_availability(
     hass: HomeAssistant,
-    request,
+    request: pytest.FixtureRequest,
     device,
     last_seen_delta,
     is_available,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
