### PR TITLE
Move enable_bluetooth fixture to decorator

### DIFF
--- a/tests/components/private_ble_device/test_device_tracker.py
+++ b/tests/components/private_ble_device/test_device_tracker.py
@@ -22,7 +22,8 @@ from . import (
 from tests.components.bluetooth.test_advertisement_tracker import ONE_HOUR_SECONDS
 
 
-async def test_tracker_created(hass: HomeAssistant, enable_bluetooth: None) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_tracker_created(hass: HomeAssistant) -> None:
     """Test creating a tracker entity when no devices have been seen."""
     await async_mock_config_entry(hass)
 
@@ -31,9 +32,8 @@ async def test_tracker_created(hass: HomeAssistant, enable_bluetooth: None) -> N
     assert state.state == "not_home"
 
 
-async def test_tracker_ignore_other_rpa(
-    hass: HomeAssistant, enable_bluetooth: None
-) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_tracker_ignore_other_rpa(hass: HomeAssistant) -> None:
     """Test that tracker ignores RPA's that don't match us."""
     await async_mock_config_entry(hass)
     await async_inject_broadcast(hass, MAC_STATIC)
@@ -43,9 +43,8 @@ async def test_tracker_ignore_other_rpa(
     assert state.state == "not_home"
 
 
-async def test_tracker_already_home(
-    hass: HomeAssistant, enable_bluetooth: None
-) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_tracker_already_home(hass: HomeAssistant) -> None:
     """Test creating a tracker and the device was already discovered by HA."""
     await async_inject_broadcast(hass, MAC_RPA_VALID_1)
     await async_mock_config_entry(hass)
@@ -55,7 +54,8 @@ async def test_tracker_already_home(
     assert state.state == "home"
 
 
-async def test_tracker_arrive_home(hass: HomeAssistant, enable_bluetooth: None) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_tracker_arrive_home(hass: HomeAssistant) -> None:
     """Test transition from not_home to home."""
     await async_mock_config_entry(hass)
     await async_inject_broadcast(hass, MAC_RPA_VALID_1, b"1")
@@ -85,7 +85,8 @@ async def test_tracker_arrive_home(hass: HomeAssistant, enable_bluetooth: None) 
     assert state.attributes["current_address"] == "40:01:02:0a:c4:a6"
 
 
-async def test_tracker_isolation(hass: HomeAssistant, enable_bluetooth: None) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_tracker_isolation(hass: HomeAssistant) -> None:
     """Test creating 2 tracker entities doesn't confuse anything."""
     await async_mock_config_entry(hass)
     await async_mock_config_entry(hass, irk="1" * 32)
@@ -102,7 +103,8 @@ async def test_tracker_isolation(hass: HomeAssistant, enable_bluetooth: None) ->
     assert state.state == "not_home"
 
 
-async def test_tracker_mac_rotate(hass: HomeAssistant, enable_bluetooth: None) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_tracker_mac_rotate(hass: HomeAssistant) -> None:
     """Test MAC address rotation."""
     await async_inject_broadcast(hass, MAC_RPA_VALID_1)
     await async_mock_config_entry(hass)
@@ -119,7 +121,8 @@ async def test_tracker_mac_rotate(hass: HomeAssistant, enable_bluetooth: None) -
     assert state.attributes["current_address"] == MAC_RPA_VALID_2
 
 
-async def test_tracker_start_stale(hass: HomeAssistant, enable_bluetooth: None) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_tracker_start_stale(hass: HomeAssistant) -> None:
     """Test edge case where we find an existing stale record, and it expires before we see any more."""
     time.monotonic()
 
@@ -138,7 +141,8 @@ async def test_tracker_start_stale(hass: HomeAssistant, enable_bluetooth: None) 
     assert state.state == "not_home"
 
 
-async def test_tracker_leave_home(hass: HomeAssistant, enable_bluetooth: None) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_tracker_leave_home(hass: HomeAssistant) -> None:
     """Test tracker notices we have left."""
     time.monotonic()
 
@@ -157,9 +161,8 @@ async def test_tracker_leave_home(hass: HomeAssistant, enable_bluetooth: None) -
     assert state.state == "not_home"
 
 
-async def test_old_tracker_leave_home(
-    hass: HomeAssistant, enable_bluetooth: None
-) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_old_tracker_leave_home(hass: HomeAssistant) -> None:
     """Test tracker ignores an old stale mac address timing out."""
     start_time = time.monotonic()
 

--- a/tests/components/ruuvitag_ble/test_sensor.py
+++ b/tests/components/ruuvitag_ble/test_sensor.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from homeassistant.components.ruuvitag_ble.const import DOMAIN
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
@@ -13,7 +15,8 @@ from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
 
 
-async def test_sensors(enable_bluetooth: None, hass: HomeAssistant) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_sensors(hass: HomeAssistant) -> None:
     """Test the RuuviTag BLE sensors."""
     entry = MockConfigEntry(domain=DOMAIN, unique_id=RUUVITAG_SERVICE_INFO.address)
     entry.add_to_hass(hass)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, avoid unused variable (see #118456)

https://github.com/home-assistant/core/blob/72309364f5848acc24793a5b7156d66c589183da/pylint/plugins/hass_enforce_type_hints.py#L107

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
