### PR TITLE
Import Generator from typing_extensions (2)

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncGenerator, Generator, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from contextlib import asynccontextmanager, contextmanager
 from datetime import UTC, datetime, timedelta
 from enum import Enum
@@ -23,6 +23,7 @@ from unittest.mock import AsyncMock, Mock, patch
 from aiohttp.test_utils import unused_port as get_test_instance_port  # noqa: F401
 import pytest
 from syrupy import SnapshotAssertion
+from typing_extensions import AsyncGenerator, Generator
 import voluptuous as vol
 
 from homeassistant import auth, bootstrap, config_entries, loader
@@ -161,7 +162,7 @@ def get_test_config_dir(*add_path):
 
 
 @contextmanager
-def get_test_home_assistant() -> Generator[HomeAssistant, None, None]:
+def get_test_home_assistant() -> Generator[HomeAssistant]:
     """Return a Home Assistant object pointing at test config directory."""
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
@@ -222,7 +223,7 @@ async def async_test_home_assistant(
     event_loop: asyncio.AbstractEventLoop | None = None,
     load_registries: bool = True,
     config_dir: str | None = None,
-) -> AsyncGenerator[HomeAssistant, None]:
+) -> AsyncGenerator[HomeAssistant]:
     """Return a Home Assistant object pointing at test config dir."""
     hass = HomeAssistant(config_dir or get_test_config_dir())
     store = auth_store.AuthStore(hass)
@@ -1325,9 +1326,7 @@ class MockEntity(entity.Entity):
 
 
 @contextmanager
-def mock_storage(
-    data: dict[str, Any] | None = None,
-) -> Generator[dict[str, Any], None, None]:
+def mock_storage(data: dict[str, Any] | None = None) -> Generator[dict[str, Any]]:
     """Mock storage.
 
     Data is a dict {'key': {'version': version, 'data': data}}

--- a/tests/components/abode/conftest.py
+++ b/tests/components/abode/conftest.py
@@ -1,18 +1,18 @@
 """Configuration for Abode tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 from jaraco.abode.helpers import urls as URL
 import pytest
 from requests_mock import Mocker
+from typing_extensions import Generator
 
 from tests.common import load_fixture
 from tests.components.light.conftest import mock_light_profiles  # noqa: F401
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.abode.async_setup_entry", return_value=True

--- a/tests/components/accuweather/conftest.py
+++ b/tests/components/accuweather/conftest.py
@@ -1,9 +1,9 @@
 """Common fixtures for the AccuWeather tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.accuweather.const import DOMAIN
 
@@ -11,7 +11,7 @@ from tests.common import load_json_array_fixture, load_json_object_fixture
 
 
 @pytest.fixture
-def mock_accuweather_client() -> Generator[AsyncMock, None, None]:
+def mock_accuweather_client() -> Generator[AsyncMock]:
     """Mock a AccuWeather client."""
     current = load_json_object_fixture("current_conditions_data.json", DOMAIN)
     forecast = load_json_array_fixture("forecast_data.json", DOMAIN)

--- a/tests/components/aemet/conftest.py
+++ b/tests/components/aemet/conftest.py
@@ -1,13 +1,13 @@
 """Test fixtures for aemet."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.aemet.async_setup_entry", return_value=True

--- a/tests/components/aftership/conftest.py
+++ b/tests/components/aftership/conftest.py
@@ -1,13 +1,13 @@
 """Common fixtures for the AfterShip tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.aftership.async_setup_entry", return_value=True

--- a/tests/components/agent_dvr/conftest.py
+++ b/tests/components/agent_dvr/conftest.py
@@ -1,13 +1,13 @@
 """Test fixtures for Agent DVR."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.agent_dvr.async_setup_entry", return_value=True

--- a/tests/components/airgradient/conftest.py
+++ b/tests/components/airgradient/conftest.py
@@ -1,10 +1,10 @@
 """AirGradient tests configuration."""
 
-from collections.abc import Generator
 from unittest.mock import patch
 
 from airgradient import Config, Measures
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.airgradient.const import DOMAIN
 from homeassistant.const import CONF_HOST
@@ -14,7 +14,7 @@ from tests.components.smhi.common import AsyncMock
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.airgradient.async_setup_entry",
@@ -24,7 +24,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_airgradient_client() -> Generator[AsyncMock, None, None]:
+def mock_airgradient_client() -> Generator[AsyncMock]:
     """Mock an AirGradient client."""
     with (
         patch(
@@ -50,7 +50,7 @@ def mock_airgradient_client() -> Generator[AsyncMock, None, None]:
 @pytest.fixture
 def mock_new_airgradient_client(
     mock_airgradient_client: AsyncMock,
-) -> Generator[AsyncMock, None, None]:
+) -> Generator[AsyncMock]:
     """Mock a new AirGradient client."""
     mock_airgradient_client.get_config.return_value = Config.from_json(
         load_fixture("get_config.json", DOMAIN)
@@ -61,7 +61,7 @@ def mock_new_airgradient_client(
 @pytest.fixture
 def mock_cloud_airgradient_client(
     mock_airgradient_client: AsyncMock,
-) -> Generator[AsyncMock, None, None]:
+) -> Generator[AsyncMock]:
     """Mock a cloud AirGradient client."""
     mock_airgradient_client.get_config.return_value = Config.from_json(
         load_fixture("get_config_cloud.json", DOMAIN)

--- a/tests/components/airq/conftest.py
+++ b/tests/components/airq/conftest.py
@@ -1,13 +1,13 @@
 """Test fixtures for air-Q."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.airq.async_setup_entry", return_value=True

--- a/tests/components/airtouch5/conftest.py
+++ b/tests/components/airtouch5/conftest.py
@@ -1,13 +1,13 @@
 """Common fixtures for the Airtouch 5 tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.airtouch5.async_setup_entry", return_value=True

--- a/tests/components/airvisual/conftest.py
+++ b/tests/components/airvisual/conftest.py
@@ -1,10 +1,10 @@
 """Define test fixtures for AirVisual."""
 
-from collections.abc import Generator
 import json
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.airvisual import (
     CONF_CITY,
@@ -152,7 +152,7 @@ async def setup_config_entry_fixture(hass, config_entry, mock_pyairvisual):
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.airvisual.async_setup_entry", return_value=True

--- a/tests/components/airvisual_pro/conftest.py
+++ b/tests/components/airvisual_pro/conftest.py
@@ -1,10 +1,10 @@
 """Define test fixtures for AirVisual Pro."""
 
-from collections.abc import Generator
 import json
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.airvisual_pro.const import DOMAIN
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD
@@ -14,7 +14,7 @@ from tests.common import MockConfigEntry, load_fixture
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.airvisual_pro.async_setup_entry", return_value=True

--- a/tests/components/aladdin_connect/conftest.py
+++ b/tests/components/aladdin_connect/conftest.py
@@ -1,9 +1,9 @@
 """Test fixtures for the Aladdin Connect Garage Door integration."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.aladdin_connect import DOMAIN
 
@@ -11,7 +11,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.aladdin_connect.async_setup_entry", return_value=True

--- a/tests/components/alarm_control_panel/conftest.py
+++ b/tests/components/alarm_control_panel/conftest.py
@@ -1,9 +1,9 @@
 """Fixturs for Alarm Control Panel tests."""
 
-from collections.abc import Generator
 from unittest.mock import MagicMock
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.alarm_control_panel import (
     DOMAIN as ALARM_CONTROL_PANEL_DOMAIN,
@@ -108,7 +108,7 @@ class MockFlow(ConfigFlow):
 
 
 @pytest.fixture(autouse=True)
-def config_flow_fixture(hass: HomeAssistant) -> Generator[None, None, None]:
+def config_flow_fixture(hass: HomeAssistant) -> Generator[None]:
     """Mock config flow."""
     mock_platform(hass, f"{TEST_DOMAIN}.config_flow")
 

--- a/tests/components/amberelectric/conftest.py
+++ b/tests/components/amberelectric/conftest.py
@@ -1,13 +1,13 @@
 """Provide common Amber fixtures."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.amberelectric.async_setup_entry", return_value=True

--- a/tests/components/ambient_network/conftest.py
+++ b/tests/components/ambient_network/conftest.py
@@ -1,11 +1,11 @@
 """Common fixtures for the Ambient Weather Network integration tests."""
 
-from collections.abc import Generator
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 from aioambient import OpenAPI
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components import ambient_network
 from homeassistant.core import HomeAssistant
@@ -18,7 +18,7 @@ from tests.common import (
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.ambient_network.async_setup_entry", return_value=True

--- a/tests/components/analytics_insights/conftest.py
+++ b/tests/components/analytics_insights/conftest.py
@@ -1,11 +1,11 @@
 """Common fixtures for the Homeassistant Analytics tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from python_homeassistant_analytics import CurrentAnalytics
 from python_homeassistant_analytics.models import CustomIntegration, Integration
+from typing_extensions import Generator
 
 from homeassistant.components.analytics_insights.const import (
     CONF_TRACKED_CUSTOM_INTEGRATIONS,
@@ -17,7 +17,7 @@ from tests.common import MockConfigEntry, load_fixture, load_json_object_fixture
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.analytics_insights.async_setup_entry",
@@ -27,7 +27,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_analytics_client() -> Generator[AsyncMock, None, None]:
+def mock_analytics_client() -> Generator[AsyncMock]:
     """Mock a Homeassistant Analytics client."""
     with (
         patch(

--- a/tests/components/androidtv_remote/conftest.py
+++ b/tests/components/androidtv_remote/conftest.py
@@ -1,9 +1,10 @@
 """Fixtures for the Android TV Remote integration tests."""
 
-from collections.abc import Callable, Generator
+from collections.abc import Callable
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.androidtv_remote.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -12,7 +13,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.androidtv_remote.async_setup_entry",
@@ -22,7 +23,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_unload_entry() -> Generator[AsyncMock, None, None]:
+def mock_unload_entry() -> Generator[AsyncMock]:
     """Mock unloading a config entry."""
     with patch(
         "homeassistant.components.androidtv_remote.async_unload_entry",

--- a/tests/components/aosmith/conftest.py
+++ b/tests/components/aosmith/conftest.py
@@ -1,6 +1,5 @@
 """Common fixtures for the A. O. Smith tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from py_aosmith import AOSmithAPIClient
@@ -15,6 +14,7 @@ from py_aosmith.models import (
     SupportedOperationModeInfo,
 )
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.aosmith.const import DOMAIN
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
@@ -128,7 +128,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.aosmith.async_setup_entry", return_value=True
@@ -166,7 +166,7 @@ async def mock_client(
     get_devices_fixture_mode_pending: bool,
     get_devices_fixture_setpoint_pending: bool,
     get_devices_fixture_has_vacation_mode: bool,
-) -> Generator[MagicMock, None, None]:
+) -> Generator[MagicMock]:
     """Return a mocked client."""
     get_devices_fixture = [
         build_device_fixture(

--- a/tests/components/aosmith/test_sensor.py
+++ b/tests/components/aosmith/test_sensor.py
@@ -1,10 +1,10 @@
 """Tests for the sensor platform of the A. O. Smith integration."""
 
-from collections.abc import AsyncGenerator
 from unittest.mock import patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from typing_extensions import AsyncGenerator
 
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -14,7 +14,7 @@ from tests.common import MockConfigEntry, snapshot_platform
 
 
 @pytest.fixture(autouse=True)
-async def platforms() -> AsyncGenerator[list[str], None]:
+async def platforms() -> AsyncGenerator[list[str]]:
     """Return the platforms to be loaded for this test."""
     with patch("homeassistant.components.aosmith.PLATFORMS", [Platform.SENSOR]):
         yield

--- a/tests/components/aosmith/test_water_heater.py
+++ b/tests/components/aosmith/test_water_heater.py
@@ -1,11 +1,11 @@
 """Tests for the water heater platform of the A. O. Smith integration."""
 
-from collections.abc import AsyncGenerator
 from unittest.mock import MagicMock, patch
 
 from py_aosmith.models import OperationMode
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from typing_extensions import AsyncGenerator
 
 from homeassistant.components.water_heater import (
     ATTR_AWAY_MODE,
@@ -29,7 +29,7 @@ from tests.common import MockConfigEntry, snapshot_platform
 
 
 @pytest.fixture(autouse=True)
-async def platforms() -> AsyncGenerator[list[str], None]:
+async def platforms() -> AsyncGenerator[list[str]]:
     """Return the platforms to be loaded for this test."""
     with patch("homeassistant.components.aosmith.PLATFORMS", [Platform.WATER_HEATER]):
         yield

--- a/tests/components/application_credentials/test_init.py
+++ b/tests/components/application_credentials/test_init.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Generator
+from collections.abc import Callable
 import logging
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.application_credentials import (
@@ -114,7 +115,7 @@ class FakeConfigFlow(config_entry_oauth2_flow.AbstractOAuth2FlowHandler):
 @pytest.fixture(autouse=True)
 def config_flow_handler(
     hass: HomeAssistant, current_request_with_host: None
-) -> Generator[None, None, None]:
+) -> Generator[None]:
     """Fixture for a test config flow."""
     mock_platform(hass, f"{TEST_DOMAIN}.config_flow")
     with mock_config_flow(TEST_DOMAIN, FakeConfigFlow):

--- a/tests/components/aprs/test_device_tracker.py
+++ b/tests/components/aprs/test_device_tracker.py
@@ -1,11 +1,11 @@
 """Test APRS device tracker."""
 
-from collections.abc import Generator
 from unittest.mock import MagicMock, Mock, patch
 
 import aprslib
 from aprslib import IS
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.aprs import device_tracker
 from homeassistant.core import HomeAssistant
@@ -20,7 +20,7 @@ TEST_PASSWORD = "testpass"
 
 
 @pytest.fixture(name="mock_ais")
-def mock_ais() -> Generator[MagicMock, None, None]:
+def mock_ais() -> Generator[MagicMock]:
     """Mock aprslib."""
     with patch("aprslib.IS") as mock_ais:
         yield mock_ais

--- a/tests/components/apsystems/conftest.py
+++ b/tests/components/apsystems/conftest.py
@@ -1,13 +1,13 @@
 """Common fixtures for the APsystems Local API tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.apsystems.async_setup_entry",

--- a/tests/components/arve/conftest.py
+++ b/tests/components/arve/conftest.py
@@ -1,10 +1,10 @@
 """Common fixtures for the Arve tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from asyncarve import ArveCustomer, ArveDevices, ArveSensPro, ArveSensProData
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.arve.const import DOMAIN
 from homeassistant.core import HomeAssistant
@@ -15,7 +15,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.arve.async_setup_entry", return_value=True

--- a/tests/components/assist_pipeline/conftest.py
+++ b/tests/components/assist_pipeline/conftest.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterable, Generator
+from collections.abc import AsyncIterable
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components import stt, tts, wake_word
 from homeassistant.components.assist_pipeline import DOMAIN, select as assist_select
@@ -272,7 +273,7 @@ class MockFlow(ConfigFlow):
 
 
 @pytest.fixture
-def config_flow_fixture(hass: HomeAssistant) -> Generator[None, None, None]:
+def config_flow_fixture(hass: HomeAssistant) -> Generator[None]:
     """Mock config flow."""
     mock_platform(hass, "test.config_flow")
 

--- a/tests/components/assist_pipeline/test_pipeline.py
+++ b/tests/components/assist_pipeline/test_pipeline.py
@@ -1,10 +1,10 @@
 """Websocket tests for Voice Assistant integration."""
 
-from collections.abc import AsyncGenerator
 from typing import Any
 from unittest.mock import ANY, patch
 
 import pytest
+from typing_extensions import AsyncGenerator
 
 from homeassistant.components import conversation
 from homeassistant.components.assist_pipeline.const import DOMAIN
@@ -32,7 +32,7 @@ from tests.common import flush_store
 
 
 @pytest.fixture(autouse=True)
-async def delay_save_fixture() -> AsyncGenerator[None, None]:
+async def delay_save_fixture() -> AsyncGenerator[None]:
     """Load the homeassistant integration."""
     with patch("homeassistant.helpers.collection.SAVE_DELAY", new=0):
         yield

--- a/tests/components/asterisk_mbox/test_init.py
+++ b/tests/components/asterisk_mbox/test_init.py
@@ -1,9 +1,9 @@
 """Test mailbox."""
 
-from collections.abc import Generator
 from unittest.mock import Mock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.asterisk_mbox import DOMAIN
 from homeassistant.core import HomeAssistant
@@ -14,7 +14,7 @@ from .const import CONFIG
 
 
 @pytest.fixture
-def client() -> Generator[Mock, None, None]:
+def client() -> Generator[Mock]:
     """Mock client."""
     with patch(
         "homeassistant.components.asterisk_mbox.asteriskClient", autospec=True

--- a/tests/components/atag/conftest.py
+++ b/tests/components/atag/conftest.py
@@ -1,14 +1,14 @@
 """Provide common Atag fixtures."""
 
 import asyncio
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.atag.async_setup_entry", return_value=True

--- a/tests/components/aurora/conftest.py
+++ b/tests/components/aurora/conftest.py
@@ -1,9 +1,9 @@
 """Common fixtures for the Aurora tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.aurora.const import CONF_THRESHOLD, DOMAIN
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
@@ -12,7 +12,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.aurora.async_setup_entry",
@@ -22,7 +22,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_aurora_client() -> Generator[AsyncMock, None, None]:
+def mock_aurora_client() -> Generator[AsyncMock]:
     """Mock a Homeassistant Analytics client."""
     with (
         patch(

--- a/tests/components/axis/conftest.py
+++ b/tests/components/axis/conftest.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Generator
+from collections.abc import Callable
 from copy import deepcopy
 from types import MappingProxyType
 from typing import Any
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, patch
 from axis.rtsp import Signal, State
 import pytest
 import respx
+from typing_extensions import Generator
 
 from homeassistant.components.axis.const import DOMAIN as AXIS_DOMAIN
 from homeassistant.config_entries import ConfigEntry
@@ -49,7 +50,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.axis.async_setup_entry", return_value=True
@@ -280,7 +281,7 @@ async def setup_config_entry_fixture(
 
 
 @pytest.fixture(autouse=True)
-def mock_axis_rtspclient() -> Generator[Callable[[dict | None, str], None], None, None]:
+def mock_axis_rtspclient() -> Generator[Callable[[dict | None, str], None]]:
     """No real RTSP communication allowed."""
     with patch("axis.stream_manager.RTSPClient") as rtsp_client_mock:
         rtsp_client_mock.return_value.session.state = State.STOPPED

--- a/tests/components/azure_data_explorer/conftest.py
+++ b/tests/components/azure_data_explorer/conftest.py
@@ -1,12 +1,12 @@
 """Test fixtures for Azure Data Explorer."""
 
-from collections.abc import Generator
 from datetime import timedelta
 import logging
 from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.azure_data_explorer.const import (
     CONF_FILTER,
@@ -94,7 +94,7 @@ async def mock_entry_with_one_event(
 
 # Fixtures for config_flow tests
 @pytest.fixture
-def mock_setup_entry() -> Generator[MockConfigEntry, None, None]:
+def mock_setup_entry() -> Generator[MockConfigEntry]:
     """Mock the setup entry call, used for config flow tests."""
     with patch(
         f"{AZURE_DATA_EXPLORER_PATH}.async_setup_entry", return_value=True

--- a/tests/components/azure_devops/conftest.py
+++ b/tests/components/azure_devops/conftest.py
@@ -1,9 +1,9 @@
 """Test fixtures for Azure DevOps."""
 
-from collections.abc import AsyncGenerator, Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from typing_extensions import AsyncGenerator, Generator
 
 from homeassistant.components.azure_devops.const import DOMAIN
 
@@ -13,7 +13,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-async def mock_devops_client() -> AsyncGenerator[MagicMock, None]:
+async def mock_devops_client() -> AsyncGenerator[MagicMock]:
     """Mock the Azure DevOps client."""
 
     with (
@@ -49,7 +49,7 @@ async def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.azure_devops.async_setup_entry",

--- a/tests/components/balboa/conftest.py
+++ b/tests/components/balboa/conftest.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Generator
+from collections.abc import Callable
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from pybalboa.enums import HeatMode, LowHighRange
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.core import HomeAssistant
 
@@ -22,7 +23,7 @@ async def integration_fixture(hass: HomeAssistant) -> MockConfigEntry:
 
 
 @pytest.fixture(name="client")
-def client_fixture() -> Generator[MagicMock, None, None]:
+def client_fixture() -> Generator[MagicMock]:
     """Mock balboa spa client."""
     with patch(
         "homeassistant.components.balboa.SpaClient", autospec=True

--- a/tests/components/bang_olufsen/conftest.py
+++ b/tests/components/bang_olufsen/conftest.py
@@ -1,10 +1,10 @@
 """Test fixtures for bang_olufsen."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 from mozart_api.models import BeolinkPeer
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.bang_olufsen.const import DOMAIN
 
@@ -31,7 +31,7 @@ def mock_config_entry():
 
 
 @pytest.fixture
-def mock_mozart_client() -> Generator[AsyncMock, None, None]:
+def mock_mozart_client() -> Generator[AsyncMock]:
     """Mock MozartClient."""
 
     with (

--- a/tests/components/binary_sensor/test_init.py
+++ b/tests/components/binary_sensor/test_init.py
@@ -1,9 +1,9 @@
 """The tests for the Binary sensor component."""
 
-from collections.abc import Generator
 from unittest import mock
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components import binary_sensor
 from homeassistant.config_entries import ConfigEntry, ConfigFlow
@@ -48,7 +48,7 @@ class MockFlow(ConfigFlow):
 
 
 @pytest.fixture(autouse=True)
-def config_flow_fixture(hass: HomeAssistant) -> Generator[None, None, None]:
+def config_flow_fixture(hass: HomeAssistant) -> Generator[None]:
     """Mock config flow."""
     mock_platform(hass, f"{TEST_DOMAIN}.config_flow")
 

--- a/tests/components/blueprint/common.py
+++ b/tests/components/blueprint/common.py
@@ -1,10 +1,11 @@
 """Blueprints test helpers."""
 
-from collections.abc import Generator
 from unittest.mock import patch
 
+from typing_extensions import Generator
 
-def stub_blueprint_populate_fixture_helper() -> Generator[None, None, None]:
+
+def stub_blueprint_populate_fixture_helper() -> Generator[None]:
     """Stub copying the blueprints to the config folder."""
     with patch(
         "homeassistant.components.blueprint.models.DomainBlueprints.async_populate"

--- a/tests/components/bluetooth/conftest.py
+++ b/tests/components/bluetooth/conftest.py
@@ -1,12 +1,12 @@
 """Tests for the bluetooth component."""
 
-from collections.abc import Generator
 from unittest.mock import patch
 
 from bleak_retry_connector import bleak_manager
 from dbus_fast.aio import message_bus
 import habluetooth.util as habluetooth_utils
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture(name="disable_bluez_manager_socket", autouse=True, scope="package")
@@ -75,7 +75,7 @@ def mock_operating_system_90():
 
 
 @pytest.fixture(name="macos_adapter")
-def macos_adapter() -> Generator[None, None, None]:
+def macos_adapter() -> Generator[None]:
     """Fixture that mocks the macos adapter."""
     with (
         patch("bleak.get_platform_scanner_backend_type"),
@@ -110,7 +110,7 @@ def windows_adapter():
 
 
 @pytest.fixture(name="no_adapters")
-def no_adapter_fixture() -> Generator[None, None, None]:
+def no_adapter_fixture() -> Generator[None]:
     """Fixture that mocks no adapters on Linux."""
     with (
         patch(
@@ -138,7 +138,7 @@ def no_adapter_fixture() -> Generator[None, None, None]:
 
 
 @pytest.fixture(name="one_adapter")
-def one_adapter_fixture() -> Generator[None, None, None]:
+def one_adapter_fixture() -> Generator[None]:
     """Fixture that mocks one adapter on Linux."""
     with (
         patch(
@@ -177,7 +177,7 @@ def one_adapter_fixture() -> Generator[None, None, None]:
 
 
 @pytest.fixture(name="two_adapters")
-def two_adapters_fixture() -> Generator[None, None, None]:
+def two_adapters_fixture() -> Generator[None]:
     """Fixture that mocks two adapters on Linux."""
     with (
         patch(

--- a/tests/components/bluetooth/test_manager.py
+++ b/tests/components/bluetooth/test_manager.py
@@ -1,6 +1,5 @@
 """Tests for the Bluetooth integration manager."""
 
-from collections.abc import Generator
 from datetime import timedelta
 import time
 from typing import Any
@@ -10,6 +9,7 @@ from bleak.backends.scanner import AdvertisementData, BLEDevice
 from bluetooth_adapters import AdvertisementHistory
 from habluetooth.advertisement_tracker import TRACKER_BUFFERING_WOBBLE_SECONDS
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components import bluetooth
 from homeassistant.components.bluetooth import (
@@ -54,7 +54,7 @@ from tests.common import async_fire_time_changed, load_fixture
 
 
 @pytest.fixture
-def register_hci0_scanner(hass: HomeAssistant) -> Generator[None, None, None]:
+def register_hci0_scanner(hass: HomeAssistant) -> Generator[None]:
     """Register an hci0 scanner."""
     hci0_scanner = FakeScanner("hci0", "hci0")
     cancel = bluetooth.async_register_scanner(hass, hci0_scanner)
@@ -63,7 +63,7 @@ def register_hci0_scanner(hass: HomeAssistant) -> Generator[None, None, None]:
 
 
 @pytest.fixture
-def register_hci1_scanner(hass: HomeAssistant) -> Generator[None, None, None]:
+def register_hci1_scanner(hass: HomeAssistant) -> Generator[None]:
     """Register an hci1 scanner."""
     hci1_scanner = FakeScanner("hci1", "hci1")
     cancel = bluetooth.async_register_scanner(hass, hci1_scanner)

--- a/tests/components/bmw_connected_drive/conftest.py
+++ b/tests/components/bmw_connected_drive/conftest.py
@@ -1,18 +1,17 @@
 """Fixtures for BMW tests."""
 
-from collections.abc import Generator
-
 from bimmer_connected.tests import ALL_CHARGING_SETTINGS, ALL_PROFILES, ALL_STATES
 from bimmer_connected.tests.common import MyBMWMockRouter
 from bimmer_connected.vehicle import remote_services
 import pytest
 import respx
+from typing_extensions import Generator
 
 
 @pytest.fixture
 def bmw_fixture(
     request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
-) -> Generator[respx.MockRouter, None, None]:
+) -> Generator[respx.MockRouter]:
     """Patch MyBMW login API calls."""
 
     # we use the library's mock router to mock the API calls, but only with a subset of vehicles

--- a/tests/components/braviatv/conftest.py
+++ b/tests/components/braviatv/conftest.py
@@ -1,13 +1,13 @@
 """Test fixtures for Bravia TV."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.braviatv.async_setup_entry", return_value=True

--- a/tests/components/bring/conftest.py
+++ b/tests/components/bring/conftest.py
@@ -1,9 +1,9 @@
 """Common fixtures for the Bring! tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.bring import DOMAIN
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
@@ -17,7 +17,7 @@ UUID = "00000000-00000000-00000000-00000000"
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.bring.async_setup_entry", return_value=True
@@ -26,7 +26,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_bring_client() -> Generator[AsyncMock, None, None]:
+def mock_bring_client() -> Generator[AsyncMock]:
     """Mock a Bring client."""
     with (
         patch(

--- a/tests/components/brother/conftest.py
+++ b/tests/components/brother/conftest.py
@@ -1,11 +1,11 @@
 """Test fixtures for brother."""
 
-from collections.abc import Generator
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
 from brother import BrotherSensors
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.brother.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_TYPE
@@ -78,7 +78,7 @@ BROTHER_DATA = BrotherSensors(
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.brother.async_setup_entry", return_value=True
@@ -87,7 +87,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_brother_client() -> Generator[AsyncMock, None, None]:
+def mock_brother_client() -> Generator[AsyncMock]:
     """Mock Brother client."""
     with (
         patch("homeassistant.components.brother.Brother", autospec=True) as mock_client,

--- a/tests/components/brottsplatskartan/conftest.py
+++ b/tests/components/brottsplatskartan/conftest.py
@@ -1,13 +1,13 @@
 """Test fixtures for Brottplatskartan."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.brottsplatskartan.async_setup_entry",
@@ -17,7 +17,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture(autouse=True)
-def uuid_generator() -> Generator[AsyncMock, None, None]:
+def uuid_generator() -> Generator[AsyncMock]:
     """Generate uuid for app-id."""
     with patch(
         "homeassistant.components.brottsplatskartan.config_flow.uuid.getnode",

--- a/tests/components/brunt/conftest.py
+++ b/tests/components/brunt/conftest.py
@@ -1,13 +1,13 @@
 """Configuration for brunt tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.brunt.async_setup_entry", return_value=True

--- a/tests/components/bsblan/conftest.py
+++ b/tests/components/bsblan/conftest.py
@@ -1,10 +1,10 @@
 """Fixtures for BSBLAN integration tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from bsblan import Device, Info, State
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.bsblan.const import CONF_PASSKEY, DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
@@ -31,7 +31,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.bsblan.async_setup_entry", return_value=True

--- a/tests/components/buienradar/conftest.py
+++ b/tests/components/buienradar/conftest.py
@@ -1,13 +1,13 @@
 """Test fixtures for buienradar2."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.buienradar.async_setup_entry", return_value=True

--- a/tests/components/button/test_init.py
+++ b/tests/components/button/test_init.py
@@ -1,11 +1,11 @@
 """The tests for the Button component."""
 
-from collections.abc import Generator
 from datetime import timedelta
 from unittest.mock import MagicMock
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.button import (
     DOMAIN,
@@ -121,7 +121,7 @@ class MockFlow(ConfigFlow):
 
 
 @pytest.fixture(autouse=True)
-def config_flow_fixture(hass: HomeAssistant) -> Generator[None, None, None]:
+def config_flow_fixture(hass: HomeAssistant) -> Generator[None]:
     """Mock config flow."""
     mock_platform(hass, f"{TEST_DOMAIN}.config_flow")
 

--- a/tests/components/caldav/test_config_flow.py
+++ b/tests/components/caldav/test_config_flow.py
@@ -1,11 +1,11 @@
 """Test the CalDAV config flow."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, Mock, patch
 
 from caldav.lib.error import AuthorizationError, DAVError
 import pytest
 import requests
+from typing_extensions import Generator
 
 from homeassistant import config_entries
 from homeassistant.components.caldav.const import DOMAIN
@@ -19,7 +19,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         f"homeassistant.components.{DOMAIN}.async_setup_entry", return_value=True

--- a/tests/components/calendar/conftest.py
+++ b/tests/components/calendar/conftest.py
@@ -1,12 +1,12 @@
 """Test fixtures for calendar sensor platforms."""
 
-from collections.abc import Generator
 import datetime
 import secrets
 from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.calendar import DOMAIN, CalendarEntity, CalendarEvent
 from homeassistant.config_entries import ConfigEntry, ConfigFlow
@@ -92,7 +92,7 @@ class MockCalendarEntity(CalendarEntity):
 
 
 @pytest.fixture
-def config_flow_fixture(hass: HomeAssistant) -> Generator[None, None, None]:
+def config_flow_fixture(hass: HomeAssistant) -> Generator[None]:
     """Mock config flow."""
     mock_platform(hass, f"{TEST_DOMAIN}.config_flow")
 

--- a/tests/components/calendar/test_init.py
+++ b/tests/components/calendar/test_init.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from datetime import timedelta
 from http import HTTPStatus
 from typing import Any
@@ -10,6 +9,7 @@ from typing import Any
 from freezegun import freeze_time
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from typing_extensions import Generator
 import voluptuous as vol
 
 from homeassistant.components.calendar import (
@@ -37,7 +37,7 @@ def mock_frozen_time() -> None:
 
 
 @pytest.fixture(autouse=True)
-def mock_set_frozen_time(frozen_time: Any) -> Generator[None, None, None]:
+def mock_set_frozen_time(frozen_time: Any) -> Generator[None]:
     """Fixture to freeze time that also can work for other fixtures."""
     if not frozen_time:
         yield

--- a/tests/components/calendar/test_trigger.py
+++ b/tests/components/calendar/test_trigger.py
@@ -9,7 +9,7 @@ forward exercising the triggers.
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Callable, Generator
+from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 import datetime
 import logging
@@ -19,6 +19,7 @@ import zoneinfo
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components import automation, calendar
 from homeassistant.components.calendar.trigger import EVENT_END, EVENT_START
@@ -86,7 +87,7 @@ class FakeSchedule:
 @pytest.fixture
 def fake_schedule(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory
-) -> Generator[FakeSchedule, None, None]:
+) -> Generator[FakeSchedule]:
     """Fixture that tests can use to make fake events."""
 
     # Setup start time for all tests
@@ -161,7 +162,7 @@ def calls_data(hass: HomeAssistant) -> Callable[[], list[dict[str, Any]]]:
 
 
 @pytest.fixture(autouse=True)
-def mock_update_interval() -> Generator[None, None, None]:
+def mock_update_interval() -> Generator[None]:
     """Fixture to override the update interval for refreshing events."""
     with patch(
         "homeassistant.components.calendar.trigger.UPDATE_INTERVAL",

--- a/tests/components/ccm15/conftest.py
+++ b/tests/components/ccm15/conftest.py
@@ -1,14 +1,14 @@
 """Common fixtures for the Midea ccm15 AC Controller tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 from ccm15 import CCM15DeviceState, CCM15SlaveDevice
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.ccm15.async_setup_entry", return_value=True
@@ -17,7 +17,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def ccm15_device() -> Generator[AsyncMock, None, None]:
+def ccm15_device() -> Generator[AsyncMock]:
     """Mock ccm15 device."""
     ccm15_devices = {
         0: CCM15SlaveDevice(bytes.fromhex("000000b0b8001b")),
@@ -32,7 +32,7 @@ def ccm15_device() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def network_failure_ccm15_device() -> Generator[AsyncMock, None, None]:
+def network_failure_ccm15_device() -> Generator[AsyncMock]:
     """Mock empty set of ccm15 device."""
     device_state = CCM15DeviceState(devices={})
     with patch(

--- a/tests/components/cert_expiry/conftest.py
+++ b/tests/components/cert_expiry/conftest.py
@@ -1,13 +1,13 @@
 """Configuration for cert_expiry tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.cert_expiry.async_setup_entry", return_value=True

--- a/tests/components/climate/conftest.py
+++ b/tests/components/climate/conftest.py
@@ -1,8 +1,7 @@
 """Fixtures for Climate platform tests."""
 
-from collections.abc import Generator
-
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.core import HomeAssistant
@@ -15,7 +14,7 @@ class MockFlow(ConfigFlow):
 
 
 @pytest.fixture
-def config_flow_fixture(hass: HomeAssistant) -> Generator[None, None, None]:
+def config_flow_fixture(hass: HomeAssistant) -> Generator[None]:
     """Mock config flow."""
     mock_platform(hass, "test.config_flow")
 

--- a/tests/components/climate/test_intent.py
+++ b/tests/components/climate/test_intent.py
@@ -1,9 +1,9 @@
 """Test climate intents."""
 
-from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.climate import (
     DOMAIN,
@@ -34,7 +34,7 @@ class MockFlow(ConfigFlow):
 
 
 @pytest.fixture(autouse=True)
-def config_flow_fixture(hass: HomeAssistant) -> Generator[None, None, None]:
+def config_flow_fixture(hass: HomeAssistant) -> Generator[None]:
     """Mock config flow."""
     mock_platform(hass, f"{TEST_DOMAIN}.config_flow")
 

--- a/tests/components/cloud/conftest.py
+++ b/tests/components/cloud/conftest.py
@@ -1,6 +1,6 @@
 """Fixtures for cloud tests."""
 
-from collections.abc import AsyncGenerator, Callable, Coroutine
+from collections.abc import Callable, Coroutine
 from pathlib import Path
 from typing import Any
 from unittest.mock import DEFAULT, MagicMock, PropertyMock, patch
@@ -15,6 +15,7 @@ from hass_nabucasa.remote import RemoteUI
 from hass_nabucasa.voice import Voice
 import jwt
 import pytest
+from typing_extensions import AsyncGenerator
 
 from homeassistant.components.cloud import CloudClient, const, prefs
 from homeassistant.core import HomeAssistant
@@ -34,7 +35,7 @@ async def load_homeassistant(hass: HomeAssistant) -> None:
 
 
 @pytest.fixture(name="cloud")
-async def cloud_fixture() -> AsyncGenerator[MagicMock, None]:
+async def cloud_fixture() -> AsyncGenerator[MagicMock]:
     """Mock the cloud object.
 
     See the real hass_nabucasa.Cloud class for how to configure the mock.

--- a/tests/components/cloud/test_binary_sensor.py
+++ b/tests/components/cloud/test_binary_sensor.py
@@ -1,10 +1,10 @@
 """Tests for the cloud binary sensor."""
 
-from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 from hass_nabucasa.const import DISPATCH_REMOTE_CONNECT, DISPATCH_REMOTE_DISCONNECT
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import EntityRegistry
@@ -12,7 +12,7 @@ from homeassistant.setup import async_setup_component
 
 
 @pytest.fixture(autouse=True)
-def mock_wait_until() -> Generator[None, None, None]:
+def mock_wait_until() -> Generator[None]:
     """Mock WAIT_UNTIL_CHANGE to execute callback immediately."""
     with patch("homeassistant.components.cloud.binary_sensor.WAIT_UNTIL_CHANGE", 0):
         yield

--- a/tests/components/cloud/test_stt.py
+++ b/tests/components/cloud/test_stt.py
@@ -1,6 +1,5 @@
 """Test the speech-to-text platform for the cloud integration."""
 
-from collections.abc import AsyncGenerator
 from copy import deepcopy
 from http import HTTPStatus
 from typing import Any
@@ -8,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from hass_nabucasa.voice import STTResponse, VoiceError
 import pytest
+from typing_extensions import AsyncGenerator
 
 from homeassistant.components.assist_pipeline.pipeline import STORAGE_KEY
 from homeassistant.components.cloud import DOMAIN
@@ -21,7 +21,7 @@ from tests.typing import ClientSessionGenerator
 
 
 @pytest.fixture(autouse=True)
-async def delay_save_fixture() -> AsyncGenerator[None, None]:
+async def delay_save_fixture() -> AsyncGenerator[None]:
     """Load the homeassistant integration."""
     with patch("homeassistant.helpers.collection.SAVE_DELAY", new=0):
         yield

--- a/tests/components/cloud/test_tts.py
+++ b/tests/components/cloud/test_tts.py
@@ -1,6 +1,6 @@
 """Tests for cloud tts."""
 
-from collections.abc import AsyncGenerator, Callable, Coroutine
+from collections.abc import Callable, Coroutine
 from copy import deepcopy
 from http import HTTPStatus
 from typing import Any
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from hass_nabucasa.voice import TTS_VOICES, VoiceError, VoiceTokenError
 import pytest
+from typing_extensions import AsyncGenerator
 import voluptuous as vol
 
 from homeassistant.components.assist_pipeline.pipeline import STORAGE_KEY
@@ -39,7 +40,7 @@ from tests.typing import ClientSessionGenerator
 
 
 @pytest.fixture(autouse=True)
-async def delay_save_fixture() -> AsyncGenerator[None, None]:
+async def delay_save_fixture() -> AsyncGenerator[None]:
     """Load the homeassistant integration."""
     with patch("homeassistant.helpers.collection.SAVE_DELAY", new=0):
         yield

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Generator
+from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
@@ -21,7 +22,7 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture(scope="session", autouse=True)
-def patch_zeroconf_multiple_catcher() -> Generator[None, None, None]:
+def patch_zeroconf_multiple_catcher() -> Generator[None]:
     """Patch zeroconf wrapper that detects if multiple instances are used."""
     with patch(
         "homeassistant.components.zeroconf.install_multiple_zeroconf_catcher",
@@ -31,7 +32,7 @@ def patch_zeroconf_multiple_catcher() -> Generator[None, None, None]:
 
 
 @pytest.fixture(scope="session", autouse=True)
-def prevent_io() -> Generator[None, None, None]:
+def prevent_io() -> Generator[None]:
     """Fixture to prevent certain I/O from happening."""
     with patch(
         "homeassistant.components.http.ban.load_yaml_config_file",
@@ -40,7 +41,7 @@ def prevent_io() -> Generator[None, None, None]:
 
 
 @pytest.fixture
-def entity_registry_enabled_by_default() -> Generator[None, None, None]:
+def entity_registry_enabled_by_default() -> Generator[None]:
     """Test fixture that ensures all entities are enabled in the registry."""
     with patch(
         "homeassistant.helpers.entity.Entity.entity_registry_enabled_default",
@@ -51,7 +52,7 @@ def entity_registry_enabled_by_default() -> Generator[None, None, None]:
 
 # Blueprint test fixtures
 @pytest.fixture(name="stub_blueprint_populate")
-def stub_blueprint_populate_fixture() -> Generator[None, None, None]:
+def stub_blueprint_populate_fixture() -> Generator[None]:
     """Stub copying the blueprints to the config folder."""
     from tests.components.blueprint.common import stub_blueprint_populate_fixture_helper
 
@@ -60,7 +61,7 @@ def stub_blueprint_populate_fixture() -> Generator[None, None, None]:
 
 # TTS test fixtures
 @pytest.fixture(name="mock_tts_get_cache_files")
-def mock_tts_get_cache_files_fixture() -> Generator[MagicMock, None, None]:
+def mock_tts_get_cache_files_fixture() -> Generator[MagicMock]:
     """Mock the list TTS cache function."""
     from tests.components.tts.common import mock_tts_get_cache_files_fixture_helper
 
@@ -70,7 +71,7 @@ def mock_tts_get_cache_files_fixture() -> Generator[MagicMock, None, None]:
 @pytest.fixture(name="mock_tts_init_cache_dir")
 def mock_tts_init_cache_dir_fixture(
     init_tts_cache_dir_side_effect: Any,
-) -> Generator[MagicMock, None, None]:
+) -> Generator[MagicMock]:
     """Mock the TTS cache dir in memory."""
     from tests.components.tts.common import mock_tts_init_cache_dir_fixture_helper
 
@@ -93,7 +94,7 @@ def mock_tts_cache_dir_fixture(
     mock_tts_init_cache_dir: MagicMock,
     mock_tts_get_cache_files: MagicMock,
     request: pytest.FixtureRequest,
-) -> Generator[Path, None, None]:
+) -> Generator[Path]:
     """Mock the TTS cache dir with empty dir."""
     from tests.components.tts.common import mock_tts_cache_dir_fixture_helper
 
@@ -103,7 +104,7 @@ def mock_tts_cache_dir_fixture(
 
 
 @pytest.fixture(name="tts_mutagen_mock")
-def tts_mutagen_mock_fixture() -> Generator[MagicMock, None, None]:
+def tts_mutagen_mock_fixture() -> Generator[MagicMock]:
     """Mock writing tags."""
     from tests.components.tts.common import tts_mutagen_mock_fixture_helper
 
@@ -121,7 +122,7 @@ def mock_conversation_agent_fixture(hass: HomeAssistant) -> MockAgent:
 
 
 @pytest.fixture(scope="session", autouse=True)
-def prevent_ffmpeg_subprocess() -> Generator[None, None, None]:
+def prevent_ffmpeg_subprocess() -> Generator[None]:
     """Prevent ffmpeg from creating a subprocess."""
     with patch(
         "homeassistant.components.ffmpeg.FFVersion.get_version", return_value="6.0"

--- a/tests/components/cpuspeed/conftest.py
+++ b/tests/components/cpuspeed/conftest.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.cpuspeed.const import DOMAIN
 from homeassistant.core import HomeAssistant
@@ -25,7 +25,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_cpuinfo_config_flow() -> Generator[MagicMock, None, None]:
+def mock_cpuinfo_config_flow() -> Generator[MagicMock]:
     """Return a mocked get_cpu_info.
 
     It is only used to check truthy or falsy values, so it is mocked
@@ -39,7 +39,7 @@ def mock_cpuinfo_config_flow() -> Generator[MagicMock, None, None]:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.cpuspeed.async_setup_entry", return_value=True
@@ -48,7 +48,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_cpuinfo() -> Generator[MagicMock, None, None]:
+def mock_cpuinfo() -> Generator[MagicMock]:
     """Return a mocked get_cpu_info."""
     info = {
         "hz_actual": (3200000001, 0),

--- a/tests/components/crownstone/test_config_flow.py
+++ b/tests/components/crownstone/test_config_flow.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from crownstone_cloud.cloud_models.spheres import Spheres
@@ -12,6 +11,7 @@ from crownstone_cloud.exceptions import (
 )
 import pytest
 from serial.tools.list_ports_common import ListPortInfo
+from typing_extensions import Generator
 
 from homeassistant.components import usb
 from homeassistant.components.crownstone.const import (
@@ -30,7 +30,7 @@ from homeassistant.data_entry_flow import FlowResultType
 
 from tests.common import MockConfigEntry
 
-type MockFixture = Generator[MagicMock | AsyncMock, None, None]
+type MockFixture = Generator[MagicMock | AsyncMock]
 
 
 @pytest.fixture(name="crownstone_setup")

--- a/tests/components/device_tracker/test_config_entry.py
+++ b/tests/components/device_tracker/test_config_entry.py
@@ -1,9 +1,9 @@
 """Test Device Tracker config entry things."""
 
-from collections.abc import Generator
 from typing import Any
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.device_tracker import (
     ATTR_HOST_NAME,
@@ -55,7 +55,7 @@ class MockFlow(ConfigFlow):
 
 
 @pytest.fixture(autouse=True)
-def config_flow_fixture(hass: HomeAssistant) -> Generator[None, None, None]:
+def config_flow_fixture(hass: HomeAssistant) -> Generator[None]:
     """Mock config flow."""
     mock_platform(hass, f"{TEST_DOMAIN}.config_flow")
 

--- a/tests/components/devolo_home_control/conftest.py
+++ b/tests/components/devolo_home_control/conftest.py
@@ -1,9 +1,9 @@
 """Fixtures for tests."""
 
-from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
@@ -19,9 +19,7 @@ def maintenance() -> bool:
 
 
 @pytest.fixture(autouse=True)
-def patch_mydevolo(
-    credentials_valid: bool, maintenance: bool
-) -> Generator[None, None, None]:
+def patch_mydevolo(credentials_valid: bool, maintenance: bool) -> Generator[None]:
     """Fixture to patch mydevolo into a desired state."""
     with (
         patch(

--- a/tests/components/discovergy/conftest.py
+++ b/tests/components/discovergy/conftest.py
@@ -1,10 +1,10 @@
 """Fixtures for Discovergy integration tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 from pydiscovergy.models import Reading
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.discovergy.const import DOMAIN
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
@@ -25,7 +25,7 @@ def _meter_last_reading(meter_id: str) -> Reading:
 
 
 @pytest.fixture(name="discovergy")
-def mock_discovergy() -> Generator[AsyncMock, None, None]:
+def mock_discovergy() -> Generator[AsyncMock]:
     """Mock the pydiscovergy client."""
     with (
         patch(

--- a/tests/components/dlink/conftest.py
+++ b/tests/components/dlink/conftest.py
@@ -1,10 +1,11 @@
 """Configure pytest for D-Link tests."""
 
-from collections.abc import Awaitable, Callable, Generator
+from collections.abc import Awaitable, Callable
 from copy import deepcopy
 from unittest.mock import MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components import dhcp
 from homeassistant.components.dlink.const import CONF_USE_LEGACY_PROTOCOL, DOMAIN
@@ -130,7 +131,7 @@ async def setup_integration(
     hass: HomeAssistant,
     config_entry_with_uid: MockConfigEntry,
     mocked_plug: MagicMock,
-) -> Generator[ComponentSetup, None, None]:
+) -> Generator[ComponentSetup]:
     """Set up the D-Link integration in Home Assistant."""
 
     async def func() -> None:
@@ -144,7 +145,7 @@ async def setup_integration_legacy(
     hass: HomeAssistant,
     config_entry_with_uid: MockConfigEntry,
     mocked_plug_legacy: MagicMock,
-) -> Generator[ComponentSetup, None, None]:
+) -> Generator[ComponentSetup]:
     """Set up the D-Link integration in Home Assistant with different data."""
 
     async def func() -> None:

--- a/tests/components/duotecno/conftest.py
+++ b/tests/components/duotecno/conftest.py
@@ -1,13 +1,13 @@
 """Common fixtures for the duotecno tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.duotecno.async_setup_entry", return_value=True

--- a/tests/components/dwd_weather_warnings/conftest.py
+++ b/tests/components/dwd_weather_warnings/conftest.py
@@ -1,9 +1,9 @@
 """Configuration for Deutscher Wetterdienst (DWD) Weather Warnings tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.dwd_weather_warnings.const import (
     ADVANCE_WARNING_SENSOR,
@@ -23,7 +23,7 @@ MOCK_CONDITIONS = [CURRENT_WARNING_SENSOR, ADVANCE_WARNING_SENSOR]
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.dwd_weather_warnings.async_setup_entry",
@@ -59,7 +59,7 @@ def mock_tracker_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_dwdwfsapi() -> Generator[MagicMock, None, None]:
+def mock_dwdwfsapi() -> Generator[MagicMock]:
     """Return a mocked dwdwfsapi API client."""
     with (
         patch(

--- a/tests/components/easyenergy/conftest.py
+++ b/tests/components/easyenergy/conftest.py
@@ -1,11 +1,11 @@
 """Fixtures for easyEnergy integration tests."""
 
-from collections.abc import Generator
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from easyenergy import Electricity, Gas
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.easyenergy.const import DOMAIN
 from homeassistant.core import HomeAssistant
@@ -14,7 +14,7 @@ from tests.common import MockConfigEntry, load_fixture
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.easyenergy.async_setup_entry", return_value=True
@@ -34,7 +34,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_easyenergy() -> Generator[MagicMock, None, None]:
+def mock_easyenergy() -> Generator[MagicMock]:
     """Return a mocked easyEnergy client."""
     with patch(
         "homeassistant.components.easyenergy.coordinator.EasyEnergy", autospec=True

--- a/tests/components/ecoforest/conftest.py
+++ b/tests/components/ecoforest/conftest.py
@@ -1,10 +1,10 @@
 """Common fixtures for the Ecoforest tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, Mock, patch
 
 from pyecoforest.models.device import Alarm, Device, OperationMode, State
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.ecoforest import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
@@ -14,7 +14,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.ecoforest.async_setup_entry", return_value=True

--- a/tests/components/ecovacs/conftest.py
+++ b/tests/components/ecovacs/conftest.py
@@ -1,6 +1,5 @@
 """Common fixtures for the Ecovacs tests."""
 
-from collections.abc import AsyncGenerator, Generator
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -10,6 +9,7 @@ from deebot_client.device import Device
 from deebot_client.exceptions import ApiError
 from deebot_client.models import Credentials
 import pytest
+from typing_extensions import AsyncGenerator, Generator
 
 from homeassistant.components.ecovacs import PLATFORMS
 from homeassistant.components.ecovacs.const import DOMAIN
@@ -23,7 +23,7 @@ from tests.common import MockConfigEntry, load_json_object_fixture
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.ecovacs.async_setup_entry", return_value=True
@@ -54,7 +54,7 @@ def device_fixture() -> str:
 
 
 @pytest.fixture
-def mock_authenticator(device_fixture: str) -> Generator[Mock, None, None]:
+def mock_authenticator(device_fixture: str) -> Generator[Mock]:
     """Mock the authenticator."""
     with (
         patch(
@@ -99,7 +99,7 @@ def mock_authenticator_authenticate(mock_authenticator: Mock) -> AsyncMock:
 
 
 @pytest.fixture
-def mock_mqtt_client(mock_authenticator: Mock) -> Generator[Mock, None, None]:
+def mock_mqtt_client(mock_authenticator: Mock) -> Generator[Mock]:
     """Mock the MQTT client."""
     with (
         patch(
@@ -118,7 +118,7 @@ def mock_mqtt_client(mock_authenticator: Mock) -> Generator[Mock, None, None]:
 
 
 @pytest.fixture
-def mock_device_execute() -> Generator[AsyncMock, None, None]:
+def mock_device_execute() -> Generator[AsyncMock]:
     """Mock the device execute function."""
     with patch.object(
         Device,
@@ -142,7 +142,7 @@ async def init_integration(
     mock_mqtt_client: Mock,
     mock_device_execute: AsyncMock,
     platforms: Platform | list[Platform],
-) -> AsyncGenerator[MockConfigEntry, None]:
+) -> AsyncGenerator[MockConfigEntry]:
     """Set up the Ecovacs integration for testing."""
     if not isinstance(platforms, list):
         platforms = [platforms]

--- a/tests/components/edl21/conftest.py
+++ b/tests/components/edl21/conftest.py
@@ -1,13 +1,13 @@
 """Define test fixtures for EDL21."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.edl21.async_setup_entry", return_value=True

--- a/tests/components/electric_kiwi/conftest.py
+++ b/tests/components/electric_kiwi/conftest.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Generator
+from collections.abc import Awaitable, Callable
 from time import time
 from unittest.mock import AsyncMock, patch
 
 from electrickiwi_api.model import AccountBalance, Hop, HopIntervals
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.application_credentials import (
     ClientCredential,
@@ -23,7 +24,7 @@ CLIENT_ID = "1234"
 CLIENT_SECRET = "5678"
 REDIRECT_URI = "https://example.com/auth/external/callback"
 
-type YieldFixture = Generator[AsyncMock, None, None]
+type YieldFixture = Generator[AsyncMock]
 type ComponentSetup = Callable[[], Awaitable[bool]]
 
 
@@ -79,7 +80,7 @@ def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.electric_kiwi.async_setup_entry", return_value=True

--- a/tests/components/elgato/conftest.py
+++ b/tests/components/elgato/conftest.py
@@ -1,10 +1,10 @@
 """Fixtures for Elgato integration tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from elgato import BatteryInfo, ElgatoNoBatteryError, Info, Settings, State
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.elgato.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_PORT
@@ -42,7 +42,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.elgato.async_setup_entry", return_value=True

--- a/tests/components/elmax/conftest.py
+++ b/tests/components/elmax/conftest.py
@@ -1,6 +1,5 @@
 """Configuration for Elmax tests."""
 
-from collections.abc import Generator
 import json
 from unittest.mock import AsyncMock, patch
 
@@ -13,6 +12,7 @@ from elmax_api.constants import (
 from httpx import Response
 import pytest
 import respx
+from typing_extensions import Generator
 
 from . import (
     MOCK_DIRECT_HOST,
@@ -30,7 +30,7 @@ MOCK_DIRECT_BASE_URI = (
 
 
 @pytest.fixture(autouse=True)
-def httpx_mock_cloud_fixture() -> Generator[respx.MockRouter, None, None]:
+def httpx_mock_cloud_fixture() -> Generator[respx.MockRouter]:
     """Configure httpx fixture for cloud API communication."""
     with respx.mock(base_url=BASE_URL, assert_all_called=False) as respx_mock:
         # Mock Login POST.
@@ -57,7 +57,7 @@ def httpx_mock_cloud_fixture() -> Generator[respx.MockRouter, None, None]:
 
 
 @pytest.fixture(autouse=True)
-def httpx_mock_direct_fixture() -> Generator[respx.MockRouter, None, None]:
+def httpx_mock_direct_fixture() -> Generator[respx.MockRouter]:
     """Configure httpx fixture for direct Panel-API communication."""
     with respx.mock(
         base_url=MOCK_DIRECT_BASE_URI, assert_all_called=False
@@ -80,7 +80,7 @@ def httpx_mock_direct_fixture() -> Generator[respx.MockRouter, None, None]:
 
 
 @pytest.fixture(autouse=True)
-def elmax_mock_direct_cert() -> Generator[AsyncMock, None, None]:
+def elmax_mock_direct_cert() -> Generator[AsyncMock]:
     """Patch elmax library to return a specific PEM for SSL communication."""
     with patch(
         "elmax_api.http.GenericElmax.retrieve_server_certificate",

--- a/tests/components/elvia/conftest.py
+++ b/tests/components/elvia/conftest.py
@@ -1,13 +1,13 @@
 """Common fixtures for the Elvia tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.elvia.async_setup_entry", return_value=True

--- a/tests/components/emulated_hue/test_upnp.py
+++ b/tests/components/emulated_hue/test_upnp.py
@@ -1,7 +1,6 @@
 """The tests for the emulated Hue component."""
 
 from asyncio import AbstractEventLoop
-from collections.abc import Generator
 from http import HTTPStatus
 import json
 import unittest
@@ -11,6 +10,7 @@ from aiohttp import web
 from aiohttp.test_utils import TestClient
 import defusedxml.ElementTree as ET
 import pytest
+from typing_extensions import Generator
 
 from homeassistant import setup
 from homeassistant.components import emulated_hue
@@ -49,7 +49,7 @@ def aiohttp_client(
 @pytest.fixture
 def hue_client(
     aiohttp_client: ClientSessionGenerator,
-) -> Generator[TestClient, None, None]:
+) -> Generator[TestClient]:
     """Return a hue API client."""
     app = web.Application()
     with unittest.mock.patch(

--- a/tests/components/energenie_power_sockets/conftest.py
+++ b/tests/components/energenie_power_sockets/conftest.py
@@ -1,11 +1,11 @@
 """Configure tests for Energenie-Power-Sockets."""
 
-from collections.abc import Generator
 from typing import Final
 from unittest.mock import MagicMock, patch
 
 from pyegps.fakes.powerstrip import FakePowerStrip
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.energenie_power_sockets.const import (
     CONF_DEVICE_API_ID,
@@ -58,7 +58,7 @@ def get_pyegps_device_mock() -> MagicMock:
 
 
 @pytest.fixture(name="mock_get_device")
-def patch_get_device(pyegps_device_mock: MagicMock) -> Generator[MagicMock, None, None]:
+def patch_get_device(pyegps_device_mock: MagicMock) -> Generator[MagicMock]:
     """Fixture to patch the `get_device` api method."""
     with (
         patch("homeassistant.components.energenie_power_sockets.get_device") as m1,
@@ -74,7 +74,7 @@ def patch_get_device(pyegps_device_mock: MagicMock) -> Generator[MagicMock, None
 @pytest.fixture(name="mock_search_for_devices")
 def patch_search_devices(
     pyegps_device_mock: MagicMock,
-) -> Generator[MagicMock, None, None]:
+) -> Generator[MagicMock]:
     """Fixture to patch the `search_for_devices` api method."""
     with patch(
         "homeassistant.components.energenie_power_sockets.config_flow.search_for_devices",

--- a/tests/components/energyzero/conftest.py
+++ b/tests/components/energyzero/conftest.py
@@ -1,11 +1,11 @@
 """Fixtures for EnergyZero integration tests."""
 
-from collections.abc import Generator
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from energyzero import Electricity, Gas
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.energyzero.const import DOMAIN
 from homeassistant.core import HomeAssistant
@@ -14,7 +14,7 @@ from tests.common import MockConfigEntry, load_fixture
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.energyzero.async_setup_entry", return_value=True
@@ -34,7 +34,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_energyzero() -> Generator[MagicMock, None, None]:
+def mock_energyzero() -> Generator[MagicMock]:
     """Return a mocked EnergyZero client."""
     with patch(
         "homeassistant.components.energyzero.coordinator.EnergyZero", autospec=True

--- a/tests/components/event/test_init.py
+++ b/tests/components/event/test_init.py
@@ -1,10 +1,10 @@
 """The tests for the event integration."""
 
-from collections.abc import Generator
 from typing import Any
 
 from freezegun import freeze_time
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.event import (
     ATTR_EVENT_TYPE,
@@ -238,7 +238,7 @@ class MockFlow(ConfigFlow):
 
 
 @pytest.fixture
-def config_flow_fixture(hass: HomeAssistant) -> Generator[None, None, None]:
+def config_flow_fixture(hass: HomeAssistant) -> Generator[None]:
     """Mock config flow."""
     mock_platform(hass, f"{TEST_DOMAIN}.config_flow")
 

--- a/tests/components/fibaro/conftest.py
+++ b/tests/components/fibaro/conftest.py
@@ -1,9 +1,9 @@
 """Test helpers."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.fibaro import CONF_IMPORT_PLUGINS, DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME
@@ -21,7 +21,7 @@ TEST_MODEL = "HC3"
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.fibaro.async_setup_entry", return_value=True
@@ -66,7 +66,7 @@ def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_fibaro_client() -> Generator[Mock, None, None]:
+def mock_fibaro_client() -> Generator[Mock]:
     """Return a mocked FibaroClient."""
     info_mock = Mock()
     info_mock.serial_number = TEST_SERIALNUMBER

--- a/tests/components/file/conftest.py
+++ b/tests/components/file/conftest.py
@@ -1,15 +1,15 @@
 """Test fixtures for file platform."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.core import HomeAssistant
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.file.async_setup_entry", return_value=True

--- a/tests/components/filesize/conftest.py
+++ b/tests/components/filesize/conftest.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.filesize.const import DOMAIN
 from homeassistant.const import CONF_FILE_PATH
@@ -29,7 +29,7 @@ def mock_config_entry(tmp_path: Path) -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[None, None, None]:
+def mock_setup_entry() -> Generator[None]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.filesize.async_setup_entry", return_value=True

--- a/tests/components/fitbit/conftest.py
+++ b/tests/components/fitbit/conftest.py
@@ -1,6 +1,6 @@
 """Test fixtures for fitbit."""
 
-from collections.abc import Awaitable, Callable, Generator
+from collections.abc import Awaitable, Callable
 import datetime
 from http import HTTPStatus
 import time
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 import pytest
 from requests_mock.mocker import Mocker
+from typing_extensions import Generator
 
 from homeassistant.components.application_credentials import (
     ClientCredential,
@@ -122,7 +123,7 @@ def mock_fitbit_config_yaml(token_expiration_time: float) -> dict[str, Any] | No
 @pytest.fixture(name="fitbit_config_setup")
 def mock_fitbit_config_setup(
     fitbit_config_yaml: dict[str, Any] | None,
-) -> Generator[None, None, None]:
+) -> Generator[None]:
     """Fixture to mock out fitbit.conf file data loading and persistence."""
     has_config = fitbit_config_yaml is not None
     with (

--- a/tests/components/flexit_bacnet/conftest.py
+++ b/tests/components/flexit_bacnet/conftest.py
@@ -1,10 +1,10 @@
 """Configuration for Flexit Nordic (BACnet) tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 from flexit_bacnet import FlexitBACnet
 import pytest
+from typing_extensions import Generator
 
 from homeassistant import config_entries
 from homeassistant.components.flexit_bacnet.const import DOMAIN
@@ -29,7 +29,7 @@ async def flow_id(hass: HomeAssistant) -> str:
 
 
 @pytest.fixture
-def mock_flexit_bacnet() -> Generator[AsyncMock, None, None]:
+def mock_flexit_bacnet() -> Generator[AsyncMock]:
     """Mock data from the device."""
     flexit_bacnet = AsyncMock(spec=FlexitBACnet)
     with (
@@ -83,7 +83,7 @@ def mock_flexit_bacnet() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.flexit_bacnet.async_setup_entry", return_value=True

--- a/tests/components/folder_watcher/conftest.py
+++ b/tests/components/folder_watcher/conftest.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import patch
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.folder_watcher.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
@@ -17,7 +17,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[None, None, None]:
+def mock_setup_entry() -> Generator[None]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.folder_watcher.async_setup_entry", return_value=True

--- a/tests/components/forecast_solar/conftest.py
+++ b/tests/components/forecast_solar/conftest.py
@@ -1,11 +1,11 @@
 """Fixtures for Forecast.Solar integration tests."""
 
-from collections.abc import Generator
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from forecast_solar import models
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.forecast_solar.const import (
     CONF_AZIMUTH,
@@ -24,7 +24,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.forecast_solar.async_setup_entry", return_value=True

--- a/tests/components/freedompro/conftest.py
+++ b/tests/components/freedompro/conftest.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from copy import deepcopy
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.freedompro.const import DOMAIN
 
@@ -17,7 +17,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.freedompro.async_setup_entry", return_value=True

--- a/tests/components/frontier_silicon/conftest.py
+++ b/tests/components/frontier_silicon/conftest.py
@@ -1,9 +1,9 @@
 """Configuration for frontier_silicon tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.frontier_silicon.const import CONF_WEBFSAPI_URL, DOMAIN
 from homeassistant.const import CONF_PIN
@@ -22,7 +22,7 @@ def config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture(autouse=True)
-def mock_valid_device_url() -> Generator[None, None, None]:
+def mock_valid_device_url() -> Generator[None]:
     """Return a valid webfsapi endpoint."""
     with patch(
         "afsapi.AFSAPI.get_webfsapi_endpoint",
@@ -32,7 +32,7 @@ def mock_valid_device_url() -> Generator[None, None, None]:
 
 
 @pytest.fixture(autouse=True)
-def mock_valid_pin() -> Generator[None, None, None]:
+def mock_valid_pin() -> Generator[None]:
     """Make get_friendly_name return a value, indicating a valid pin."""
     with patch(
         "afsapi.AFSAPI.get_friendly_name",
@@ -42,14 +42,14 @@ def mock_valid_pin() -> Generator[None, None, None]:
 
 
 @pytest.fixture(autouse=True)
-def mock_radio_id() -> Generator[None, None, None]:
+def mock_radio_id() -> Generator[None]:
     """Return a valid radio_id."""
     with patch("afsapi.AFSAPI.get_radio_id", return_value="mock_radio_id"):
         yield
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.frontier_silicon.async_setup_entry", return_value=True

--- a/tests/components/fully_kiosk/conftest.py
+++ b/tests/components/fully_kiosk/conftest.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.fully_kiosk.const import DOMAIN
 from homeassistant.const import (
@@ -39,7 +39,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.fully_kiosk.async_setup_entry", return_value=True
@@ -48,7 +48,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_fully_kiosk_config_flow() -> Generator[MagicMock, None, None]:
+def mock_fully_kiosk_config_flow() -> Generator[MagicMock]:
     """Return a mocked Fully Kiosk client for the config flow."""
     with patch(
         "homeassistant.components.fully_kiosk.config_flow.FullyKiosk",
@@ -64,7 +64,7 @@ def mock_fully_kiosk_config_flow() -> Generator[MagicMock, None, None]:
 
 
 @pytest.fixture
-def mock_fully_kiosk() -> Generator[MagicMock, None, None]:
+def mock_fully_kiosk() -> Generator[MagicMock]:
     """Return a mocked Fully Kiosk client."""
     with patch(
         "homeassistant.components.fully_kiosk.coordinator.FullyKiosk",

--- a/tests/components/fyta/conftest.py
+++ b/tests/components/fyta/conftest.py
@@ -1,10 +1,10 @@
 """Test helpers for FYTA."""
 
-from collections.abc import Generator
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.fyta.const import CONF_EXPIRATION, DOMAIN as FYTA_DOMAIN
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_PASSWORD, CONF_USERNAME
@@ -69,7 +69,7 @@ def mock_fyta_connector():
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.fyta.async_setup_entry", return_value=True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncGenerator, Callable, Coroutine, Generator
+from collections.abc import Callable, Coroutine
 from contextlib import asynccontextmanager, contextmanager
 import functools
 import gc
@@ -32,6 +32,7 @@ import pytest
 import pytest_socket
 import requests_mock
 from syrupy.assertion import SnapshotAssertion
+from typing_extensions import AsyncGenerator, Generator
 
 # Setup patching if dt_util time functions before any other Home Assistant imports
 from . import patch_time  # noqa: F401, isort:skip
@@ -292,7 +293,7 @@ def wait_for_stop_scripts_after_shutdown() -> bool:
 @pytest.fixture(autouse=True)
 def skip_stop_scripts(
     wait_for_stop_scripts_after_shutdown: bool,
-) -> Generator[None, None, None]:
+) -> Generator[None]:
     """Add ability to bypass _schedule_stop_scripts_after_shutdown."""
     if wait_for_stop_scripts_after_shutdown:
         yield
@@ -305,7 +306,7 @@ def skip_stop_scripts(
 
 
 @contextmanager
-def long_repr_strings() -> Generator[None, None, None]:
+def long_repr_strings() -> Generator[None]:
     """Increase reprlib maxstring and maxother to 300."""
     arepr = reprlib.aRepr
     original_maxstring = arepr.maxstring
@@ -330,7 +331,7 @@ def verify_cleanup(
     event_loop: asyncio.AbstractEventLoop,
     expected_lingering_tasks: bool,
     expected_lingering_timers: bool,
-) -> Generator[None, None, None]:
+) -> Generator[None]:
     """Verify that the test has cleaned up resources correctly."""
     threads_before = frozenset(threading.enumerate())
     tasks_before = asyncio.all_tasks(event_loop)
@@ -378,14 +379,14 @@ def verify_cleanup(
 
 
 @pytest.fixture(autouse=True)
-def reset_hass_threading_local_object() -> Generator[None, None, None]:
+def reset_hass_threading_local_object() -> Generator[None]:
     """Reset the _Hass threading.local object for every test case."""
     yield
     ha._hass.__dict__.clear()
 
 
 @pytest.fixture(scope="session", autouse=True)
-def bcrypt_cost() -> Generator[None, None, None]:
+def bcrypt_cost() -> Generator[None]:
     """Run with reduced rounds during tests, to speed up uses."""
     import bcrypt
 
@@ -400,7 +401,7 @@ def bcrypt_cost() -> Generator[None, None, None]:
 
 
 @pytest.fixture
-def hass_storage() -> Generator[dict[str, Any], None, None]:
+def hass_storage() -> Generator[dict[str, Any]]:
     """Fixture to mock storage."""
     with mock_storage() as stored_data:
         yield stored_data
@@ -458,7 +459,7 @@ def aiohttp_client_cls() -> type[CoalescingClient]:
 @pytest.fixture
 def aiohttp_client(
     event_loop: asyncio.AbstractEventLoop,
-) -> Generator[ClientSessionGenerator, None, None]:
+) -> Generator[ClientSessionGenerator]:
     """Override the default aiohttp_client since 3.x does not support aiohttp_client_cls.
 
     Remove this when upgrading to 4.x as aiohttp_client_cls
@@ -523,7 +524,7 @@ async def hass(
     hass_storage: dict[str, Any],
     request: pytest.FixtureRequest,
     mock_recorder_before_hass: None,
-) -> AsyncGenerator[HomeAssistant, None]:
+) -> AsyncGenerator[HomeAssistant]:
     """Create a test instance of Home Assistant."""
 
     loop = asyncio.get_running_loop()
@@ -582,7 +583,7 @@ async def hass(
 
 
 @pytest.fixture
-async def stop_hass() -> AsyncGenerator[None, None]:
+async def stop_hass() -> AsyncGenerator[None]:
     """Make sure all hass are stopped."""
     orig_hass = ha.HomeAssistant
 
@@ -608,21 +609,21 @@ async def stop_hass() -> AsyncGenerator[None, None]:
 
 
 @pytest.fixture(name="requests_mock")
-def requests_mock_fixture() -> Generator[requests_mock.Mocker, None, None]:
+def requests_mock_fixture() -> Generator[requests_mock.Mocker]:
     """Fixture to provide a requests mocker."""
     with requests_mock.mock() as m:
         yield m
 
 
 @pytest.fixture
-def aioclient_mock() -> Generator[AiohttpClientMocker, None, None]:
+def aioclient_mock() -> Generator[AiohttpClientMocker]:
     """Fixture to mock aioclient calls."""
     with mock_aiohttp_client() as mock_session:
         yield mock_session
 
 
 @pytest.fixture
-def mock_device_tracker_conf() -> Generator[list[Device], None, None]:
+def mock_device_tracker_conf() -> Generator[list[Device]]:
     """Prevent device tracker from reading/writing data."""
     devices: list[Device] = []
 
@@ -801,7 +802,7 @@ def hass_client_no_auth(
 
 
 @pytest.fixture
-def current_request() -> Generator[MagicMock, None, None]:
+def current_request() -> Generator[MagicMock]:
     """Mock current request."""
     with patch("homeassistant.components.http.current_request") as mock_request_context:
         mocked_request = make_mocked_request(
@@ -851,7 +852,7 @@ def hass_ws_client(
         auth_ok = await websocket.receive_json()
         assert auth_ok["type"] == TYPE_AUTH_OK
 
-        def _get_next_id() -> Generator[int, None, None]:
+        def _get_next_id() -> Generator[int]:
             i = 0
             while True:
                 yield (i := i + 1)
@@ -903,7 +904,7 @@ def mqtt_config_entry_data() -> dict[str, Any] | None:
 
 
 @pytest.fixture
-def mqtt_client_mock(hass: HomeAssistant) -> Generator[MqttMockPahoClient, None, None]:
+def mqtt_client_mock(hass: HomeAssistant) -> Generator[MqttMockPahoClient]:
     """Fixture to mock MQTT client."""
 
     mid: int = 0
@@ -975,7 +976,7 @@ async def mqtt_mock(
     mqtt_client_mock: MqttMockPahoClient,
     mqtt_config_entry_data: dict[str, Any] | None,
     mqtt_mock_entry: MqttMockHAClientGenerator,
-) -> AsyncGenerator[MqttMockHAClient, None]:
+) -> AsyncGenerator[MqttMockHAClient]:
     """Fixture to mock MQTT component."""
     return await mqtt_mock_entry()
 
@@ -985,7 +986,7 @@ async def _mqtt_mock_entry(
     hass: HomeAssistant,
     mqtt_client_mock: MqttMockPahoClient,
     mqtt_config_entry_data: dict[str, Any] | None,
-) -> AsyncGenerator[MqttMockHAClientGenerator, None]:
+) -> AsyncGenerator[MqttMockHAClientGenerator]:
     """Fixture to mock a delayed setup of the MQTT config entry."""
     # Local import to avoid processing MQTT modules when running a testcase
     # which does not use MQTT.
@@ -1059,9 +1060,7 @@ def hass_config() -> ConfigType:
 
 
 @pytest.fixture
-def mock_hass_config(
-    hass: HomeAssistant, hass_config: ConfigType
-) -> Generator[None, None, None]:
+def mock_hass_config(hass: HomeAssistant, hass_config: ConfigType) -> Generator[None]:
     """Fixture to mock the content of main configuration.
 
     Patches homeassistant.config.load_yaml_config_file and hass.config_entries
@@ -1100,7 +1099,7 @@ def hass_config_yaml_files(hass_config_yaml: str) -> dict[str, str]:
 @pytest.fixture
 def mock_hass_config_yaml(
     hass: HomeAssistant, hass_config_yaml_files: dict[str, str]
-) -> Generator[None, None, None]:
+) -> Generator[None]:
     """Fixture to mock the content of the yaml configuration files.
 
     Patches yaml configuration files using the `hass_config_yaml`
@@ -1115,7 +1114,7 @@ async def mqtt_mock_entry(
     hass: HomeAssistant,
     mqtt_client_mock: MqttMockPahoClient,
     mqtt_config_entry_data: dict[str, Any] | None,
-) -> AsyncGenerator[MqttMockHAClientGenerator, None]:
+) -> AsyncGenerator[MqttMockHAClientGenerator]:
     """Set up an MQTT config entry."""
 
     async def _async_setup_config_entry(
@@ -1137,7 +1136,7 @@ async def mqtt_mock_entry(
 
 
 @pytest.fixture(autouse=True, scope="session")
-def mock_network() -> Generator[None, None, None]:
+def mock_network() -> Generator[None]:
     """Mock network."""
     with patch(
         "homeassistant.components.network.util.ifaddr.get_adapters",
@@ -1153,7 +1152,7 @@ def mock_network() -> Generator[None, None, None]:
 
 
 @pytest.fixture(autouse=True, scope="session")
-def mock_get_source_ip() -> Generator[_patch, None, None]:
+def mock_get_source_ip() -> Generator[_patch]:
     """Mock network util's async_get_source_ip."""
     patcher = patch(
         "homeassistant.components.network.util.async_get_source_ip",
@@ -1167,7 +1166,7 @@ def mock_get_source_ip() -> Generator[_patch, None, None]:
 
 
 @pytest.fixture(autouse=True, scope="session")
-def translations_once() -> Generator[_patch, None, None]:
+def translations_once() -> Generator[_patch]:
     """Only load translations once per session."""
     from homeassistant.helpers.translation import _TranslationsCacheData
 
@@ -1186,7 +1185,7 @@ def translations_once() -> Generator[_patch, None, None]:
 @pytest.fixture
 def disable_translations_once(
     translations_once: _patch,
-) -> Generator[None, None, None]:
+) -> Generator[None]:
     """Override loading translations once."""
     translations_once.stop()
     yield
@@ -1194,7 +1193,7 @@ def disable_translations_once(
 
 
 @pytest.fixture
-def mock_zeroconf() -> Generator[MagicMock, None, None]:
+def mock_zeroconf() -> Generator[MagicMock]:
     """Mock zeroconf."""
     from zeroconf import DNSCache  # pylint: disable=import-outside-toplevel
 
@@ -1210,7 +1209,7 @@ def mock_zeroconf() -> Generator[MagicMock, None, None]:
 
 
 @pytest.fixture
-def mock_async_zeroconf(mock_zeroconf: MagicMock) -> Generator[MagicMock, None, None]:
+def mock_async_zeroconf(mock_zeroconf: MagicMock) -> Generator[MagicMock]:
     """Mock AsyncZeroconf."""
     from zeroconf import DNSCache, Zeroconf  # pylint: disable=import-outside-toplevel
     from zeroconf.asyncio import (  # pylint: disable=import-outside-toplevel
@@ -1315,7 +1314,7 @@ def recorder_config() -> dict[str, Any] | None:
 def recorder_db_url(
     pytestconfig: pytest.Config,
     hass_fixture_setup: list[bool],
-) -> Generator[str, None, None]:
+) -> Generator[str]:
     """Prepare a default database for tests and return a connection URL."""
     assert not hass_fixture_setup
 
@@ -1368,7 +1367,7 @@ def hass_recorder(
     enable_migrate_event_type_ids: bool,
     enable_migrate_entity_ids: bool,
     hass_storage,
-) -> Generator[Callable[..., HomeAssistant], None, None]:
+) -> Generator[Callable[..., HomeAssistant]]:
     """Home Assistant fixture with in-memory recorder."""
     # pylint: disable-next=import-outside-toplevel
     from homeassistant.components import recorder
@@ -1509,7 +1508,7 @@ async def async_setup_recorder_instance(
     enable_migrate_context_ids: bool,
     enable_migrate_event_type_ids: bool,
     enable_migrate_entity_ids: bool,
-) -> AsyncGenerator[RecorderInstanceGenerator, None]:
+) -> AsyncGenerator[RecorderInstanceGenerator]:
     """Yield callable to setup recorder instance."""
     # pylint: disable-next=import-outside-toplevel
     from homeassistant.components import recorder
@@ -1632,7 +1631,7 @@ async def mock_enable_bluetooth(
     hass: HomeAssistant,
     mock_bleak_scanner_start: MagicMock,
     mock_bluetooth_adapters: None,
-) -> AsyncGenerator[None, None]:
+) -> AsyncGenerator[None]:
     """Fixture to mock starting the bleak scanner."""
     entry = MockConfigEntry(domain="bluetooth", unique_id="00:00:00:00:00:01")
     entry.add_to_hass(hass)
@@ -1644,7 +1643,7 @@ async def mock_enable_bluetooth(
 
 
 @pytest.fixture(scope="session")
-def mock_bluetooth_adapters() -> Generator[None, None, None]:
+def mock_bluetooth_adapters() -> Generator[None]:
     """Fixture to mock bluetooth adapters."""
     with (
         patch("bluetooth_auto_recovery.recover_adapter"),
@@ -1670,7 +1669,7 @@ def mock_bluetooth_adapters() -> Generator[None, None, None]:
 
 
 @pytest.fixture
-def mock_bleak_scanner_start() -> Generator[MagicMock, None, None]:
+def mock_bleak_scanner_start() -> Generator[MagicMock]:
     """Fixture to mock starting the bleak scanner."""
 
     # Late imports to avoid loading bleak unless we need it
@@ -1693,7 +1692,7 @@ def mock_bleak_scanner_start() -> Generator[MagicMock, None, None]:
 
 
 @pytest.fixture
-def mock_integration_frame() -> Generator[Mock, None, None]:
+def mock_integration_frame() -> Generator[Mock]:
     """Mock as if we're calling code from inside an integration."""
     correct_frame = Mock(
         filename="/home/paulus/homeassistant/components/hue/light.py",

--- a/tests/helpers/test_config_entry_flow.py
+++ b/tests/helpers/test_config_entry_flow.py
@@ -1,9 +1,9 @@
 """Tests for the Config Entry Flow helper."""
 
-from collections.abc import Generator
 from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.config import async_process_ha_core_config
@@ -14,7 +14,7 @@ from tests.common import MockConfigEntry, MockModule, mock_integration, mock_pla
 
 
 @pytest.fixture
-def discovery_flow_conf(hass: HomeAssistant) -> Generator[dict[str, bool], None, None]:
+def discovery_flow_conf(hass: HomeAssistant) -> Generator[dict[str, bool]]:
     """Register a handler."""
     handler_conf = {"discovered": False}
 
@@ -30,7 +30,7 @@ def discovery_flow_conf(hass: HomeAssistant) -> Generator[dict[str, bool], None,
 
 
 @pytest.fixture
-def webhook_flow_conf(hass: HomeAssistant) -> Generator[None, None, None]:
+def webhook_flow_conf(hass: HomeAssistant) -> Generator[None]:
     """Register a handler."""
     with patch.dict(config_entries.HANDLERS):
         config_entry_flow.register_webhook_flow("test_single", "Test Single", {}, False)

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,7 +1,7 @@
 """Test the bootstrapping."""
 
 import asyncio
-from collections.abc import Generator, Iterable
+from collections.abc import Iterable
 import contextlib
 import glob
 import logging
@@ -11,6 +11,7 @@ from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant import bootstrap, loader, runner
 import homeassistant.config as config_util
@@ -38,7 +39,7 @@ VERSION_PATH = os.path.join(get_test_config_dir(), config_util.VERSION_FILE)
 
 
 @pytest.fixture(autouse=True)
-def disable_installed_check() -> Generator[None, None, None]:
+def disable_installed_check() -> Generator[None]:
     """Disable package installed check."""
     with patch("homeassistant.util.package.is_installed", return_value=True):
         yield
@@ -55,7 +56,7 @@ async def apply_stop_hass(stop_hass: None) -> None:
 
 
 @pytest.fixture(scope="module", autouse=True)
-def mock_http_start_stop() -> Generator[None, None, None]:
+def mock_http_start_stop() -> Generator[None]:
     """Mock HTTP start and stop."""
     with (
         patch("homeassistant.components.http.start_http_server_and_save_config"),
@@ -583,7 +584,7 @@ async def test_setup_after_deps_not_present(hass: HomeAssistant) -> None:
 
 
 @pytest.fixture
-def mock_is_virtual_env() -> Generator[Mock, None, None]:
+def mock_is_virtual_env() -> Generator[Mock]:
     """Mock is_virtual_env."""
     with patch(
         "homeassistant.bootstrap.is_virtual_env", return_value=False
@@ -592,14 +593,14 @@ def mock_is_virtual_env() -> Generator[Mock, None, None]:
 
 
 @pytest.fixture
-def mock_enable_logging() -> Generator[Mock, None, None]:
+def mock_enable_logging() -> Generator[Mock]:
     """Mock enable logging."""
     with patch("homeassistant.bootstrap.async_enable_logging") as enable_logging:
         yield enable_logging
 
 
 @pytest.fixture
-def mock_mount_local_lib_path() -> Generator[AsyncMock, None, None]:
+def mock_mount_local_lib_path() -> Generator[AsyncMock]:
     """Mock enable logging."""
     with patch(
         "homeassistant.bootstrap.async_mount_local_lib_path"
@@ -608,7 +609,7 @@ def mock_mount_local_lib_path() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_process_ha_config_upgrade() -> Generator[Mock, None, None]:
+def mock_process_ha_config_upgrade() -> Generator[Mock]:
     """Mock enable logging."""
     with patch(
         "homeassistant.config.process_ha_config_upgrade"
@@ -617,7 +618,7 @@ def mock_process_ha_config_upgrade() -> Generator[Mock, None, None]:
 
 
 @pytest.fixture
-def mock_ensure_config_exists() -> Generator[AsyncMock, None, None]:
+def mock_ensure_config_exists() -> Generator[AsyncMock]:
     """Mock enable logging."""
     with patch(
         "homeassistant.config.async_ensure_config_exists", return_value=True
@@ -1179,7 +1180,7 @@ async def test_bootstrap_empty_integrations(
 
 
 @pytest.fixture(name="mock_mqtt_config_flow")
-def mock_mqtt_config_flow_fixture() -> Generator[None, None, None]:
+def mock_mqtt_config_flow_fixture() -> Generator[None]:
     """Mock MQTT config flow."""
 
     class MockConfigFlow:

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Generator
 from datetime import timedelta
 from functools import cached_property
 import logging
@@ -13,6 +12,7 @@ from unittest.mock import ANY, AsyncMock, Mock, patch
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from typing_extensions import Generator
 
 from homeassistant import config_entries, data_entry_flow, loader
 from homeassistant.components import dhcp
@@ -53,7 +53,7 @@ from tests.common import async_get_persistent_notifications
 
 
 @pytest.fixture(autouse=True)
-def mock_handlers() -> Generator[None, None, None]:
+def mock_handlers() -> Generator[None]:
     """Mock config flows."""
 
     class MockFlowHandler(config_entries.ConfigFlow):

--- a/tests/util/yaml/test_init.py
+++ b/tests/util/yaml/test_init.py
@@ -1,6 +1,5 @@
 """Test Home Assistant yaml loader."""
 
-from collections.abc import Generator
 import importlib
 import io
 import os
@@ -10,6 +9,7 @@ import unittest
 from unittest.mock import Mock, patch
 
 import pytest
+from typing_extensions import Generator
 import voluptuous as vol
 import yaml as pyyaml
 
@@ -604,7 +604,7 @@ async def test_loading_actual_file_with_syntax_error(
 
 
 @pytest.fixture
-def mock_integration_frame() -> Generator[Mock, None, None]:
+def mock_integration_frame() -> Generator[Mock]:
     """Mock as if we're calling code from inside an integration."""
     correct_frame = Mock(
         filename="/home/paulus/homeassistant/components/hue/light.py",


### PR DESCRIPTION
## Proposed change
For details see: #118986

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
