### PR TITLE
Add return type hints in tests (k-z)

### DIFF
--- a/tests/components/knx/test_device_trigger.py
+++ b/tests/components/knx/test_device_trigger.py
@@ -397,7 +397,7 @@ async def test_invalid_trigger_configuration(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     knx: KNXTestKit,
-):
+) -> None:
     """Test invalid telegram device trigger configuration at attach_trigger."""
     await knx.setup_integration({})
     device_entry = device_registry.async_get_device(

--- a/tests/components/knx/test_telegrams.py
+++ b/tests/components/knx/test_telegrams.py
@@ -66,7 +66,7 @@ async def test_store_telegam_history(
     hass: HomeAssistant,
     knx: KNXTestKit,
     hass_storage: dict[str, Any],
-):
+) -> None:
     """Test storing telegram history."""
     await knx.setup_integration({})
 
@@ -89,7 +89,7 @@ async def test_load_telegam_history(
     hass: HomeAssistant,
     knx: KNXTestKit,
     hass_storage: dict[str, Any],
-):
+) -> None:
     """Test telegram history restoration."""
     hass_storage["knx/telegrams_history.json"] = {"version": 1, "data": MOCK_TELEGRAMS}
     await knx.setup_integration({})
@@ -103,7 +103,7 @@ async def test_remove_telegam_history(
     hass: HomeAssistant,
     knx: KNXTestKit,
     hass_storage: dict[str, Any],
-):
+) -> None:
     """Test telegram history removal when configured to size 0."""
     hass_storage["knx/telegrams_history.json"] = {"version": 1, "data": MOCK_TELEGRAMS}
     knx.mock_config_entry.add_to_hass(hass)

--- a/tests/components/knx/test_websocket.py
+++ b/tests/components/knx/test_websocket.py
@@ -14,7 +14,7 @@ from tests.typing import WebSocketGenerator
 
 async def test_knx_info_command(
     hass: HomeAssistant, knx: KNXTestKit, hass_ws_client: WebSocketGenerator
-):
+) -> None:
     """Test knx/info command."""
     await knx.setup_integration({})
     client = await hass_ws_client(hass)
@@ -33,7 +33,7 @@ async def test_knx_info_command_with_project(
     knx: KNXTestKit,
     hass_ws_client: WebSocketGenerator,
     load_knxproj: None,
-):
+) -> None:
     """Test knx/info command with loaded project."""
     await knx.setup_integration({})
     client = await hass_ws_client(hass)
@@ -55,7 +55,7 @@ async def test_knx_project_file_process(
     knx: KNXTestKit,
     hass_ws_client: WebSocketGenerator,
     hass_storage: dict[str, Any],
-):
+) -> None:
     """Test knx/project_file_process command for storing and loading new data."""
     _file_id = "1234"
     _password = "pw-test"
@@ -93,7 +93,7 @@ async def test_knx_project_file_process_error(
     hass: HomeAssistant,
     knx: KNXTestKit,
     hass_ws_client: WebSocketGenerator,
-):
+) -> None:
     """Test knx/project_file_process exception handling."""
     await knx.setup_integration({})
     client = await hass_ws_client(hass)
@@ -126,7 +126,7 @@ async def test_knx_project_file_remove(
     knx: KNXTestKit,
     hass_ws_client: WebSocketGenerator,
     load_knxproj: None,
-):
+) -> None:
     """Test knx/project_file_remove command."""
     await knx.setup_integration({})
     client = await hass_ws_client(hass)
@@ -146,7 +146,7 @@ async def test_knx_get_project(
     knx: KNXTestKit,
     hass_ws_client: WebSocketGenerator,
     load_knxproj: None,
-):
+) -> None:
     """Test retrieval of kxnproject from store."""
     await knx.setup_integration({})
     client = await hass_ws_client(hass)
@@ -161,7 +161,7 @@ async def test_knx_get_project(
 
 async def test_knx_group_monitor_info_command(
     hass: HomeAssistant, knx: KNXTestKit, hass_ws_client: WebSocketGenerator
-):
+) -> None:
     """Test knx/group_monitor_info command."""
     await knx.setup_integration({})
     client = await hass_ws_client(hass)
@@ -176,7 +176,7 @@ async def test_knx_group_monitor_info_command(
 
 async def test_knx_subscribe_telegrams_command_recent_telegrams(
     hass: HomeAssistant, knx: KNXTestKit, hass_ws_client: WebSocketGenerator
-):
+) -> None:
     """Test knx/subscribe_telegrams command sending recent telegrams."""
     await knx.setup_integration(
         {
@@ -224,7 +224,7 @@ async def test_knx_subscribe_telegrams_command_recent_telegrams(
 
 async def test_knx_subscribe_telegrams_command_no_project(
     hass: HomeAssistant, knx: KNXTestKit, hass_ws_client: WebSocketGenerator
-):
+) -> None:
     """Test knx/subscribe_telegrams command without project data."""
     await knx.setup_integration(
         {
@@ -299,7 +299,7 @@ async def test_knx_subscribe_telegrams_command_project(
     knx: KNXTestKit,
     hass_ws_client: WebSocketGenerator,
     load_knxproj: None,
-):
+) -> None:
     """Test knx/subscribe_telegrams command with project data."""
     await knx.setup_integration({})
     client = await hass_ws_client(hass)

--- a/tests/components/lg_netcast/test_config_flow.py
+++ b/tests/components/lg_netcast/test_config_flow.py
@@ -187,7 +187,7 @@ async def test_import_not_online(hass: HomeAssistant) -> None:
         assert result["reason"] == "cannot_connect"
 
 
-async def test_import_duplicate_error(hass):
+async def test_import_duplicate_error(hass: HomeAssistant) -> None:
     """Test that errors are shown when duplicates are added during import."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -217,7 +217,7 @@ async def test_import_duplicate_error(hass):
         assert result["reason"] == "already_configured"
 
 
-async def test_display_access_token_aborted(hass: HomeAssistant):
+async def test_display_access_token_aborted(hass: HomeAssistant) -> None:
     """Test Access token display is cancelled."""
 
     def _async_track_time_interval(

--- a/tests/components/lg_netcast/test_trigger.py
+++ b/tests/components/lg_netcast/test_trigger.py
@@ -79,7 +79,7 @@ async def test_lg_netcast_turn_on_trigger_device_id(
 
 async def test_lg_netcast_turn_on_trigger_entity_id(
     hass: HomeAssistant, calls: list[ServiceCall]
-):
+) -> None:
     """Test for turn_on triggers by entity firing."""
     await setup_lgnetcast(hass)
 

--- a/tests/components/local_calendar/test_calendar.py
+++ b/tests/components/local_calendar/test_calendar.py
@@ -785,7 +785,7 @@ async def test_all_day_iter_order(
     setup_integration: None,
     get_events: GetEventsFn,
     event_order: list[str],
-):
+) -> None:
     """Test the sort order of an all day events depending on the time zone."""
     client = await ws_client()
     await client.cmd_result(

--- a/tests/components/logbook/test_models.py
+++ b/tests/components/logbook/test_models.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 from homeassistant.components.logbook.models import LazyEventPartialState
 
 
-def test_lazy_event_partial_state_context():
+def test_lazy_event_partial_state_context() -> None:
     """Test we can extract context from a lazy event partial state."""
     state = LazyEventPartialState(
         Mock(

--- a/tests/components/loqed/test_init.py
+++ b/tests/components/loqed/test_init.py
@@ -42,7 +42,7 @@ async def test_webhook_accepts_valid_message(
 
 async def test_setup_webhook_in_bridge(
     hass: HomeAssistant, config_entry: MockConfigEntry, lock: loqed.Lock
-):
+) -> None:
     """Test webhook setup in loqed bridge."""
     config: dict[str, Any] = {DOMAIN: {}}
     config_entry.add_to_hass(hass)
@@ -65,7 +65,7 @@ async def test_setup_webhook_in_bridge(
 
 async def test_cannot_connect_to_bridge_will_retry(
     hass: HomeAssistant, config_entry: MockConfigEntry, lock: loqed.Lock
-):
+) -> None:
     """Test webhook setup in loqed bridge."""
     config: dict[str, Any] = {DOMAIN: {}}
     config_entry.add_to_hass(hass)
@@ -81,7 +81,7 @@ async def test_cannot_connect_to_bridge_will_retry(
 
 async def test_setup_cloudhook_in_bridge(
     hass: HomeAssistant, config_entry: MockConfigEntry, lock: loqed.Lock
-):
+) -> None:
     """Test webhook setup in loqed bridge."""
     config: dict[str, Any] = {DOMAIN: {}}
     config_entry.add_to_hass(hass)
@@ -112,7 +112,7 @@ async def test_setup_cloudhook_in_bridge(
 
 async def test_setup_cloudhook_from_entry_in_bridge(
     hass: HomeAssistant, cloud_config_entry: MockConfigEntry, lock: loqed.Lock
-):
+) -> None:
     """Test webhook setup in loqed bridge."""
     webhooks_fixture = json.loads(load_fixture("loqed/get_all_webhooks.json"))
 
@@ -143,7 +143,9 @@ async def test_setup_cloudhook_from_entry_in_bridge(
     lock.registerWebhook.assert_called_with(f"{get_url(hass)}/api/webhook/Webhook_id")
 
 
-async def test_unload_entry(hass, integration: MockConfigEntry, lock: loqed.Lock):
+async def test_unload_entry(
+    hass, integration: MockConfigEntry, lock: loqed.Lock
+) -> None:
     """Test successful unload of entry."""
 
     assert await hass.config_entries.async_unload(integration.entry_id)
@@ -154,7 +156,9 @@ async def test_unload_entry(hass, integration: MockConfigEntry, lock: loqed.Lock
     assert not hass.data.get(DOMAIN)
 
 
-async def test_unload_entry_fails(hass, integration: MockConfigEntry, lock: loqed.Lock):
+async def test_unload_entry_fails(
+    hass, integration: MockConfigEntry, lock: loqed.Lock
+) -> None:
     """Test unsuccessful unload of entry."""
     lock.deleteWebhook = AsyncMock(side_effect=Exception)
 

--- a/tests/components/matrix/test_commands.py
+++ b/tests/components/matrix/test_commands.py
@@ -131,7 +131,7 @@ async def test_commands(
     matrix_bot: MatrixBot,
     command_events: list[Event],
     command_params: CommandTestParameters,
-):
+) -> None:
     """Test that the configured commands are used correctly."""
     room = MatrixRoom(room_id=command_params.room_id, own_user_id=matrix_bot._mx_id)
 
@@ -160,7 +160,7 @@ async def test_non_commands(
     matrix_bot: MatrixBot,
     command_events: list[Event],
     command_params: CommandTestParameters,
-):
+) -> None:
     """Test that normal/non-qualifying messages don't wrongly trigger commands."""
     room = MatrixRoom(room_id=command_params.room_id, own_user_id=matrix_bot._mx_id)
 
@@ -173,7 +173,7 @@ async def test_non_commands(
     assert len(command_events) == 0
 
 
-async def test_commands_parsing(hass: HomeAssistant, matrix_bot: MatrixBot):
+async def test_commands_parsing(hass: HomeAssistant, matrix_bot: MatrixBot) -> None:
     """Test that the configured commands were parsed correctly."""
 
     await hass.async_start()

--- a/tests/components/matrix/test_login.py
+++ b/tests/components/matrix/test_login.py
@@ -90,7 +90,7 @@ bad_password_missing_access_token = LoginTestParameters(
 )
 async def test_login(
     matrix_bot: MatrixBot, caplog: pytest.LogCaptureFixture, params: LoginTestParameters
-):
+) -> None:
     """Test logging in with the given parameters and expected state."""
     await matrix_bot._client.logout()
     matrix_bot._password = params.password
@@ -105,7 +105,7 @@ async def test_login(
     assert set(caplog.messages).issuperset(params.expected_caplog_messages)
 
 
-async def test_get_auth_tokens(matrix_bot: MatrixBot, mock_load_json):
+async def test_get_auth_tokens(matrix_bot: MatrixBot, mock_load_json) -> None:
     """Test loading access_tokens from a mocked file."""
 
     # Test loading good tokens.

--- a/tests/components/matrix/test_matrix_bot.py
+++ b/tests/components/matrix/test_matrix_bot.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from .conftest import TEST_NOTIFIER_NAME
 
 
-async def test_services(hass: HomeAssistant, matrix_bot: MatrixBot):
+async def test_services(hass: HomeAssistant, matrix_bot: MatrixBot) -> None:
     """Test hass/MatrixBot state."""
 
     services = hass.services.async_services()

--- a/tests/components/matrix/test_send_message.py
+++ b/tests/components/matrix/test_send_message.py
@@ -21,7 +21,7 @@ async def test_send_message(
     image_path,
     matrix_events,
     caplog: pytest.LogCaptureFixture,
-):
+) -> None:
     """Test the send_message service."""
 
     await hass.async_start()
@@ -65,7 +65,7 @@ async def test_unsendable_message(
     matrix_bot: MatrixBot,
     matrix_events,
     caplog: pytest.LogCaptureFixture,
-):
+) -> None:
     """Test the send_message service with an invalid room."""
     assert len(matrix_events) == 0
     await matrix_bot._login()

--- a/tests/components/matter/test_fan.py
+++ b/tests/components/matter/test_fan.py
@@ -98,7 +98,7 @@ async def test_fan_turn_on_with_percentage(
     hass: HomeAssistant,
     matter_client: MagicMock,
     air_purifier: MatterNode,
-):
+) -> None:
     """Test turning on the fan with a specific percentage."""
     entity_id = "fan.air_purifier"
     await hass.services.async_call(
@@ -119,7 +119,7 @@ async def test_fan_turn_on_with_preset_mode(
     hass: HomeAssistant,
     matter_client: MagicMock,
     air_purifier: MatterNode,
-):
+) -> None:
     """Test turning on the fan with a specific preset mode."""
     entity_id = "fan.air_purifier"
     await hass.services.async_call(
@@ -191,7 +191,7 @@ async def test_fan_turn_off(
     hass: HomeAssistant,
     matter_client: MagicMock,
     air_purifier: MatterNode,
-):
+) -> None:
     """Test turning off the fan."""
     entity_id = "fan.air_purifier"
     await hass.services.async_call(
@@ -233,7 +233,7 @@ async def test_fan_oscillate(
     hass: HomeAssistant,
     matter_client: MagicMock,
     air_purifier: MatterNode,
-):
+) -> None:
     """Test oscillating the fan."""
     entity_id = "fan.air_purifier"
     for oscillating, value in ((True, 1), (False, 0)):
@@ -256,7 +256,7 @@ async def test_fan_set_direction(
     hass: HomeAssistant,
     matter_client: MagicMock,
     air_purifier: MatterNode,
-):
+) -> None:
     """Test oscillating the fan."""
     entity_id = "fan.air_purifier"
     for direction, value in ((DIRECTION_FORWARD, 0), (DIRECTION_REVERSE, 1)):

--- a/tests/components/matter/test_init.py
+++ b/tests/components/matter/test_init.py
@@ -386,7 +386,7 @@ async def test_update_addon(
     backup_calls: int,
     update_addon_side_effect: Exception | None,
     create_backup_side_effect: Exception | None,
-):
+) -> None:
     """Test update the Matter add-on during entry setup."""
     addon_info.return_value["version"] = addon_version
     addon_info.return_value["update_available"] = update_available
@@ -453,7 +453,7 @@ async def test_issue_registry_invalid_version(
     ],
 )
 async def test_stop_addon(
-    hass,
+    hass: HomeAssistant,
     matter_client: MagicMock,
     addon_installed: AsyncMock,
     addon_running: AsyncMock,
@@ -461,7 +461,7 @@ async def test_stop_addon(
     stop_addon: AsyncMock,
     stop_addon_side_effect: Exception | None,
     entry_state: ConfigEntryState,
-):
+) -> None:
     """Test stop the Matter add-on on entry unload if entry is disabled."""
     stop_addon.side_effect = stop_addon_side_effect
     entry = MockConfigEntry(

--- a/tests/components/nibe_heatpump/test_button.py
+++ b/tests/components/nibe_heatpump/test_button.py
@@ -41,7 +41,7 @@ async def test_reset_button(
     entity_id: str,
     coils: dict[int, Any],
     freezer_ticker: Any,
-):
+) -> None:
     """Test reset button."""
 
     unit = UNIT_COILGROUPS[model.series]["main"]

--- a/tests/components/openhome/test_update.py
+++ b/tests/components/openhome/test_update.py
@@ -89,7 +89,7 @@ async def setup_integration(
         await hass.async_block_till_done()
 
 
-async def test_not_supported(hass: HomeAssistant):
+async def test_not_supported(hass: HomeAssistant) -> None:
     """Ensure update entity works if service not supported."""
 
     update_firmware = AsyncMock()
@@ -107,7 +107,7 @@ async def test_not_supported(hass: HomeAssistant):
     update_firmware.assert_not_called()
 
 
-async def test_on_latest_firmware(hass: HomeAssistant):
+async def test_on_latest_firmware(hass: HomeAssistant) -> None:
     """Test device on latest firmware."""
 
     update_firmware = AsyncMock()
@@ -125,7 +125,7 @@ async def test_on_latest_firmware(hass: HomeAssistant):
     update_firmware.assert_not_called()
 
 
-async def test_update_available(hass: HomeAssistant):
+async def test_update_available(hass: HomeAssistant) -> None:
     """Test device has firmware update available."""
 
     update_firmware = AsyncMock()
@@ -158,7 +158,7 @@ async def test_update_available(hass: HomeAssistant):
     update_firmware.assert_called_once()
 
 
-async def test_firmware_update_not_required(hass: HomeAssistant):
+async def test_firmware_update_not_required(hass: HomeAssistant) -> None:
     """Ensure firmware install does nothing if up to date."""
 
     update_firmware = AsyncMock()

--- a/tests/components/opensky/test_sensor.py
+++ b/tests/components/opensky/test_sensor.py
@@ -27,7 +27,7 @@ async def test_sensor(
     config_entry: MockConfigEntry,
     snapshot: SnapshotAssertion,
     opensky_client: AsyncMock,
-):
+) -> None:
     """Test setup sensor."""
     await setup_integration(hass, config_entry)
 
@@ -48,7 +48,7 @@ async def test_sensor_altitude(
     config_entry_altitude: MockConfigEntry,
     opensky_client: AsyncMock,
     snapshot: SnapshotAssertion,
-):
+) -> None:
     """Test setup sensor with a set altitude."""
     await setup_integration(hass, config_entry_altitude)
 
@@ -62,7 +62,7 @@ async def test_sensor_updating(
     opensky_client: AsyncMock,
     freezer: FrozenDateTimeFactory,
     snapshot: SnapshotAssertion,
-):
+) -> None:
     """Test updating sensor."""
     await setup_integration(hass, config_entry)
 

--- a/tests/components/ping/test_binary_sensor.py
+++ b/tests/components/ping/test_binary_sensor.py
@@ -49,7 +49,7 @@ async def test_disabled_after_import(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
-):
+) -> None:
     """Test if binary sensor is disabled after import."""
     config_entry.add_to_hass(hass)
     hass.config_entries.async_update_entry(
@@ -69,7 +69,7 @@ async def test_disabled_after_import(
 async def test_import_issue_creation(
     hass: HomeAssistant,
     issue_registry: ir.IssueRegistry,
-):
+) -> None:
     """Test if import issue is raised."""
 
     await async_setup_component(

--- a/tests/components/ping/test_device_tracker.py
+++ b/tests/components/ping/test_device_tracker.py
@@ -88,7 +88,7 @@ async def test_setup_and_update(
 async def test_import_issue_creation(
     hass: HomeAssistant,
     issue_registry: ir.IssueRegistry,
-):
+) -> None:
     """Test if import issue is raised."""
 
     await async_setup_component(
@@ -107,10 +107,7 @@ async def test_import_issue_creation(
     assert issue
 
 
-async def test_import_delete_known_devices(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-):
+async def test_import_delete_known_devices(hass: HomeAssistant) -> None:
     """Test if import deletes known devices."""
     yaml_devices = {
         "test": {
@@ -147,7 +144,7 @@ async def test_reload_not_triggering_home(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
     config_entry: MockConfigEntry,
-):
+) -> None:
     """Test if reload/restart does not trigger home when device is unavailable."""
     assert hass.states.get("device_tracker.10_10_10_10").state == "home"
 

--- a/tests/components/rest_command/test_init.py
+++ b/tests/components/rest_command/test_init.py
@@ -154,7 +154,7 @@ async def test_rest_command_methods(
     setup_component: ComponentSetup,
     aioclient_mock: AiohttpClientMocker,
     method: str,
-):
+) -> None:
     """Test various http methods."""
     await setup_component()
 

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -881,7 +881,7 @@ async def test_legacy_color_action_no_template(
     hass: HomeAssistant,
     setup_light,
     calls: list[ServiceCall],
-):
+) -> None:
     """Test setting color with optimistic template."""
     state = hass.states.get("light.test_template_light")
     assert state.attributes.get("hs_color") is None
@@ -1103,12 +1103,12 @@ async def test_rgbww_color_action_no_template(
     ],
 )
 async def test_legacy_color_template(
-    hass,
-    expected_hs,
-    expected_color_mode,
-    count,
-    color_template,
-):
+    hass: HomeAssistant,
+    expected_hs: tuple[float, float] | None,
+    expected_color_mode: ColorMode,
+    count: int,
+    color_template: str,
+) -> None:
     """Test the template for the color."""
     light_config = {
         "test_template_light": {

--- a/tests/components/tplink/test_diagnostics.py
+++ b/tests/components/tplink/test_diagnostics.py
@@ -38,7 +38,7 @@ async def test_diagnostics(
     fixture_file: str,
     sysinfo_vars: list[str],
     expected_oui: str | None,
-):
+) -> None:
     """Test diagnostics for config entry."""
     diagnostics_data = json.loads(load_fixture(fixture_file, "tplink"))
 

--- a/tests/components/vultr/test_switch.py
+++ b/tests/components/vultr/test_switch.py
@@ -50,7 +50,7 @@ def load_hass_devices(hass: HomeAssistant):
 
 
 @pytest.mark.usefixtures("valid_config")
-def test_switch(hass: HomeAssistant, hass_devices: list[vultr.VultrSwitch]):
+def test_switch(hass: HomeAssistant, hass_devices: list[vultr.VultrSwitch]) -> None:
     """Test successful instance."""
 
     assert len(hass_devices) == 3
@@ -97,7 +97,7 @@ def test_switch(hass: HomeAssistant, hass_devices: list[vultr.VultrSwitch]):
 
 
 @pytest.mark.usefixtures("valid_config")
-def test_turn_on(hass: HomeAssistant, hass_devices: list[vultr.VultrSwitch]):
+def test_turn_on(hass: HomeAssistant, hass_devices: list[vultr.VultrSwitch]) -> None:
     """Test turning a subscription on."""
     with (
         patch(
@@ -116,7 +116,7 @@ def test_turn_on(hass: HomeAssistant, hass_devices: list[vultr.VultrSwitch]):
 
 
 @pytest.mark.usefixtures("valid_config")
-def test_turn_off(hass: HomeAssistant, hass_devices: list[vultr.VultrSwitch]):
+def test_turn_off(hass: HomeAssistant, hass_devices: list[vultr.VultrSwitch]) -> None:
     """Test turning a subscription off."""
     with (
         patch(

--- a/tests/components/wemo/test_coordinator.py
+++ b/tests/components/wemo/test_coordinator.py
@@ -191,8 +191,8 @@ async def test_dli_device_info(
 
 
 async def test_options_enable_subscription_false(
-    hass, pywemo_registry, pywemo_device, wemo_entity
-):
+    hass: HomeAssistant, pywemo_registry, pywemo_device, wemo_entity
+) -> None:
     """Test setting Options.enable_subscription = False."""
     config_entry = hass.config_entries.async_get_entry(wemo_entity.config_entry_id)
     assert hass.config_entries.async_update_entry(
@@ -203,7 +203,9 @@ async def test_options_enable_subscription_false(
     pywemo_registry.unregister.assert_called_once_with(pywemo_device)
 
 
-async def test_options_enable_long_press_false(hass, pywemo_device, wemo_entity):
+async def test_options_enable_long_press_false(
+    hass: HomeAssistant, pywemo_device, wemo_entity
+) -> None:
     """Test setting Options.enable_long_press = False."""
     config_entry = hass.config_entries.async_get_entry(wemo_entity.config_entry_id)
     assert hass.config_entries.async_update_entry(

--- a/tests/components/zha/test_base.py
+++ b/tests/components/zha/test_base.py
@@ -9,11 +9,11 @@ from tests.components.zha.test_cluster_handlers import (  # noqa: F401
 )
 
 
-def test_parse_and_log_command(poll_control_ch):  # noqa: F811
+def test_parse_and_log_command(poll_control_ch) -> None:  # noqa: F811
     """Test that `parse_and_log_command` correctly parses a known command."""
     assert parse_and_log_command(poll_control_ch, 0x00, 0x01, []) == "fast_poll_stop"
 
 
-def test_parse_and_log_command_unknown(poll_control_ch):  # noqa: F811
+def test_parse_and_log_command_unknown(poll_control_ch) -> None:  # noqa: F811
     """Test that `parse_and_log_command` correctly parses an unknown command."""
     assert parse_and_log_command(poll_control_ch, 0x00, 0xAB, []) == "0xAB"

--- a/tests/components/zha/test_gateway.py
+++ b/tests/components/zha/test_gateway.py
@@ -300,7 +300,7 @@ async def test_single_reload_on_multiple_connection_loss(
     hass: HomeAssistant,
     zigpy_app_controller: ControllerApplication,
     config_entry: MockConfigEntry,
-):
+) -> None:
     """Test that we only reload once when we lose the connection multiple times."""
     config_entry.add_to_hass(hass)
 
@@ -333,7 +333,7 @@ async def test_startup_concurrency_limit(
     zigpy_app_controller: ControllerApplication,
     config_entry: MockConfigEntry,
     zigpy_device_mock,
-):
+) -> None:
     """Test ZHA gateway limits concurrency on startup."""
     config_entry.add_to_hass(hass)
     zha_gateway = ZHAGateway(hass, {}, config_entry)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA
`test_*` functions should always return None
Also move a few unused arguments to the decorator.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
