### PR TITLE
Cleanup unused FixtureRequest in tests

### DIFF
--- a/tests/components/hassio/test_sensor.py
+++ b/tests/components/hassio/test_sensor.py
@@ -28,7 +28,7 @@ MOCK_ENVIRON = {"SUPERVISOR": "127.0.0.1", "SUPERVISOR_TOKEN": "abcdefgh"}
 
 
 @pytest.fixture(autouse=True)
-def mock_all(aioclient_mock: AiohttpClientMocker, request):
+def mock_all(aioclient_mock: AiohttpClientMocker) -> None:
     """Mock all setup requests."""
     _install_default_mocks(aioclient_mock)
     _install_test_addon_stats_mock(aioclient_mock)

--- a/tests/components/homekit_controller/conftest.py
+++ b/tests/components/homekit_controller/conftest.py
@@ -1,10 +1,12 @@
 """HomeKit controller session fixtures."""
 
+from collections.abc import Generator
 import datetime
 import unittest.mock
 
 from aiohomekit.testing import FakeController
 from freezegun import freeze_time
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 import homeassistant.util.dt as dt_util
@@ -15,7 +17,7 @@ pytest.register_assert_rewrite("tests.components.homekit_controller.common")
 
 
 @pytest.fixture(autouse=True)
-def freeze_time_in_future(request):
+def freeze_time_in_future() -> Generator[FrozenDateTimeFactory, None, None]:
     """Freeze time at a known point."""
     now = dt_util.utcnow()
     start_dt = datetime.datetime(now.year + 1, 1, 1, 0, 0, 0, tzinfo=now.tzinfo)

--- a/tests/components/ipma/test_config_flow.py
+++ b/tests/components/ipma/test_config_flow.py
@@ -1,5 +1,6 @@
 """Tests for IPMA config flow."""
 
+from collections.abc import Generator
 from unittest.mock import patch
 
 from pyipma import IPMAException
@@ -15,7 +16,7 @@ from tests.components.ipma import MockLocation
 
 
 @pytest.fixture(name="ipma_setup", autouse=True)
-def ipma_setup_fixture(request):
+def ipma_setup_fixture() -> Generator[None, None, None]:
     """Patch ipma setup entry."""
     with patch("homeassistant.components.ipma.async_setup_entry", return_value=True):
         yield

--- a/tests/components/knx/conftest.py
+++ b/tests/components/knx/conftest.py
@@ -266,7 +266,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-async def knx(request, hass, mock_config_entry: MockConfigEntry):
+async def knx(hass: HomeAssistant, mock_config_entry: MockConfigEntry):
     """Create a KNX TestKit instance."""
     knx_test_kit = KNXTestKit(hass, mock_config_entry)
     yield knx_test_kit

--- a/tests/components/lametric/conftest.py
+++ b/tests/components/lametric/conftest.py
@@ -74,7 +74,7 @@ def device_fixture() -> str:
 
 
 @pytest.fixture
-def mock_lametric(request, device_fixture: str) -> Generator[MagicMock, None, None]:
+def mock_lametric(device_fixture: str) -> Generator[MagicMock, None, None]:
     """Return a mocked LaMetric TIME client."""
     with (
         patch(

--- a/tests/components/nest/conftest.py
+++ b/tests/components/nest/conftest.py
@@ -196,7 +196,7 @@ def subscriber_id() -> str:
 
 
 @pytest.fixture
-def nest_test_config(request) -> NestTestConfig:
+def nest_test_config() -> NestTestConfig:
     """Fixture that sets up the configuration used for the test."""
     return TEST_CONFIG_APP_CREDS
 

--- a/tests/components/nest/test_config_flow.py
+++ b/tests/components/nest/test_config_flow.py
@@ -48,7 +48,7 @@ FAKE_DHCP_DATA = dhcp.DhcpServiceInfo(
 
 
 @pytest.fixture
-def nest_test_config(request) -> NestTestConfig:
+def nest_test_config() -> NestTestConfig:
     """Fixture with empty configuration and no existing config entry."""
     return TEST_CONFIGFLOW_APP_CREDS
 

--- a/tests/components/tedee/conftest.py
+++ b/tests/components/tedee/conftest.py
@@ -46,7 +46,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_tedee(request) -> Generator[MagicMock, None, None]:
+def mock_tedee() -> Generator[MagicMock, None, None]:
     """Return a mocked Tedee client."""
     with (
         patch(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
