### PR TITLE
Address post-merge review comments from Vallox reconfigure support PR

### DIFF
--- a/tests/components/vallox/test_config_flow.py
+++ b/tests/components/vallox/test_config_flow.py
@@ -69,6 +69,26 @@ async def test_form_invalid_ip(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"host": "invalid_host"}
 
+    with (
+        patch(
+            "homeassistant.components.vallox.config_flow.Vallox.fetch_metric_data",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.vallox.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            init["flow_id"],
+            {"host": "1.2.3.4"},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Vallox"
+    assert result["data"] == {"host": "1.2.3.4", "name": "Vallox"}
+
 
 async def test_form_vallox_api_exception_cannot_connect(hass: HomeAssistant) -> None:
     """Test that cannot connect error is handled."""
@@ -88,6 +108,26 @@ async def test_form_vallox_api_exception_cannot_connect(hass: HomeAssistant) -> 
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"host": "cannot_connect"}
+
+    with (
+        patch(
+            "homeassistant.components.vallox.config_flow.Vallox.fetch_metric_data",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.vallox.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            init["flow_id"],
+            {"host": "1.2.3.4"},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Vallox"
+    assert result["data"] == {"host": "1.2.3.4", "name": "Vallox"}
 
 
 async def test_form_os_error_cannot_connect(hass: HomeAssistant) -> None:
@@ -109,6 +149,26 @@ async def test_form_os_error_cannot_connect(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"host": "cannot_connect"}
 
+    with (
+        patch(
+            "homeassistant.components.vallox.config_flow.Vallox.fetch_metric_data",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.vallox.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            init["flow_id"],
+            {"host": "1.2.3.4"},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Vallox"
+    assert result["data"] == {"host": "1.2.3.4", "name": "Vallox"}
+
 
 async def test_form_unknown_exception(hass: HomeAssistant) -> None:
     """Test that unknown exceptions are handled."""
@@ -128,6 +188,26 @@ async def test_form_unknown_exception(hass: HomeAssistant) -> None:
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"host": "unknown"}
+
+    with (
+        patch(
+            "homeassistant.components.vallox.config_flow.Vallox.fetch_metric_data",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.vallox.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            init["flow_id"],
+            {"host": "1.2.3.4"},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Vallox"
+    assert result["data"] == {"host": "1.2.3.4", "name": "Vallox"}
 
 
 async def test_form_already_configured(hass: HomeAssistant) -> None:
@@ -209,6 +289,20 @@ async def test_reconfigure_host_to_invalid_ip_fails(
     # entry not changed
     assert entry.data["host"] == "192.168.100.50"
 
+    # makes sure we can recover and continue
+    reconfigure_result = await hass.config_entries.flow.async_configure(
+        init_flow_result["flow_id"],
+        {
+            "host": "192.168.100.60",
+        },
+    )
+    await hass.async_block_till_done()
+    assert reconfigure_result["type"] is FlowResultType.ABORT
+    assert reconfigure_result["reason"] == "reconfigure_successful"
+
+    # changed entry
+    assert entry.data["host"] == "192.168.100.60"
+
 
 async def test_reconfigure_host_vallox_api_exception_cannot_connect(
     hass: HomeAssistant, init_reconfigure_flow
@@ -234,6 +328,20 @@ async def test_reconfigure_host_vallox_api_exception_cannot_connect(
     # entry not changed
     assert entry.data["host"] == "192.168.100.50"
 
+    # makes sure we can recover and continue
+    reconfigure_result = await hass.config_entries.flow.async_configure(
+        init_flow_result["flow_id"],
+        {
+            "host": "192.168.100.60",
+        },
+    )
+    await hass.async_block_till_done()
+    assert reconfigure_result["type"] is FlowResultType.ABORT
+    assert reconfigure_result["reason"] == "reconfigure_successful"
+
+    # changed entry
+    assert entry.data["host"] == "192.168.100.60"
+
 
 async def test_reconfigure_host_unknown_exception(
     hass: HomeAssistant, init_reconfigure_flow
@@ -258,3 +366,17 @@ async def test_reconfigure_host_unknown_exception(
 
     # entry not changed
     assert entry.data["host"] == "192.168.100.50"
+
+    # makes sure we can recover and continue
+    reconfigure_result = await hass.config_entries.flow.async_configure(
+        init_flow_result["flow_id"],
+        {
+            "host": "192.168.100.60",
+        },
+    )
+    await hass.async_block_till_done()
+    assert reconfigure_result["type"] is FlowResultType.ABORT
+    assert reconfigure_result["reason"] == "reconfigure_successful"
+
+    # changed entry
+    assert entry.data["host"] == "192.168.100.60"


### PR DESCRIPTION
## Proposed change

Address late review from https://github.com/home-assistant/core/pull/115915#pullrequestreview-2082672446.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
