### PR TITLE
Move mock_bluetooth* fixtures to decorator

### DIFF
--- a/tests/components/bluetooth/test_active_update_coordinator.py
+++ b/tests/components/bluetooth/test_active_update_coordinator.py
@@ -9,6 +9,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 from bleak.exc import BleakError
+import pytest
 
 from homeassistant.components.bluetooth import (
     DOMAIN,
@@ -96,11 +97,8 @@ class MyCoordinator(ActiveBluetoothDataUpdateCoordinator[dict[str, Any]]):
         super()._async_handle_bluetooth_event(service_info, change)
 
 
-async def test_basic_usage(
-    hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
-) -> None:
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
+async def test_basic_usage(hass: HomeAssistant) -> None:
     """Test basic usage of the ActiveBluetoothDataUpdateCoordinator."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -136,11 +134,8 @@ async def test_basic_usage(
     unregister_listener()
 
 
-async def test_bleak_error_during_polling(
-    hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
-) -> None:
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
+async def test_bleak_error_during_polling(hass: HomeAssistant) -> None:
     """Test bleak error during polling ActiveBluetoothDataUpdateCoordinator."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     poll_count = 0
@@ -189,11 +184,8 @@ async def test_bleak_error_during_polling(
     unregister_listener()
 
 
-async def test_generic_exception_during_polling(
-    hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
-) -> None:
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
+async def test_generic_exception_during_polling(hass: HomeAssistant) -> None:
     """Test generic exception during polling ActiveBluetoothDataUpdateCoordinator."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     poll_count = 0
@@ -242,11 +234,8 @@ async def test_generic_exception_during_polling(
     unregister_listener()
 
 
-async def test_polling_debounce(
-    hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
-) -> None:
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
+async def test_polling_debounce(hass: HomeAssistant) -> None:
     """Test basic usage of the ActiveBluetoothDataUpdateCoordinator."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     poll_count = 0
@@ -288,11 +277,8 @@ async def test_polling_debounce(
     unregister_listener()
 
 
-async def test_polling_debounce_with_custom_debouncer(
-    hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
-) -> None:
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
+async def test_polling_debounce_with_custom_debouncer(hass: HomeAssistant) -> None:
     """Test basic usage of the ActiveBluetoothDataUpdateCoordinator."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     poll_count = 0
@@ -337,11 +323,8 @@ async def test_polling_debounce_with_custom_debouncer(
     unregister_listener()
 
 
-async def test_polling_rejecting_the_first_time(
-    hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
-) -> None:
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
+async def test_polling_rejecting_the_first_time(hass: HomeAssistant) -> None:
     """Test need_poll rejects the first time ActiveBluetoothDataUpdateCoordinator."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     attempt = 0
@@ -399,11 +382,8 @@ async def test_polling_rejecting_the_first_time(
     unregister_listener()
 
 
-async def test_no_polling_after_stop_event(
-    hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
-) -> None:
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
+async def test_no_polling_after_stop_event(hass: HomeAssistant) -> None:
     """Test we do not poll after the stop event."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     needs_poll_calls = 0

--- a/tests/components/bluetooth/test_active_update_processor.py
+++ b/tests/components/bluetooth/test_active_update_processor.py
@@ -49,11 +49,8 @@ GENERIC_BLUETOOTH_SERVICE_INFO_2 = BluetoothServiceInfo(
 )
 
 
-async def test_basic_usage(
-    hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
-) -> None:
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
+async def test_basic_usage(hass: HomeAssistant) -> None:
     """Test basic usage of the ActiveBluetoothProcessorCoordinator."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -98,11 +95,8 @@ async def test_basic_usage(
     cancel()
 
 
-async def test_poll_can_be_skipped(
-    hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
-) -> None:
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
+async def test_poll_can_be_skipped(hass: HomeAssistant) -> None:
     """Test need_poll callback works and can skip a poll if its not needed."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -157,11 +151,9 @@ async def test_poll_can_be_skipped(
     cancel()
 
 
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
 async def test_bleak_error_and_recover(
-    hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
-    caplog: pytest.LogCaptureFixture,
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test bleak error handling and recovery."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
@@ -222,11 +214,8 @@ async def test_bleak_error_and_recover(
     cancel()
 
 
-async def test_poll_failure_and_recover(
-    hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
-) -> None:
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
+async def test_poll_failure_and_recover(hass: HomeAssistant) -> None:
     """Test error handling and recovery."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -281,11 +270,8 @@ async def test_poll_failure_and_recover(
     cancel()
 
 
-async def test_second_poll_needed(
-    hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
-) -> None:
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
+async def test_second_poll_needed(hass: HomeAssistant) -> None:
     """If a poll is queued, by the time it starts it may no longer be needed."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -332,11 +318,8 @@ async def test_second_poll_needed(
     cancel()
 
 
-async def test_rate_limit(
-    hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
-) -> None:
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
+async def test_rate_limit(hass: HomeAssistant) -> None:
     """Test error handling and recovery."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -384,11 +367,8 @@ async def test_rate_limit(
     cancel()
 
 
-async def test_no_polling_after_stop_event(
-    hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
-) -> None:
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
+async def test_no_polling_after_stop_event(hass: HomeAssistant) -> None:
     """Test we do not poll after the stop event."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     needs_poll_calls = 0

--- a/tests/components/bluetooth/test_config_flow.py
+++ b/tests/components/bluetooth/test_config_flow.py
@@ -1,6 +1,6 @@
 """Test the bluetooth config flow."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from bluetooth_adapters import DEFAULT_ADDRESS, AdapterDetails
 import pytest
@@ -20,12 +20,11 @@ from tests.common import MockConfigEntry
 from tests.typing import WebSocketGenerator
 
 
-@pytest.mark.usefixtures("macos_adapter")
+@pytest.mark.usefixtures(
+    "macos_adapter", "mock_bleak_scanner_start", "mock_bluetooth_adapters"
+)
 async def test_options_flow_disabled_not_setup(
-    hass: HomeAssistant,
-    hass_ws_client: WebSocketGenerator,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test options are disabled if the integration has not been setup."""
     await async_setup_component(hass, "config", {})
@@ -338,12 +337,10 @@ async def test_async_step_integration_discovery_already_exists(
     assert result["reason"] == "already_configured"
 
 
-@pytest.mark.usefixtures("one_adapter")
-async def test_options_flow_linux(
-    hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
-) -> None:
+@pytest.mark.usefixtures(
+    "one_adapter", "mock_bleak_scanner_start", "mock_bluetooth_adapters"
+)
+async def test_options_flow_linux(hass: HomeAssistant) -> None:
     """Test options on Linux."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -392,12 +389,11 @@ async def test_options_flow_linux(
     await hass.config_entries.async_unload(entry.entry_id)
 
 
-@pytest.mark.usefixtures("macos_adapter")
+@pytest.mark.usefixtures(
+    "macos_adapter", "mock_bleak_scanner_start", "mock_bluetooth_adapters"
+)
 async def test_options_flow_disabled_macos(
-    hass: HomeAssistant,
-    hass_ws_client: WebSocketGenerator,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test options are disabled on MacOS."""
     await async_setup_component(hass, "config", {})
@@ -422,12 +418,11 @@ async def test_options_flow_disabled_macos(
     await hass.config_entries.async_unload(entry.entry_id)
 
 
-@pytest.mark.usefixtures("one_adapter")
+@pytest.mark.usefixtures(
+    "one_adapter", "mock_bleak_scanner_start", "mock_bluetooth_adapters"
+)
 async def test_options_flow_enabled_linux(
-    hass: HomeAssistant,
-    hass_ws_client: WebSocketGenerator,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test options are enabled on Linux."""
     await async_setup_component(hass, "config", {})

--- a/tests/components/bluetooth/test_diagnostics.py
+++ b/tests/components/bluetooth/test_diagnostics.py
@@ -237,12 +237,11 @@ async def test_diagnostics(
 
 
 @patch("homeassistant.components.bluetooth.HaScanner", FakeHaScanner)
-@pytest.mark.usefixtures("macos_adapter")
+@pytest.mark.usefixtures(
+    "macos_adapter", "mock_bleak_scanner_start", "mock_bluetooth_adapters"
+)
 async def test_diagnostics_macos(
-    hass: HomeAssistant,
-    hass_client: ClientSessionGenerator,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> None:
     """Test diagnostics for macos."""
     # Normally we do not want to patch our classes, but since bleak will import
@@ -414,12 +413,14 @@ async def test_diagnostics_macos(
 
 
 @patch("homeassistant.components.bluetooth.HaScanner", FakeHaScanner)
-@pytest.mark.usefixtures("enable_bluetooth", "one_adapter")
+@pytest.mark.usefixtures(
+    "enable_bluetooth",
+    "one_adapter",
+    "mock_bleak_scanner_start",
+    "mock_bluetooth_adapters",
+)
 async def test_diagnostics_remote_adapter(
-    hass: HomeAssistant,
-    hass_client: ClientSessionGenerator,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> None:
     """Test diagnostics for remote adapter."""
     manager = _get_manager()

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -432,11 +432,11 @@ async def test_discovery_match_by_service_uuid(
         }
     ],
 )
+@pytest.mark.usefixtures("mock_bluetooth_adapters")
 async def test_discovery_match_by_service_uuid_and_short_local_name(
     mock_async_get_bluetooth: AsyncMock,
     hass: HomeAssistant,
     mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
 ) -> None:
     """Test bluetooth discovery match by service_uuid and short local name."""
     entry = MockConfigEntry(domain="bluetooth", unique_id="00:00:00:00:00:01")

--- a/tests/components/bluetooth/test_manager.py
+++ b/tests/components/bluetooth/test_manager.py
@@ -744,8 +744,9 @@ async def test_switching_adapters_when_one_stop_scanning(
     cancel_hci2()
 
 
+@pytest.mark.usefixtures("mock_bluetooth_adapters")
 async def test_goes_unavailable_connectable_only_and_recovers(
-    hass: HomeAssistant, mock_bluetooth_adapters: None
+    hass: HomeAssistant,
 ) -> None:
     """Test all connectable scanners go unavailable, and than recover when there is a non-connectable scanner."""
     assert await async_setup_component(hass, bluetooth.DOMAIN, {})
@@ -907,8 +908,9 @@ async def test_goes_unavailable_connectable_only_and_recovers(
     unsetup_not_connectable_scanner()
 
 
+@pytest.mark.usefixtures("mock_bluetooth_adapters")
 async def test_goes_unavailable_dismisses_discovery_and_makes_discoverable(
-    hass: HomeAssistant, mock_bluetooth_adapters: None
+    hass: HomeAssistant,
 ) -> None:
     """Test that unavailable will dismiss any active discoveries and make device discoverable again."""
     mock_bt = [

--- a/tests/components/bluetooth/test_passive_update_coordinator.py
+++ b/tests/components/bluetooth/test_passive_update_coordinator.py
@@ -8,6 +8,8 @@ import time
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from homeassistant.components.bluetooth import (
     DOMAIN,
     FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
@@ -65,11 +67,8 @@ class MyCoordinator(PassiveBluetoothDataUpdateCoordinator):
         super()._async_handle_bluetooth_event(service_info, change)
 
 
-async def test_basic_usage(
-    hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
-) -> None:
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
+async def test_basic_usage(hass: HomeAssistant) -> None:
     """Test basic usage of the PassiveBluetoothDataUpdateCoordinator."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     coordinator = MyCoordinator(
@@ -97,10 +96,9 @@ async def test_basic_usage(
     cancel()
 
 
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
 async def test_context_compatiblity_with_data_update_coordinator(
     hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
 ) -> None:
     """Test contexts can be passed for compatibility with DataUpdateCoordinator."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
@@ -135,10 +133,9 @@ async def test_context_compatiblity_with_data_update_coordinator(
     assert not set(coordinator.async_contexts())
 
 
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
 async def test_unavailable_callbacks_mark_the_coordinator_unavailable(
     hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
 ) -> None:
     """Test that the coordinator goes unavailable when the bluetooth stack no longer sees the device."""
     start_monotonic = time.monotonic()
@@ -196,11 +193,8 @@ async def test_unavailable_callbacks_mark_the_coordinator_unavailable(
     assert coordinator.available is False
 
 
-async def test_passive_bluetooth_coordinator_entity(
-    hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
-) -> None:
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
+async def test_passive_bluetooth_coordinator_entity(hass: HomeAssistant) -> None:
     """Test integration of PassiveBluetoothDataUpdateCoordinator with PassiveBluetoothCoordinatorEntity."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     coordinator = MyCoordinator(

--- a/tests/components/bluetooth/test_passive_update_processor.py
+++ b/tests/components/bluetooth/test_passive_update_processor.py
@@ -174,11 +174,8 @@ GENERIC_PASSIVE_BLUETOOTH_DATA_UPDATE_WITH_DEVICE_NAME_AND_TEMP_CHANGE = (
 )
 
 
-async def test_basic_usage(
-    hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
-) -> None:
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
+async def test_basic_usage(hass: HomeAssistant) -> None:
     """Test basic usage of the PassiveBluetoothProcessorCoordinator."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -276,10 +273,9 @@ async def test_basic_usage(
     cancel_coordinator()
 
 
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
 async def test_entity_key_is_dispatched_on_entity_key_change(
     hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
 ) -> None:
     """Test entity key listeners are only dispatched on change."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
@@ -398,11 +394,8 @@ async def test_entity_key_is_dispatched_on_entity_key_change(
     cancel_coordinator()
 
 
-async def test_unavailable_after_no_data(
-    hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
-) -> None:
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
+async def test_unavailable_after_no_data(hass: HomeAssistant) -> None:
     """Test that the coordinator is unavailable after no data for a while."""
     start_monotonic = time.monotonic()
 
@@ -513,11 +506,8 @@ async def test_unavailable_after_no_data(
     cancel_coordinator()
 
 
-async def test_no_updates_once_stopping(
-    hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
-) -> None:
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
+async def test_no_updates_once_stopping(hass: HomeAssistant) -> None:
     """Test updates are ignored once hass is stopping."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -570,11 +560,9 @@ async def test_no_updates_once_stopping(
     cancel_coordinator()
 
 
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
 async def test_exception_from_update_method(
-    hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test we handle exceptions from the update method."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
@@ -639,11 +627,8 @@ async def test_exception_from_update_method(
     cancel_coordinator()
 
 
-async def test_bad_data_from_update_method(
-    hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
-) -> None:
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
+async def test_bad_data_from_update_method(hass: HomeAssistant) -> None:
     """Test we handle bad data from the update method."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -996,11 +981,8 @@ GOVEE_B5178_PRIMARY_AND_REMOTE_PASSIVE_BLUETOOTH_DATA_UPDATE = (
 )
 
 
-async def test_integration_with_entity(
-    hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
-) -> None:
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
+async def test_integration_with_entity(hass: HomeAssistant) -> None:
     """Test integration of PassiveBluetoothProcessorCoordinator with PassiveBluetoothCoordinatorEntity."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -1158,11 +1140,8 @@ NO_DEVICES_PASSIVE_BLUETOOTH_DATA_UPDATE = PassiveBluetoothDataUpdate(
 )
 
 
-async def test_integration_with_entity_without_a_device(
-    hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
-) -> None:
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
+async def test_integration_with_entity_without_a_device(hass: HomeAssistant) -> None:
     """Test integration with PassiveBluetoothCoordinatorEntity with no device."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -1224,10 +1203,9 @@ async def test_integration_with_entity_without_a_device(
     cancel_coordinator()
 
 
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
 async def test_passive_bluetooth_entity_with_entity_platform(
     hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
 ) -> None:
     """Test with a mock entity platform."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
@@ -1331,11 +1309,8 @@ DEVICE_ONLY_PASSIVE_BLUETOOTH_DATA_UPDATE = PassiveBluetoothDataUpdate(
 )
 
 
-async def test_integration_multiple_entity_platforms(
-    hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
-) -> None:
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
+async def test_integration_multiple_entity_platforms(hass: HomeAssistant) -> None:
     """Test integration of PassiveBluetoothProcessorCoordinator with multiple platforms."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -1426,11 +1401,9 @@ async def test_integration_multiple_entity_platforms(
     cancel_coordinator()
 
 
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
 async def test_exception_from_coordinator_update_method(
-    hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test we handle exceptions from the update method."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
@@ -1485,11 +1458,9 @@ async def test_exception_from_coordinator_update_method(
     cancel_coordinator()
 
 
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
 async def test_integration_multiple_entity_platforms_with_reload_and_restart(
-    hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
-    hass_storage: dict[str, Any],
+    hass: HomeAssistant, hass_storage: dict[str, Any]
 ) -> None:
     """Test integration of PassiveBluetoothProcessorCoordinator with multiple platforms with reload."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
@@ -1791,11 +1762,8 @@ NAMING_PASSIVE_BLUETOOTH_DATA_UPDATE = PassiveBluetoothDataUpdate(
 )
 
 
-async def test_naming(
-    hass: HomeAssistant,
-    mock_bleak_scanner_start: MagicMock,
-    mock_bluetooth_adapters: None,
-) -> None:
+@pytest.mark.usefixtures("mock_bleak_scanner_start", "mock_bluetooth_adapters")
+async def test_naming(hass: HomeAssistant) -> None:
     """Test basic usage of the PassiveBluetoothProcessorCoordinator."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 

--- a/tests/components/bluetooth_le_tracker/test_device_tracker.py
+++ b/tests/components/bluetooth_le_tracker/test_device_tracker.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from bleak import BleakError
 from freezegun import freeze_time
+import pytest
 
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 from homeassistant.components.bluetooth_le_tracker import device_tracker
@@ -17,7 +18,6 @@ from homeassistant.components.device_tracker import (
     CONF_SCAN_INTERVAL,
     CONF_TRACK_NEW,
     DOMAIN,
-    legacy,
 )
 from homeassistant.const import CONF_PLATFORM
 from homeassistant.core import HomeAssistant
@@ -66,11 +66,8 @@ class MockBleakClientBattery5(MockBleakClient):
         return b"\x05"
 
 
-async def test_do_not_see_device_if_time_not_updated(
-    hass: HomeAssistant,
-    mock_bluetooth: None,
-    mock_device_tracker_conf: list[legacy.Device],
-) -> None:
+@pytest.mark.usefixtures("mock_bluetooth", "mock_device_tracker_conf")
+async def test_do_not_see_device_if_time_not_updated(hass: HomeAssistant) -> None:
     """Test device going not_home after consider_home threshold from first scan if the subsequent scans have not incremented last seen time."""
 
     address = "DE:AD:BE:EF:13:37"
@@ -132,11 +129,8 @@ async def test_do_not_see_device_if_time_not_updated(
     assert state.state == "not_home"
 
 
-async def test_see_device_if_time_updated(
-    hass: HomeAssistant,
-    mock_bluetooth: None,
-    mock_device_tracker_conf: list[legacy.Device],
-) -> None:
+@pytest.mark.usefixtures("mock_bluetooth", "mock_device_tracker_conf")
+async def test_see_device_if_time_updated(hass: HomeAssistant) -> None:
     """Test device remaining home after consider_home threshold from first scan if the subsequent scans have incremented last seen time."""
 
     address = "DE:AD:BE:EF:13:37"
@@ -214,11 +208,8 @@ async def test_see_device_if_time_updated(
     assert state.state == "home"
 
 
-async def test_preserve_new_tracked_device_name(
-    hass: HomeAssistant,
-    mock_bluetooth: None,
-    mock_device_tracker_conf: list[legacy.Device],
-) -> None:
+@pytest.mark.usefixtures("mock_bluetooth", "mock_device_tracker_conf")
+async def test_preserve_new_tracked_device_name(hass: HomeAssistant) -> None:
     """Test preserving tracked device name across new seens."""
 
     address = "DE:AD:BE:EF:13:37"
@@ -284,11 +275,8 @@ async def test_preserve_new_tracked_device_name(
     assert state.name == name
 
 
-async def test_tracking_battery_times_out(
-    hass: HomeAssistant,
-    mock_bluetooth: None,
-    mock_device_tracker_conf: list[legacy.Device],
-) -> None:
+@pytest.mark.usefixtures("mock_bluetooth", "mock_device_tracker_conf")
+async def test_tracking_battery_times_out(hass: HomeAssistant) -> None:
     """Test tracking the battery times out."""
 
     address = "DE:AD:BE:EF:13:37"
@@ -353,11 +341,8 @@ async def test_tracking_battery_times_out(
     assert "battery" not in state.attributes
 
 
-async def test_tracking_battery_fails(
-    hass: HomeAssistant,
-    mock_bluetooth: None,
-    mock_device_tracker_conf: list[legacy.Device],
-) -> None:
+@pytest.mark.usefixtures("mock_bluetooth", "mock_device_tracker_conf")
+async def test_tracking_battery_fails(hass: HomeAssistant) -> None:
     """Test tracking the battery fails."""
 
     address = "DE:AD:BE:EF:13:37"
@@ -421,11 +406,8 @@ async def test_tracking_battery_fails(
     assert "battery" not in state.attributes
 
 
-async def test_tracking_battery_successful(
-    hass: HomeAssistant,
-    mock_bluetooth: None,
-    mock_device_tracker_conf: list[legacy.Device],
-) -> None:
+@pytest.mark.usefixtures("mock_bluetooth", "mock_device_tracker_conf")
+async def test_tracking_battery_successful(hass: HomeAssistant) -> None:
     """Test tracking the battery gets a value."""
 
     address = "DE:AD:BE:EF:13:37"

--- a/tests/components/default_config/test_init.py
+++ b/tests/components/default_config/test_init.py
@@ -33,9 +33,8 @@ def recorder_url_mock():
         yield
 
 
-async def test_setup(
-    hass: HomeAssistant, mock_zeroconf: None, mock_bluetooth: None
-) -> None:
+@pytest.mark.usefixtures("mock_bluetooth", "mock_zeroconf")
+async def test_setup(hass: HomeAssistant) -> None:
     """Test setup."""
     recorder_helper.async_initialize_recorder(hass)
     # default_config needs the homeassistant integration, assert it will be

--- a/tests/components/ibeacon/test_config_flow.py
+++ b/tests/components/ibeacon/test_config_flow.py
@@ -12,9 +12,8 @@ from homeassistant.data_entry_flow import FlowResultType
 from tests.common import MockConfigEntry
 
 
-async def test_setup_user_no_bluetooth(
-    hass: HomeAssistant, mock_bluetooth_adapters: None
-) -> None:
+@pytest.mark.usefixtures("mock_bluetooth_adapters")
+async def test_setup_user_no_bluetooth(hass: HomeAssistant) -> None:
     """Test setting up via user interaction when bluetooth is not enabled."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/private_ble_device/test_config_flow.py
+++ b/tests/components/private_ble_device/test_config_flow.py
@@ -20,9 +20,8 @@ def assert_form_error(result: FlowResult, key: str, value: str) -> None:
     assert result["errors"][key] == value
 
 
-async def test_setup_user_no_bluetooth(
-    hass: HomeAssistant, mock_bluetooth_adapters: None
-) -> None:
+@pytest.mark.usefixtures("mock_bluetooth_adapters")
+async def test_setup_user_no_bluetooth(hass: HomeAssistant) -> None:
     """Test setting up via user interaction when bluetooth is not enabled."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, avoid unused variable (see #118456)

https://github.com/home-assistant/core/blob/72309364f5848acc24793a5b7156d66c589183da/pylint/plugins/hass_enforce_type_hints.py#L139-L140

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
