### PR TITLE
Add type hints to hdmi_cec assert_state function

### DIFF
--- a/tests/components/hdmi_cec/test_media_player.py
+++ b/tests/components/hdmi_cec/test_media_player.py
@@ -56,6 +56,8 @@ from homeassistant.core import HomeAssistant
 
 from . import MockHDMIDevice, assert_key_press_release
 
+type AssertState = Callable[[str, str], bool]
+
 
 @pytest.fixture(
     name="assert_state",
@@ -72,14 +74,14 @@ from . import MockHDMIDevice, assert_key_press_release
     ],
     ids=["skip_assert_state", "run_assert_state"],
 )
-def assert_state_fixture(request: pytest.FixtureRequest) -> Callable[[str, str], bool]:
+def assert_state_fixture(request: pytest.FixtureRequest) -> AssertState:
     """Allow for skipping the assert state changes.
 
     This is broken in this entity, but we still want to test that
     the rest of the code works as expected.
     """
 
-    def _test_state(state: str, expected: str) -> bool:
+    def _test_state(state: str, expected: str) -> None:
         if request.param:
             assert state == expected
         else:
@@ -133,7 +135,7 @@ async def test_service_on(
     hass: HomeAssistant,
     create_hdmi_network,
     create_cec_entity,
-    assert_state: Callable[[str, str], bool],
+    assert_state: AssertState,
 ) -> None:
     """Test that media_player triggers on `on` service."""
     hdmi_network = await create_hdmi_network({"platform": "media_player"})
@@ -160,7 +162,7 @@ async def test_service_off(
     hass: HomeAssistant,
     create_hdmi_network,
     create_cec_entity,
-    assert_state: Callable[[str, str], bool],
+    assert_state: AssertState,
 ) -> None:
     """Test that media_player triggers on `off` service."""
     hdmi_network = await create_hdmi_network({"platform": "media_player"})
@@ -360,7 +362,7 @@ async def test_playback_services(
     hass: HomeAssistant,
     create_hdmi_network,
     create_cec_entity,
-    assert_state: Callable[[str, str], bool],
+    assert_state: AssertState,
     service: str,
     key: int,
     expected_state: str,
@@ -390,7 +392,7 @@ async def test_play_pause_service(
     hass: HomeAssistant,
     create_hdmi_network,
     create_cec_entity,
-    assert_state: Callable[[str, str], bool],
+    assert_state: AssertState,
 ) -> None:
     """Test play pause service."""
     hdmi_network = await create_hdmi_network({"platform": "media_player"})

--- a/tests/components/hdmi_cec/test_media_player.py
+++ b/tests/components/hdmi_cec/test_media_player.py
@@ -1,5 +1,7 @@
 """Tests for the HDMI-CEC media player platform."""
 
+from collections.abc import Callable
+
 from pycec.const import (
     DEVICE_TYPE_NAMES,
     KEY_BACKWARD,
@@ -70,20 +72,20 @@ from . import MockHDMIDevice, assert_key_press_release
     ],
     ids=["skip_assert_state", "run_assert_state"],
 )
-def assert_state_fixture(request: pytest.FixtureRequest):
+def assert_state_fixture(request: pytest.FixtureRequest) -> Callable[[str, str], bool]:
     """Allow for skipping the assert state changes.
 
     This is broken in this entity, but we still want to test that
     the rest of the code works as expected.
     """
 
-    def test_state(state, expected):
+    def _test_state(state: str, expected: str) -> bool:
         if request.param:
             assert state == expected
         else:
             assert True
 
-    return test_state
+    return _test_state
 
 
 async def test_load_platform(
@@ -128,7 +130,10 @@ async def test_load_types(
 
 
 async def test_service_on(
-    hass: HomeAssistant, create_hdmi_network, create_cec_entity, assert_state
+    hass: HomeAssistant,
+    create_hdmi_network,
+    create_cec_entity,
+    assert_state: Callable[[str, str], bool],
 ) -> None:
     """Test that media_player triggers on `on` service."""
     hdmi_network = await create_hdmi_network({"platform": "media_player"})
@@ -152,7 +157,10 @@ async def test_service_on(
 
 
 async def test_service_off(
-    hass: HomeAssistant, create_hdmi_network, create_cec_entity, assert_state
+    hass: HomeAssistant,
+    create_hdmi_network,
+    create_cec_entity,
+    assert_state: Callable[[str, str], bool],
 ) -> None:
     """Test that media_player triggers on `off` service."""
     hdmi_network = await create_hdmi_network({"platform": "media_player"})
@@ -352,10 +360,10 @@ async def test_playback_services(
     hass: HomeAssistant,
     create_hdmi_network,
     create_cec_entity,
-    assert_state,
-    service,
-    key,
-    expected_state,
+    assert_state: Callable[[str, str], bool],
+    service: str,
+    key: int,
+    expected_state: str,
 ) -> None:
     """Test playback related commands."""
     hdmi_network = await create_hdmi_network({"platform": "media_player"})
@@ -382,7 +390,7 @@ async def test_play_pause_service(
     hass: HomeAssistant,
     create_hdmi_network,
     create_cec_entity,
-    assert_state,
+    assert_state: Callable[[str, str], bool],
 ) -> None:
     """Test play pause service."""
     hdmi_network = await create_hdmi_network({"platform": "media_player"})

--- a/tests/components/hdmi_cec/test_media_player.py
+++ b/tests/components/hdmi_cec/test_media_player.py
@@ -56,7 +56,7 @@ from homeassistant.core import HomeAssistant
 
 from . import MockHDMIDevice, assert_key_press_release
 
-type AssertState = Callable[[str, str], bool]
+type AssertState = Callable[[str, str], None]
 
 
 @pytest.fixture(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
