### PR TITLE
Bump blebox-uniapi fom 2.2.2 to 2.4.2

### DIFF
--- a/homeassistant/components/blebox/manifest.json
+++ b/homeassistant/components/blebox/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/blebox",
   "iot_class": "local_polling",
   "loggers": ["blebox_uniapi"],
-  "requirements": ["blebox-uniapi==2.2.2"],
+  "requirements": ["blebox-uniapi==2.4.0"],
   "zeroconf": ["_bbxsrv._tcp.local."]
 }

--- a/homeassistant/components/blebox/manifest.json
+++ b/homeassistant/components/blebox/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/blebox",
   "iot_class": "local_polling",
   "loggers": ["blebox_uniapi"],
-  "requirements": ["blebox-uniapi==2.4.0"],
+  "requirements": ["blebox-uniapi==2.4.1"],
   "zeroconf": ["_bbxsrv._tcp.local."]
 }

--- a/homeassistant/components/blebox/manifest.json
+++ b/homeassistant/components/blebox/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/blebox",
   "iot_class": "local_polling",
   "loggers": ["blebox_uniapi"],
-  "requirements": ["blebox-uniapi==2.4.1"],
+  "requirements": ["blebox-uniapi==2.4.2"],
   "zeroconf": ["_bbxsrv._tcp.local."]
 }

--- a/homeassistant/components/blebox/sensor.py
+++ b/homeassistant/components/blebox/sensor.py
@@ -13,16 +13,9 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     PERCENTAGE,
-    LIGHT_LUX,
-    POWER_VOLT_AMPERE_REACTIVE,
     UnitOfEnergy,
     UnitOfSpeed,
     UnitOfTemperature,
-    UnitOfPower,
-    UnitOfApparentPower,
-    UnitOfElectricPotential,
-    UnitOfElectricCurrent,
-    UnitOfFrequency,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -66,51 +59,6 @@ SENSOR_TYPES = (
         key="wind",
         device_class=SensorDeviceClass.WIND_SPEED,
         native_unit_of_measurement=UnitOfSpeed.METERS_PER_SECOND,
-    ),
-    SensorEntityDescription(
-        key="illuminance",
-        device_class=SensorDeviceClass.ILLUMINANCE,
-        native_unit_of_measurement=LIGHT_LUX,
-    ),
-    SensorEntityDescription(
-        key="forwardActiveEnergy",
-        device_class=SensorDeviceClass.ENERGY,
-        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-    ),
-    SensorEntityDescription(
-        key="reverseActiveEnergy",
-        device_class=SensorDeviceClass.ENERGY,
-        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-    ),
-    SensorEntityDescription(
-        key="reactivePower",
-        device_class=SensorDeviceClass.POWER,
-        native_unit_of_measurement=POWER_VOLT_AMPERE_REACTIVE,
-    ),
-    SensorEntityDescription(
-        key="activePower",
-        device_class=SensorDeviceClass.POWER,
-        native_unit_of_measurement=UnitOfPower.WATT,
-    ),
-    SensorEntityDescription(
-        key="apparentPower",
-        device_class=SensorDeviceClass.APPARENT_POWER,
-        native_unit_of_measurement=UnitOfApparentPower.VOLT_AMPERE,
-    ),
-    SensorEntityDescription(
-        key="voltage",
-        device_class=SensorDeviceClass.VOLTAGE,
-        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-    ),
-    SensorEntityDescription(
-        key="current",
-        device_class=SensorDeviceClass.CURRENT,
-        native_unit_of_measurement=UnitOfElectricCurrent.MILLIAMPERE,
-    ),
-    SensorEntityDescription(
-        key="frequency",
-        device_class=SensorDeviceClass.FREQUENCY,
-        native_unit_of_measurement=UnitOfFrequency.HERTZ,
     ),
 )
 

--- a/homeassistant/components/blebox/sensor.py
+++ b/homeassistant/components/blebox/sensor.py
@@ -13,9 +13,16 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     PERCENTAGE,
+    LIGHT_LUX,
+    POWER_VOLT_AMPERE_REACTIVE,
     UnitOfEnergy,
     UnitOfSpeed,
     UnitOfTemperature,
+    UnitOfPower,
+    UnitOfApparentPower,
+    UnitOfElectricPotential,
+    UnitOfElectricCurrent,
+    UnitOfFrequency,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -51,12 +58,6 @@ SENSOR_TYPES = (
         state_class=SensorStateClass.TOTAL,
     ),
     SensorEntityDescription(
-        key="powerMeasurement",  # deprecated
-        device_class=SensorDeviceClass.ENERGY,
-        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        state_class=SensorStateClass.TOTAL,
-    ),
-    SensorEntityDescription(
         key="humidity",
         device_class=SensorDeviceClass.HUMIDITY,
         native_unit_of_measurement=PERCENTAGE,
@@ -67,9 +68,49 @@ SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfSpeed.METERS_PER_SECOND,
     ),
     SensorEntityDescription(
-        key="wind_speed",  # deprecated
-        device_class=SensorDeviceClass.WIND_SPEED,
-        native_unit_of_measurement=UnitOfSpeed.METERS_PER_SECOND,
+        key="illuminance",
+        device_class=SensorDeviceClass.ILLUMINANCE,
+        native_unit_of_measurement=LIGHT_LUX,
+    ),
+    SensorEntityDescription(
+        key="forwardActiveEnergy",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+    ),
+    SensorEntityDescription(
+        key="reverseActiveEnergy",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+    ),
+    SensorEntityDescription(
+        key="reactivePower",
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=POWER_VOLT_AMPERE_REACTIVE,
+    ),
+    SensorEntityDescription(
+        key="activePower",
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.WATT,
+    ),
+    SensorEntityDescription(
+        key="apparentPower",
+        device_class=SensorDeviceClass.APPARENT_POWER,
+        native_unit_of_measurement=UnitOfApparentPower.VOLT_AMPERE,
+    ),
+    SensorEntityDescription(
+        key="voltage",
+        device_class=SensorDeviceClass.VOLTAGE,
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+    ),
+    SensorEntityDescription(
+        key="current",
+        device_class=SensorDeviceClass.CURRENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.MILLIAMPERE,
+    ),
+    SensorEntityDescription(
+        key="frequency",
+        device_class=SensorDeviceClass.FREQUENCY,
+        native_unit_of_measurement=UnitOfFrequency.HERTZ,
     ),
 )
 

--- a/homeassistant/components/blebox/sensor.py
+++ b/homeassistant/components/blebox/sensor.py
@@ -45,7 +45,13 @@ SENSOR_TYPES = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
     ),
     SensorEntityDescription(
-        key="powerMeasurement",
+        key="powerConsumption",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL,
+    ),
+    SensorEntityDescription(
+        key="powerMeasurement",  # deprecated
         device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL,
@@ -56,7 +62,12 @@ SENSOR_TYPES = (
         native_unit_of_measurement=PERCENTAGE,
     ),
     SensorEntityDescription(
-        key="wind_speed",
+        key="wind",
+        device_class=SensorDeviceClass.WIND_SPEED,
+        native_unit_of_measurement=UnitOfSpeed.METERS_PER_SECOND,
+    ),
+    SensorEntityDescription(
+        key="wind_speed",  # deprecated
         device_class=SensorDeviceClass.WIND_SPEED,
         native_unit_of_measurement=UnitOfSpeed.METERS_PER_SECOND,
     ),

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -566,7 +566,7 @@ bleak-retry-connector==3.5.0
 bleak==0.22.1
 
 # homeassistant.components.blebox
-blebox-uniapi==2.2.2
+blebox-uniapi==2.4.2
 
 # homeassistant.components.blink
 blinkpy==0.22.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -488,7 +488,7 @@ bleak-retry-connector==3.5.0
 bleak==0.22.1
 
 # homeassistant.components.blebox
-blebox-uniapi==2.2.2
+blebox-uniapi==2.4.2
 
 # homeassistant.components.blink
 blinkpy==0.22.6


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
This updates blebox_uniapi dependency for blebox integration and provides new sensor description mappings enabling wider and better support for Blebox devices


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

We fell a little behind blebox_uniapi dependency so the update goes straight from 2.2.2 to 2.4.2.

Across all these versions numerous bugs have been added but also support for multiple new sensor types have been added/improved. Also internal code quality have been improved in hopes of bringing new devs to that library.

From core's perspective only two things have really changed: wind speed and power consumption sensors have different identifying keys on the `blebox_uniapi` side as this is a result of simplification of the sensing module in that library.

[Full v2.2.2...v2.4.2 diff](https://github.com/blebox/blebox_uniapi/compare/v2.2.2...v2.4.2)

### v2.2.2 → v2.4.2 changelog of the library:

**2.4.2 (2024-06-04)**

* fix: add missing support for active power sensors on switchbox/switchboxd devices by @swistakm in https://github.com/blebox/blebox_uniapi/pull/175

2.4.1 (2024-06-04)

* fix: rectify ambiguity around powerConsumption and wind sensor types

**2.4.0 (2024-06-03)**
* Fix: Refactor sensor_factory by @Pastucha in https://github.com/blebox/blebox_uniapi/pull/163
* Order in BOX_TYPES by @Pastucha in https://github.com/blebox/blebox_uniapi/pull/164
* Feature: smart meter by @swistakm in https://github.com/blebox/blebox_uniapi/pull/168
* Smartmeter by @pvsti in https://github.com/blebox/blebox_uniapi/pull/170
* fix: resolve regressions in cover and climate due to jmespath introduction by @swistakm in https://github.com/blebox/blebox_uniapi/pull/173

**2.3.0 (2024-03-13)**

* feat: add new methods to cover feature enabling handling of tilt open/close actions by @swistakm in https://github.com/blebox/blebox_uniapi/pull/154
* add support for flood sensing for multisensors as binary moisture sensor by @swistakm in https://github.com/blebox/blebox_uniapi/pull/153
* feat/fix: Add Ruff and Pre-commit Configuration, Resolve Undefined Name by @Pastucha in https://github.com/blebox/blebox_uniapi/pull/158
* gatebox and shutterbox improvements: by @swistakm in https://github.com/blebox/blebox_uniapi/pull/156
* BleBox Multisensor Illuminance Integration by @Pastucha in https://github.com/blebox/blebox_uniapi/pull/161

This also supersedes #116371 completely.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
