### PR TITLE
Move enable_custom_integrations fixture to decorator

### DIFF
--- a/tests/components/analytics/test_analytics.py
+++ b/tests/components/analytics/test_analytics.py
@@ -566,10 +566,10 @@ async def test_reusing_uuid(
     assert analytics.uuid == "NOT_MOCK_UUID"
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_custom_integrations(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    enable_custom_integrations: None,
     caplog: pytest.LogCaptureFixture,
     installation_type_mock: Generator[Any, Any, None],
     snapshot: SnapshotAssertion,

--- a/tests/components/button/test_init.py
+++ b/tests/components/button/test_init.py
@@ -55,12 +55,11 @@ async def test_button(hass: HomeAssistant) -> None:
     assert button.press.called
 
 
+@pytest.mark.usefixtures("enable_custom_integrations", "setup_platform")
 async def test_custom_integration(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    enable_custom_integrations: None,
     freezer: FrozenDateTimeFactory,
-    setup_platform: None,
 ) -> None:
     """Test we integration."""
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
@@ -95,9 +94,8 @@ async def test_custom_integration(
     assert hass.states.get("button.button_1").state == new_time_isoformat
 
 
-async def test_restore_state(
-    hass: HomeAssistant, enable_custom_integrations: None, setup_platform: None
-) -> None:
+@pytest.mark.usefixtures("enable_custom_integrations", "setup_platform")
+async def test_restore_state(hass: HomeAssistant) -> None:
     """Test we restore state integration."""
     mock_restore_cache(hass, (State("button.button_1", "2021-01-01T23:59:59+00:00"),))
 
@@ -107,9 +105,8 @@ async def test_restore_state(
     assert hass.states.get("button.button_1").state == "2021-01-01T23:59:59+00:00"
 
 
-async def test_restore_state_does_not_restore_unavailable(
-    hass: HomeAssistant, enable_custom_integrations: None, setup_platform: None
-) -> None:
+@pytest.mark.usefixtures("enable_custom_integrations", "setup_platform")
+async def test_restore_state_does_not_restore_unavailable(hass: HomeAssistant) -> None:
     """Test we restore state integration except for unavailable."""
     mock_restore_cache(hass, (State("button.button_1", STATE_UNAVAILABLE),))
 

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -507,9 +507,8 @@ async def test_abort(hass: HomeAssistant, client) -> None:
     }
 
 
-async def test_create_account(
-    hass: HomeAssistant, client, enable_custom_integrations: None
-) -> None:
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_create_account(hass: HomeAssistant, client) -> None:
     """Test a flow that creates an account."""
     mock_platform(hass, "test.config_flow", None)
 
@@ -566,9 +565,8 @@ async def test_create_account(
     }
 
 
-async def test_two_step_flow(
-    hass: HomeAssistant, client, enable_custom_integrations: None
-) -> None:
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_two_step_flow(hass: HomeAssistant, client) -> None:
     """Test we can finish a two step flow."""
     mock_integration(
         hass, MockModule("test", async_setup_entry=AsyncMock(return_value=True))
@@ -2227,9 +2225,8 @@ async def test_flow_with_multiple_schema_errors_base(
         }
 
 
-async def test_supports_reconfigure(
-    hass: HomeAssistant, client, enable_custom_integrations: None
-) -> None:
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_supports_reconfigure(hass: HomeAssistant, client) -> None:
     """Test a flow that support reconfigure step."""
     mock_platform(hass, "test.config_flow", None)
 
@@ -2317,8 +2314,9 @@ async def test_supports_reconfigure(
     }
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_does_not_support_reconfigure(
-    hass: HomeAssistant, client: TestClient, enable_custom_integrations: None
+    hass: HomeAssistant, client: TestClient
 ) -> None:
     """Test a flow that does not support reconfigure step."""
     mock_platform(hass, "test.config_flow", None)

--- a/tests/components/device_sun_light_trigger/test_init.py
+++ b/tests/components/device_sun_light_trigger/test_init.py
@@ -108,9 +108,8 @@ async def test_lights_on_when_sun_sets(
     )
 
 
-async def test_lights_turn_off_when_everyone_leaves(
-    hass: HomeAssistant, enable_custom_integrations: None
-) -> None:
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_lights_turn_off_when_everyone_leaves(hass: HomeAssistant) -> None:
     """Test lights turn off when everyone leaves the house."""
     assert await async_setup_component(
         hass, "light", {light.DOMAIN: {CONF_PLATFORM: "test"}}

--- a/tests/components/diagnostics/test_init.py
+++ b/tests/components/diagnostics/test_init.py
@@ -80,10 +80,9 @@ async def test_websocket(
     }
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_download_diagnostics(
-    hass: HomeAssistant,
-    hass_client: ClientSessionGenerator,
-    enable_custom_integrations: None,
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> None:
     """Test download diagnostics."""
     config_entry = MockConfigEntry(domain="fake_integration")

--- a/tests/components/group/test_switch.py
+++ b/tests/components/group/test_switch.py
@@ -3,6 +3,8 @@
 import asyncio
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant import config as hass_config
 from homeassistant.components.group import DOMAIN, SERVICE_RELOAD
 from homeassistant.components.switch import (
@@ -232,9 +234,8 @@ async def test_state_reporting_all(hass: HomeAssistant) -> None:
     assert hass.states.get("switch.switch_group").state == STATE_UNAVAILABLE
 
 
-async def test_service_calls(
-    hass: HomeAssistant, enable_custom_integrations: None
-) -> None:
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_service_calls(hass: HomeAssistant) -> None:
     """Test service calls."""
     await async_setup_component(
         hass,

--- a/tests/components/image_processing/test_init.py
+++ b/tests/components/image_processing/test_init.py
@@ -89,11 +89,11 @@ async def test_setup_component_with_service(hass: HomeAssistant) -> None:
     "homeassistant.components.demo.camera.Path.read_bytes",
     return_value=b"Test",
 )
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_get_image_from_camera(
     mock_camera_read,
     hass: HomeAssistant,
     aiohttp_unused_port_factory,
-    enable_custom_integrations: None,
 ) -> None:
     """Grab an image from camera entity."""
     await setup_image_processing(hass, aiohttp_unused_port_factory)
@@ -112,11 +112,11 @@ async def test_get_image_from_camera(
     "homeassistant.components.image_processing.async_get_image",
     side_effect=HomeAssistantError(),
 )
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_get_image_without_exists_camera(
     mock_image,
     hass: HomeAssistant,
     aiohttp_unused_port_factory,
-    enable_custom_integrations: None,
 ) -> None:
     """Try to get image without exists camera."""
     await setup_image_processing(hass, aiohttp_unused_port_factory)
@@ -188,10 +188,10 @@ async def test_face_event_call_no_confidence(
     assert event_data[0]["entity_id"] == "image_processing.demo_face"
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_update_missing_camera(
     hass: HomeAssistant,
     aiohttp_unused_port_factory,
-    enable_custom_integrations: None,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test when entity does not set camera."""

--- a/tests/components/input_boolean/test_recorder.py
+++ b/tests/components/input_boolean/test_recorder.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+import pytest
+
 from homeassistant.components.input_boolean import DOMAIN
-from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_EDITABLE
 from homeassistant.core import HomeAssistant
@@ -16,9 +17,8 @@ from tests.common import async_fire_time_changed
 from tests.components.recorder.common import async_wait_recording_done
 
 
-async def test_exclude_attributes(
-    recorder_mock: Recorder, hass: HomeAssistant, enable_custom_integrations: None
-) -> None:
+@pytest.mark.usefixtures("recorder_mock", "enable_custom_integrations")
+async def test_exclude_attributes(hass: HomeAssistant) -> None:
     """Test attributes to be excluded."""
     now = dt_util.utcnow()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {"test": {}}})

--- a/tests/components/input_button/test_recorder.py
+++ b/tests/components/input_button/test_recorder.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+import pytest
+
 from homeassistant.components.input_button import DOMAIN
-from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_EDITABLE
 from homeassistant.core import HomeAssistant
@@ -16,9 +17,8 @@ from tests.common import async_fire_time_changed
 from tests.components.recorder.common import async_wait_recording_done
 
 
-async def test_exclude_attributes(
-    recorder_mock: Recorder, hass: HomeAssistant, enable_custom_integrations: None
-) -> None:
+@pytest.mark.usefixtures("recorder_mock", "enable_custom_integrations")
+async def test_exclude_attributes(hass: HomeAssistant) -> None:
     """Test attributes to be excluded."""
     now = dt_util.utcnow()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {"test": {}}})

--- a/tests/components/input_datetime/test_recorder.py
+++ b/tests/components/input_datetime/test_recorder.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+import pytest
+
 from homeassistant.components.input_datetime import CONF_HAS_DATE, CONF_HAS_TIME, DOMAIN
-from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_EDITABLE
 from homeassistant.core import HomeAssistant
@@ -16,9 +17,8 @@ from tests.common import async_fire_time_changed
 from tests.components.recorder.common import async_wait_recording_done
 
 
-async def test_exclude_attributes(
-    recorder_mock: Recorder, hass: HomeAssistant, enable_custom_integrations: None
-) -> None:
+@pytest.mark.usefixtures("recorder_mock", "enable_custom_integrations")
+async def test_exclude_attributes(hass: HomeAssistant) -> None:
     """Test attributes to be excluded."""
     now = dt_util.utcnow()
     assert await async_setup_component(

--- a/tests/components/input_number/test_recorder.py
+++ b/tests/components/input_number/test_recorder.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+import pytest
+
 from homeassistant.components.input_number import (
     ATTR_MAX,
     ATTR_MIN,
@@ -11,7 +13,6 @@ from homeassistant.components.input_number import (
     ATTR_STEP,
     DOMAIN,
 )
-from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_EDITABLE
 from homeassistant.core import HomeAssistant
@@ -22,9 +23,8 @@ from tests.common import async_fire_time_changed
 from tests.components.recorder.common import async_wait_recording_done
 
 
-async def test_exclude_attributes(
-    recorder_mock: Recorder, hass: HomeAssistant, enable_custom_integrations: None
-) -> None:
+@pytest.mark.usefixtures("recorder_mock", "enable_custom_integrations")
+async def test_exclude_attributes(hass: HomeAssistant) -> None:
     """Test attributes to be excluded."""
     now = dt_util.utcnow()
     assert await async_setup_component(

--- a/tests/components/input_select/test_recorder.py
+++ b/tests/components/input_select/test_recorder.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+import pytest
+
 from homeassistant.components.input_select import ATTR_OPTIONS, DOMAIN
-from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_EDITABLE
 from homeassistant.core import HomeAssistant
@@ -16,9 +17,8 @@ from tests.common import async_fire_time_changed
 from tests.components.recorder.common import async_wait_recording_done
 
 
-async def test_exclude_attributes(
-    recorder_mock: Recorder, hass: HomeAssistant, enable_custom_integrations: None
-) -> None:
+@pytest.mark.usefixtures("recorder_mock", "enable_custom_integrations")
+async def test_exclude_attributes(hass: HomeAssistant) -> None:
     """Test attributes to be excluded."""
     now = dt_util.utcnow()
     assert await async_setup_component(

--- a/tests/components/input_text/test_recorder.py
+++ b/tests/components/input_text/test_recorder.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+import pytest
+
 from homeassistant.components.input_text import (
     ATTR_MAX,
     ATTR_MIN,
@@ -12,7 +14,6 @@ from homeassistant.components.input_text import (
     DOMAIN,
     MODE_TEXT,
 )
-from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_EDITABLE
 from homeassistant.core import HomeAssistant
@@ -23,9 +24,8 @@ from tests.common import async_fire_time_changed
 from tests.components.recorder.common import async_wait_recording_done
 
 
-async def test_exclude_attributes(
-    recorder_mock: Recorder, hass: HomeAssistant, enable_custom_integrations: None
-) -> None:
+@pytest.mark.usefixtures("recorder_mock", "enable_custom_integrations")
+async def test_exclude_attributes(hass: HomeAssistant) -> None:
     """Test attributes to be excluded."""
     now = dt_util.utcnow()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {"test": {}}})

--- a/tests/components/light/test_device_action.py
+++ b/tests/components/light/test_device_action.py
@@ -466,12 +466,12 @@ async def test_get_action_capabilities_features_legacy(
         assert capabilities == expected
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_action(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off actions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -631,12 +631,12 @@ async def test_action(
     assert turn_on_calls[-1].data == {"entity_id": entry.entity_id, "flash": FLASH_LONG}
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_action_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off actions."""
     config_entry = MockConfigEntry(domain="test", data={})

--- a/tests/components/light/test_device_condition.py
+++ b/tests/components/light/test_device_condition.py
@@ -180,12 +180,12 @@ async def test_get_condition_capabilities_legacy(
         assert capabilities == expected_capabilities
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_if_state(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -267,12 +267,12 @@ async def test_if_state(
     assert calls[1].data["some"] == "is_off event - test_event2"
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_if_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})

--- a/tests/components/light/test_device_trigger.py
+++ b/tests/components/light/test_device_trigger.py
@@ -184,12 +184,12 @@ async def test_get_trigger_capabilities_legacy(
         assert capabilities == expected_capabilities
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -277,12 +277,12 @@ async def test_if_fires_on_state_change(
     }
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -331,12 +331,12 @@ async def test_if_fires_on_state_change_legacy(
     )
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_if_fires_on_state_change_with_for(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for triggers firing with delay."""
     config_entry = MockConfigEntry(domain="test", data={})

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -980,9 +980,9 @@ async def test_light_brightness_step(hass: HomeAssistant) -> None:
     assert entity0.state == "off"  # 126 - 126; brightness is 0, light should turn off
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_light_brightness_pct_conversion(
     hass: HomeAssistant,
-    enable_custom_integrations: None,
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test that light brightness percent conversion."""

--- a/tests/components/person/test_recorder.py
+++ b/tests/components/person/test_recorder.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+import pytest
+
 from homeassistant.components.person import ATTR_DEVICE_TRACKERS, DOMAIN
-from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -15,10 +16,9 @@ from tests.common import MockUser, async_fire_time_changed
 from tests.components.recorder.common import async_wait_recording_done
 
 
+@pytest.mark.usefixtures("recorder_mock", "enable_custom_integrations")
 async def test_exclude_attributes(
-    recorder_mock: Recorder,
     hass: HomeAssistant,
-    enable_custom_integrations: None,
     hass_admin_user: MockUser,
     storage_setup,
 ) -> None:

--- a/tests/components/remote/test_device_action.py
+++ b/tests/components/remote/test_device_action.py
@@ -109,12 +109,12 @@ async def test_get_actions_hidden_auxiliary(
     assert actions == unordered(expected_actions)
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_action(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off actions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -184,12 +184,12 @@ async def test_action(
     assert turn_on_calls[-1].data == {"entity_id": entry.entity_id}
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_action_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off actions."""
     config_entry = MockConfigEntry(domain="test", data={})

--- a/tests/components/remote/test_device_condition.py
+++ b/tests/components/remote/test_device_condition.py
@@ -178,12 +178,12 @@ async def test_get_condition_capabilities_legacy(
         assert capabilities == expected_capabilities
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_if_state(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -265,12 +265,12 @@ async def test_if_state(
     assert calls[1].data["some"] == "is_off event - test_event2"
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_if_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -324,12 +324,12 @@ async def test_if_state_legacy(
     assert calls[0].data["some"] == "is_on event - test_event1"
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_if_fires_on_for_condition(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for firing if condition is on with delay."""
     point1 = dt_util.utcnow()

--- a/tests/components/remote/test_device_trigger.py
+++ b/tests/components/remote/test_device_trigger.py
@@ -176,12 +176,12 @@ async def test_get_trigger_capabilities_legacy(
         assert capabilities == expected_capabilities
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -286,12 +286,12 @@ async def test_if_fires_on_state_change(
     }
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -346,12 +346,12 @@ async def test_if_fires_on_state_change_legacy(
     )
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_if_fires_on_state_change_with_for(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for triggers firing with delay."""
     config_entry = MockConfigEntry(domain="test", data={})

--- a/tests/components/scene/test_init.py
+++ b/tests/components/scene/test_init.py
@@ -37,8 +37,9 @@ def entities(
     return entities
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_config_yaml_alias_anchor(
-    hass: HomeAssistant, entities, enable_custom_integrations: None
+    hass: HomeAssistant, entities: list[MockLight]
 ) -> None:
     """Test the usage of YAML aliases and anchors.
 
@@ -84,9 +85,8 @@ async def test_config_yaml_alias_anchor(
     assert light_2.last_call("turn_on")[1].get("brightness") == 100
 
 
-async def test_config_yaml_bool(
-    hass: HomeAssistant, entities, enable_custom_integrations: None
-) -> None:
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_config_yaml_bool(hass: HomeAssistant, entities: list[MockLight]) -> None:
     """Test parsing of booleans in yaml config."""
     light_1, light_2 = await setup_lights(hass, entities)
 
@@ -113,9 +113,8 @@ async def test_config_yaml_bool(
     assert light_2.last_call("turn_on")[1].get("brightness") == 100
 
 
-async def test_activate_scene(
-    hass: HomeAssistant, entities, enable_custom_integrations: None
-) -> None:
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_activate_scene(hass: HomeAssistant, entities: list[MockLight]) -> None:
     """Test active scene."""
     light_1, light_2 = await setup_lights(hass, entities)
 
@@ -167,9 +166,8 @@ async def test_activate_scene(
     assert calls[0].data.get("transition") == 42
 
 
-async def test_restore_state(
-    hass: HomeAssistant, entities, enable_custom_integrations: None
-) -> None:
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_restore_state(hass: HomeAssistant, entities: list[MockLight]) -> None:
     """Test we restore state integration."""
     mock_restore_cache(hass, (State("scene.test", "2021-01-01T23:59:59+00:00"),))
 
@@ -195,8 +193,9 @@ async def test_restore_state(
     assert hass.states.get("scene.test").state == "2021-01-01T23:59:59+00:00"
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_restore_state_does_not_restore_unavailable(
-    hass: HomeAssistant, entities, enable_custom_integrations: None
+    hass: HomeAssistant, entities: list[MockLight]
 ) -> None:
     """Test we restore state integration but ignore unavailable."""
     mock_restore_cache(hass, (State("scene.test", STATE_UNAVAILABLE),))

--- a/tests/components/schedule/test_recorder.py
+++ b/tests/components/schedule/test_recorder.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from homeassistant.components.recorder import Recorder
+import pytest
+
 from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.components.schedule.const import ATTR_NEXT_EVENT, DOMAIN
 from homeassistant.const import ATTR_EDITABLE, ATTR_FRIENDLY_NAME, ATTR_ICON
@@ -16,11 +17,8 @@ from tests.common import async_fire_time_changed
 from tests.components.recorder.common import async_wait_recording_done
 
 
-async def test_exclude_attributes(
-    recorder_mock: Recorder,
-    hass: HomeAssistant,
-    enable_custom_integrations: None,
-) -> None:
+@pytest.mark.usefixtures("recorder_mock", "enable_custom_integrations")
+async def test_exclude_attributes(hass: HomeAssistant) -> None:
     """Test attributes to be excluded."""
     now = dt_util.utcnow()
     assert await async_setup_component(

--- a/tests/components/sensor/test_device_condition.py
+++ b/tests/components/sensor/test_device_condition.py
@@ -462,13 +462,13 @@ async def test_get_condition_capabilities_none(
         assert capabilities == expected_capabilities
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_if_state_not_above_below(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
     caplog: pytest.LogCaptureFixture,
-    enable_custom_integrations: None,
 ) -> None:
     """Test for bad value conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -505,12 +505,12 @@ async def test_if_state_not_above_below(
     assert "must contain at least one of below, above" in caplog.text
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_if_state_above(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for value conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -574,12 +574,12 @@ async def test_if_state_above(
     assert calls[0].data["some"] == "event - test_event1"
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_if_state_above_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for value conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -643,12 +643,12 @@ async def test_if_state_above_legacy(
     assert calls[0].data["some"] == "event - test_event1"
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_if_state_below(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for value conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -712,12 +712,12 @@ async def test_if_state_below(
     assert calls[0].data["some"] == "event - test_event1"
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_if_state_between(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for value conditions."""
     config_entry = MockConfigEntry(domain="test", data={})

--- a/tests/components/sensor/test_device_trigger.py
+++ b/tests/components/sensor/test_device_trigger.py
@@ -419,13 +419,13 @@ async def test_get_trigger_capabilities_none(
         assert capabilities == expected_capabilities
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_if_fires_not_on_above_below(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
     caplog: pytest.LogCaptureFixture,
-    enable_custom_integrations: None,
 ) -> None:
     """Test for value triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -459,12 +459,12 @@ async def test_if_fires_not_on_above_below(
     assert "must contain at least one of below, above" in caplog.text
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_if_fires_on_state_above(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for value triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -524,12 +524,12 @@ async def test_if_fires_on_state_above(
     )
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_if_fires_on_state_below(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for value triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -589,12 +589,12 @@ async def test_if_fires_on_state_below(
     )
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_if_fires_on_state_between(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for value triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -666,12 +666,12 @@ async def test_if_fires_on_state_between(
     )
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_if_fires_on_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for value triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -731,12 +731,12 @@ async def test_if_fires_on_state_legacy(
     )
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_if_fires_on_state_change_with_for(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for triggers firing with delay."""
     config_entry = MockConfigEntry(domain="test", data={})

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -5234,9 +5234,8 @@ async def async_record_states_partially_unavailable(hass, zero, entity_id, attri
     return four, states
 
 
-async def test_exclude_attributes(
-    hass: HomeAssistant, enable_custom_integrations: None
-) -> None:
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_exclude_attributes(hass: HomeAssistant) -> None:
     """Test sensor attributes to be excluded."""
     entity0 = MockSensor(
         has_entity_name=True,

--- a/tests/components/switch/test_device_action.py
+++ b/tests/components/switch/test_device_action.py
@@ -110,12 +110,12 @@ async def test_get_actions_hidden_auxiliary(
     assert actions == unordered(expected_actions)
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_action(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off actions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -185,12 +185,12 @@ async def test_action(
     assert turn_on_calls[-1].data == {"entity_id": entry.entity_id}
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_action_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off actions."""
     config_entry = MockConfigEntry(domain="test", data={})

--- a/tests/components/switch/test_device_condition.py
+++ b/tests/components/switch/test_device_condition.py
@@ -178,12 +178,12 @@ async def test_get_condition_capabilities_legacy(
         assert capabilities == expected_capabilities
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_if_state(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -265,12 +265,12 @@ async def test_if_state(
     assert calls[1].data["some"] == "is_off event - test_event2"
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_if_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -323,12 +323,12 @@ async def test_if_state_legacy(
     assert calls[0].data["some"] == "is_on event - test_event1"
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_if_fires_on_for_condition(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for firing if condition is on with delay."""
     point1 = dt_util.utcnow()

--- a/tests/components/switch/test_device_trigger.py
+++ b/tests/components/switch/test_device_trigger.py
@@ -176,12 +176,12 @@ async def test_get_trigger_capabilities_legacy(
         assert capabilities == expected_capabilities
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -287,12 +287,12 @@ async def test_if_fires_on_state_change(
     }
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -348,12 +348,12 @@ async def test_if_fires_on_state_change_legacy(
     )
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_if_fires_on_state_change_with_for(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-    enable_custom_integrations: None,
 ) -> None:
     """Test for triggers firing with delay."""
     config_entry = MockConfigEntry(domain="test", data={})

--- a/tests/components/switch/test_init.py
+++ b/tests/components/switch/test_init.py
@@ -20,15 +20,16 @@ from tests.common import (
 
 
 @pytest.fixture(autouse=True)
-def entities(hass: HomeAssistant, mock_switch_entities: list[MockSwitch]):
+def entities(
+    hass: HomeAssistant, mock_switch_entities: list[MockSwitch]
+) -> list[MockSwitch]:
     """Initialize the test switch."""
     setup_test_component_platform(hass, switch.DOMAIN, mock_switch_entities)
     return mock_switch_entities
 
 
-async def test_methods(
-    hass: HomeAssistant, entities, enable_custom_integrations: None
-) -> None:
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_methods(hass: HomeAssistant, entities: list[MockSwitch]) -> None:
     """Test is_on, turn_on, turn_off methods."""
     switch_1, switch_2, switch_3 = entities
     assert await async_setup_component(
@@ -60,11 +61,11 @@ async def test_methods(
     assert switch.is_on(hass, switch_3.entity_id)
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_switch_context(
     hass: HomeAssistant,
     entities,
     hass_admin_user: MockUser,
-    enable_custom_integrations: None,
 ) -> None:
     """Test that switch context works."""
     assert await async_setup_component(hass, "switch", {"switch": {"platform": "test"}})

--- a/tests/components/trace/test_websocket_api.py
+++ b/tests/components/trace/test_websocket_api.py
@@ -119,6 +119,7 @@ async def _assert_contexts(client, next_id, contexts, domain=None, item_id=None)
         ("script", "sequence", [set(), set()], [UNDEFINED, UNDEFINED], "id", []),
     ],
 )
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_get_trace(
     hass: HomeAssistant,
     hass_storage: dict[str, Any],
@@ -129,7 +130,6 @@ async def test_get_trace(
     trigger,
     context_key,
     condition_results,
-    enable_custom_integrations: None,
 ) -> None:
     """Test tracing a script or automation."""
     await async_setup_component(hass, "homeassistant", {})
@@ -1573,10 +1573,10 @@ async def test_script_mode_2(
     assert trace["script_execution"] == "finished"
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_trace_blueprint_automation(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
-    enable_custom_integrations: None,
 ) -> None:
     """Test trace of blueprint automation."""
     await async_setup_component(hass, "homeassistant", {})

--- a/tests/components/webhook/test_init.py
+++ b/tests/components/webhook/test_init.py
@@ -249,11 +249,11 @@ async def test_webhook_local_only(hass: HomeAssistant, mock_client) -> None:
     assert len(hooks) == 1
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_listing_webhook(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     hass_access_token: str,
-    enable_custom_integrations: None,
 ) -> None:
     """Test unregistering a webhook."""
     assert await async_setup_component(hass, "webhook", {})


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, avoid unused variable (see #118456)

https://github.com/home-assistant/core/blob/72309364f5848acc24793a5b7156d66c589183da/pylint/plugins/hass_enforce_type_hints.py#L108

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
