### PR TITLE
Move None bluetooth fixtures to decorator

### DIFF
--- a/tests/components/bluetooth/conftest.py
+++ b/tests/components/bluetooth/conftest.py
@@ -1,5 +1,6 @@
 """Tests for the bluetooth component."""
 
+from collections.abc import Generator
 from unittest.mock import patch
 
 from bleak_retry_connector import bleak_manager
@@ -74,7 +75,7 @@ def mock_operating_system_90():
 
 
 @pytest.fixture(name="macos_adapter")
-def macos_adapter():
+def macos_adapter() -> Generator[None, None, None]:
     """Fixture that mocks the macos adapter."""
     with (
         patch("bleak.get_platform_scanner_backend_type"),
@@ -109,7 +110,7 @@ def windows_adapter():
 
 
 @pytest.fixture(name="no_adapters")
-def no_adapter_fixture():
+def no_adapter_fixture() -> Generator[None, None, None]:
     """Fixture that mocks no adapters on Linux."""
     with (
         patch(
@@ -137,7 +138,7 @@ def no_adapter_fixture():
 
 
 @pytest.fixture(name="one_adapter")
-def one_adapter_fixture():
+def one_adapter_fixture() -> Generator[None, None, None]:
     """Fixture that mocks one adapter on Linux."""
     with (
         patch(
@@ -176,7 +177,7 @@ def one_adapter_fixture():
 
 
 @pytest.fixture(name="two_adapters")
-def two_adapters_fixture():
+def two_adapters_fixture() -> Generator[None, None, None]:
     """Fixture that mocks two adapters on Linux."""
     with (
         patch(

--- a/tests/components/bluetooth/test_advertisement_tracker.py
+++ b/tests/components/bluetooth/test_advertisement_tracker.py
@@ -33,11 +33,9 @@ from tests.common import async_fire_time_changed
 ONE_HOUR_SECONDS = 3600
 
 
+@pytest.mark.usefixtures("enable_bluetooth", "macos_adapter")
 async def test_advertisment_interval_shorter_than_adapter_stack_timeout(
     hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
-    enable_bluetooth: None,
-    macos_adapter: None,
 ) -> None:
     """Test we can determine the advertisement interval."""
     start_monotonic_time = time.monotonic()
@@ -83,11 +81,9 @@ async def test_advertisment_interval_shorter_than_adapter_stack_timeout(
     switchbot_device_unavailable_cancel()
 
 
+@pytest.mark.usefixtures("enable_bluetooth", "macos_adapter")
 async def test_advertisment_interval_longer_than_adapter_stack_timeout_connectable(
     hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
-    enable_bluetooth: None,
-    macos_adapter: None,
 ) -> None:
     """Test device with a long advertisement interval."""
     start_monotonic_time = time.monotonic()
@@ -135,11 +131,9 @@ async def test_advertisment_interval_longer_than_adapter_stack_timeout_connectab
     switchbot_device_unavailable_cancel()
 
 
+@pytest.mark.usefixtures("enable_bluetooth", "macos_adapter")
 async def test_advertisment_interval_longer_than_adapter_stack_timeout_adapter_change_connectable(
     hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
-    enable_bluetooth: None,
-    macos_adapter: None,
 ) -> None:
     """Test device with a long advertisement interval with an adapter change."""
     start_monotonic_time = time.monotonic()
@@ -200,11 +194,9 @@ async def test_advertisment_interval_longer_than_adapter_stack_timeout_adapter_c
     switchbot_device_unavailable_cancel()
 
 
+@pytest.mark.usefixtures("enable_bluetooth", "macos_adapter")
 async def test_advertisment_interval_longer_than_adapter_stack_timeout_not_connectable(
     hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
-    enable_bluetooth: None,
-    macos_adapter: None,
 ) -> None:
     """Test device with a long advertisement interval that is not connectable not reaching the advertising interval."""
     start_monotonic_time = time.monotonic()
@@ -255,11 +247,9 @@ async def test_advertisment_interval_longer_than_adapter_stack_timeout_not_conne
     switchbot_device_unavailable_cancel()
 
 
+@pytest.mark.usefixtures("enable_bluetooth", "macos_adapter")
 async def test_advertisment_interval_shorter_than_adapter_stack_timeout_adapter_change_not_connectable(
     hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
-    enable_bluetooth: None,
-    macos_adapter: None,
 ) -> None:
     """Test device with a short advertisement interval with an adapter change that is not connectable."""
     start_monotonic_time = time.monotonic()
@@ -330,11 +320,9 @@ async def test_advertisment_interval_shorter_than_adapter_stack_timeout_adapter_
     switchbot_device_unavailable_cancel()
 
 
+@pytest.mark.usefixtures("enable_bluetooth", "macos_adapter")
 async def test_advertisment_interval_longer_than_adapter_stack_timeout_adapter_change_not_connectable(
     hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
-    enable_bluetooth: None,
-    macos_adapter: None,
 ) -> None:
     """Test device with a long advertisement interval with an adapter change that is not connectable."""
     start_monotonic_time = time.monotonic()
@@ -436,11 +424,9 @@ async def test_advertisment_interval_longer_than_adapter_stack_timeout_adapter_c
     switchbot_device_unavailable_cancel()
 
 
+@pytest.mark.usefixtures("enable_bluetooth", "macos_adapter")
 async def test_advertisment_interval_longer_increasing_than_adapter_stack_timeout_adapter_change_not_connectable(
     hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
-    enable_bluetooth: None,
-    macos_adapter: None,
 ) -> None:
     """Test device with a increasing advertisement interval with an adapter change that is not connectable."""
     start_monotonic_time = time.monotonic()

--- a/tests/components/bluetooth/test_api.py
+++ b/tests/components/bluetooth/test_api.py
@@ -24,7 +24,8 @@ from . import (
 )
 
 
-async def test_scanner_by_source(hass: HomeAssistant, enable_bluetooth: None) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_scanner_by_source(hass: HomeAssistant) -> None:
     """Test we can get a scanner by source."""
 
     hci2_scanner = FakeScanner("hci2", "hci2")
@@ -40,16 +41,16 @@ async def test_monotonic_time() -> None:
     assert MONOTONIC_TIME() == pytest.approx(time.monotonic(), abs=0.1)
 
 
-async def test_async_get_advertisement_callback(
-    hass: HomeAssistant, enable_bluetooth: None
-) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_async_get_advertisement_callback(hass: HomeAssistant) -> None:
     """Test getting advertisement callback."""
     callback = bluetooth.async_get_advertisement_callback(hass)
     assert callback is not None
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_async_scanner_devices_by_address_connectable(
-    hass: HomeAssistant, enable_bluetooth: None
+    hass: HomeAssistant,
 ) -> None:
     """Test getting scanner devices by address with connectable devices."""
     manager = _get_manager()
@@ -105,8 +106,9 @@ async def test_async_scanner_devices_by_address_connectable(
     cancel()
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_async_scanner_devices_by_address_non_connectable(
-    hass: HomeAssistant, enable_bluetooth: None
+    hass: HomeAssistant,
 ) -> None:
     """Test getting scanner devices by address with non-connectable devices."""
     manager = _get_manager()

--- a/tests/components/bluetooth/test_base_scanner.py
+++ b/tests/components/bluetooth/test_base_scanner.py
@@ -66,9 +66,8 @@ class FakeScanner(BaseHaRemoteScanner):
 
 
 @pytest.mark.parametrize("name_2", [None, "w"])
-async def test_remote_scanner(
-    hass: HomeAssistant, enable_bluetooth: None, name_2: str | None
-) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_remote_scanner(hass: HomeAssistant, name_2: str | None) -> None:
     """Test the remote scanner base class merges advertisement_data."""
     manager = _get_manager()
 
@@ -159,9 +158,8 @@ async def test_remote_scanner(
     unsetup()
 
 
-async def test_remote_scanner_expires_connectable(
-    hass: HomeAssistant, enable_bluetooth: None
-) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_remote_scanner_expires_connectable(hass: HomeAssistant) -> None:
     """Test the remote scanner expires stale connectable data."""
     manager = _get_manager()
 
@@ -213,9 +211,8 @@ async def test_remote_scanner_expires_connectable(
     unsetup()
 
 
-async def test_remote_scanner_expires_non_connectable(
-    hass: HomeAssistant, enable_bluetooth: None
-) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_remote_scanner_expires_non_connectable(hass: HomeAssistant) -> None:
     """Test the remote scanner expires stale non connectable data."""
     manager = _get_manager()
 
@@ -287,9 +284,8 @@ async def test_remote_scanner_expires_non_connectable(
     unsetup()
 
 
-async def test_base_scanner_connecting_behavior(
-    hass: HomeAssistant, enable_bluetooth: None
-) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_base_scanner_connecting_behavior(hass: HomeAssistant) -> None:
     """Test that the default behavior is to mark the scanner as not scanning when connecting."""
     manager = _get_manager()
 
@@ -392,9 +388,8 @@ async def test_restore_history_remote_adapter(
     unsetup()
 
 
-async def test_device_with_ten_minute_advertising_interval(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, enable_bluetooth: None
-) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_device_with_ten_minute_advertising_interval(hass: HomeAssistant) -> None:
     """Test a device with a 10 minute advertising interval."""
     manager = _get_manager()
 
@@ -496,9 +491,8 @@ async def test_device_with_ten_minute_advertising_interval(
     unsetup()
 
 
-async def test_scanner_stops_responding(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, enable_bluetooth: None
-) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_scanner_stops_responding(hass: HomeAssistant) -> None:
     """Test we mark a scanner are not scanning when it stops responding."""
     manager = _get_manager()
 

--- a/tests/components/bluetooth/test_config_flow.py
+++ b/tests/components/bluetooth/test_config_flow.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 from bluetooth_adapters import DEFAULT_ADDRESS, AdapterDetails
+import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.bluetooth.const import (
@@ -19,12 +20,12 @@ from tests.common import MockConfigEntry
 from tests.typing import WebSocketGenerator
 
 
+@pytest.mark.usefixtures("macos_adapter")
 async def test_options_flow_disabled_not_setup(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     mock_bleak_scanner_start: MagicMock,
     mock_bluetooth_adapters: None,
-    macos_adapter: None,
 ) -> None:
     """Test options are disabled if the integration has not been setup."""
     await async_setup_component(hass, "config", {})
@@ -49,7 +50,8 @@ async def test_options_flow_disabled_not_setup(
     await hass.config_entries.async_unload(entry.entry_id)
 
 
-async def test_async_step_user_macos(hass: HomeAssistant, macos_adapter: None) -> None:
+@pytest.mark.usefixtures("macos_adapter")
+async def test_async_step_user_macos(hass: HomeAssistant) -> None:
     """Test setting up manually with one adapter on MacOS."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -73,9 +75,8 @@ async def test_async_step_user_macos(hass: HomeAssistant, macos_adapter: None) -
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_async_step_user_linux_one_adapter(
-    hass: HomeAssistant, one_adapter: None
-) -> None:
+@pytest.mark.usefixtures("one_adapter")
+async def test_async_step_user_linux_one_adapter(hass: HomeAssistant) -> None:
     """Test setting up manually with one adapter on Linux."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -117,9 +118,8 @@ async def test_async_step_user_linux_crashed_adapter(
     assert result["reason"] == "no_adapters"
 
 
-async def test_async_step_user_linux_two_adapters(
-    hass: HomeAssistant, two_adapters: None
-) -> None:
+@pytest.mark.usefixtures("two_adapters")
+async def test_async_step_user_linux_two_adapters(hass: HomeAssistant) -> None:
     """Test setting up manually with two adapters on Linux."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -147,9 +147,8 @@ async def test_async_step_user_linux_two_adapters(
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_async_step_user_only_allows_one(
-    hass: HomeAssistant, macos_adapter: None
-) -> None:
+@pytest.mark.usefixtures("macos_adapter")
+async def test_async_step_user_only_allows_one(hass: HomeAssistant) -> None:
     """Test setting up manually with an existing entry."""
     entry = MockConfigEntry(domain=DOMAIN, unique_id=DEFAULT_ADDRESS)
     entry.add_to_hass(hass)
@@ -199,8 +198,9 @@ async def test_async_step_integration_discovery(hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
+@pytest.mark.usefixtures("one_adapter")
 async def test_async_step_integration_discovery_during_onboarding_one_adapter(
-    hass: HomeAssistant, one_adapter: None
+    hass: HomeAssistant,
 ) -> None:
     """Test setting up from integration discovery during onboarding."""
     details = AdapterDetails(
@@ -232,8 +232,9 @@ async def test_async_step_integration_discovery_during_onboarding_one_adapter(
     assert len(mock_onboarding.mock_calls) == 1
 
 
+@pytest.mark.usefixtures("two_adapters")
 async def test_async_step_integration_discovery_during_onboarding_two_adapters(
-    hass: HomeAssistant, two_adapters: None
+    hass: HomeAssistant,
 ) -> None:
     """Test setting up from integration discovery during onboarding."""
     details1 = AdapterDetails(
@@ -281,8 +282,9 @@ async def test_async_step_integration_discovery_during_onboarding_two_adapters(
     assert len(mock_onboarding.mock_calls) == 2
 
 
+@pytest.mark.usefixtures("macos_adapter")
 async def test_async_step_integration_discovery_during_onboarding(
-    hass: HomeAssistant, macos_adapter: None
+    hass: HomeAssistant,
 ) -> None:
     """Test setting up from integration discovery during onboarding."""
     details = AdapterDetails(
@@ -336,11 +338,11 @@ async def test_async_step_integration_discovery_already_exists(
     assert result["reason"] == "already_configured"
 
 
+@pytest.mark.usefixtures("one_adapter")
 async def test_options_flow_linux(
     hass: HomeAssistant,
     mock_bleak_scanner_start: MagicMock,
     mock_bluetooth_adapters: None,
-    one_adapter: None,
 ) -> None:
     """Test options on Linux."""
     entry = MockConfigEntry(
@@ -390,12 +392,12 @@ async def test_options_flow_linux(
     await hass.config_entries.async_unload(entry.entry_id)
 
 
+@pytest.mark.usefixtures("macos_adapter")
 async def test_options_flow_disabled_macos(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     mock_bleak_scanner_start: MagicMock,
     mock_bluetooth_adapters: None,
-    macos_adapter: None,
 ) -> None:
     """Test options are disabled on MacOS."""
     await async_setup_component(hass, "config", {})
@@ -420,12 +422,12 @@ async def test_options_flow_disabled_macos(
     await hass.config_entries.async_unload(entry.entry_id)
 
 
+@pytest.mark.usefixtures("one_adapter")
 async def test_options_flow_enabled_linux(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     mock_bleak_scanner_start: MagicMock,
     mock_bluetooth_adapters: None,
-    one_adapter: None,
 ) -> None:
     """Test options are enabled on Linux."""
     await async_setup_component(hass, "config", {})
@@ -453,9 +455,8 @@ async def test_options_flow_enabled_linux(
     await hass.config_entries.async_unload(entry.entry_id)
 
 
-async def test_async_step_user_linux_adapter_is_ignored(
-    hass: HomeAssistant, one_adapter: None
-) -> None:
+@pytest.mark.usefixtures("one_adapter")
+async def test_async_step_user_linux_adapter_is_ignored(hass: HomeAssistant) -> None:
     """Test we give a hint that the adapter is ignored."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/bluetooth/test_diagnostics.py
+++ b/tests/components/bluetooth/test_diagnostics.py
@@ -4,6 +4,7 @@ from unittest.mock import ANY, MagicMock, patch
 
 from bleak.backends.scanner import AdvertisementData, BLEDevice
 from bluetooth_adapters import DEFAULT_ADDRESS
+import pytest
 
 from homeassistant.components import bluetooth
 from homeassistant.components.bluetooth import (
@@ -43,12 +44,11 @@ class FakeHaScanner(FakeScannerMixin, HaScanner):
 
 
 @patch("homeassistant.components.bluetooth.HaScanner", FakeHaScanner)
+@pytest.mark.usefixtures("enable_bluetooth", "two_adapters")
 async def test_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     mock_bleak_scanner_start: MagicMock,
-    enable_bluetooth: None,
-    two_adapters: None,
 ) -> None:
     """Test we can setup and unsetup bluetooth with multiple adapters."""
     # Normally we do not want to patch our classes, but since bleak will import
@@ -237,12 +237,12 @@ async def test_diagnostics(
 
 
 @patch("homeassistant.components.bluetooth.HaScanner", FakeHaScanner)
+@pytest.mark.usefixtures("macos_adapter")
 async def test_diagnostics_macos(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     mock_bleak_scanner_start: MagicMock,
     mock_bluetooth_adapters: None,
-    macos_adapter,
 ) -> None:
     """Test diagnostics for macos."""
     # Normally we do not want to patch our classes, but since bleak will import
@@ -414,13 +414,12 @@ async def test_diagnostics_macos(
 
 
 @patch("homeassistant.components.bluetooth.HaScanner", FakeHaScanner)
+@pytest.mark.usefixtures("enable_bluetooth", "one_adapter")
 async def test_diagnostics_remote_adapter(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     mock_bleak_scanner_start: MagicMock,
     mock_bluetooth_adapters: None,
-    enable_bluetooth: None,
-    one_adapter: None,
 ) -> None:
     """Test diagnostics for remote adapter."""
     manager = _get_manager()

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -59,8 +59,9 @@ from . import (
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_setup_and_stop(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test we and setup and stop the scanner."""
     mock_bt = [
@@ -84,8 +85,9 @@ async def test_setup_and_stop(
     assert len(mock_bleak_scanner_start.mock_calls) == 1
 
 
+@pytest.mark.usefixtures("one_adapter")
 async def test_setup_and_stop_passive(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, one_adapter: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test we and setup and stop the scanner the passive scanner."""
     entry = MockConfigEntry(
@@ -183,8 +185,9 @@ async def test_setup_and_stop_old_bluez(
     }
 
 
+@pytest.mark.usefixtures("one_adapter")
 async def test_setup_and_stop_no_bluetooth(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, one_adapter: None
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test we fail gracefully when bluetooth is not available."""
     mock_bt = [
@@ -211,8 +214,9 @@ async def test_setup_and_stop_no_bluetooth(
     assert "Failed to initialize Bluetooth" in caplog.text
 
 
+@pytest.mark.usefixtures("macos_adapter")
 async def test_setup_and_stop_broken_bluetooth(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, macos_adapter: None
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test we fail gracefully when bluetooth/dbus is broken."""
     mock_bt = []
@@ -236,8 +240,9 @@ async def test_setup_and_stop_broken_bluetooth(
     assert len(bluetooth.async_discovered_service_info(hass)) == 0
 
 
+@pytest.mark.usefixtures("macos_adapter")
 async def test_setup_and_stop_broken_bluetooth_hanging(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, macos_adapter: None
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test we fail gracefully when bluetooth/dbus is hanging."""
     mock_bt = []
@@ -265,8 +270,9 @@ async def test_setup_and_stop_broken_bluetooth_hanging(
     assert "Timed out starting Bluetooth" in caplog.text
 
 
+@pytest.mark.usefixtures("macos_adapter")
 async def test_setup_and_retry_adapter_not_yet_available(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, macos_adapter: None
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test we retry if the adapter is not yet available."""
     mock_bt = []
@@ -304,8 +310,9 @@ async def test_setup_and_retry_adapter_not_yet_available(
         await hass.async_block_till_done()
 
 
+@pytest.mark.usefixtures("macos_adapter")
 async def test_no_race_during_manual_reload_in_retry_state(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, macos_adapter: None
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test we can successfully reload when the entry is in a retry state."""
     mock_bt = []
@@ -344,8 +351,9 @@ async def test_no_race_during_manual_reload_in_retry_state(
         await hass.async_block_till_done()
 
 
+@pytest.mark.usefixtures("macos_adapter")
 async def test_calling_async_discovered_devices_no_bluetooth(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, macos_adapter: None
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test we fail gracefully when asking for discovered devices and there is no blueooth."""
     mock_bt = []
@@ -370,8 +378,9 @@ async def test_calling_async_discovered_devices_no_bluetooth(
     assert not bluetooth.async_address_present(hass, "aa:bb:bb:dd:ee:ff")
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_discovery_match_by_service_uuid(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test bluetooth discovery match by service_uuid."""
     mock_bt = [
@@ -467,8 +476,9 @@ def _domains_from_mock_config_flow(mock_config_flow: Mock) -> list[str]:
     return [call[1][0] for call in mock_config_flow.mock_calls if call[1][0] != DOMAIN]
 
 
+@pytest.mark.usefixtures("macos_adapter")
 async def test_discovery_match_by_service_uuid_connectable(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, macos_adapter: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test bluetooth discovery match by service_uuid and the ble device is connectable."""
     mock_bt = [
@@ -518,8 +528,9 @@ async def test_discovery_match_by_service_uuid_connectable(
         assert called_domains == ["switchbot"]
 
 
+@pytest.mark.usefixtures("macos_adapter")
 async def test_discovery_match_by_service_uuid_not_connectable(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, macos_adapter: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test bluetooth discovery match by service_uuid and the ble device is not connectable."""
     mock_bt = [
@@ -567,8 +578,9 @@ async def test_discovery_match_by_service_uuid_not_connectable(
         assert len(_domains_from_mock_config_flow(mock_config_flow)) == 0
 
 
+@pytest.mark.usefixtures("macos_adapter")
 async def test_discovery_match_by_name_connectable_false(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, macos_adapter: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test bluetooth discovery match by name and the integration will take non-connectable devices."""
     mock_bt = [
@@ -645,8 +657,9 @@ async def test_discovery_match_by_name_connectable_false(
         assert _domains_from_mock_config_flow(mock_config_flow) == ["qingping"]
 
 
+@pytest.mark.usefixtures("macos_adapter")
 async def test_discovery_match_by_local_name(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, macos_adapter: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test bluetooth discovery match by local_name."""
     mock_bt = [{"domain": "switchbot", "local_name": "wohand"}]
@@ -683,8 +696,9 @@ async def test_discovery_match_by_local_name(
         assert mock_config_flow.mock_calls[0][1][0] == "switchbot"
 
 
+@pytest.mark.usefixtures("macos_adapter")
 async def test_discovery_match_by_manufacturer_id_and_manufacturer_data_start(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, macos_adapter: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test bluetooth discovery match by manufacturer_id and manufacturer_data_start."""
     mock_bt = [
@@ -759,8 +773,9 @@ async def test_discovery_match_by_manufacturer_id_and_manufacturer_data_start(
         assert len(mock_config_flow.mock_calls) == 0
 
 
+@pytest.mark.usefixtures("macos_adapter")
 async def test_discovery_match_by_service_data_uuid_then_others(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, macos_adapter: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test bluetooth discovery match by service_data_uuid and then other fields."""
     mock_bt = [
@@ -913,8 +928,9 @@ async def test_discovery_match_by_service_data_uuid_then_others(
         assert len(mock_config_flow.mock_calls) == 0
 
 
+@pytest.mark.usefixtures("macos_adapter")
 async def test_discovery_match_by_service_data_uuid_when_format_changes(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, macos_adapter: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test bluetooth discovery match by service_data_uuid when format changes."""
     mock_bt = [
@@ -996,8 +1012,9 @@ async def test_discovery_match_by_service_data_uuid_when_format_changes(
         mock_config_flow.reset_mock()
 
 
+@pytest.mark.usefixtures("macos_adapter")
 async def test_discovery_match_by_service_data_uuid_bthome(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, macos_adapter: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test bluetooth discovery match by service_data_uuid for bthome."""
     mock_bt = [
@@ -1038,8 +1055,9 @@ async def test_discovery_match_by_service_data_uuid_bthome(
         mock_config_flow.reset_mock()
 
 
+@pytest.mark.usefixtures("macos_adapter")
 async def test_discovery_match_first_by_service_uuid_and_then_manufacturer_id(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, macos_adapter: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test bluetooth discovery matches twice for service_uuid and then manufacturer_id."""
     mock_bt = [
@@ -1102,8 +1120,9 @@ async def test_discovery_match_first_by_service_uuid_and_then_manufacturer_id(
         assert len(mock_config_flow.mock_calls) == 0
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_rediscovery(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test bluetooth discovery can be re-enabled for a given domain."""
     mock_bt = [
@@ -1149,8 +1168,9 @@ async def test_rediscovery(
         assert mock_config_flow.mock_calls[1][1][0] == "switchbot"
 
 
+@pytest.mark.usefixtures("macos_adapter")
 async def test_async_discovered_device_api(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, macos_adapter: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test the async_discovered_device API."""
     mock_bt = []
@@ -1255,8 +1275,9 @@ async def test_async_discovered_device_api(
             assert bluetooth.async_address_present(hass, "44:44:33:11:23:45") is True
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_register_callbacks(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test registering a callback."""
     mock_bt = []
@@ -1336,10 +1357,10 @@ async def test_register_callbacks(
     assert service_info.manufacturer_id == 89
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_register_callbacks_raises_exception(
     hass: HomeAssistant,
     mock_bleak_scanner_start: MagicMock,
-    enable_bluetooth: None,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test registering a callback that raises ValueError."""
@@ -1401,8 +1422,9 @@ async def test_register_callbacks_raises_exception(
     assert "ValueError" in caplog.text
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_register_callback_by_address(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test registering a callback by address."""
     mock_bt = []
@@ -1492,8 +1514,9 @@ async def test_register_callback_by_address(
         assert service_info.manufacturer_id == 89
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_register_callback_by_address_connectable_only(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test registering a callback by address connectable only."""
     mock_bt = []
@@ -1571,8 +1594,9 @@ async def test_register_callback_by_address_connectable_only(
     assert len(non_connectable_callbacks) == 2
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_register_callback_by_manufacturer_id(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test registering a callback by manufacturer_id."""
     mock_bt = []
@@ -1626,8 +1650,9 @@ async def test_register_callback_by_manufacturer_id(
     assert service_info.manufacturer_id == 21
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_register_callback_by_connectable(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test registering a callback by connectable."""
     mock_bt = []
@@ -1681,8 +1706,9 @@ async def test_register_callback_by_connectable(
     assert service_info.name == "empty"
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_not_filtering_wanted_apple_devices(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test filtering noisy apple devices."""
     mock_bt = []
@@ -1741,8 +1767,9 @@ async def test_not_filtering_wanted_apple_devices(
     assert len(callbacks) == 3
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_filtering_noisy_apple_devices(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test filtering noisy apple devices."""
     mock_bt = []
@@ -1791,8 +1818,9 @@ async def test_filtering_noisy_apple_devices(
     assert len(callbacks) == 0
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_register_callback_by_address_connectable_manufacturer_id(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test registering a callback by address, manufacturer_id, and connectable."""
     mock_bt = []
@@ -1845,8 +1873,9 @@ async def test_register_callback_by_address_connectable_manufacturer_id(
     assert service_info.manufacturer_id == 21
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_register_callback_by_manufacturer_id_and_address(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test registering a callback by manufacturer_id and address."""
     mock_bt = []
@@ -1910,8 +1939,9 @@ async def test_register_callback_by_manufacturer_id_and_address(
     assert service_info.manufacturer_id == 21
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_register_callback_by_service_uuid_and_address(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test registering a callback by service_uuid and address."""
     mock_bt = []
@@ -1983,8 +2013,9 @@ async def test_register_callback_by_service_uuid_and_address(
     assert service_info.name == "switchbot"
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_register_callback_by_service_data_uuid_and_address(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test registering a callback by service_data_uuid and address."""
     mock_bt = []
@@ -2056,8 +2087,9 @@ async def test_register_callback_by_service_data_uuid_and_address(
     assert service_info.name == "switchbot"
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_register_callback_by_local_name(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test registering a callback by local_name."""
     mock_bt = []
@@ -2119,11 +2151,9 @@ async def test_register_callback_by_local_name(
     assert service_info.manufacturer_id == 21
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_register_callback_by_local_name_overly_broad(
-    hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    enable_bluetooth: None,
-    caplog: pytest.LogCaptureFixture,
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test registering a callback by local_name that is too broad."""
     mock_bt = []
@@ -2147,8 +2177,9 @@ async def test_register_callback_by_local_name_overly_broad(
         )
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_register_callback_by_service_data_uuid(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test registering a callback by service_data_uuid."""
     mock_bt = []
@@ -2202,8 +2233,9 @@ async def test_register_callback_by_service_data_uuid(
     assert service_info.name == "xiaomi"
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_register_callback_survives_reload(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test registering a callback by address survives bluetooth being reloaded."""
     mock_bt = []
@@ -2265,8 +2297,9 @@ async def test_register_callback_survives_reload(
     cancel()
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_process_advertisements_bail_on_good_advertisement(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test as soon as we see a 'good' advertisement we return it."""
     done = asyncio.Future()
@@ -2304,8 +2337,9 @@ async def test_process_advertisements_bail_on_good_advertisement(
     assert result.name == "wohand"
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_process_advertisements_ignore_bad_advertisement(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Check that we ignore bad advertisements."""
     done = asyncio.Event()
@@ -2358,8 +2392,9 @@ async def test_process_advertisements_ignore_bad_advertisement(
     assert result.service_data["00000d00-0000-1000-8000-00805f9b34fa"] == b"H\x10c"
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_process_advertisements_timeout(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test we timeout if no advertisements at all."""
 
@@ -2372,8 +2407,9 @@ async def test_process_advertisements_timeout(
         )
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_wrapped_instance_with_filter(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test consumers can use the wrapped instance with a filter as if it was normal BleakScanner."""
     with patch(
@@ -2444,8 +2480,9 @@ async def test_wrapped_instance_with_filter(
         assert len(detected) == 4
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_wrapped_instance_with_service_uuids(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test consumers can use the wrapped instance with a service_uuids list as if it was normal BleakScanner."""
     with patch(
@@ -2500,8 +2537,9 @@ async def test_wrapped_instance_with_service_uuids(
         assert len(detected) == 2
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_wrapped_instance_with_service_uuids_with_coro_callback(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test consumers can use the wrapped instance with a service_uuids list as if it was normal BleakScanner.
 
@@ -2559,8 +2597,9 @@ async def test_wrapped_instance_with_service_uuids_with_coro_callback(
         assert len(detected) == 2
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_wrapped_instance_with_broken_callbacks(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test broken callbacks do not cause the scanner to fail."""
     with (
@@ -2606,8 +2645,9 @@ async def test_wrapped_instance_with_broken_callbacks(
         assert len(detected) == 1
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_wrapped_instance_changes_uuids(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test consumers can use the wrapped instance can change the uuids later."""
     with patch(
@@ -2661,8 +2701,9 @@ async def test_wrapped_instance_changes_uuids(
         assert len(detected) == 2
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_wrapped_instance_changes_filters(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test consumers can use the wrapped instance can change the filter later."""
     with patch(
@@ -2717,11 +2758,11 @@ async def test_wrapped_instance_changes_filters(
         assert len(detected) == 2
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_wrapped_instance_unsupported_filter(
     hass: HomeAssistant,
     mock_bleak_scanner_start: MagicMock,
     caplog: pytest.LogCaptureFixture,
-    enable_bluetooth: None,
 ) -> None:
     """Test we want when their filter is ineffective."""
     with patch(
@@ -2743,8 +2784,9 @@ async def test_wrapped_instance_unsupported_filter(
         assert "Only UUIDs filters are supported" in caplog.text
 
 
+@pytest.mark.usefixtures("macos_adapter")
 async def test_async_ble_device_from_address(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, macos_adapter: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test the async_ble_device_from_address api."""
     set_manager(None)
@@ -2800,8 +2842,9 @@ async def test_async_ble_device_from_address(
         )
 
 
+@pytest.mark.usefixtures("macos_adapter")
 async def test_can_unsetup_bluetooth_single_adapter_macos(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, macos_adapter: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test we can setup and unsetup bluetooth."""
     entry = MockConfigEntry(domain=bluetooth.DOMAIN, data={}, unique_id=DEFAULT_ADDRESS)
@@ -2815,10 +2858,10 @@ async def test_can_unsetup_bluetooth_single_adapter_macos(
         await hass.async_block_till_done()
 
 
+@pytest.mark.usefixtures("one_adapter")
 async def test_default_address_config_entries_removed_linux(
     hass: HomeAssistant,
     mock_bleak_scanner_start: MagicMock,
-    one_adapter: None,
 ) -> None:
     """Test default address entries are removed on linux."""
     entry = MockConfigEntry(domain=bluetooth.DOMAIN, data={}, unique_id=DEFAULT_ADDRESS)
@@ -2828,11 +2871,9 @@ async def test_default_address_config_entries_removed_linux(
     assert not hass.config_entries.async_entries(bluetooth.DOMAIN)
 
 
+@pytest.mark.usefixtures("enable_bluetooth", "one_adapter")
 async def test_can_unsetup_bluetooth_single_adapter_linux(
-    hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    enable_bluetooth: None,
-    one_adapter: None,
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test we can setup and unsetup bluetooth."""
     entry = MockConfigEntry(
@@ -2848,11 +2889,10 @@ async def test_can_unsetup_bluetooth_single_adapter_linux(
         await hass.async_block_till_done()
 
 
+@pytest.mark.usefixtures("enable_bluetooth", "two_adapters")
 async def test_can_unsetup_bluetooth_multiple_adapters(
     hass: HomeAssistant,
     mock_bleak_scanner_start: MagicMock,
-    enable_bluetooth: None,
-    two_adapters: None,
 ) -> None:
     """Test we can setup and unsetup bluetooth with multiple adapters."""
     entry1 = MockConfigEntry(
@@ -2874,11 +2914,10 @@ async def test_can_unsetup_bluetooth_multiple_adapters(
             await hass.async_block_till_done()
 
 
+@pytest.mark.usefixtures("enable_bluetooth", "two_adapters")
 async def test_three_adapters_one_missing(
     hass: HomeAssistant,
     mock_bleak_scanner_start: MagicMock,
-    enable_bluetooth: None,
-    two_adapters: None,
 ) -> None:
     """Test three adapters but one is missing results in a retry on setup."""
     entry = MockConfigEntry(
@@ -2890,9 +2929,8 @@ async def test_three_adapters_one_missing(
     assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_auto_detect_bluetooth_adapters_linux(
-    hass: HomeAssistant, one_adapter: None
-) -> None:
+@pytest.mark.usefixtures("one_adapter")
+async def test_auto_detect_bluetooth_adapters_linux(hass: HomeAssistant) -> None:
     """Test we auto detect bluetooth adapters on linux."""
     assert await async_setup_component(hass, bluetooth.DOMAIN, {})
     await hass.async_block_till_done()
@@ -2900,8 +2938,9 @@ async def test_auto_detect_bluetooth_adapters_linux(
     assert len(hass.config_entries.flow.async_progress(bluetooth.DOMAIN)) == 1
 
 
+@pytest.mark.usefixtures("two_adapters")
 async def test_auto_detect_bluetooth_adapters_linux_multiple(
-    hass: HomeAssistant, two_adapters: None
+    hass: HomeAssistant,
 ) -> None:
     """Test we auto detect bluetooth adapters on linux with multiple adapters."""
     assert await async_setup_component(hass, bluetooth.DOMAIN, {})
@@ -2959,17 +2998,17 @@ async def test_no_auto_detect_bluetooth_adapters_windows(hass: HomeAssistant) ->
     assert len(hass.config_entries.flow.async_progress(bluetooth.DOMAIN)) == 0
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_getting_the_scanner_returns_the_wrapped_instance(
-    hass: HomeAssistant, enable_bluetooth: None
+    hass: HomeAssistant,
 ) -> None:
     """Test getting the scanner returns the wrapped instance."""
     scanner = bluetooth.async_get_scanner(hass)
     assert isinstance(scanner, HaBleakScannerWrapper)
 
 
-async def test_scanner_count_connectable(
-    hass: HomeAssistant, enable_bluetooth: None
-) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_scanner_count_connectable(hass: HomeAssistant) -> None:
     """Test getting the connectable scanner count."""
     scanner = FakeScanner("any", "any")
     cancel = bluetooth.async_register_scanner(hass, scanner)
@@ -2977,7 +3016,8 @@ async def test_scanner_count_connectable(
     cancel()
 
 
-async def test_scanner_count(hass: HomeAssistant, enable_bluetooth: None) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_scanner_count(hass: HomeAssistant) -> None:
     """Test getting the connectable and non-connectable scanner count."""
     scanner = FakeScanner("any", "any")
     cancel = bluetooth.async_register_scanner(hass, scanner)
@@ -2985,8 +3025,9 @@ async def test_scanner_count(hass: HomeAssistant, enable_bluetooth: None) -> Non
     cancel()
 
 
+@pytest.mark.usefixtures("macos_adapter")
 async def test_migrate_single_entry_macos(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, macos_adapter: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test we can migrate a single entry on MacOS."""
     entry = MockConfigEntry(domain=bluetooth.DOMAIN, data={})
@@ -2996,8 +3037,9 @@ async def test_migrate_single_entry_macos(
     assert entry.unique_id == DEFAULT_ADDRESS
 
 
+@pytest.mark.usefixtures("one_adapter")
 async def test_migrate_single_entry_linux(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, one_adapter: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test we can migrate a single entry on Linux."""
     entry = MockConfigEntry(domain=bluetooth.DOMAIN, data={})
@@ -3007,8 +3049,9 @@ async def test_migrate_single_entry_linux(
     assert entry.unique_id == "00:00:00:00:00:01"
 
 
+@pytest.mark.usefixtures("one_adapter")
 async def test_discover_new_usb_adapters(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, one_adapter: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test we can discover new usb adapters."""
     entry = MockConfigEntry(
@@ -3067,8 +3110,9 @@ async def test_discover_new_usb_adapters(
     assert len(hass.config_entries.flow.async_progress(DOMAIN)) == 1
 
 
+@pytest.mark.usefixtures("one_adapter")
 async def test_discover_new_usb_adapters_with_firmware_fallback_delay(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, one_adapter: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test we can discover new usb adapters with a firmware fallback delay."""
     entry = MockConfigEntry(
@@ -3146,10 +3190,10 @@ async def test_discover_new_usb_adapters_with_firmware_fallback_delay(
     assert len(hass.config_entries.flow.async_progress(DOMAIN)) == 1
 
 
+@pytest.mark.usefixtures("no_adapters")
 async def test_issue_outdated_haos_removed(
     hass: HomeAssistant,
     mock_bleak_scanner_start: MagicMock,
-    no_adapters: None,
     operating_system_85: None,
     issue_registry: ir.IssueRegistry,
 ) -> None:
@@ -3163,10 +3207,10 @@ async def test_issue_outdated_haos_removed(
     assert issue is None
 
 
+@pytest.mark.usefixtures("one_adapter")
 async def test_haos_9_or_later(
     hass: HomeAssistant,
     mock_bleak_scanner_start: MagicMock,
-    one_adapter: None,
     operating_system_90: None,
     issue_registry: ir.IssueRegistry,
 ) -> None:
@@ -3183,8 +3227,9 @@ async def test_haos_9_or_later(
     assert issue is None
 
 
+@pytest.mark.usefixtures("one_adapter")
 async def test_title_updated_if_mac_address(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, one_adapter: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test the title is updated if it is the mac address."""
     entry = MockConfigEntry(

--- a/tests/components/bluetooth/test_manager.py
+++ b/tests/components/bluetooth/test_manager.py
@@ -71,9 +71,9 @@ def register_hci1_scanner(hass: HomeAssistant) -> Generator[None, None, None]:
     cancel()
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_advertisements_do_not_switch_adapters_for_no_reason(
     hass: HomeAssistant,
-    enable_bluetooth: None,
     register_hci0_scanner: None,
     register_hci1_scanner: None,
 ) -> None:
@@ -128,9 +128,9 @@ async def test_advertisements_do_not_switch_adapters_for_no_reason(
     )
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_switching_adapters_based_on_rssi(
     hass: HomeAssistant,
-    enable_bluetooth: None,
     register_hci0_scanner: None,
     register_hci1_scanner: None,
 ) -> None:
@@ -189,9 +189,9 @@ async def test_switching_adapters_based_on_rssi(
     )
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_switching_adapters_based_on_zero_rssi(
     hass: HomeAssistant,
-    enable_bluetooth: None,
     register_hci0_scanner: None,
     register_hci1_scanner: None,
 ) -> None:
@@ -250,9 +250,9 @@ async def test_switching_adapters_based_on_zero_rssi(
     )
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_switching_adapters_based_on_stale(
     hass: HomeAssistant,
-    enable_bluetooth: None,
     register_hci0_scanner: None,
     register_hci1_scanner: None,
 ) -> None:
@@ -317,9 +317,9 @@ async def test_switching_adapters_based_on_stale(
     )
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_switching_adapters_based_on_stale_with_discovered_interval(
     hass: HomeAssistant,
-    enable_bluetooth: None,
     register_hci0_scanner: None,
     register_hci1_scanner: None,
 ) -> None:
@@ -400,8 +400,9 @@ async def test_switching_adapters_based_on_stale_with_discovered_interval(
     )
 
 
+@pytest.mark.usefixtures("one_adapter")
 async def test_restore_history_from_dbus(
-    hass: HomeAssistant, one_adapter: None, disable_new_discovery_flows
+    hass: HomeAssistant, disable_new_discovery_flows
 ) -> None:
     """Test we can restore history from dbus."""
     address = "AA:BB:CC:CC:CC:FF"
@@ -423,9 +424,9 @@ async def test_restore_history_from_dbus(
     assert bluetooth.async_ble_device_from_address(hass, address) is ble_device
 
 
+@pytest.mark.usefixtures("one_adapter")
 async def test_restore_history_from_dbus_and_remote_adapters(
     hass: HomeAssistant,
-    one_adapter: None,
     hass_storage: dict[str, Any],
     disable_new_discovery_flows,
 ) -> None:
@@ -463,9 +464,9 @@ async def test_restore_history_from_dbus_and_remote_adapters(
     assert disable_new_discovery_flows.call_count > 1
 
 
+@pytest.mark.usefixtures("one_adapter")
 async def test_restore_history_from_dbus_and_corrupted_remote_adapters(
     hass: HomeAssistant,
-    one_adapter: None,
     hass_storage: dict[str, Any],
     disable_new_discovery_flows,
 ) -> None:
@@ -501,9 +502,9 @@ async def test_restore_history_from_dbus_and_corrupted_remote_adapters(
     assert disable_new_discovery_flows.call_count >= 1
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_switching_adapters_based_on_rssi_connectable_to_non_connectable(
     hass: HomeAssistant,
-    enable_bluetooth: None,
     register_hci0_scanner: None,
     register_hci1_scanner: None,
 ) -> None:
@@ -589,9 +590,9 @@ async def test_switching_adapters_based_on_rssi_connectable_to_non_connectable(
     )
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_connectable_advertisement_can_be_retrieved_with_best_path_is_non_connectable(
     hass: HomeAssistant,
-    enable_bluetooth: None,
     register_hci0_scanner: None,
     register_hci1_scanner: None,
 ) -> None:
@@ -640,8 +641,9 @@ async def test_connectable_advertisement_can_be_retrieved_with_best_path_is_non_
     )
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_switching_adapters_when_one_goes_away(
-    hass: HomeAssistant, enable_bluetooth: None, register_hci0_scanner: None
+    hass: HomeAssistant, register_hci0_scanner: None
 ) -> None:
     """Test switching adapters when one goes away."""
     cancel_hci2 = bluetooth.async_register_scanner(hass, FakeScanner("hci2", "hci2"))
@@ -689,8 +691,9 @@ async def test_switching_adapters_when_one_goes_away(
     )
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_switching_adapters_when_one_stop_scanning(
-    hass: HomeAssistant, enable_bluetooth: None, register_hci0_scanner: None
+    hass: HomeAssistant, register_hci0_scanner: None
 ) -> None:
     """Test switching adapters when stops scanning."""
     hci2_scanner = FakeScanner("hci2", "hci2")
@@ -1076,9 +1079,9 @@ async def test_goes_unavailable_dismisses_discovery_and_makes_discoverable(
     cancel_connectable_scanner()
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_debug_logging(
     hass: HomeAssistant,
-    enable_bluetooth: None,
     register_hci0_scanner: None,
     register_hci1_scanner: None,
     caplog: pytest.LogCaptureFixture,
@@ -1135,12 +1138,8 @@ async def test_debug_logging(
     assert "wohand_good_signal_hci0" not in caplog.text
 
 
-async def test_set_fallback_interval_small(
-    hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
-    enable_bluetooth: None,
-    macos_adapter: None,
-) -> None:
+@pytest.mark.usefixtures("enable_bluetooth", "macos_adapter")
+async def test_set_fallback_interval_small(hass: HomeAssistant) -> None:
     """Test we can set the fallback advertisement interval."""
     assert async_get_fallback_availability_interval(hass, "44:44:33:11:23:12") is None
 
@@ -1193,12 +1192,8 @@ async def test_set_fallback_interval_small(
     assert async_get_fallback_availability_interval(hass, "44:44:33:11:23:12") is None
 
 
-async def test_set_fallback_interval_big(
-    hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
-    enable_bluetooth: None,
-    macos_adapter: None,
-) -> None:
+@pytest.mark.usefixtures("enable_bluetooth", "macos_adapter")
+async def test_set_fallback_interval_big(hass: HomeAssistant) -> None:
     """Test we can set the fallback advertisement interval."""
     assert async_get_fallback_availability_interval(hass, "44:44:33:11:23:12") is None
 

--- a/tests/components/bluetooth/test_models.py
+++ b/tests/components/bluetooth/test_models.py
@@ -29,9 +29,8 @@ from . import (
 )
 
 
-async def test_wrapped_bleak_scanner(
-    hass: HomeAssistant, enable_bluetooth: None
-) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_wrapped_bleak_scanner(hass: HomeAssistant) -> None:
     """Test wrapped bleak scanner dispatches calls as expected."""
     scanner = HaBleakScannerWrapper()
     switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
@@ -43,9 +42,8 @@ async def test_wrapped_bleak_scanner(
     assert await scanner.discover() == [switchbot_device]
 
 
-async def test_wrapped_bleak_client_raises_device_missing(
-    hass: HomeAssistant, enable_bluetooth: None
-) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_wrapped_bleak_client_raises_device_missing(hass: HomeAssistant) -> None:
     """Test wrapped bleak client dispatches calls as expected."""
     switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
     client = HaBleakClientWrapper(switchbot_device)
@@ -57,8 +55,9 @@ async def test_wrapped_bleak_client_raises_device_missing(
     assert await client.clear_cache() is False
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_wrapped_bleak_client_set_disconnected_callback_before_connected(
-    hass: HomeAssistant, enable_bluetooth: None
+    hass: HomeAssistant,
 ) -> None:
     """Test wrapped bleak client can set a disconnected callback before connected."""
     switchbot_device = generate_ble_device("44:44:33:11:23:45", "wohand")
@@ -66,9 +65,8 @@ async def test_wrapped_bleak_client_set_disconnected_callback_before_connected(
     client.set_disconnected_callback(lambda client: None)
 
 
-async def test_wrapped_bleak_client_local_adapter_only(
-    hass: HomeAssistant, enable_bluetooth: None, one_adapter: None
-) -> None:
+@pytest.mark.usefixtures("enable_bluetooth", "one_adapter")
+async def test_wrapped_bleak_client_local_adapter_only(hass: HomeAssistant) -> None:
     """Test wrapped bleak client with only a local adapter."""
     manager = _get_manager()
 
@@ -132,8 +130,9 @@ async def test_wrapped_bleak_client_local_adapter_only(
     cancel()
 
 
+@pytest.mark.usefixtures("enable_bluetooth", "one_adapter")
 async def test_wrapped_bleak_client_set_disconnected_callback_after_connected(
-    hass: HomeAssistant, enable_bluetooth: None, one_adapter: None
+    hass: HomeAssistant,
 ) -> None:
     """Test wrapped bleak client can set a disconnected callback after connected."""
     manager = _get_manager()
@@ -222,8 +221,9 @@ async def test_wrapped_bleak_client_set_disconnected_callback_after_connected(
     cancel()
 
 
+@pytest.mark.usefixtures("enable_bluetooth", "one_adapter")
 async def test_ble_device_with_proxy_client_out_of_connections_no_scanners(
-    hass: HomeAssistant, enable_bluetooth: None, one_adapter: None
+    hass: HomeAssistant,
 ) -> None:
     """Test we switch to the next available proxy when one runs out of connections with no scanners."""
     manager = _get_manager()
@@ -260,8 +260,9 @@ async def test_ble_device_with_proxy_client_out_of_connections_no_scanners(
     await client.disconnect()
 
 
+@pytest.mark.usefixtures("enable_bluetooth", "one_adapter")
 async def test_ble_device_with_proxy_client_out_of_connections(
-    hass: HomeAssistant, enable_bluetooth: None, one_adapter: None
+    hass: HomeAssistant,
 ) -> None:
     """Test handling all scanners are out of connection slots."""
     manager = _get_manager()
@@ -326,9 +327,8 @@ async def test_ble_device_with_proxy_client_out_of_connections(
     cancel()
 
 
-async def test_ble_device_with_proxy_clear_cache(
-    hass: HomeAssistant, enable_bluetooth: None, one_adapter: None
-) -> None:
+@pytest.mark.usefixtures("enable_bluetooth", "one_adapter")
+async def test_ble_device_with_proxy_clear_cache(hass: HomeAssistant) -> None:
     """Test we can clear cache on the proxy."""
     manager = _get_manager()
 
@@ -388,8 +388,9 @@ async def test_ble_device_with_proxy_clear_cache(
     cancel()
 
 
+@pytest.mark.usefixtures("enable_bluetooth", "one_adapter")
 async def test_ble_device_with_proxy_client_out_of_connections_uses_best_available(
-    hass: HomeAssistant, enable_bluetooth: None, one_adapter: None
+    hass: HomeAssistant,
 ) -> None:
     """Test we switch to the next available proxy when one runs out of connections."""
     manager = _get_manager()
@@ -495,8 +496,9 @@ async def test_ble_device_with_proxy_client_out_of_connections_uses_best_availab
     cancel()
 
 
+@pytest.mark.usefixtures("enable_bluetooth", "macos_adapter")
 async def test_ble_device_with_proxy_client_out_of_connections_uses_best_available_macos(
-    hass: HomeAssistant, enable_bluetooth: None, macos_adapter: None
+    hass: HomeAssistant,
 ) -> None:
     """Test we switch to the next available proxy when one runs out of connections on MacOS."""
     manager = _get_manager()

--- a/tests/components/bluetooth/test_scanner.py
+++ b/tests/components/bluetooth/test_scanner.py
@@ -39,11 +39,9 @@ NEED_RESET_ERRORS = [
 ]
 
 
+@pytest.mark.usefixtures("enable_bluetooth", "macos_adapter")
 async def test_config_entry_can_be_reloaded_when_stop_raises(
-    hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
-    enable_bluetooth: None,
-    macos_adapter: None,
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test we can reload if stopping the scanner raises."""
     entry = hass.config_entries.async_entries(bluetooth.DOMAIN)[0]
@@ -60,8 +58,9 @@ async def test_config_entry_can_be_reloaded_when_stop_raises(
     assert "Error stopping scanner" in caplog.text
 
 
+@pytest.mark.usefixtures("one_adapter")
 async def test_dbus_socket_missing_in_container(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, one_adapter: None
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test we handle dbus being missing in the container."""
 
@@ -83,8 +82,9 @@ async def test_dbus_socket_missing_in_container(
     assert "docker" in caplog.text
 
 
+@pytest.mark.usefixtures("one_adapter")
 async def test_dbus_socket_missing(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, one_adapter: None
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test we handle dbus being missing."""
 
@@ -106,8 +106,9 @@ async def test_dbus_socket_missing(
     assert "docker" not in caplog.text
 
 
+@pytest.mark.usefixtures("one_adapter")
 async def test_dbus_broken_pipe_in_container(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, one_adapter: None
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test we handle dbus broken pipe in the container."""
 
@@ -130,8 +131,9 @@ async def test_dbus_broken_pipe_in_container(
     assert "container" in caplog.text
 
 
+@pytest.mark.usefixtures("one_adapter")
 async def test_dbus_broken_pipe(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, one_adapter: None
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test we handle dbus broken pipe."""
 
@@ -154,8 +156,9 @@ async def test_dbus_broken_pipe(
     assert "container" not in caplog.text
 
 
+@pytest.mark.usefixtures("one_adapter")
 async def test_invalid_dbus_message(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, one_adapter: None
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test we handle invalid dbus message."""
 
@@ -174,9 +177,8 @@ async def test_invalid_dbus_message(
 
 
 @pytest.mark.parametrize("error", NEED_RESET_ERRORS)
-async def test_adapter_needs_reset_at_start(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, one_adapter: None, error: str
-) -> None:
+@pytest.mark.usefixtures("one_adapter")
+async def test_adapter_needs_reset_at_start(hass: HomeAssistant, error: str) -> None:
     """Test we cycle the adapter when it needs a restart."""
 
     with (
@@ -199,9 +201,8 @@ async def test_adapter_needs_reset_at_start(
     await hass.async_block_till_done()
 
 
-async def test_recovery_from_dbus_restart(
-    hass: HomeAssistant, one_adapter: None
-) -> None:
+@pytest.mark.usefixtures("one_adapter")
+async def test_recovery_from_dbus_restart(hass: HomeAssistant) -> None:
     """Test we can recover when DBus gets restarted out from under us."""
 
     called_start = 0
@@ -281,7 +282,8 @@ async def test_recovery_from_dbus_restart(
         assert called_start == 2
 
 
-async def test_adapter_recovery(hass: HomeAssistant, one_adapter: None) -> None:
+@pytest.mark.usefixtures("one_adapter")
+async def test_adapter_recovery(hass: HomeAssistant) -> None:
     """Test we can recover when the adapter stops responding."""
 
     called_start = 0
@@ -365,9 +367,8 @@ async def test_adapter_recovery(hass: HomeAssistant, one_adapter: None) -> None:
         assert called_start == 2
 
 
-async def test_adapter_scanner_fails_to_start_first_time(
-    hass: HomeAssistant, one_adapter: None
-) -> None:
+@pytest.mark.usefixtures("one_adapter")
+async def test_adapter_scanner_fails_to_start_first_time(hass: HomeAssistant) -> None:
     """Test we can recover when the adapter stops responding and the first recovery fails."""
 
     called_start = 0
@@ -474,8 +475,9 @@ async def test_adapter_scanner_fails_to_start_first_time(
         assert called_start == 5
 
 
+@pytest.mark.usefixtures("one_adapter")
 async def test_adapter_fails_to_start_and_takes_a_bit_to_init(
-    hass: HomeAssistant, one_adapter: None, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test we can recover the adapter at startup and we wait for Dbus to init."""
     assert await async_setup_component(hass, "logger", {})
@@ -545,8 +547,9 @@ async def test_adapter_fails_to_start_and_takes_a_bit_to_init(
     assert "Waiting for adapter to initialize" in caplog.text
 
 
+@pytest.mark.usefixtures("one_adapter")
 async def test_restart_takes_longer_than_watchdog_time(
-    hass: HomeAssistant, one_adapter: None, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test we do not try to recover the adapter again if the restart is still in progress."""
 
@@ -614,8 +617,9 @@ async def test_restart_takes_longer_than_watchdog_time(
 
 
 @pytest.mark.skipif("platform.system() != 'Darwin'")
+@pytest.mark.usefixtures("macos_adapter")
 async def test_setup_and_stop_macos(
-    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, macos_adapter: None
+    hass: HomeAssistant, mock_bleak_scanner_start: MagicMock
 ) -> None:
     """Test we enable use_bdaddr on MacOS."""
     entry = MockConfigEntry(

--- a/tests/components/bluetooth/test_usage.py
+++ b/tests/components/bluetooth/test_usage.py
@@ -8,6 +8,7 @@ from habluetooth.usage import (
     uninstall_multiple_bleak_catcher,
 )
 from habluetooth.wrappers import HaBleakClientWrapper, HaBleakScannerWrapper
+import pytest
 
 from homeassistant.core import HomeAssistant
 
@@ -38,9 +39,8 @@ async def test_multiple_bleak_scanner_instances(hass: HomeAssistant) -> None:
     assert not isinstance(instance, HaBleakScannerWrapper)
 
 
-async def test_wrapping_bleak_client(
-    hass: HomeAssistant, enable_bluetooth: None
-) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_wrapping_bleak_client(hass: HomeAssistant) -> None:
     """Test we wrap BleakClient."""
     install_multiple_bleak_catcher()
 

--- a/tests/components/bluetooth/test_wrappers.py
+++ b/tests/components/bluetooth/test_wrappers.py
@@ -194,10 +194,9 @@ def _generate_scanners_with_fake_devices(hass):
     return hci0_device_advs, cancel_hci0, cancel_hci1
 
 
+@pytest.mark.usefixtures("enable_bluetooth", "two_adapters")
 async def test_test_switch_adapters_when_out_of_slots(
     hass: HomeAssistant,
-    two_adapters: None,
-    enable_bluetooth: None,
     install_bleak_catcher,
     mock_platform_client,
 ) -> None:
@@ -254,10 +253,9 @@ async def test_test_switch_adapters_when_out_of_slots(
     cancel_hci1()
 
 
+@pytest.mark.usefixtures("enable_bluetooth", "two_adapters")
 async def test_release_slot_on_connect_failure(
     hass: HomeAssistant,
-    two_adapters: None,
-    enable_bluetooth: None,
     install_bleak_catcher,
     mock_platform_client_that_fails_to_connect,
 ) -> None:
@@ -283,10 +281,9 @@ async def test_release_slot_on_connect_failure(
     cancel_hci1()
 
 
+@pytest.mark.usefixtures("enable_bluetooth", "two_adapters")
 async def test_release_slot_on_connect_exception(
     hass: HomeAssistant,
-    two_adapters: None,
-    enable_bluetooth: None,
     install_bleak_catcher,
     mock_platform_client_that_raises_on_connect,
 ) -> None:
@@ -314,10 +311,9 @@ async def test_release_slot_on_connect_exception(
     cancel_hci1()
 
 
+@pytest.mark.usefixtures("enable_bluetooth", "two_adapters")
 async def test_we_switch_adapters_on_failure(
     hass: HomeAssistant,
-    two_adapters: None,
-    enable_bluetooth: None,
     install_bleak_catcher,
 ) -> None:
     """Ensure we try the next best adapter after a failure."""
@@ -374,10 +370,9 @@ async def test_we_switch_adapters_on_failure(
     cancel_hci1()
 
 
+@pytest.mark.usefixtures("enable_bluetooth", "two_adapters")
 async def test_passing_subclassed_str_as_address(
     hass: HomeAssistant,
-    two_adapters: None,
-    enable_bluetooth: None,
     install_bleak_catcher,
 ) -> None:
     """Ensure the client wrapper can handle a subclassed str as the address."""
@@ -406,10 +401,9 @@ async def test_passing_subclassed_str_as_address(
     cancel_hci1()
 
 
+@pytest.mark.usefixtures("enable_bluetooth", "two_adapters")
 async def test_raise_after_shutdown(
     hass: HomeAssistant,
-    two_adapters: None,
-    enable_bluetooth: None,
     install_bleak_catcher,
     mock_platform_client_that_raises_on_connect,
 ) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA
https://github.com/home-assistant/core/blob/1eb13b48a2c894b47d6d0b1f5fd45c1e55ae71f9/pylint/plugins/hass_enforce_type_hints.py#L107

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
