### PR TITLE
Move entity_registry_enabled_by_default to decorator [q-z]

### DIFF
--- a/tests/components/qnap_qsw/test_binary_sensor.py
+++ b/tests/components/qnap_qsw/test_binary_sensor.py
@@ -1,5 +1,7 @@
 """The binary sensor tests for the QNAP QSW platform."""
 
+import pytest
+
 from homeassistant.components.qnap_qsw.const import ATTR_MESSAGE
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
@@ -8,9 +10,9 @@ from homeassistant.helpers import entity_registry as er
 from .util import async_init_integration
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_qnap_qsw_create_binary_sensors(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test creation of binary sensors."""

--- a/tests/components/qnap_qsw/test_sensor.py
+++ b/tests/components/qnap_qsw/test_sensor.py
@@ -1,14 +1,16 @@
 """The sensor tests for the QNAP QSW platform."""
 
+import pytest
+
 from homeassistant.components.qnap_qsw.const import ATTR_MAX
 from homeassistant.core import HomeAssistant
 
 from .util import async_init_integration
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_qnap_qsw_create_sensors(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test creation of sensors."""
 

--- a/tests/components/radarr/test_sensor.py
+++ b/tests/components/radarr/test_sensor.py
@@ -52,10 +52,10 @@ from tests.test_util.aiohttp import AiohttpClientMocker
         ),
     ],
 )
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensors(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    entity_registry_enabled_by_default: None,
     windows: bool,
     single: bool,
     root_folder: str,

--- a/tests/components/sensibo/test_binary_sensor.py
+++ b/tests/components/sensibo/test_binary_sensor.py
@@ -15,9 +15,9 @@ from homeassistant.util import dt as dt_util
 from tests.common import async_fire_time_changed
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_binary_sensor(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,
     get_data: SensiboData,

--- a/tests/components/sensibo/test_climate.py
+++ b/tests/components/sensibo/test_climate.py
@@ -832,9 +832,9 @@ async def test_climate_no_fan_no_swing(
     assert state.attributes["swing_modes"] is None
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_climate_set_timer(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,
     get_data: SensiboData,
@@ -947,9 +947,9 @@ async def test_climate_set_timer(
     )
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_climate_pure_boost(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,
     get_data: SensiboData,
@@ -1058,9 +1058,9 @@ async def test_climate_pure_boost(
     assert state4.state == "s"
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_climate_climate_react(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,
     get_data: SensiboData,
@@ -1228,9 +1228,9 @@ async def test_climate_climate_react(
     assert state4.state == "temperature"
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_climate_climate_react_fahrenheit(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,
     get_data: SensiboData,
@@ -1374,9 +1374,9 @@ async def test_climate_climate_react_fahrenheit(
     assert state4.state == "temperature"
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_climate_full_ac_state(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,
     get_data: SensiboData,

--- a/tests/components/sensibo/test_number.py
+++ b/tests/components/sensibo/test_number.py
@@ -22,9 +22,9 @@ from homeassistant.util import dt as dt_util
 from tests.common import async_fire_time_changed
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_number(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,
     get_data: SensiboData,
@@ -52,9 +52,9 @@ async def test_number(
     assert state1.state == "0.2"
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_number_set_value(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     load_int: ConfigEntry,
     get_data: SensiboData,
 ) -> None:

--- a/tests/components/sensibo/test_sensor.py
+++ b/tests/components/sensibo/test_sensor.py
@@ -16,9 +16,9 @@ from homeassistant.util import dt as dt_util
 from tests.common import async_fire_time_changed
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensor(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,
     get_data: SensiboData,

--- a/tests/components/shelly/test_sensor.py
+++ b/tests/components/shelly/test_sensor.py
@@ -355,11 +355,11 @@ async def test_rpc_sensor(
     assert hass.states.get(entity_id).state == STATE_UNKNOWN
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_rpc_rssi_sensor_removal(
     hass: HomeAssistant,
     mock_rpc_device: Mock,
     monkeypatch: pytest.MonkeyPatch,
-    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test RPC RSSI sensor removal if no WiFi stations enabled."""
     entity_id = f"{SENSOR_DOMAIN}.test_name_rssi"
@@ -548,9 +548,8 @@ async def test_rpc_restored_sleeping_sensor_no_last_state(
     assert hass.states.get(entity_id).state == "22.9"
 
 
-async def test_rpc_em1_sensors(
-    hass: HomeAssistant, mock_rpc_device: Mock, entity_registry_enabled_by_default: None
-) -> None:
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_rpc_em1_sensors(hass: HomeAssistant, mock_rpc_device: Mock) -> None:
     """Test RPC sensors for EM1 component."""
     registry = async_get(hass)
     await init_integration(hass, 2)

--- a/tests/components/shelly/test_switch.py
+++ b/tests/components/shelly/test_switch.py
@@ -472,10 +472,10 @@ async def test_wall_display_relay_mode(
     assert entry.unique_id == "123456789ABC-switch:0"
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_create_issue_valve_switch(
     hass: HomeAssistant,
     mock_block_device: Mock,
-    entity_registry_enabled_by_default: None,
     monkeypatch: pytest.MonkeyPatch,
     issue_registry: ir.IssueRegistry,
 ) -> None:

--- a/tests/components/shelly/test_update.py
+++ b/tests/components/shelly/test_update.py
@@ -44,13 +44,13 @@ from . import (
 from tests.common import mock_restore_cache
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_block_update(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
     mock_block_device: Mock,
     entity_registry: EntityRegistry,
     monkeypatch: pytest.MonkeyPatch,
-    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test block device update entity."""
     entity_id = "update.test_name_firmware_update"
@@ -96,13 +96,13 @@ async def test_block_update(
     assert entry.unique_id == "123456789ABC-fwupdate"
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_block_beta_update(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
     mock_block_device: Mock,
     entity_registry: EntityRegistry,
     monkeypatch: pytest.MonkeyPatch,
-    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test block device beta update entity."""
     entity_id = "update.test_name_beta_firmware_update"
@@ -156,12 +156,12 @@ async def test_block_beta_update(
     assert entry.unique_id == "123456789ABC-fwupdate_beta"
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_block_update_connection_error(
     hass: HomeAssistant,
     mock_block_device: Mock,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
-    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test block device update connection error."""
     monkeypatch.setitem(mock_block_device.status["update"], "old_version", "1")
@@ -183,11 +183,11 @@ async def test_block_update_connection_error(
         assert "Error starting OTA update" in caplog.text
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_block_update_auth_error(
     hass: HomeAssistant,
     mock_block_device: Mock,
     monkeypatch: pytest.MonkeyPatch,
-    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test block device update authentication error."""
     monkeypatch.setitem(mock_block_device.status["update"], "old_version", "1")
@@ -475,13 +475,13 @@ async def test_rpc_restored_sleeping_update_no_last_state(
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == UpdateEntityFeature(0)
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_rpc_beta_update(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
     mock_rpc_device: Mock,
     entity_registry: EntityRegistry,
     monkeypatch: pytest.MonkeyPatch,
-    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test RPC device beta update entity."""
     entity_id = "update.test_name_beta_firmware_update"
@@ -601,6 +601,7 @@ async def test_rpc_beta_update(
         (RpcCallError(-1, "error"), "OTA update request error"),
     ],
 )
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_rpc_update_errors(
     hass: HomeAssistant,
     exc: Exception,
@@ -608,7 +609,6 @@ async def test_rpc_update_errors(
     mock_rpc_device: Mock,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
-    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test RPC device update connection/call errors."""
     monkeypatch.setitem(mock_rpc_device.shelly, "ver", "1")
@@ -635,12 +635,12 @@ async def test_rpc_update_errors(
         assert error in caplog.text
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_rpc_update_auth_error(
     hass: HomeAssistant,
     mock_rpc_device: Mock,
     entity_registry: EntityRegistry,
     monkeypatch: pytest.MonkeyPatch,
-    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test RPC device update authentication error."""
     monkeypatch.setitem(mock_rpc_device.shelly, "ver", "1")

--- a/tests/components/solaredge/test_coordinator.py
+++ b/tests/components/solaredge/test_coordinator.py
@@ -21,7 +21,7 @@ API_KEY = "a1b2c3d4e5f6g7h8"
 
 
 @pytest.fixture(autouse=True)
-def enable_all_entities(entity_registry_enabled_by_default):
+def enable_all_entities(entity_registry_enabled_by_default: None) -> None:
     """Make sure all entities are enabled."""
 
 

--- a/tests/components/sonarr/test_sensor.py
+++ b/tests/components/sonarr/test_sensor.py
@@ -22,12 +22,12 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 UPCOMING_ENTITY_ID = f"{SENSOR_DOMAIN}.sonarr_upcoming"
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensors(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
     mock_sonarr: MagicMock,
-    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test the creation and values of the sensors."""
     sensors = {

--- a/tests/components/sun/test_sensor.py
+++ b/tests/components/sun/test_sensor.py
@@ -15,11 +15,11 @@ from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_setting_rising(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     freezer: FrozenDateTimeFactory,
-    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test retrieving sun setting and rising."""
     utc_now = datetime(2016, 11, 1, 8, 0, 0, tzinfo=dt_util.UTC)

--- a/tests/components/switchbot/test_sensor.py
+++ b/tests/components/switchbot/test_sensor.py
@@ -1,5 +1,7 @@
 """Test the switchbot sensors."""
 
+import pytest
+
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.components.switchbot.const import DOMAIN
 from homeassistant.const import (
@@ -19,9 +21,8 @@ from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
 
 
-async def test_sensors(
-    hass: HomeAssistant, entity_registry_enabled_by_default: None
-) -> None:
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_sensors(hass: HomeAssistant) -> None:
     """Test setting up creates the sensors."""
     await async_setup_component(hass, DOMAIN, {})
     inject_bluetooth_service_info(hass, WOHAND_SERVICE_INFO)

--- a/tests/components/systemmonitor/test_binary_sensor.py
+++ b/tests/components/systemmonitor/test_binary_sensor.py
@@ -20,9 +20,9 @@ from .conftest import MockProcess
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_binary_sensor(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     mock_psutil: Mock,
     mock_os: Mock,
     entity_registry: er.EntityRegistry,
@@ -62,9 +62,9 @@ async def test_binary_sensor(
             assert state.attributes == snapshot(name=f"{state.name} - attributes")
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_binary_sensor_icon(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     mock_psutil: Mock,
     mock_os: Mock,
     mock_config_entry: MockConfigEntry,

--- a/tests/components/systemmonitor/test_repairs.py
+++ b/tests/components/systemmonitor/test_repairs.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from http import HTTPStatus
 from unittest.mock import Mock
 
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.repairs.websocket_api import (
@@ -22,10 +23,10 @@ from tests.common import ANY, MockConfigEntry
 from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_migrate_process_sensor(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    entity_registry_enabled_by_default: None,
     mock_psutil: Mock,
     mock_os: Mock,
     hass_client: ClientSessionGenerator,
@@ -120,11 +121,11 @@ async def test_migrate_process_sensor(
     assert hass.config_entries.async_entries(DOMAIN) == snapshot(name="after_migration")
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_other_fixable_issues(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     hass_ws_client: WebSocketGenerator,
-    entity_registry_enabled_by_default: None,
     mock_added_config_entry: ConfigEntry,
 ) -> None:
     """Test fixing other issues."""

--- a/tests/components/systemmonitor/test_sensor.py
+++ b/tests/components/systemmonitor/test_sensor.py
@@ -24,9 +24,9 @@ from .conftest import MockProcess
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensor(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     mock_psutil: Mock,
     mock_os: Mock,
     entity_registry: er.EntityRegistry,
@@ -76,9 +76,9 @@ async def test_sensor(
             assert state.attributes == snapshot(name=f"{state.name} - attributes")
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_process_sensor_not_loaded(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     mock_psutil: Mock,
     mock_os: Mock,
     entity_registry: er.EntityRegistry,
@@ -108,9 +108,9 @@ async def test_process_sensor_not_loaded(
     assert process_sensor is None
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensor_not_loading_veth_networks(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     mock_added_config_entry: ConfigEntry,
 ) -> None:
     """Test the sensor."""
@@ -123,9 +123,9 @@ async def test_sensor_not_loading_veth_networks(
     assert network_sensor_2 is None
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensor_icon(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     mock_psutil: Mock,
     mock_os: Mock,
     mock_config_entry: MockConfigEntry,
@@ -142,9 +142,9 @@ async def test_sensor_icon(
         assert get_cpu_icon() == "mdi:cpu-64-bit"
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensor_yaml(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     mock_psutil: Mock,
     mock_os: Mock,
 ) -> None:
@@ -172,10 +172,10 @@ async def test_sensor_yaml(
     assert process_sensor.state == STATE_ON
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensor_yaml_fails_missing_argument(
     caplog: pytest.LogCaptureFixture,
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     mock_psutil: Mock,
     mock_os: Mock,
 ) -> None:
@@ -302,10 +302,10 @@ async def test_sensor_process_fails(
     assert "Failed to load process with ID: 1, old name: python3" in caplog.text
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensor_network_sensors(
     freezer: FrozenDateTimeFactory,
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     mock_added_config_entry: ConfigEntry,
     mock_psutil: Mock,
 ) -> None:
@@ -378,9 +378,9 @@ async def test_sensor_network_sensors(
     assert throughput_network_out_sensor.state == STATE_UNKNOWN
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_missing_cpu_temperature(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     mock_psutil: Mock,
     mock_os: Mock,
     mock_config_entry: MockConfigEntry,
@@ -402,9 +402,9 @@ async def test_missing_cpu_temperature(
     assert temp_sensor is None
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_processor_temperature(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     mock_psutil: Mock,
     mock_os: Mock,
     mock_config_entry: MockConfigEntry,
@@ -452,9 +452,9 @@ async def test_processor_temperature(
         await hass.async_block_till_done()
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_exception_handling_disk_sensor(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     mock_psutil: Mock,
     mock_added_config_entry: ConfigEntry,
     caplog: pytest.LogCaptureFixture,
@@ -511,9 +511,9 @@ async def test_exception_handling_disk_sensor(
     assert disk_sensor.attributes["unit_of_measurement"] == "%"
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_cpu_percentage_is_zero_returns_unknown(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     mock_psutil: Mock,
     mock_added_config_entry: ConfigEntry,
     caplog: pytest.LogCaptureFixture,

--- a/tests/components/systemmonitor/test_util.py
+++ b/tests/components/systemmonitor/test_util.py
@@ -17,9 +17,9 @@ from tests.common import MockConfigEntry
         (OSError("OS error"), "was excluded because of: OS error"),
     ],
 )
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_disk_setup_failure(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     mock_psutil: Mock,
     mock_os: Mock,
     mock_config_entry: MockConfigEntry,
@@ -40,9 +40,9 @@ async def test_disk_setup_failure(
     assert error_text in caplog.text
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_disk_util(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     mock_psutil: Mock,
     mock_os: Mock,
     mock_config_entry: MockConfigEntry,

--- a/tests/components/trafikverket_camera/test_binary_sensor.py
+++ b/tests/components/trafikverket_camera/test_binary_sensor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 from pytrafikverket.trafikverket_camera import CameraInfo
 
 from homeassistant.config_entries import ConfigEntry
@@ -9,9 +10,9 @@ from homeassistant.const import STATE_ON
 from homeassistant.core import HomeAssistant
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensor(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     load_int: ConfigEntry,
     get_camera: CameraInfo,
 ) -> None:

--- a/tests/components/trafikverket_camera/test_recorder.py
+++ b/tests/components/trafikverket_camera/test_recorder.py
@@ -15,9 +15,9 @@ from tests.components.recorder.common import async_wait_recording_done
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_exclude_attributes(
     recorder_mock: Recorder,
-    entity_registry_enabled_by_default: None,
     hass: HomeAssistant,
     load_int: ConfigEntry,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/components/trafikverket_camera/test_sensor.py
+++ b/tests/components/trafikverket_camera/test_sensor.py
@@ -2,15 +2,16 @@
 
 from __future__ import annotations
 
+import pytest
 from pytrafikverket.trafikverket_camera import CameraInfo
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensor(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     load_int: ConfigEntry,
     get_camera: CameraInfo,
 ) -> None:

--- a/tests/components/trafikverket_ferry/test_coordinator.py
+++ b/tests/components/trafikverket_ferry/test_coordinator.py
@@ -22,9 +22,9 @@ from . import ENTRY_CONFIG
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_coordinator(
     hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
     freezer: FrozenDateTimeFactory,
     monkeypatch: pytest.MonkeyPatch,
     get_ferries: list[FerryStop],

--- a/tests/components/trafikverket_train/test_sensor.py
+++ b/tests/components/trafikverket_train/test_sensor.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 from unittest.mock import patch
 
 from freezegun.api import FrozenDateTimeFactory
+import pytest
 from pytrafikverket.exceptions import InvalidAuthentication, NoTrainAnnouncementFound
 from pytrafikverket.trafikverket_train import TrainStop
 from syrupy.assertion import SnapshotAssertion
@@ -17,10 +18,10 @@ from homeassistant.core import HomeAssistant
 from tests.common import async_fire_time_changed
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensor_next(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
-    entity_registry_enabled_by_default: None,
     load_int: ConfigEntry,
     get_trains_next: list[TrainStop],
     get_train_stop: TrainStop,
@@ -64,10 +65,10 @@ async def test_sensor_next(
         assert state == snapshot
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensor_single_stop(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
-    entity_registry_enabled_by_default: None,
     load_int: ConfigEntry,
     get_trains_next: list[TrainStop],
     snapshot: SnapshotAssertion,
@@ -80,10 +81,10 @@ async def test_sensor_single_stop(
     assert state == snapshot
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensor_update_auth_failure(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
-    entity_registry_enabled_by_default: None,
     load_int: ConfigEntry,
     get_trains_next: list[TrainStop],
     snapshot: SnapshotAssertion,
@@ -113,10 +114,10 @@ async def test_sensor_update_auth_failure(
         assert flow == snapshot
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensor_update_failure(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
-    entity_registry_enabled_by_default: None,
     load_int: ConfigEntry,
     get_trains_next: list[TrainStop],
     snapshot: SnapshotAssertion,
@@ -143,10 +144,10 @@ async def test_sensor_update_failure(
     assert state.state == STATE_UNAVAILABLE
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensor_update_failure_no_state(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
-    entity_registry_enabled_by_default: None,
     load_int: ConfigEntry,
     get_trains_next: list[TrainStop],
     snapshot: SnapshotAssertion,

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -458,13 +458,13 @@ async def test_bandwidth_sensors(
         (60, 64, 60),
     ],
 )
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_uptime_sensors(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     aioclient_mock: AiohttpClientMocker,
     freezer: FrozenDateTimeFactory,
     mock_unifi_websocket,
-    entity_registry_enabled_by_default: None,
     initial_uptime,
     event_uptime,
     new_uptime,
@@ -545,11 +545,11 @@ async def test_uptime_sensors(
     assert hass.states.get("sensor.client1_uptime")
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_remove_sensors(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     mock_unifi_websocket,
-    entity_registry_enabled_by_default: None,
 ) -> None:
     """Verify removing of clients work as expected."""
     wired_client = {

--- a/tests/components/unifiprotect/test_sensor.py
+++ b/tests/components/unifiprotect/test_sensor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from unittest.mock import Mock
 
+import pytest
 from pyunifiprotect.data import (
     NVR,
     Camera,
@@ -399,10 +400,10 @@ async def test_sensor_setup_camera(
     assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensor_setup_camera_with_last_trip_time(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    entity_registry_enabled_by_default: None,
     ufp: MockUFPFixture,
     doorbell: Camera,
     fixed_now: datetime,
@@ -474,10 +475,10 @@ async def test_sensor_update_alarm(
     await time_changed(hass, 10)
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensor_update_alarm_with_last_trip_time(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    entity_registry_enabled_by_default: None,
     ufp: MockUFPFixture,
     sensor_all: Sensor,
     fixed_now: datetime,

--- a/tests/components/v2c/test_sensor.py
+++ b/tests/components/v2c/test_sensor.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from syrupy import SnapshotAssertion
 
 from homeassistant.const import Platform
@@ -13,13 +14,13 @@ from . import init_integration
 from tests.common import MockConfigEntry, snapshot_platform
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensor(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
     mock_v2c_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
-    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test states of the sensor."""
     with patch("homeassistant.components.v2c.PLATFORMS", [Platform.SENSOR]):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
