### PR TITLE
Initialize the Sentry SDK within an import executor job to not block event loop

### DIFF
--- a/homeassistant/components/sentry/__init__.py
+++ b/homeassistant/components/sentry/__init__.py
@@ -21,6 +21,7 @@ from homeassistant.helpers import config_validation as cv, entity_platform, inst
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.system_info import async_get_system_info
 from homeassistant.loader import Integration, async_get_custom_components
+from homeassistant.setup import SetupPhases, async_pause_setup
 
 from .const import (
     CONF_DSN,
@@ -40,7 +41,6 @@ from .const import (
 )
 
 CONFIG_SCHEMA = cv.removed(DOMAIN, raise_if_present=False)
-
 
 LOGGER_INFO_REGEX = re.compile(r"^(\w+)\.?(\w+)?\.?(\w+)?\.?(\w+)?(?:\..*)?$")
 
@@ -81,23 +81,33 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             ),
         }
 
-    sentry_sdk.init(
-        dsn=entry.data[CONF_DSN],
-        environment=entry.options.get(CONF_ENVIRONMENT),
-        integrations=[sentry_logging, AioHttpIntegration(), SqlalchemyIntegration()],
-        release=current_version,
-        before_send=lambda event, hint: process_before_send(
-            hass,
-            entry.options,
-            channel,
-            huuid,
-            system_info,
-            custom_components,
-            event,
-            hint,
-        ),
-        **tracing,
-    )
+    with async_pause_setup(hass, SetupPhases.WAIT_IMPORT_PACKAGES):
+        # sentry_sdk.init imports modules based on the selected integrations
+        def _init_sdk():
+            """Initialize the Sentry SDK."""
+            sentry_sdk.init(
+                dsn=entry.data[CONF_DSN],
+                environment=entry.options.get(CONF_ENVIRONMENT),
+                integrations=[
+                    sentry_logging,
+                    AioHttpIntegration(),
+                    SqlalchemyIntegration(),
+                ],
+                release=current_version,
+                before_send=lambda event, hint: process_before_send(
+                    hass,
+                    entry.options,
+                    channel,
+                    huuid,
+                    system_info,
+                    custom_components,
+                    event,
+                    hint,
+                ),
+                **tracing,
+            )
+
+        await hass.async_add_import_executor_job(_init_sdk)
 
     async def update_system_info(now):
         nonlocal system_info


### PR DESCRIPTION
## Proposed change
SSIA. Wrapped this into a function to keep the keyword args to not break anything when converting this to positional ones.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #118814
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
