### PR TITLE
Improve type hints in rainforest_raven tests

### DIFF
--- a/tests/components/rainforest_raven/test_config_flow.py
+++ b/tests/components/rainforest_raven/test_config_flow.py
@@ -1,10 +1,11 @@
 """Test Rainforest RAVEn config flow."""
 
-from unittest.mock import patch
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
 
 from aioraven.device import RAVEnConnectionError
 import pytest
-import serial.tools.list_ports
+from serial.tools.list_ports_common import ListPortInfo
 
 from homeassistant.components.rainforest_raven.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USB, SOURCE_USER
@@ -19,7 +20,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def mock_device():
+def mock_device() -> Generator[AsyncMock, None, None]:
     """Mock a functioning RAVEn device."""
     device = create_mock_device()
     with patch(
@@ -30,7 +31,7 @@ def mock_device():
 
 
 @pytest.fixture
-def mock_device_no_open(mock_device):
+def mock_device_no_open(mock_device: AsyncMock) -> AsyncMock:
     """Mock a device which fails to open."""
     mock_device.__aenter__.side_effect = RAVEnConnectionError
     mock_device.open.side_effect = RAVEnConnectionError
@@ -38,7 +39,7 @@ def mock_device_no_open(mock_device):
 
 
 @pytest.fixture
-def mock_device_comm_error(mock_device):
+def mock_device_comm_error(mock_device: AsyncMock) -> AsyncMock:
     """Mock a device which fails to read or parse raw data."""
     mock_device.get_meter_list.side_effect = RAVEnConnectionError
     mock_device.get_meter_info.side_effect = RAVEnConnectionError
@@ -46,7 +47,7 @@ def mock_device_comm_error(mock_device):
 
 
 @pytest.fixture
-def mock_device_timeout(mock_device):
+def mock_device_timeout(mock_device: AsyncMock) -> AsyncMock:
     """Mock a device which times out when queried."""
     mock_device.get_meter_list.side_effect = TimeoutError
     mock_device.get_meter_info.side_effect = TimeoutError
@@ -54,9 +55,9 @@ def mock_device_timeout(mock_device):
 
 
 @pytest.fixture
-def mock_comports():
+def mock_comports() -> Generator[list[ListPortInfo], None, None]:
     """Mock serial port list."""
-    port = serial.tools.list_ports_common.ListPortInfo(DISCOVERY_INFO.device)
+    port = ListPortInfo(DISCOVERY_INFO.device)
     port.serial_number = DISCOVERY_INFO.serial_number
     port.manufacturer = DISCOVERY_INFO.manufacturer
     port.device = DISCOVERY_INFO.device
@@ -68,7 +69,8 @@ def mock_comports():
         yield comports
 
 
-async def test_flow_usb(hass: HomeAssistant, mock_comports, mock_device):
+@pytest.mark.usefixtures("mock_comports", "mock_device")
+async def test_flow_usb(hass: HomeAssistant) -> None:
     """Test usb flow connection."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={CONF_SOURCE: SOURCE_USB}, data=DISCOVERY_INFO
@@ -86,9 +88,8 @@ async def test_flow_usb(hass: HomeAssistant, mock_comports, mock_device):
     assert result.get("type") is FlowResultType.CREATE_ENTRY
 
 
-async def test_flow_usb_cannot_connect(
-    hass: HomeAssistant, mock_comports, mock_device_no_open
-):
+@pytest.mark.usefixtures("mock_comports", "mock_device_no_open")
+async def test_flow_usb_cannot_connect(hass: HomeAssistant) -> None:
     """Test usb flow connection error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={CONF_SOURCE: SOURCE_USB}, data=DISCOVERY_INFO
@@ -98,9 +99,8 @@ async def test_flow_usb_cannot_connect(
     assert result.get("reason") == "cannot_connect"
 
 
-async def test_flow_usb_timeout_connect(
-    hass: HomeAssistant, mock_comports, mock_device_timeout
-):
+@pytest.mark.usefixtures("mock_comports", "mock_device_timeout")
+async def test_flow_usb_timeout_connect(hass: HomeAssistant) -> None:
     """Test usb flow connection timeout."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={CONF_SOURCE: SOURCE_USB}, data=DISCOVERY_INFO
@@ -110,9 +110,8 @@ async def test_flow_usb_timeout_connect(
     assert result.get("reason") == "timeout_connect"
 
 
-async def test_flow_usb_comm_error(
-    hass: HomeAssistant, mock_comports, mock_device_comm_error
-):
+@pytest.mark.usefixtures("mock_comports", "mock_device_comm_error")
+async def test_flow_usb_comm_error(hass: HomeAssistant) -> None:
     """Test usb flow connection failure to communicate."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={CONF_SOURCE: SOURCE_USB}, data=DISCOVERY_INFO
@@ -122,7 +121,8 @@ async def test_flow_usb_comm_error(
     assert result.get("reason") == "cannot_connect"
 
 
-async def test_flow_user(hass: HomeAssistant, mock_comports, mock_device):
+@pytest.mark.usefixtures("mock_comports", "mock_device")
+async def test_flow_user(hass: HomeAssistant) -> None:
     """Test user flow connection."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -153,7 +153,8 @@ async def test_flow_user(hass: HomeAssistant, mock_comports, mock_device):
     assert result.get("type") is FlowResultType.CREATE_ENTRY
 
 
-async def test_flow_user_no_available_devices(hass: HomeAssistant, mock_comports):
+@pytest.mark.usefixtures("mock_comports")
+async def test_flow_user_no_available_devices(hass: HomeAssistant) -> None:
     """Test user flow with no available devices."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -169,7 +170,8 @@ async def test_flow_user_no_available_devices(hass: HomeAssistant, mock_comports
     assert result.get("reason") == "no_devices_found"
 
 
-async def test_flow_user_in_progress(hass: HomeAssistant, mock_comports):
+@pytest.mark.usefixtures("mock_comports")
+async def test_flow_user_in_progress(hass: HomeAssistant) -> None:
     """Test user flow with no available devices."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -190,9 +192,8 @@ async def test_flow_user_in_progress(hass: HomeAssistant, mock_comports):
     assert result.get("reason") == "already_in_progress"
 
 
-async def test_flow_user_cannot_connect(
-    hass: HomeAssistant, mock_comports, mock_device_no_open
-):
+@pytest.mark.usefixtures("mock_comports", "mock_device_no_open")
+async def test_flow_user_cannot_connect(hass: HomeAssistant) -> None:
     """Test user flow connection failure to communicate."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -206,9 +207,8 @@ async def test_flow_user_cannot_connect(
     assert result.get("errors") == {CONF_DEVICE: "cannot_connect"}
 
 
-async def test_flow_user_timeout_connect(
-    hass: HomeAssistant, mock_comports, mock_device_timeout
-):
+@pytest.mark.usefixtures("mock_comports", "mock_device_timeout")
+async def test_flow_user_timeout_connect(hass: HomeAssistant) -> None:
     """Test user flow connection failure to communicate."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -222,9 +222,8 @@ async def test_flow_user_timeout_connect(
     assert result.get("errors") == {CONF_DEVICE: "timeout_connect"}
 
 
-async def test_flow_user_comm_error(
-    hass: HomeAssistant, mock_comports, mock_device_comm_error
-):
+@pytest.mark.usefixtures("mock_comports", "mock_device_comm_error")
+async def test_flow_user_comm_error(hass: HomeAssistant) -> None:
     """Test user flow connection failure to communicate."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/rainforest_raven/test_coordinator.py
+++ b/tests/components/rainforest_raven/test_coordinator.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import functools
+from unittest.mock import AsyncMock
 
 from aioraven.device import RAVEnConnectionError
 import pytest
@@ -13,7 +14,8 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from . import create_mock_entry
 
 
-async def test_coordinator_device_info(hass: HomeAssistant, mock_device):
+@pytest.mark.usefixtures("mock_device")
+async def test_coordinator_device_info(hass: HomeAssistant) -> None:
     """Test reporting device information from the coordinator."""
     entry = create_mock_entry()
     coordinator = RAVEnDataCoordinator(hass, entry)
@@ -37,7 +39,9 @@ async def test_coordinator_device_info(hass: HomeAssistant, mock_device):
     assert coordinator.device_name == "RAVEn Device"
 
 
-async def test_coordinator_cache_device(hass: HomeAssistant, mock_device):
+async def test_coordinator_cache_device(
+    hass: HomeAssistant, mock_device: AsyncMock
+) -> None:
     """Test that the device isn't re-opened for subsequent refreshes."""
     entry = create_mock_entry()
     coordinator = RAVEnDataCoordinator(hass, entry)
@@ -51,7 +55,9 @@ async def test_coordinator_cache_device(hass: HomeAssistant, mock_device):
     assert mock_device.open.call_count == 1
 
 
-async def test_coordinator_device_error_setup(hass: HomeAssistant, mock_device):
+async def test_coordinator_device_error_setup(
+    hass: HomeAssistant, mock_device: AsyncMock
+) -> None:
     """Test handling of a device error during initialization."""
     entry = create_mock_entry()
     coordinator = RAVEnDataCoordinator(hass, entry)
@@ -61,7 +67,9 @@ async def test_coordinator_device_error_setup(hass: HomeAssistant, mock_device):
         await coordinator.async_config_entry_first_refresh()
 
 
-async def test_coordinator_device_error_update(hass: HomeAssistant, mock_device):
+async def test_coordinator_device_error_update(
+    hass: HomeAssistant, mock_device: AsyncMock
+) -> None:
     """Test handling of a device error during an update."""
     entry = create_mock_entry()
     coordinator = RAVEnDataCoordinator(hass, entry)
@@ -74,7 +82,9 @@ async def test_coordinator_device_error_update(hass: HomeAssistant, mock_device)
     assert coordinator.last_update_success is False
 
 
-async def test_coordinator_device_timeout_update(hass: HomeAssistant, mock_device):
+async def test_coordinator_device_timeout_update(
+    hass: HomeAssistant, mock_device: AsyncMock
+) -> None:
     """Test handling of a device timeout during an update."""
     entry = create_mock_entry()
     coordinator = RAVEnDataCoordinator(hass, entry)
@@ -87,7 +97,9 @@ async def test_coordinator_device_timeout_update(hass: HomeAssistant, mock_devic
     assert coordinator.last_update_success is False
 
 
-async def test_coordinator_comm_error(hass: HomeAssistant, mock_device):
+async def test_coordinator_comm_error(
+    hass: HomeAssistant, mock_device: AsyncMock
+) -> None:
     """Test handling of an error parsing or reading raw device data."""
     entry = create_mock_entry()
     coordinator = RAVEnDataCoordinator(hass, entry)

--- a/tests/components/rainforest_raven/test_init.py
+++ b/tests/components/rainforest_raven/test_init.py
@@ -4,8 +4,12 @@ from homeassistant.components.rainforest_raven.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
+from tests.common import MockConfigEntry
 
-async def test_load_unload_entry(hass: HomeAssistant, mock_entry):
+
+async def test_load_unload_entry(
+    hass: HomeAssistant, mock_entry: MockConfigEntry
+) -> None:
     """Test load and unload."""
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     assert mock_entry.state is ConfigEntryState.LOADED

--- a/tests/components/rainforest_raven/test_sensor.py
+++ b/tests/components/rainforest_raven/test_sensor.py
@@ -1,9 +1,12 @@
 """Tests for the Rainforest RAVEn sensors."""
 
+import pytest
+
 from homeassistant.core import HomeAssistant
 
 
-async def test_sensors(hass: HomeAssistant, mock_device, mock_entry):
+@pytest.mark.usefixtures("mock_entry")
+async def test_sensors(hass: HomeAssistant) -> None:
     """Test the sensors."""
     assert len(hass.states.async_all()) == 5
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
