### PR TITLE
Centralize duplicate fixtures in rainforest_raven tests

### DIFF
--- a/tests/components/rainforest_raven/__init__.py
+++ b/tests/components/rainforest_raven/__init__.py
@@ -17,7 +17,7 @@ from .const import (
 from tests.common import AsyncMock, MockConfigEntry
 
 
-def create_mock_device():
+def create_mock_device() -> AsyncMock:
     """Create a mock instance of RAVEnStreamDevice."""
     device = AsyncMock()
 
@@ -33,7 +33,7 @@ def create_mock_device():
     return device
 
 
-def create_mock_entry(no_meters=False):
+def create_mock_entry(no_meters: bool = False) -> MockConfigEntry:
     """Create a mock config entry for a RAVEn device."""
     return MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/rainforest_raven/conftest.py
+++ b/tests/components/rainforest_raven/conftest.py
@@ -1,0 +1,33 @@
+"""Fixtures for the Rainforest RAVEn tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+
+from . import create_mock_device, create_mock_entry
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_device() -> Generator[AsyncMock, None, None]:
+    """Mock a functioning RAVEn device."""
+    mock_device = create_mock_device()
+    with patch(
+        "homeassistant.components.rainforest_raven.coordinator.RAVEnSerialDevice",
+        return_value=mock_device,
+    ):
+        yield mock_device
+
+
+@pytest.fixture
+async def mock_entry(hass: HomeAssistant, mock_device: AsyncMock) -> MockConfigEntry:
+    """Mock a functioning RAVEn config entry."""
+    mock_entry = create_mock_entry()
+    mock_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+    return mock_entry

--- a/tests/components/rainforest_raven/test_coordinator.py
+++ b/tests/components/rainforest_raven/test_coordinator.py
@@ -10,20 +10,7 @@ from homeassistant.components.rainforest_raven.coordinator import RAVEnDataCoord
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from . import create_mock_device, create_mock_entry
-
-from tests.common import patch
-
-
-@pytest.fixture
-def mock_device():
-    """Mock a functioning RAVEn device."""
-    mock_device = create_mock_device()
-    with patch(
-        "homeassistant.components.rainforest_raven.coordinator.RAVEnSerialDevice",
-        return_value=mock_device,
-    ):
-        yield mock_device
+from . import create_mock_entry
 
 
 async def test_coordinator_device_info(hass: HomeAssistant, mock_device):

--- a/tests/components/rainforest_raven/test_diagnostics.py
+++ b/tests/components/rainforest_raven/test_diagnostics.py
@@ -8,33 +8,11 @@ from homeassistant.components.diagnostics import REDACTED
 from homeassistant.const import CONF_MAC
 from homeassistant.core import HomeAssistant
 
-from . import create_mock_device, create_mock_entry
+from . import create_mock_entry
 from .const import DEMAND, NETWORK_INFO, PRICE_CLUSTER, SUMMATION
 
-from tests.common import patch
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
-
-
-@pytest.fixture
-def mock_device():
-    """Mock a functioning RAVEn device."""
-    mock_device = create_mock_device()
-    with patch(
-        "homeassistant.components.rainforest_raven.coordinator.RAVEnSerialDevice",
-        return_value=mock_device,
-    ):
-        yield mock_device
-
-
-@pytest.fixture
-async def mock_entry(hass: HomeAssistant, mock_device):
-    """Mock a functioning RAVEn config entry."""
-    mock_entry = create_mock_entry()
-    mock_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_entry.entry_id)
-    await hass.async_block_till_done()
-    return mock_entry
 
 
 @pytest.fixture

--- a/tests/components/rainforest_raven/test_init.py
+++ b/tests/components/rainforest_raven/test_init.py
@@ -1,35 +1,8 @@
 """Tests for the Rainforest RAVEn component initialisation."""
 
-import pytest
-
 from homeassistant.components.rainforest_raven.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
-
-from . import create_mock_device, create_mock_entry
-
-from tests.common import patch
-
-
-@pytest.fixture
-def mock_device():
-    """Mock a functioning RAVEn device."""
-    mock_device = create_mock_device()
-    with patch(
-        "homeassistant.components.rainforest_raven.coordinator.RAVEnSerialDevice",
-        return_value=mock_device,
-    ):
-        yield mock_device
-
-
-@pytest.fixture
-async def mock_entry(hass: HomeAssistant, mock_device):
-    """Mock a functioning RAVEn config entry."""
-    mock_entry = create_mock_entry()
-    mock_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_entry.entry_id)
-    await hass.async_block_till_done()
-    return mock_entry
 
 
 async def test_load_unload_entry(hass: HomeAssistant, mock_entry):

--- a/tests/components/rainforest_raven/test_sensor.py
+++ b/tests/components/rainforest_raven/test_sensor.py
@@ -1,33 +1,6 @@
 """Tests for the Rainforest RAVEn sensors."""
 
-import pytest
-
 from homeassistant.core import HomeAssistant
-
-from . import create_mock_device, create_mock_entry
-
-from tests.common import patch
-
-
-@pytest.fixture
-def mock_device():
-    """Mock a functioning RAVEn device."""
-    mock_device = create_mock_device()
-    with patch(
-        "homeassistant.components.rainforest_raven.coordinator.RAVEnSerialDevice",
-        return_value=mock_device,
-    ):
-        yield mock_device
-
-
-@pytest.fixture
-async def mock_entry(hass: HomeAssistant, mock_device):
-    """Mock a functioning RAVEn config entry."""
-    mock_entry = create_mock_entry()
-    mock_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_entry.entry_id)
-    await hass.async_block_till_done()
-    return mock_entry
 
 
 async def test_sensors(hass: HomeAssistant, mock_device, mock_entry):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
