### PR TITLE
Add return type hints in tests (a-i)

### DIFF
--- a/tests/components/airthings_ble/test_sensor.py
+++ b/tests/components/airthings_ble/test_sensor.py
@@ -30,7 +30,7 @@ async def test_migration_from_v1_to_v3_unique_id(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     device_registry: dr.DeviceRegistry,
-):
+) -> None:
     """Verify that we can migrate from v1 (pre 2023.9.0) to the latest unique id format."""
     entry = create_entry(hass)
     device = create_device(entry, device_registry)
@@ -71,7 +71,7 @@ async def test_migration_from_v2_to_v3_unique_id(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     device_registry: dr.DeviceRegistry,
-):
+) -> None:
     """Verify that we can migrate from v2 (introduced in 2023.9.0) to the latest unique id format."""
     entry = create_entry(hass)
     device = create_device(entry, device_registry)
@@ -112,7 +112,7 @@ async def test_migration_from_v1_and_v2_to_v3_unique_id(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     device_registry: dr.DeviceRegistry,
-):
+) -> None:
     """Test if migration works when we have both v1 (pre 2023.9.0) and v2 (introduced in 2023.9.0) unique ids."""
     entry = create_entry(hass)
     device = create_device(entry, device_registry)
@@ -162,7 +162,7 @@ async def test_migration_with_all_unique_ids(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     device_registry: dr.DeviceRegistry,
-):
+) -> None:
     """Test if migration works when we have all unique ids."""
     entry = create_entry(hass)
     device = create_device(entry, device_registry)

--- a/tests/components/alarm_control_panel/test_device_trigger.py
+++ b/tests/components/alarm_control_panel/test_device_trigger.py
@@ -251,7 +251,7 @@ async def test_if_fires_on_state_change(
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls: list[ServiceCall],
-):
+) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)

--- a/tests/components/anova/test_sensor.py
+++ b/tests/components/anova/test_sensor.py
@@ -3,6 +3,7 @@
 import logging
 
 from anova_wifi import AnovaApi
+import pytest
 
 from homeassistant.core import HomeAssistant
 
@@ -40,7 +41,8 @@ async def test_sensors(hass: HomeAssistant, anova_api: AnovaApi) -> None:
     )
 
 
-async def test_no_data_sensors(hass: HomeAssistant, anova_api_no_data: AnovaApi):
+@pytest.mark.usefixtures("anova_api_no_data")
+async def test_no_data_sensors(hass: HomeAssistant) -> None:
     """Test that if we have no data for the device, and we have not set it up previously, It is not immediately set up."""
     await async_init_integration(hass)
     assert hass.states.get("sensor.anova_precision_cooker_triac_temperature") is None

--- a/tests/components/blebox/test_helpers.py
+++ b/tests/components/blebox/test_helpers.py
@@ -6,13 +6,13 @@ from homeassistant.components.blebox.helpers import get_maybe_authenticated_sess
 from homeassistant.core import HomeAssistant
 
 
-async def test_get_maybe_authenticated_session_none(hass: HomeAssistant):
+async def test_get_maybe_authenticated_session_none(hass: HomeAssistant) -> None:
     """Tests if session auth is None."""
     session = get_maybe_authenticated_session(hass=hass, username="", password="")
     assert session.auth is None
 
 
-async def test_get_maybe_authenticated_session_auth(hass: HomeAssistant):
+async def test_get_maybe_authenticated_session_auth(hass: HomeAssistant) -> None:
     """Tests if session have BasicAuth."""
     session = get_maybe_authenticated_session(
         hass=hass, username="user", password="password"

--- a/tests/components/button/test_device_action.py
+++ b/tests/components/button/test_device_action.py
@@ -63,7 +63,7 @@ async def test_get_actions_hidden_auxiliary(
     entity_registry: er.EntityRegistry,
     hidden_by: er.RegistryEntryHider | None,
     entity_category: EntityCategory | None,
-):
+) -> None:
     """Test we get the expected actions from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)

--- a/tests/components/button/test_device_trigger.py
+++ b/tests/components/button/test_device_trigger.py
@@ -67,12 +67,12 @@ async def test_get_triggers(
     ],
 )
 async def test_get_triggers_hidden_auxiliary(
-    hass,
+    hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     hidden_by: er.RegistryEntryHider | None,
     entity_category: EntityCategory | None,
-):
+) -> None:
     """Test we get the expected triggers from a hidden or auxiliary entity."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)

--- a/tests/components/cloud/test_repairs.py
+++ b/tests/components/cloud/test_repairs.py
@@ -1,9 +1,10 @@
 """Test cloud repairs."""
 
-from collections.abc import Generator
 from datetime import timedelta
 from http import HTTPStatus
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
+
+import pytest
 
 from homeassistant.components.cloud import DOMAIN
 import homeassistant.components.cloud.repairs as cloud_repairs
@@ -36,12 +37,12 @@ async def test_do_not_create_repair_issues_at_startup_if_not_logged_in(
     )
 
 
+@pytest.mark.usefixtures("mock_auth")
 async def test_create_repair_issues_at_startup_if_logged_in(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    mock_auth: Generator[None, AsyncMock, None],
     issue_registry: ir.IssueRegistry,
-):
+) -> None:
     """Test that we create repair issue at startup if we are logged in."""
     aioclient_mock.get(
         "https://accounts.nabucasa.com/payments/subscription_info",
@@ -75,13 +76,13 @@ async def test_legacy_subscription_delete_issue_if_no_longer_legacy(
     )
 
 
+@pytest.mark.usefixtures("mock_auth")
 async def test_legacy_subscription_repair_flow(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    mock_auth: Generator[None, AsyncMock, None],
     hass_client: ClientSessionGenerator,
     issue_registry: ir.IssueRegistry,
-):
+) -> None:
     """Test desired flow of the fix flow for legacy subscription."""
     aioclient_mock.get(
         "https://accounts.nabucasa.com/payments/subscription_info",
@@ -160,13 +161,13 @@ async def test_legacy_subscription_repair_flow(
     )
 
 
+@pytest.mark.usefixtures("mock_auth")
 async def test_legacy_subscription_repair_flow_timeout(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
-    mock_auth: Generator[None, AsyncMock, None],
     aioclient_mock: AiohttpClientMocker,
     issue_registry: ir.IssueRegistry,
-):
+) -> None:
     """Test timeout flow of the fix flow for legacy subscription."""
     aioclient_mock.post(
         "https://accounts.nabucasa.com/payments/migrate_paypal_agreement",

--- a/tests/components/cloudflare/test_helpers.py
+++ b/tests/components/cloudflare/test_helpers.py
@@ -3,7 +3,7 @@
 from homeassistant.components.cloudflare.helpers import get_zone_id
 
 
-def test_get_zone_id():
+def test_get_zone_id() -> None:
     """Test get_zone_id."""
     zones = [
         {"id": "1", "name": "example.com"},

--- a/tests/components/co2signal/test_sensor.py
+++ b/tests/components/co2signal/test_sensor.py
@@ -91,7 +91,7 @@ async def test_sensor_reauth_triggered(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
     electricity_maps: AsyncMock,
-):
+) -> None:
     """Test if reauth flow is triggered."""
     assert (state := hass.states.get("sensor.electricity_maps_co2_intensity"))
     assert state.state == "45.9862319009581"

--- a/tests/components/device_tracker/test_legacy.py
+++ b/tests/components/device_tracker/test_legacy.py
@@ -9,7 +9,7 @@ from homeassistant.util.yaml import dump
 from tests.common import patch_yaml_files
 
 
-def test_remove_device_from_config(hass: HomeAssistant):
+def test_remove_device_from_config(hass: HomeAssistant) -> None:
     """Test the removal of a device from a config."""
     yaml_devices = {
         "test": {

--- a/tests/components/dsmr_reader/test_definitions.py
+++ b/tests/components/dsmr_reader/test_definitions.py
@@ -13,7 +13,6 @@ from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, async_fire_mqtt_message
-from tests.typing import MqttMockHAClient
 
 
 @pytest.mark.parametrize(
@@ -40,10 +39,8 @@ async def test_tariff_transform(input, expected) -> None:
     assert tariff_transform(input) == expected
 
 
-async def test_entity_tariff(
-    hass: HomeAssistant,
-    mqtt_mock: MqttMockHAClient,
-):
+@pytest.mark.usefixtures("mqtt_mock")
+async def test_entity_tariff(hass: HomeAssistant) -> None:
     """Test the state attribute of DSMRReaderSensorEntityDescription when a tariff transform is needed."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -74,7 +71,8 @@ async def test_entity_tariff(
     assert hass.states.get(electricity_tariff).state == "low"
 
 
-async def test_entity_dsmr_transform(hass: HomeAssistant, mqtt_mock: MqttMockHAClient):
+@pytest.mark.usefixtures("mqtt_mock")
+async def test_entity_dsmr_transform(hass: HomeAssistant) -> None:
     """Test the state attribute of DSMRReaderSensorEntityDescription when a dsmr transform is needed."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/duotecno/test_config_flow.py
+++ b/tests/components/duotecno/test_config_flow.py
@@ -55,7 +55,9 @@ async def test_form(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
         (Exception, "unknown"),
     ],
 )
-async def test_invalid(hass: HomeAssistant, test_side_effect, test_error):
+async def test_invalid(
+    hass: HomeAssistant, test_side_effect: Exception, test_error: str
+) -> None:
     """Test all side_effects on the controller.connect via parameters."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/dynalite/test_config_flow.py
+++ b/tests/components/dynalite/test_config_flow.py
@@ -139,7 +139,7 @@ async def test_two_entries(hass: HomeAssistant) -> None:
     assert result["result"].state is ConfigEntryState.LOADED
 
 
-async def test_setup_user(hass):
+async def test_setup_user(hass: HomeAssistant) -> None:
     """Test configuration via the user flow."""
     host = "3.4.5.6"
     port = 1234
@@ -169,7 +169,7 @@ async def test_setup_user(hass):
     }
 
 
-async def test_setup_user_existing_host(hass):
+async def test_setup_user_existing_host(hass: HomeAssistant) -> None:
     """Test that when we setup a host that is defined, we get an error."""
     host = "3.4.5.6"
     MockConfigEntry(

--- a/tests/components/electrasmart/test_config_flow.py
+++ b/tests/components/electrasmart/test_config_flow.py
@@ -16,7 +16,7 @@ from homeassistant.data_entry_flow import FlowResultType
 from tests.common import load_fixture
 
 
-async def test_form(hass: HomeAssistant):
+async def test_form(hass: HomeAssistant) -> None:
     """Test user config."""
 
     mock_generate_token = loads(load_fixture("generate_token_response.json", DOMAIN))
@@ -44,7 +44,7 @@ async def test_form(hass: HomeAssistant):
     assert result["step_id"] == CONF_OTP
 
 
-async def test_one_time_password(hass: HomeAssistant):
+async def test_one_time_password(hass: HomeAssistant) -> None:
     """Test one time password."""
 
     mock_generate_token = loads(load_fixture("generate_token_response.json", DOMAIN))
@@ -76,7 +76,7 @@ async def test_one_time_password(hass: HomeAssistant):
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
-async def test_one_time_password_api_error(hass: HomeAssistant):
+async def test_one_time_password_api_error(hass: HomeAssistant) -> None:
     """Test one time password."""
     mock_generate_token = loads(load_fixture("generate_token_response.json", DOMAIN))
     with (
@@ -102,7 +102,7 @@ async def test_one_time_password_api_error(hass: HomeAssistant):
     assert result["type"] is FlowResultType.FORM
 
 
-async def test_cannot_connect(hass: HomeAssistant):
+async def test_cannot_connect(hass: HomeAssistant) -> None:
     """Test cannot connect."""
 
     with patch(
@@ -120,7 +120,7 @@ async def test_cannot_connect(hass: HomeAssistant):
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_invalid_phone_number(hass: HomeAssistant):
+async def test_invalid_phone_number(hass: HomeAssistant) -> None:
     """Test invalid phone number."""
 
     mock_invalid_phone_number_response = loads(
@@ -143,7 +143,7 @@ async def test_invalid_phone_number(hass: HomeAssistant):
     assert result["errors"] == {"phone_number": "invalid_phone_number"}
 
 
-async def test_invalid_auth(hass: HomeAssistant):
+async def test_invalid_auth(hass: HomeAssistant) -> None:
     """Test invalid auth."""
 
     mock_generate_token_response = loads(

--- a/tests/components/elmax/test_config_flow.py
+++ b/tests/components/elmax/test_config_flow.py
@@ -172,7 +172,7 @@ async def test_cloud_setup(hass: HomeAssistant) -> None:
         assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
-async def test_zeroconf_form_setup_api_not_supported(hass):
+async def test_zeroconf_form_setup_api_not_supported(hass: HomeAssistant) -> None:
     """Test the zeroconf setup case."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -183,7 +183,7 @@ async def test_zeroconf_form_setup_api_not_supported(hass):
     assert result["reason"] == "not_supported"
 
 
-async def test_zeroconf_discovery(hass):
+async def test_zeroconf_discovery(hass: HomeAssistant) -> None:
     """Test discovery of Elmax local api panel."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -195,7 +195,7 @@ async def test_zeroconf_discovery(hass):
     assert result["errors"] is None
 
 
-async def test_zeroconf_setup_show_form(hass):
+async def test_zeroconf_setup_show_form(hass: HomeAssistant) -> None:
     """Test discovery shows a form when activated."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -211,7 +211,7 @@ async def test_zeroconf_setup_show_form(hass):
     assert result["step_id"] == "zeroconf_setup"
 
 
-async def test_zeroconf_setup(hass):
+async def test_zeroconf_setup(hass: HomeAssistant) -> None:
     """Test the successful creation of config entry via discovery flow."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -231,7 +231,7 @@ async def test_zeroconf_setup(hass):
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
-async def test_zeroconf_already_configured(hass):
+async def test_zeroconf_already_configured(hass: HomeAssistant) -> None:
     """Ensure local discovery aborts when same panel is already added to ha."""
     MockConfigEntry(
         domain=DOMAIN,
@@ -257,7 +257,7 @@ async def test_zeroconf_already_configured(hass):
     assert result["reason"] == "already_configured"
 
 
-async def test_zeroconf_panel_changed_ip(hass):
+async def test_zeroconf_panel_changed_ip(hass: HomeAssistant) -> None:
     """Ensure local discovery updates the panel data when a the panel changes its IP."""
     # Simulate an entry already exists for ip MOCK_DIRECT_HOST.
     config_entry = MockConfigEntry(

--- a/tests/components/enigma2/test_config_flow.py
+++ b/tests/components/enigma2/test_config_flow.py
@@ -41,7 +41,7 @@ async def user_flow(hass: HomeAssistant) -> str:
 )
 async def test_form_user(
     hass: HomeAssistant, user_flow: str, test_config: dict[str, Any]
-):
+) -> None:
     """Test a successful user initiated flow."""
     with (
         patch(

--- a/tests/components/epson/test_media_player.py
+++ b/tests/components/epson/test_media_player.py
@@ -8,7 +8,7 @@ from freezegun.api import FrozenDateTimeFactory
 from homeassistant.components.epson.const import DOMAIN
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -16,9 +16,8 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 async def test_set_unique_id(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    device_registry: dr.DeviceRegistry,
     freezer: FrozenDateTimeFactory,
-):
+) -> None:
     """Test the unique id is set on runtime."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/ffmpeg/test_binary_sensor.py
+++ b/tests/components/ffmpeg/test_binary_sensor.py
@@ -30,7 +30,7 @@ async def test_noise_setup_component(hass: HomeAssistant) -> None:
 
 
 @patch("haffmpeg.sensor.SensorNoise.open_sensor", side_effect=AsyncMock())
-async def test_noise_setup_component_start(mock_start, hass: HomeAssistant):
+async def test_noise_setup_component_start(mock_start, hass: HomeAssistant) -> None:
     """Set up ffmpeg component."""
     with assert_setup_component(1, "binary_sensor"):
         await async_setup_component(hass, "binary_sensor", CONFIG_NOISE)
@@ -48,7 +48,9 @@ async def test_noise_setup_component_start(mock_start, hass: HomeAssistant):
 
 
 @patch("haffmpeg.sensor.SensorNoise")
-async def test_noise_setup_component_start_callback(mock_ffmpeg, hass: HomeAssistant):
+async def test_noise_setup_component_start_callback(
+    mock_ffmpeg, hass: HomeAssistant
+) -> None:
     """Set up ffmpeg component."""
     mock_ffmpeg().open_sensor.side_effect = AsyncMock()
     mock_ffmpeg().close = AsyncMock()
@@ -86,7 +88,7 @@ async def test_motion_setup_component(hass: HomeAssistant) -> None:
 
 
 @patch("haffmpeg.sensor.SensorMotion.open_sensor", side_effect=AsyncMock())
-async def test_motion_setup_component_start(mock_start, hass: HomeAssistant):
+async def test_motion_setup_component_start(mock_start, hass: HomeAssistant) -> None:
     """Set up ffmpeg component."""
     with assert_setup_component(1, "binary_sensor"):
         await async_setup_component(hass, "binary_sensor", CONFIG_MOTION)
@@ -104,7 +106,9 @@ async def test_motion_setup_component_start(mock_start, hass: HomeAssistant):
 
 
 @patch("haffmpeg.sensor.SensorMotion")
-async def test_motion_setup_component_start_callback(mock_ffmpeg, hass: HomeAssistant):
+async def test_motion_setup_component_start_callback(
+    mock_ffmpeg, hass: HomeAssistant
+) -> None:
     """Set up ffmpeg component."""
     mock_ffmpeg().open_sensor.side_effect = AsyncMock()
     mock_ffmpeg().close = AsyncMock()

--- a/tests/components/ffmpeg/test_init.py
+++ b/tests/components/ffmpeg/test_init.py
@@ -77,7 +77,7 @@ class MockFFmpegDev(ffmpeg.FFmpegBase):
         self.called_entities = entity_ids
 
 
-def test_setup_component():
+def test_setup_component() -> None:
     """Set up ffmpeg component."""
     with get_test_home_assistant() as hass:
         with assert_setup_component(1):
@@ -87,7 +87,7 @@ def test_setup_component():
         hass.stop()
 
 
-def test_setup_component_test_service():
+def test_setup_component_test_service() -> None:
     """Set up ffmpeg component test services."""
     with get_test_home_assistant() as hass:
         with assert_setup_component(1):

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -405,9 +405,8 @@ async def test_missing_themes(hass: HomeAssistant, ws_client) -> None:
     assert msg["result"]["themes"] == {}
 
 
-async def test_extra_js(
-    hass: HomeAssistant, mock_http_client_with_extra_js, mock_onboarded
-):
+@pytest.mark.usefixtures("mock_onboarded")
+async def test_extra_js(hass: HomeAssistant, mock_http_client_with_extra_js) -> None:
     """Test that extra javascript is loaded."""
     resp = await mock_http_client_with_extra_js.get("")
     assert resp.status == 200

--- a/tests/components/google_assistant/test_data_redaction.py
+++ b/tests/components/google_assistant/test_data_redaction.py
@@ -7,7 +7,7 @@ from homeassistant.components.google_assistant.data_redaction import async_redac
 from tests.common import load_fixture
 
 
-def test_redact_msg():
+def test_redact_msg() -> None:
     """Test async_redact_msg."""
     messages = json.loads(load_fixture("data_redaction.json", "google_assistant"))
     agent_user_id = "333dee20-1234-1234-1234-2225a0d70d4c"

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -2160,13 +2160,13 @@ async def test_fan_speed_without_percentage_step(hass: HomeAssistant) -> None:
     ],
 )
 async def test_fan_speed_ordered(
-    hass,
+    hass: HomeAssistant,
     percentage: int,
     percentage_step: float,
     speed: str,
     speeds: list[list[str]],
     percentage_result: int,
-):
+) -> None:
     """Test FanSpeed trait speed control support for fan domain."""
     assert helpers.get_google_type(fan.DOMAIN, None) is not None
     assert trait.FanSpeedTrait.supported(

--- a/tests/components/homeassistant_hardware/test_silabs_multiprotocol_addon.py
+++ b/tests/components/homeassistant_hardware/test_silabs_multiprotocol_addon.py
@@ -171,13 +171,10 @@ def get_suggested(schema, key):
     "homeassistant.components.homeassistant_hardware.silabs_multiprotocol_addon.ADDON_STATE_POLL_INTERVAL",
     0,
 )
-async def test_uninstall_addon_waiting(
-    hass: HomeAssistant,
-    addon_store_info,
-    addon_info,
-    install_addon,
-    uninstall_addon,
-):
+@pytest.mark.usefixtures(
+    "addon_store_info", "addon_info", "install_addon", "uninstall_addon"
+)
+async def test_uninstall_addon_waiting(hass: HomeAssistant) -> None:
     """Test the synchronous addon uninstall helper."""
 
     multipan_manager = await silabs_multiprotocol_addon.get_multiprotocol_addon_manager(

--- a/tests/components/homeassistant_sky_connect/test_const.py
+++ b/tests/components/homeassistant_sky_connect/test_const.py
@@ -19,7 +19,7 @@ def test_hardware_variant(
     assert HardwareVariant.from_usb_product_name(usb_product_name) == expected_variant
 
 
-def test_hardware_variant_invalid():
+def test_hardware_variant_invalid() -> None:
     """Test hardware variant parsing with an invalid product."""
     with pytest.raises(
         ValueError, match=r"^Unknown SkyConnect product name: Some other product$"

--- a/tests/components/homekit_controller/test_utils.py
+++ b/tests/components/homekit_controller/test_utils.py
@@ -3,7 +3,7 @@
 from homeassistant.components.homekit_controller.utils import unique_id_to_iids
 
 
-def test_unique_id_to_iids():
+def test_unique_id_to_iids() -> None:
     """Check that unique_id_to_iids is safe against different invalid ids."""
     assert unique_id_to_iids("pairingid_1_2_3") == (1, 2, 3)
     assert unique_id_to_iids("pairingid_1_2") == (1, 2, None)

--- a/tests/components/html5/test_notify.py
+++ b/tests/components/html5/test_notify.py
@@ -83,7 +83,7 @@ async def mock_client(hass, hass_client, registrations=None):
     return await hass_client()
 
 
-async def test_get_service_with_no_json(hass: HomeAssistant):
+async def test_get_service_with_no_json(hass: HomeAssistant) -> None:
     """Test empty json file."""
     await async_setup_component(hass, "http", {})
     m = mock_open()
@@ -94,7 +94,7 @@ async def test_get_service_with_no_json(hass: HomeAssistant):
 
 
 @patch("homeassistant.components.html5.notify.WebPusher")
-async def test_dismissing_message(mock_wp, hass: HomeAssistant):
+async def test_dismissing_message(mock_wp, hass: HomeAssistant) -> None:
     """Test dismissing message."""
     await async_setup_component(hass, "http", {})
     mock_wp().send().status_code = 201
@@ -123,7 +123,7 @@ async def test_dismissing_message(mock_wp, hass: HomeAssistant):
 
 
 @patch("homeassistant.components.html5.notify.WebPusher")
-async def test_sending_message(mock_wp, hass: HomeAssistant):
+async def test_sending_message(mock_wp, hass: HomeAssistant) -> None:
     """Test sending message."""
     await async_setup_component(hass, "http", {})
     mock_wp().send().status_code = 201
@@ -154,7 +154,7 @@ async def test_sending_message(mock_wp, hass: HomeAssistant):
 
 
 @patch("homeassistant.components.html5.notify.WebPusher")
-async def test_fcm_key_include(mock_wp, hass: HomeAssistant):
+async def test_fcm_key_include(mock_wp, hass: HomeAssistant) -> None:
     """Test if the FCM header is included."""
     await async_setup_component(hass, "http", {})
     mock_wp().send().status_code = 201
@@ -179,7 +179,7 @@ async def test_fcm_key_include(mock_wp, hass: HomeAssistant):
 
 
 @patch("homeassistant.components.html5.notify.WebPusher")
-async def test_fcm_send_with_unknown_priority(mock_wp, hass: HomeAssistant):
+async def test_fcm_send_with_unknown_priority(mock_wp, hass: HomeAssistant) -> None:
     """Test if the gcm_key is only included for GCM endpoints."""
     await async_setup_component(hass, "http", {})
     mock_wp().send().status_code = 201
@@ -204,7 +204,7 @@ async def test_fcm_send_with_unknown_priority(mock_wp, hass: HomeAssistant):
 
 
 @patch("homeassistant.components.html5.notify.WebPusher")
-async def test_fcm_no_targets(mock_wp, hass: HomeAssistant):
+async def test_fcm_no_targets(mock_wp, hass: HomeAssistant) -> None:
     """Test if the gcm_key is only included for GCM endpoints."""
     await async_setup_component(hass, "http", {})
     mock_wp().send().status_code = 201
@@ -229,7 +229,7 @@ async def test_fcm_no_targets(mock_wp, hass: HomeAssistant):
 
 
 @patch("homeassistant.components.html5.notify.WebPusher")
-async def test_fcm_additional_data(mock_wp, hass: HomeAssistant):
+async def test_fcm_additional_data(mock_wp, hass: HomeAssistant) -> None:
     """Test if the gcm_key is only included for GCM endpoints."""
     await async_setup_component(hass, "http", {})
     mock_wp().send().status_code = 201

--- a/tests/components/huawei_lte/test_config_flow.py
+++ b/tests/components/huawei_lte/test_config_flow.py
@@ -119,7 +119,7 @@ async def test_connection_errors(
     exception: Exception,
     errors: dict[str, str],
     data_patch: dict[str, Any],
-):
+) -> None:
     """Test we show user form on various errors."""
     requests_mock.request(ANY, ANY, exc=exception)
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/ipma/test_sensor.py
+++ b/tests/components/ipma/test_sensor.py
@@ -2,12 +2,14 @@
 
 from unittest.mock import patch
 
+from homeassistant.core import HomeAssistant
+
 from . import ENTRY_CONFIG, MockLocation
 
 from tests.common import MockConfigEntry
 
 
-async def test_ipma_fire_risk_create_sensors(hass):
+async def test_ipma_fire_risk_create_sensors(hass: HomeAssistant) -> None:
     """Test creation of fire risk sensors."""
 
     with patch("pyipma.location.Location.get", return_value=MockLocation()):
@@ -21,7 +23,7 @@ async def test_ipma_fire_risk_create_sensors(hass):
     assert state.state == "3"
 
 
-async def test_ipma_uv_index_create_sensors(hass):
+async def test_ipma_uv_index_create_sensors(hass: HomeAssistant) -> None:
     """Test creation of uv index sensors."""
 
     with patch("pyipma.location.Location.get", return_value=MockLocation()):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA
`test_*` functions should always return None
Also move a few unused arguments to the decorator.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
