### PR TITLE
Move enable_bluetooth fixture to decorator

### DIFF
--- a/tests/components/esphome/test_diagnostics.py
+++ b/tests/components/esphome/test_diagnostics.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import ANY
 
+import pytest
 from syrupy import SnapshotAssertion
 
 from homeassistant.components import bluetooth
@@ -14,11 +15,11 @@ from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     init_integration: MockConfigEntry,
-    enable_bluetooth: None,
     mock_dashboard,
     snapshot: SnapshotAssertion,
 ) -> None:

--- a/tests/components/ibeacon/test_config_flow.py
+++ b/tests/components/ibeacon/test_config_flow.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant import config_entries
 from homeassistant.components.ibeacon.const import CONF_ALLOW_NAMELESS_UUIDS, DOMAIN
 from homeassistant.core import HomeAssistant
@@ -22,7 +24,8 @@ async def test_setup_user_no_bluetooth(
     assert result["reason"] == "bluetooth_not_available"
 
 
-async def test_setup_user(hass: HomeAssistant, enable_bluetooth: None) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_setup_user(hass: HomeAssistant) -> None:
     """Test setting up via user interaction with bluetooth enabled."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -39,9 +42,8 @@ async def test_setup_user(hass: HomeAssistant, enable_bluetooth: None) -> None:
     assert result2["data"] == {}
 
 
-async def test_setup_user_already_setup(
-    hass: HomeAssistant, enable_bluetooth: None
-) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_setup_user_already_setup(hass: HomeAssistant) -> None:
     """Test setting up via user when already setup ."""
     MockConfigEntry(domain=DOMAIN).add_to_hass(hass)
     result = await hass.config_entries.flow.async_init(
@@ -52,7 +54,8 @@ async def test_setup_user_already_setup(
     assert result["reason"] == "single_instance_allowed"
 
 
-async def test_options_flow(hass: HomeAssistant, enable_bluetooth: None) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_options_flow(hass: HomeAssistant) -> None:
     """Test config flow options."""
     config_entry = MockConfigEntry(domain=DOMAIN)
     config_entry.add_to_hass(hass)

--- a/tests/components/private_ble_device/test_config_flow.py
+++ b/tests/components/private_ble_device/test_config_flow.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant import config_entries
 from homeassistant.components.private_ble_device import const
 from homeassistant.core import HomeAssistant
@@ -30,7 +32,8 @@ async def test_setup_user_no_bluetooth(
     assert result["reason"] == "bluetooth_not_available"
 
 
-async def test_invalid_irk(hass: HomeAssistant, enable_bluetooth: None) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_invalid_irk(hass: HomeAssistant) -> None:
     """Test invalid irk."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -43,7 +46,8 @@ async def test_invalid_irk(hass: HomeAssistant, enable_bluetooth: None) -> None:
     assert_form_error(result, "irk", "irk_not_valid")
 
 
-async def test_invalid_irk_base64(hass: HomeAssistant, enable_bluetooth: None) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_invalid_irk_base64(hass: HomeAssistant) -> None:
     """Test invalid irk."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -56,7 +60,8 @@ async def test_invalid_irk_base64(hass: HomeAssistant, enable_bluetooth: None) -
     assert_form_error(result, "irk", "irk_not_valid")
 
 
-async def test_invalid_irk_hex(hass: HomeAssistant, enable_bluetooth: None) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_invalid_irk_hex(hass: HomeAssistant) -> None:
     """Test invalid irk."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -69,7 +74,8 @@ async def test_invalid_irk_hex(hass: HomeAssistant, enable_bluetooth: None) -> N
     assert_form_error(result, "irk", "irk_not_valid")
 
 
-async def test_irk_not_found(hass: HomeAssistant, enable_bluetooth: None) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_irk_not_found(hass: HomeAssistant) -> None:
     """Test irk not found."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -83,7 +89,8 @@ async def test_irk_not_found(hass: HomeAssistant, enable_bluetooth: None) -> Non
     assert_form_error(result, "irk", "irk_not_found")
 
 
-async def test_flow_works(hass: HomeAssistant, enable_bluetooth: None) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_flow_works(hass: HomeAssistant) -> None:
     """Test config flow works."""
 
     inject_bluetooth_service_info(
@@ -120,9 +127,8 @@ async def test_flow_works(hass: HomeAssistant, enable_bluetooth: None) -> None:
     assert result["result"].unique_id == "00000000000000000000000000000000"
 
 
-async def test_flow_works_by_base64(
-    hass: HomeAssistant, enable_bluetooth: None
-) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_flow_works_by_base64(hass: HomeAssistant) -> None:
     """Test config flow works."""
 
     inject_bluetooth_service_info(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA
https://github.com/home-assistant/core/blob/1eb13b48a2c894b47d6d0b1f5fd45c1e55ae71f9/pylint/plugins/hass_enforce_type_hints.py#L107

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
