### PR TITLE
Use torrent id to identify torrents that should trigger events

### DIFF
--- a/homeassistant/components/transmission/coordinator.py
+++ b/homeassistant/components/transmission/coordinator.py
@@ -93,16 +93,14 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
 
     def check_completed_torrent(self) -> None:
         """Get completed torrent functionality."""
-        old_completed_torrent_names = {
-            torrent.name for torrent in self._completed_torrents
-        }
+        old_completed_torrents = {torrent.id for torrent in self._completed_torrents}
 
         current_completed_torrents = [
             torrent for torrent in self.torrents if torrent.status == "seeding"
         ]
 
         for torrent in current_completed_torrents:
-            if torrent.name not in old_completed_torrent_names:
+            if torrent.id not in old_completed_torrents:
                 self.hass.bus.fire(
                     EVENT_DOWNLOADED_TORRENT, {"name": torrent.name, "id": torrent.id}
                 )
@@ -111,14 +109,14 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
 
     def check_started_torrent(self) -> None:
         """Get started torrent functionality."""
-        old_started_torrent_names = {torrent.name for torrent in self._started_torrents}
+        old_started_torrents = {torrent.id for torrent in self._started_torrents}
 
         current_started_torrents = [
             torrent for torrent in self.torrents if torrent.status == "downloading"
         ]
 
         for torrent in current_started_torrents:
-            if torrent.name not in old_started_torrent_names:
+            if torrent.id not in old_started_torrents:
                 self.hass.bus.fire(
                     EVENT_STARTED_TORRENT, {"name": torrent.name, "id": torrent.id}
                 )
@@ -127,10 +125,10 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
 
     def check_removed_torrent(self) -> None:
         """Get removed torrent functionality."""
-        current_torrent_names = {torrent.name for torrent in self.torrents}
+        current_torrents = {torrent.id for torrent in self.torrents}
 
         for torrent in self._all_torrents:
-            if torrent.name not in current_torrent_names:
+            if torrent.id not in current_torrents:
                 self.hass.bus.fire(
                     EVENT_REMOVED_TORRENT, {"name": torrent.name, "id": torrent.id}
                 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I have noticed that the torrent name changes after getting added. This causes the event triggered by this integration to fire twice for the same added torrent.
By checking the torrent id instead of its name we can avoid this and ensure that the event is only fired once.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
