### PR TITLE
Import Generator from typing_extensions (3)

### DIFF
--- a/tests/components/gardena_bluetooth/conftest.py
+++ b/tests/components/gardena_bluetooth/conftest.py
@@ -1,6 +1,6 @@
 """Common fixtures for the Gardena Bluetooth tests."""
 
-from collections.abc import Awaitable, Callable, Generator
+from collections.abc import Awaitable, Callable
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -10,6 +10,7 @@ from gardena_bluetooth.const import DeviceInformation
 from gardena_bluetooth.exceptions import CharacteristicNotFound
 from gardena_bluetooth.parse import Characteristic
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.gardena_bluetooth.const import DOMAIN
 from homeassistant.components.gardena_bluetooth.coordinator import SCAN_INTERVAL
@@ -30,7 +31,7 @@ def mock_entry():
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.gardena_bluetooth.async_setup_entry",

--- a/tests/components/geo_json_events/conftest.py
+++ b/tests/components/geo_json_events/conftest.py
@@ -1,9 +1,9 @@
 """Configuration for GeoJSON Events tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.geo_json_events import DOMAIN
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_RADIUS, CONF_URL
@@ -30,7 +30,7 @@ def config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock geo_json_events entry setup."""
     with patch(
         "homeassistant.components.geo_json_events.async_setup_entry", return_value=True

--- a/tests/components/geocaching/conftest.py
+++ b/tests/components/geocaching/conftest.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from geocachingapi import GeocachingStatus
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.geocaching.const import DOMAIN
 
@@ -28,7 +28,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.geocaching.async_setup_entry", return_value=True

--- a/tests/components/github/conftest.py
+++ b/tests/components/github/conftest.py
@@ -1,9 +1,9 @@
 """conftest for the GitHub integration."""
 
-from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.github.const import CONF_REPOSITORIES, DOMAIN
 from homeassistant.const import CONF_ACCESS_TOKEN
@@ -27,7 +27,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[None, None, None]:
+def mock_setup_entry() -> Generator[None]:
     """Mock setting up a config entry."""
     with patch("homeassistant.components.github.async_setup_entry", return_value=True):
         yield

--- a/tests/components/google/conftest.py
+++ b/tests/components/google/conftest.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator, Awaitable, Callable, Generator
+from collections.abc import Awaitable, Callable
 import datetime
 import http
 import time
@@ -13,6 +13,7 @@ from aiohttp.client_exceptions import ClientError
 from gcal_sync.auth import API_BASE_URL
 from oauth2client.client import OAuth2Credentials
 import pytest
+from typing_extensions import AsyncGenerator, Generator
 import yaml
 
 from homeassistant.components.application_credentials import (
@@ -29,7 +30,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 
 type ApiResult = Callable[[dict[str, Any]], None]
 type ComponentSetup = Callable[[], Awaitable[bool]]
-type AsyncYieldFixture[_T] = AsyncGenerator[_T, None]
+type AsyncYieldFixture[_T] = AsyncGenerator[_T]
 
 
 CALENDAR_ID = "qwertyuiopasdfghjklzxcvbnm@import.calendar.google.com"
@@ -150,7 +151,7 @@ def calendars_config(calendars_config_entity: dict[str, Any]) -> list[dict[str, 
 def mock_calendars_yaml(
     hass: HomeAssistant,
     calendars_config: list[dict[str, Any]],
-) -> Generator[Mock, None, None]:
+) -> Generator[Mock]:
     """Fixture that prepares the google_calendars.yaml mocks."""
     mocked_open_function = mock_open(
         read_data=yaml.dump(calendars_config) if calendars_config else None

--- a/tests/components/google_sheets/test_config_flow.py
+++ b/tests/components/google_sheets/test_config_flow.py
@@ -1,10 +1,10 @@
 """Test the Google Sheets config flow."""
 
-from collections.abc import Generator
 from unittest.mock import Mock, patch
 
 from gspread import GSpreadException
 import pytest
+from typing_extensions import Generator
 
 from homeassistant import config_entries
 from homeassistant.components.application_credentials import (
@@ -41,7 +41,7 @@ async def setup_credentials(hass: HomeAssistant) -> None:
 
 
 @pytest.fixture(autouse=True)
-async def mock_client() -> Generator[Mock, None, None]:
+async def mock_client() -> Generator[Mock]:
     """Fixture to setup a fake spreadsheet client library."""
     with patch(
         "homeassistant.components.google_sheets.config_flow.Client"

--- a/tests/components/google_tasks/test_config_flow.py
+++ b/tests/components/google_tasks/test_config_flow.py
@@ -1,11 +1,11 @@
 """Test the Google Tasks config flow."""
 
-from collections.abc import Generator
 from unittest.mock import Mock, patch
 
 from googleapiclient.errors import HttpError
 from httplib2 import Response
 import pytest
+from typing_extensions import Generator
 
 from homeassistant import config_entries
 from homeassistant.components.google_tasks.const import (
@@ -32,7 +32,7 @@ def user_identifier() -> str:
 
 
 @pytest.fixture
-def setup_userinfo(user_identifier: str) -> Generator[Mock, None, None]:
+def setup_userinfo(user_identifier: str) -> Generator[Mock]:
     """Set up userinfo."""
     with patch("homeassistant.components.google_tasks.config_flow.build") as mock:
         mock.return_value.userinfo.return_value.get.return_value.execute.return_value = {

--- a/tests/components/google_translate/conftest.py
+++ b/tests/components/google_translate/conftest.py
@@ -1,13 +1,13 @@
 """Common fixtures for the Google Translate text-to-speech tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.google_translate.async_setup_entry", return_value=True

--- a/tests/components/google_translate/test_tts.py
+++ b/tests/components/google_translate/test_tts.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from http import HTTPStatus
 from pathlib import Path
 from typing import Any
@@ -10,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 from gtts import gTTSError
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components import tts
 from homeassistant.components.google_translate.const import CONF_TLD, DOMAIN
@@ -54,7 +54,7 @@ async def setup_internal_url(hass: HomeAssistant) -> None:
 
 
 @pytest.fixture
-def mock_gtts() -> Generator[MagicMock, None, None]:
+def mock_gtts() -> Generator[MagicMock]:
     """Mock gtts."""
     with patch("homeassistant.components.google_translate.tts.gTTS") as mock_gtts:
         yield mock_gtts

--- a/tests/components/govee_light_local/conftest.py
+++ b/tests/components/govee_light_local/conftest.py
@@ -1,11 +1,11 @@
 """Tests configuration for Govee Local API."""
 
 from asyncio import Event
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from govee_local_api import GoveeLightCapability
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.govee_light_local.coordinator import GoveeController
 
@@ -25,7 +25,7 @@ def fixture_mock_govee_api():
 
 
 @pytest.fixture(name="mock_setup_entry")
-def fixture_mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def fixture_mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.govee_light_local.async_setup_entry",

--- a/tests/components/gpsd/conftest.py
+++ b/tests/components/gpsd/conftest.py
@@ -1,13 +1,13 @@
 """Common fixtures for the GPSD tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.gpsd.async_setup_entry", return_value=True

--- a/tests/components/gree/conftest.py
+++ b/tests/components/gree/conftest.py
@@ -1,15 +1,15 @@
 """Pytest module configuration."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from .common import FakeDiscovery, build_device_mock
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.gree.async_setup_entry", return_value=True

--- a/tests/components/greeneye_monitor/conftest.py
+++ b/tests/components/greeneye_monitor/conftest.py
@@ -1,10 +1,10 @@
 """Common fixtures for testing greeneye_monitor."""
 
-from collections.abc import Generator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.greeneye_monitor import DOMAIN
 from homeassistant.components.sensor import SensorDeviceClass
@@ -99,7 +99,7 @@ def assert_sensor_registered(
 
 
 @pytest.fixture
-def monitors() -> Generator[AsyncMock, None, None]:
+def monitors() -> Generator[AsyncMock]:
     """Provide a mock greeneye.Monitors object that has listeners and can add new monitors."""
     with patch("greeneye.Monitors", autospec=True) as mock_monitors:
         mock = mock_monitors.return_value

--- a/tests/components/guardian/conftest.py
+++ b/tests/components/guardian/conftest.py
@@ -1,10 +1,10 @@
 """Define fixtures for Elexa Guardian tests."""
 
-from collections.abc import Generator
 import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.guardian import CONF_UID, DOMAIN
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PORT
@@ -14,7 +14,7 @@ from tests.common import MockConfigEntry, load_fixture
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.guardian.async_setup_entry", return_value=True

--- a/tests/components/hassio/test_addon_manager.py
+++ b/tests/components/hassio/test_addon_manager.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Generator
 import logging
 from typing import Any
 from unittest.mock import AsyncMock, call, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.hassio.addon_manager import (
     AddonError,
@@ -56,7 +56,7 @@ def mock_addon_installed(
 
 
 @pytest.fixture(name="get_addon_discovery_info")
-def get_addon_discovery_info_fixture() -> Generator[AsyncMock, None, None]:
+def get_addon_discovery_info_fixture() -> Generator[AsyncMock]:
     """Mock get add-on discovery info."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_get_addon_discovery_info"
@@ -65,7 +65,7 @@ def get_addon_discovery_info_fixture() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture(name="addon_store_info")
-def addon_store_info_fixture() -> Generator[AsyncMock, None, None]:
+def addon_store_info_fixture() -> Generator[AsyncMock]:
     """Mock Supervisor add-on store info."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_get_addon_store_info"
@@ -80,7 +80,7 @@ def addon_store_info_fixture() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture(name="addon_info")
-def addon_info_fixture() -> Generator[AsyncMock, None, None]:
+def addon_info_fixture() -> Generator[AsyncMock]:
     """Mock Supervisor add-on info."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_get_addon_info",
@@ -97,7 +97,7 @@ def addon_info_fixture() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture(name="set_addon_options")
-def set_addon_options_fixture() -> Generator[AsyncMock, None, None]:
+def set_addon_options_fixture() -> Generator[AsyncMock]:
     """Mock set add-on options."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_set_addon_options"
@@ -106,7 +106,7 @@ def set_addon_options_fixture() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture(name="install_addon")
-def install_addon_fixture() -> Generator[AsyncMock, None, None]:
+def install_addon_fixture() -> Generator[AsyncMock]:
     """Mock install add-on."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_install_addon"
@@ -115,7 +115,7 @@ def install_addon_fixture() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture(name="uninstall_addon")
-def uninstall_addon_fixture() -> Generator[AsyncMock, None, None]:
+def uninstall_addon_fixture() -> Generator[AsyncMock]:
     """Mock uninstall add-on."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_uninstall_addon"
@@ -124,7 +124,7 @@ def uninstall_addon_fixture() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture(name="start_addon")
-def start_addon_fixture() -> Generator[AsyncMock, None, None]:
+def start_addon_fixture() -> Generator[AsyncMock]:
     """Mock start add-on."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_start_addon"
@@ -133,7 +133,7 @@ def start_addon_fixture() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture(name="restart_addon")
-def restart_addon_fixture() -> Generator[AsyncMock, None, None]:
+def restart_addon_fixture() -> Generator[AsyncMock]:
     """Mock restart add-on."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_restart_addon"
@@ -142,7 +142,7 @@ def restart_addon_fixture() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture(name="stop_addon")
-def stop_addon_fixture() -> Generator[AsyncMock, None, None]:
+def stop_addon_fixture() -> Generator[AsyncMock]:
     """Mock stop add-on."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_stop_addon"
@@ -151,7 +151,7 @@ def stop_addon_fixture() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture(name="create_backup")
-def create_backup_fixture() -> Generator[AsyncMock, None, None]:
+def create_backup_fixture() -> Generator[AsyncMock]:
     """Mock create backup."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_create_backup"
@@ -160,7 +160,7 @@ def create_backup_fixture() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture(name="update_addon")
-def mock_update_addon() -> Generator[AsyncMock, None, None]:
+def mock_update_addon() -> Generator[AsyncMock]:
     """Mock update add-on."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_update_addon"

--- a/tests/components/holiday/conftest.py
+++ b/tests/components/holiday/conftest.py
@@ -1,13 +1,13 @@
 """Common fixtures for the Holiday tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.holiday.async_setup_entry", return_value=True

--- a/tests/components/homeassistant_hardware/conftest.py
+++ b/tests/components/homeassistant_hardware/conftest.py
@@ -1,14 +1,14 @@
 """Test fixtures for the Home Assistant Hardware integration."""
 
-from collections.abc import Generator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture(autouse=True)
-def mock_zha_config_flow_setup() -> Generator[None, None, None]:
+def mock_zha_config_flow_setup() -> Generator[None]:
     """Mock the radio connection and probing of the ZHA config flow."""
 
     def mock_probe(config: dict[str, Any]) -> None:
@@ -39,7 +39,7 @@ def mock_zha_config_flow_setup() -> Generator[None, None, None]:
 
 
 @pytest.fixture(autouse=True)
-def mock_zha_get_last_network_settings() -> Generator[None, None, None]:
+def mock_zha_get_last_network_settings() -> Generator[None]:
     """Mock zha.api.async_get_last_network_settings."""
 
     with patch(

--- a/tests/components/homeassistant_hardware/test_silabs_multiprotocol_addon.py
+++ b/tests/components/homeassistant_hardware/test_silabs_multiprotocol_addon.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.hassio import AddonError, AddonInfo, AddonState, HassIO
 from homeassistant.components.hassio.handler import HassioAPIError
@@ -96,7 +96,7 @@ class FakeOptionsFlow(silabs_multiprotocol_addon.OptionsFlowHandler):
 @pytest.fixture(autouse=True)
 def config_flow_handler(
     hass: HomeAssistant, current_request_with_host: None
-) -> Generator[None, None, None]:
+) -> Generator[None]:
     """Fixture for a test config flow."""
     mock_platform(hass, f"{TEST_DOMAIN}.config_flow")
     with mock_config_flow(TEST_DOMAIN, FakeConfigFlow):
@@ -104,7 +104,7 @@ def config_flow_handler(
 
 
 @pytest.fixture
-def options_flow_poll_addon_state() -> Generator[None, None, None]:
+def options_flow_poll_addon_state() -> Generator[None]:
     """Fixture for patching options flow addon state polling."""
     with patch(
         "homeassistant.components.homeassistant_hardware.silabs_multiprotocol_addon.WaitingAddonManager.async_wait_until_addon_state"
@@ -113,7 +113,7 @@ def options_flow_poll_addon_state() -> Generator[None, None, None]:
 
 
 @pytest.fixture(autouse=True)
-def hassio_integration(hass: HomeAssistant) -> Generator[None, None, None]:
+def hassio_integration(hass: HomeAssistant) -> Generator[None]:
     """Fixture to mock the `hassio` integration."""
     mock_component(hass, "hassio")
     hass.data["hassio"] = Mock(spec_set=HassIO)
@@ -148,7 +148,7 @@ class MockMultiprotocolPlatform(MockPlatform):
 @pytest.fixture
 def mock_multiprotocol_platform(
     hass: HomeAssistant,
-) -> Generator[FakeConfigFlow, None, None]:
+) -> Generator[FakeConfigFlow]:
     """Fixture for a test silabs multiprotocol platform."""
     hass.config.components.add(TEST_DOMAIN)
     platform = MockMultiprotocolPlatform()

--- a/tests/components/homeassistant_sky_connect/conftest.py
+++ b/tests/components/homeassistant_sky_connect/conftest.py
@@ -1,13 +1,13 @@
 """Test fixtures for the Home Assistant SkyConnect integration."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture(name="mock_usb_serial_by_id", autouse=True)
-def mock_usb_serial_by_id_fixture() -> Generator[MagicMock, None, None]:
+def mock_usb_serial_by_id_fixture() -> Generator[MagicMock]:
     """Mock usb serial by id."""
     with patch(
         "homeassistant.components.zha.config_flow.usb.get_serial_by_id"
@@ -39,7 +39,7 @@ def mock_zha():
 
 
 @pytest.fixture(autouse=True)
-def mock_zha_get_last_network_settings() -> Generator[None, None, None]:
+def mock_zha_get_last_network_settings() -> Generator[None]:
     """Mock zha.api.async_get_last_network_settings."""
 
     with patch(

--- a/tests/components/homeassistant_yellow/conftest.py
+++ b/tests/components/homeassistant_yellow/conftest.py
@@ -1,14 +1,14 @@
 """Test fixtures for the Home Assistant Yellow integration."""
 
-from collections.abc import Generator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture(autouse=True)
-def mock_zha_config_flow_setup() -> Generator[None, None, None]:
+def mock_zha_config_flow_setup() -> Generator[None]:
     """Mock the radio connection and probing of the ZHA config flow."""
 
     def mock_probe(config: dict[str, Any]) -> None:
@@ -39,7 +39,7 @@ def mock_zha_config_flow_setup() -> Generator[None, None, None]:
 
 
 @pytest.fixture(autouse=True)
-def mock_zha_get_last_network_settings() -> Generator[None, None, None]:
+def mock_zha_get_last_network_settings() -> Generator[None]:
     """Mock zha.api.async_get_last_network_settings."""
 
     with patch(

--- a/tests/components/homeassistant_yellow/test_config_flow.py
+++ b/tests/components/homeassistant_yellow/test_config_flow.py
@@ -1,9 +1,9 @@
 """Test the Home Assistant Yellow config flow."""
 
-from collections.abc import Generator
 from unittest.mock import Mock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.hassio import DOMAIN as HASSIO_DOMAIN
 from homeassistant.components.homeassistant_yellow.const import DOMAIN
@@ -16,7 +16,7 @@ from tests.common import MockConfigEntry, MockModule, mock_integration
 
 
 @pytest.fixture(autouse=True)
-def config_flow_handler(hass: HomeAssistant) -> Generator[None, None, None]:
+def config_flow_handler(hass: HomeAssistant) -> Generator[None]:
     """Fixture for a test config flow."""
     with patch(
         "homeassistant.components.homeassistant_hardware.silabs_multiprotocol_addon.WaitingAddonManager.async_wait_until_addon_state"

--- a/tests/components/homekit_controller/conftest.py
+++ b/tests/components/homekit_controller/conftest.py
@@ -1,6 +1,5 @@
 """HomeKit controller session fixtures."""
 
-from collections.abc import Generator
 import datetime
 import unittest.mock
 
@@ -8,6 +7,7 @@ from aiohomekit.testing import FakeController
 from freezegun import freeze_time
 from freezegun.api import FrozenDateTimeFactory
 import pytest
+from typing_extensions import Generator
 
 import homeassistant.util.dt as dt_util
 
@@ -17,7 +17,7 @@ pytest.register_assert_rewrite("tests.components.homekit_controller.common")
 
 
 @pytest.fixture(autouse=True)
-def freeze_time_in_future() -> Generator[FrozenDateTimeFactory, None, None]:
+def freeze_time_in_future() -> Generator[FrozenDateTimeFactory]:
     """Freeze time at a known point."""
     now = dt_util.utcnow()
     start_dt = datetime.datetime(now.year + 1, 1, 1, 0, 0, 0, tzinfo=now.tzinfo)

--- a/tests/components/homewizard/conftest.py
+++ b/tests/components/homewizard/conftest.py
@@ -1,11 +1,11 @@
 """Fixtures for HomeWizard integration tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homewizard_energy.errors import NotFoundError
 from homewizard_energy.models import Data, Device, State, System
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.homewizard.const import DOMAIN
 from homeassistant.const import CONF_IP_ADDRESS
@@ -62,7 +62,7 @@ def mock_homewizardenergy(
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.homewizard.async_setup_entry", return_value=True
@@ -102,7 +102,7 @@ async def init_integration(
 
 
 @pytest.fixture
-def mock_onboarding() -> Generator[MagicMock, None, None]:
+def mock_onboarding() -> Generator[MagicMock]:
     """Mock that Home Assistant is currently onboarding."""
     with patch(
         "homeassistant.components.onboarding.async_is_onboarded",

--- a/tests/components/homeworks/conftest.py
+++ b/tests/components/homeworks/conftest.py
@@ -1,9 +1,9 @@
 """Common fixtures for the Lutron Homeworks Series 4 and 8 tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.homeworks.const import (
     CONF_ADDR,
@@ -103,7 +103,7 @@ def mock_homeworks() -> Generator[None, MagicMock, None]:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.homeworks.async_setup_entry", return_value=True

--- a/tests/components/hunterdouglas_powerview/conftest.py
+++ b/tests/components/hunterdouglas_powerview/conftest.py
@@ -1,10 +1,10 @@
 """Common fixtures for Hunter Douglas Powerview tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 from aiopvapi.resources.shade import ShadePosition
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.hunterdouglas_powerview.const import DOMAIN
 
@@ -12,7 +12,7 @@ from tests.common import load_json_object_fixture, load_json_value_fixture
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.hunterdouglas_powerview.async_setup_entry",
@@ -29,7 +29,7 @@ def mock_hunterdouglas_hub(
     rooms_json: str,
     scenes_json: str,
     shades_json: str,
-) -> Generator[MagicMock, None, None]:
+) -> Generator[MagicMock]:
     """Return a mocked Powerview Hub with all data populated."""
     with (
         patch(

--- a/tests/components/husqvarna_automower/conftest.py
+++ b/tests/components/husqvarna_automower/conftest.py
@@ -1,6 +1,5 @@
 """Test helpers for Husqvarna Automower."""
 
-from collections.abc import Generator
 import time
 from unittest.mock import AsyncMock, patch
 
@@ -8,6 +7,7 @@ from aioautomower.session import AutomowerSession, _MowerCommands
 from aioautomower.utils import mower_list_to_dictionary_dataclass
 from aiohttp import ClientWebSocketResponse
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.application_credentials import (
     ClientCredential,
@@ -81,7 +81,7 @@ async def setup_credentials(hass: HomeAssistant) -> None:
 
 
 @pytest.fixture
-def mock_automower_client() -> Generator[AsyncMock, None, None]:
+def mock_automower_client() -> Generator[AsyncMock]:
     """Mock a Husqvarna Automower client."""
 
     mower_dict = mower_list_to_dictionary_dataclass(

--- a/tests/components/hydrawise/conftest.py
+++ b/tests/components/hydrawise/conftest.py
@@ -1,6 +1,6 @@
 """Common fixtures for the Hydrawise tests."""
 
-from collections.abc import Awaitable, Callable, Generator
+from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
@@ -19,6 +19,7 @@ from pydrawise.schema import (
     Zone,
 )
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.hydrawise.const import DOMAIN
 from homeassistant.const import CONF_API_KEY, CONF_PASSWORD, CONF_USERNAME
@@ -29,7 +30,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.hydrawise.async_setup_entry", return_value=True
@@ -42,7 +43,7 @@ def mock_legacy_pydrawise(
     user: User,
     controller: Controller,
     zones: list[Zone],
-) -> Generator[AsyncMock, None, None]:
+) -> Generator[AsyncMock]:
     """Mock LegacyHydrawiseAsync."""
     with patch(
         "pydrawise.legacy.LegacyHydrawiseAsync", autospec=True
@@ -61,7 +62,7 @@ def mock_pydrawise(
     zones: list[Zone],
     sensors: list[Sensor],
     controller_water_use_summary: ControllerWaterUseSummary,
-) -> Generator[AsyncMock, None, None]:
+) -> Generator[AsyncMock]:
     """Mock Hydrawise."""
     with patch("pydrawise.client.Hydrawise", autospec=True) as mock_pydrawise:
         user.controllers = [controller]
@@ -75,7 +76,7 @@ def mock_pydrawise(
 
 
 @pytest.fixture
-def mock_auth() -> Generator[AsyncMock, None, None]:
+def mock_auth() -> Generator[AsyncMock]:
     """Mock pydrawise Auth."""
     with patch("pydrawise.auth.Auth", autospec=True) as mock_auth:
         yield mock_auth.return_value

--- a/tests/components/idasen_desk/conftest.py
+++ b/tests/components/idasen_desk/conftest.py
@@ -1,14 +1,15 @@
 """IKEA Idasen Desk fixtures."""
 
-from collections.abc import Callable, Generator
+from collections.abc import Callable
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth: None) -> Generator[None, None, None]:
+def mock_bluetooth(enable_bluetooth: None) -> Generator[None]:
     """Auto mock bluetooth."""
     with mock.patch(
         "homeassistant.components.idasen_desk.bluetooth.async_ble_device_from_address"

--- a/tests/components/image/conftest.py
+++ b/tests/components/image/conftest.py
@@ -1,8 +1,7 @@
 """Test helpers for image."""
 
-from collections.abc import Generator
-
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components import image
 from homeassistant.config_entries import ConfigEntry, ConfigFlow
@@ -125,7 +124,7 @@ class MockImagePlatform:
 
 
 @pytest.fixture(name="config_flow")
-def config_flow_fixture(hass: HomeAssistant) -> Generator[None, None, None]:
+def config_flow_fixture(hass: HomeAssistant) -> Generator[None]:
     """Mock config flow."""
 
     class MockFlow(ConfigFlow):

--- a/tests/components/imap/conftest.py
+++ b/tests/components/imap/conftest.py
@@ -1,16 +1,16 @@
 """Fixtures for imap tests."""
 
-from collections.abc import AsyncGenerator, Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aioimaplib import AUTH, LOGOUT, NONAUTH, SELECTED, STARTED, Response
 import pytest
+from typing_extensions import AsyncGenerator, Generator
 
 from .const import EMPTY_SEARCH_RESPONSE, TEST_FETCH_RESPONSE_TEXT_PLAIN
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.imap.async_setup_entry", return_value=True
@@ -62,7 +62,7 @@ async def mock_imap_protocol(
     imap_pending_idle: bool,
     imap_login_state: str,
     imap_select_state: str,
-) -> AsyncGenerator[MagicMock, None]:
+) -> AsyncGenerator[MagicMock]:
     """Mock the aioimaplib IMAP protocol handler."""
 
     with patch(

--- a/tests/components/imgw_pib/conftest.py
+++ b/tests/components/imgw_pib/conftest.py
@@ -1,11 +1,11 @@
 """Common fixtures for the IMGW-PIB tests."""
 
-from collections.abc import Generator
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
 from imgw_pib import HydrologicalData, SensorData
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.imgw_pib.const import DOMAIN
 
@@ -27,7 +27,7 @@ HYDROLOGICAL_DATA = HydrologicalData(
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.imgw_pib.async_setup_entry", return_value=True
@@ -36,7 +36,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_imgw_pib_client() -> Generator[AsyncMock, None, None]:
+def mock_imgw_pib_client() -> Generator[AsyncMock]:
     """Mock a ImgwPib client."""
     with (
         patch(

--- a/tests/components/incomfort/conftest.py
+++ b/tests/components/incomfort/conftest.py
@@ -1,10 +1,10 @@
 """Fixtures for Intergas InComfort integration."""
 
-from collections.abc import Generator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.incomfort import DOMAIN
 from homeassistant.config_entries import ConfigEntry
@@ -20,7 +20,7 @@ MOCK_CONFIG = {
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.incomfort.async_setup_entry",

--- a/tests/components/influxdb/test_init.py
+++ b/tests/components/influxdb/test_init.py
@@ -1,6 +1,5 @@
 """The tests for the InfluxDB component."""
 
-from collections.abc import Generator
 from dataclasses import dataclass
 import datetime
 from http import HTTPStatus
@@ -8,6 +7,7 @@ import logging
 from unittest.mock import ANY, MagicMock, Mock, call, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components import influxdb
 from homeassistant.components.influxdb.const import DEFAULT_BUCKET
@@ -54,7 +54,7 @@ def mock_batch_timeout(hass, monkeypatch):
 @pytest.fixture(name="mock_client")
 def mock_client_fixture(
     request: pytest.FixtureRequest,
-) -> Generator[MagicMock, None, None]:
+) -> Generator[MagicMock]:
     """Patch the InfluxDBClient object with mock for version under test."""
     if request.param == influxdb.API_VERSION_2:
         client_target = f"{INFLUX_CLIENT_PATH}V2"

--- a/tests/components/influxdb/test_sensor.py
+++ b/tests/components/influxdb/test_sensor.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from dataclasses import dataclass
 from datetime import timedelta
 from http import HTTPStatus
@@ -11,6 +10,7 @@ from unittest.mock import MagicMock, patch
 from influxdb.exceptions import InfluxDBClientError, InfluxDBServerError
 from influxdb_client.rest import ApiException
 import pytest
+from typing_extensions import Generator
 from voluptuous import Invalid
 
 from homeassistant.components import sensor
@@ -82,7 +82,7 @@ class Table:
 @pytest.fixture(name="mock_client")
 def mock_client_fixture(
     request: pytest.FixtureRequest,
-) -> Generator[MagicMock, None, None]:
+) -> Generator[MagicMock]:
     """Patch the InfluxDBClient object with mock for version under test."""
     if request.param == API_VERSION_2:
         client_target = f"{INFLUXDB_CLIENT_PATH}V2"

--- a/tests/components/intellifire/conftest.py
+++ b/tests/components/intellifire/conftest.py
@@ -1,14 +1,14 @@
 """Fixtures for IntelliFire integration tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from aiohttp.client_reqrep import ConnectionKey
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.intellifire.async_setup_entry", return_value=True

--- a/tests/components/ipma/test_config_flow.py
+++ b/tests/components/ipma/test_config_flow.py
@@ -1,10 +1,10 @@
 """Tests for IPMA config flow."""
 
-from collections.abc import Generator
 from unittest.mock import patch
 
 from pyipma import IPMAException
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.ipma.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
@@ -16,7 +16,7 @@ from tests.components.ipma import MockLocation
 
 
 @pytest.fixture(name="ipma_setup", autouse=True)
-def ipma_setup_fixture() -> Generator[None, None, None]:
+def ipma_setup_fixture() -> Generator[None]:
     """Patch ipma setup entry."""
     with patch("homeassistant.components.ipma.async_setup_entry", return_value=True):
         yield

--- a/tests/components/ipp/conftest.py
+++ b/tests/components/ipp/conftest.py
@@ -1,11 +1,11 @@
 """Fixtures for IPP integration tests."""
 
-from collections.abc import Generator
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from pyipp import Printer
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.ipp.const import CONF_BASE_PATH, DOMAIN
 from homeassistant.const import (
@@ -39,7 +39,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.ipp.async_setup_entry", return_value=True

--- a/tests/components/islamic_prayer_times/conftest.py
+++ b/tests/components/islamic_prayer_times/conftest.py
@@ -1,13 +1,13 @@
 """Common fixtures for the islamic_prayer_times tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.islamic_prayer_times.async_setup_entry",

--- a/tests/components/ista_ecotrend/conftest.py
+++ b/tests/components/ista_ecotrend/conftest.py
@@ -1,10 +1,10 @@
 """Common fixtures for the ista EcoTrend tests."""
 
-from collections.abc import Generator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.ista_ecotrend.const import DOMAIN
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
@@ -26,7 +26,7 @@ def mock_ista_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.ista_ecotrend.async_setup_entry", return_value=True
@@ -35,7 +35,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_ista() -> Generator[MagicMock, None, None]:
+def mock_ista() -> Generator[MagicMock]:
     """Mock Pyecotrend_ista client."""
 
     with (

--- a/tests/components/jellyfin/conftest.py
+++ b/tests/components/jellyfin/conftest.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
 from jellyfin_apiclient_python import JellyfinClient
@@ -10,6 +9,7 @@ from jellyfin_apiclient_python.api import API
 from jellyfin_apiclient_python.configuration import Config
 from jellyfin_apiclient_python.connection_manager import ConnectionManager
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.jellyfin.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME
@@ -37,7 +37,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.jellyfin.async_setup_entry", return_value=True

--- a/tests/components/jewish_calendar/conftest.py
+++ b/tests/components/jewish_calendar/conftest.py
@@ -1,9 +1,9 @@
 """Common fixtures for the jewish_calendar tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.jewish_calendar.const import DEFAULT_NAME, DOMAIN
 
@@ -20,7 +20,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.jewish_calendar.async_setup_entry", return_value=True

--- a/tests/components/jvc_projector/conftest.py
+++ b/tests/components/jvc_projector/conftest.py
@@ -1,9 +1,9 @@
 """Fixtures for JVC Projector integration."""
 
-from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.jvc_projector.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
@@ -17,7 +17,7 @@ from tests.common import MockConfigEntry
 @pytest.fixture(name="mock_device")
 def fixture_mock_device(
     request: pytest.FixtureRequest,
-) -> Generator[MagicMock, None, None]:
+) -> Generator[MagicMock]:
     """Return a mocked JVC Projector device."""
     target = "homeassistant.components.jvc_projector.JvcProjector"
     if hasattr(request, "param"):

--- a/tests/components/kitchen_sink/test_notify.py
+++ b/tests/components/kitchen_sink/test_notify.py
@@ -1,10 +1,10 @@
 """The tests for the demo button component."""
 
-from collections.abc import AsyncGenerator
 from unittest.mock import patch
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
+from typing_extensions import AsyncGenerator
 
 from homeassistant.components.kitchen_sink import DOMAIN
 from homeassistant.components.notify import (
@@ -21,7 +21,7 @@ ENTITY_DIRECT_MESSAGE = "notify.mybox_personal_notifier"
 
 
 @pytest.fixture
-async def notify_only() -> AsyncGenerator[None, None]:
+async def notify_only() -> AsyncGenerator[None]:
     """Enable only the button platform."""
     with patch(
         "homeassistant.components.kitchen_sink.COMPONENTS_WITH_DEMO_PLATFORM",

--- a/tests/components/kmtronic/conftest.py
+++ b/tests/components/kmtronic/conftest.py
@@ -1,13 +1,13 @@
 """Define fixtures for kmtronic tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.kmtronic.async_setup_entry", return_value=True

--- a/tests/components/kostal_plenticore/conftest.py
+++ b/tests/components/kostal_plenticore/conftest.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from pykoplenti import MeData, VersionData
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.kostal_plenticore.coordinator import Plenticore
 from homeassistant.core import HomeAssistant
@@ -27,7 +27,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_plenticore() -> Generator[Plenticore, None, None]:
+def mock_plenticore() -> Generator[Plenticore]:
     """Set up a Plenticore mock with some default values."""
     with patch(
         "homeassistant.components.kostal_plenticore.Plenticore", autospec=True

--- a/tests/components/kostal_plenticore/test_config_flow.py
+++ b/tests/components/kostal_plenticore/test_config_flow.py
@@ -1,10 +1,10 @@
 """Test the Kostal Plenticore Solar Inverter config flow."""
 
-from collections.abc import Generator
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 from pykoplenti import ApiClient, AuthenticationException, SettingsData
 import pytest
+from typing_extensions import Generator
 
 from homeassistant import config_entries
 from homeassistant.components.kostal_plenticore.const import DOMAIN
@@ -25,7 +25,7 @@ def mock_apiclient() -> ApiClient:
 
 
 @pytest.fixture
-def mock_apiclient_class(mock_apiclient) -> Generator[type[ApiClient], None, None]:
+def mock_apiclient_class(mock_apiclient) -> Generator[type[ApiClient]]:
     """Return a mocked ApiClient class."""
     with patch(
         "homeassistant.components.kostal_plenticore.config_flow.ApiClient",

--- a/tests/components/kostal_plenticore/test_helper.py
+++ b/tests/components/kostal_plenticore/test_helper.py
@@ -1,10 +1,10 @@
 """Test Kostal Plenticore helper."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from pykoplenti import ApiClient, ExtendedApiClient, SettingsData
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.kostal_plenticore.const import DOMAIN
 from homeassistant.core import HomeAssistant
@@ -14,7 +14,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def mock_apiclient() -> Generator[ApiClient, None, None]:
+def mock_apiclient() -> Generator[ApiClient]:
     """Return a mocked ApiClient class."""
     with patch(
         "homeassistant.components.kostal_plenticore.coordinator.ExtendedApiClient",

--- a/tests/components/kostal_plenticore/test_number.py
+++ b/tests/components/kostal_plenticore/test_number.py
@@ -1,11 +1,11 @@
 """Test Kostal Plenticore number."""
 
-from collections.abc import Generator
 from datetime import timedelta
 from unittest.mock import patch
 
 from pykoplenti import ApiClient, SettingsData
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.number import (
     ATTR_MAX,
@@ -23,7 +23,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 @pytest.fixture
-def mock_plenticore_client() -> Generator[ApiClient, None, None]:
+def mock_plenticore_client() -> Generator[ApiClient]:
     """Return a patched ExtendedApiClient."""
     with patch(
         "homeassistant.components.kostal_plenticore.coordinator.ExtendedApiClient",

--- a/tests/components/lacrosse_view/conftest.py
+++ b/tests/components/lacrosse_view/conftest.py
@@ -1,13 +1,13 @@
 """Define fixtures for LaCrosse View tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.lacrosse_view.async_setup_entry", return_value=True

--- a/tests/components/lamarzocco/conftest.py
+++ b/tests/components/lamarzocco/conftest.py
@@ -1,10 +1,10 @@
 """Lamarzocco session fixtures."""
 
-from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 from lmcloud.const import LaMarzoccoModel
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.lamarzocco.const import CONF_MACHINE, DOMAIN
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME
@@ -59,7 +59,7 @@ def device_fixture() -> LaMarzoccoModel:
 @pytest.fixture
 def mock_lamarzocco(
     request: pytest.FixtureRequest, device_fixture: LaMarzoccoModel
-) -> Generator[MagicMock, None, None]:
+) -> Generator[MagicMock]:
     """Return a mocked LM client."""
     model_name = device_fixture
 

--- a/tests/components/lametric/conftest.py
+++ b/tests/components/lametric/conftest.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from demetriek import CloudDevice, Device
 from pydantic import parse_raw_as
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.application_credentials import (
     ClientCredential,
@@ -46,7 +46,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.lametric.async_setup_entry", return_value=True
@@ -55,7 +55,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_lametric_cloud() -> Generator[MagicMock, None, None]:
+def mock_lametric_cloud() -> Generator[MagicMock]:
     """Return a mocked LaMetric Cloud client."""
     with patch(
         "homeassistant.components.lametric.config_flow.LaMetricCloud", autospec=True
@@ -74,7 +74,7 @@ def device_fixture() -> str:
 
 
 @pytest.fixture
-def mock_lametric(device_fixture: str) -> Generator[MagicMock, None, None]:
+def mock_lametric(device_fixture: str) -> Generator[MagicMock]:
     """Return a mocked LaMetric TIME client."""
     with (
         patch(

--- a/tests/components/landisgyr_heat_meter/conftest.py
+++ b/tests/components/landisgyr_heat_meter/conftest.py
@@ -1,13 +1,13 @@
 """Define fixtures for Landis + Gyr Heat Meter tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.landisgyr_heat_meter.async_setup_entry",

--- a/tests/components/lawn_mower/test_init.py
+++ b/tests/components/lawn_mower/test_init.py
@@ -1,9 +1,9 @@
 """The tests for the lawn mower integration."""
 
-from collections.abc import Generator
 from unittest.mock import MagicMock
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.lawn_mower import (
     DOMAIN as LAWN_MOWER_DOMAIN,
@@ -52,7 +52,7 @@ class MockLawnMowerEntity(LawnMowerEntity):
 
 
 @pytest.fixture(autouse=True)
-def config_flow_fixture(hass: HomeAssistant) -> Generator[None, None, None]:
+def config_flow_fixture(hass: HomeAssistant) -> Generator[None]:
     """Mock config flow."""
     mock_platform(hass, f"{TEST_DOMAIN}.config_flow")
 

--- a/tests/components/lidarr/conftest.py
+++ b/tests/components/lidarr/conftest.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Generator
+from collections.abc import Awaitable, Callable
 from http import HTTPStatus
 
 from aiohttp.client_exceptions import ClientError
 from aiopyarr.lidarr_client import LidarrClient
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.lidarr.const import DOMAIN
 from homeassistant.const import (
@@ -132,7 +133,7 @@ def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
 async def mock_setup_integration(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-) -> Generator[ComponentSetup, None, None]:
+) -> Generator[ComponentSetup]:
     """Set up the lidarr integration in Home Assistant."""
     config_entry.add_to_hass(hass)
 

--- a/tests/components/linear_garage_door/conftest.py
+++ b/tests/components/linear_garage_door/conftest.py
@@ -1,9 +1,9 @@
 """Common fixtures for the Linear Garage Door tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.linear_garage_door import DOMAIN
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
@@ -16,7 +16,7 @@ from tests.common import (
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.linear_garage_door.async_setup_entry",
@@ -26,7 +26,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_linear() -> Generator[AsyncMock, None, None]:
+def mock_linear() -> Generator[AsyncMock]:
     """Mock a Linear Garage Door client."""
     with (
         patch(

--- a/tests/components/local_calendar/conftest.py
+++ b/tests/components/local_calendar/conftest.py
@@ -1,6 +1,6 @@
 """Fixtures for local calendar."""
 
-from collections.abc import Awaitable, Callable, Generator
+from collections.abc import Awaitable, Callable
 from http import HTTPStatus
 from pathlib import Path
 from typing import Any
@@ -9,6 +9,7 @@ import urllib
 
 from aiohttp import ClientWebSocketResponse
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.local_calendar import LocalCalendarStore
 from homeassistant.components.local_calendar.const import CONF_CALENDAR_NAME, DOMAIN
@@ -60,9 +61,7 @@ def mock_store_read_side_effect() -> Any | None:
 
 
 @pytest.fixture(name="store", autouse=True)
-def mock_store(
-    ics_content: str, store_read_side_effect: Any | None
-) -> Generator[None, None, None]:
+def mock_store(ics_content: str, store_read_side_effect: Any | None) -> Generator[None]:
     """Test cleanup, remove any media storage persisted during the test."""
 
     stores: dict[Path, FakeStore] = {}

--- a/tests/components/local_todo/conftest.py
+++ b/tests/components/local_todo/conftest.py
@@ -1,11 +1,11 @@
 """Common fixtures for the local_todo tests."""
 
-from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.local_todo import LocalTodoListStore
 from homeassistant.components.local_todo.const import (
@@ -24,7 +24,7 @@ TEST_ENTITY = "todo.my_tasks"
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.local_todo.async_setup_entry", return_value=True
@@ -72,9 +72,7 @@ def mock_store_read_side_effect() -> Any | None:
 
 
 @pytest.fixture(name="store", autouse=True)
-def mock_store(
-    ics_content: str, store_read_side_effect: Any | None
-) -> Generator[None, None, None]:
+def mock_store(ics_content: str, store_read_side_effect: Any | None) -> Generator[None]:
     """Fixture that sets up a fake local storage object."""
 
     stores: dict[Path, FakeStore] = {}

--- a/tests/components/lock/conftest.py
+++ b/tests/components/lock/conftest.py
@@ -1,10 +1,10 @@
 """Fixtures for the lock entity platform tests."""
 
-from collections.abc import Generator
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.lock import (
     DOMAIN as LOCK_DOMAIN,
@@ -65,7 +65,7 @@ class MockFlow(ConfigFlow):
 
 
 @pytest.fixture(autouse=True)
-def config_flow_fixture(hass: HomeAssistant) -> Generator[None, None, None]:
+def config_flow_fixture(hass: HomeAssistant) -> Generator[None]:
     """Mock config flow."""
     mock_platform(hass, f"{TEST_DOMAIN}.config_flow")
 

--- a/tests/components/loqed/conftest.py
+++ b/tests/components/loqed/conftest.py
@@ -1,12 +1,12 @@
 """Contains fixtures for Loqed tests."""
 
-from collections.abc import AsyncGenerator
 import json
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 from loqedAPI import loqed
 import pytest
+from typing_extensions import AsyncGenerator
 
 from homeassistant.components.loqed import DOMAIN
 from homeassistant.components.loqed.const import CONF_CLOUDHOOK_URL
@@ -81,7 +81,7 @@ def lock_fixture() -> loqed.Lock:
 @pytest.fixture(name="integration")
 async def integration_fixture(
     hass: HomeAssistant, config_entry: MockConfigEntry, lock: loqed.Lock
-) -> AsyncGenerator[MockConfigEntry, None]:
+) -> AsyncGenerator[MockConfigEntry]:
     """Set up the loqed integration with a config entry."""
     config: dict[str, Any] = {DOMAIN: {CONF_API_TOKEN: ""}}
     config_entry.add_to_hass(hass)

--- a/tests/components/lovelace/test_cast.py
+++ b/tests/components/lovelace/test_cast.py
@@ -1,10 +1,10 @@
 """Test the Lovelace Cast platform."""
 
-from collections.abc import Generator
 from time import time
 from unittest.mock import MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.lovelace import cast as lovelace_cast
 from homeassistant.components.media_player import MediaClass
@@ -17,7 +17,7 @@ from tests.common import async_mock_service
 
 
 @pytest.fixture(autouse=True)
-def mock_onboarding_done() -> Generator[MagicMock, None, None]:
+def mock_onboarding_done() -> Generator[MagicMock]:
     """Mock that Home Assistant is currently onboarding.
 
     Enabled to prevent creating default dashboards during test execution.

--- a/tests/components/lovelace/test_dashboard.py
+++ b/tests/components/lovelace/test_dashboard.py
@@ -1,11 +1,11 @@
 """Test the Lovelace initialization."""
 
-from collections.abc import Generator
 import time
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components import frontend
 from homeassistant.components.lovelace import const, dashboard
@@ -17,7 +17,7 @@ from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture(autouse=True)
-def mock_onboarding_done() -> Generator[MagicMock, None, None]:
+def mock_onboarding_done() -> Generator[MagicMock]:
     """Mock that Home Assistant is currently onboarding.
 
     Enabled to prevent creating default dashboards during test execution.

--- a/tests/components/lovelace/test_init.py
+++ b/tests/components/lovelace/test_init.py
@@ -1,10 +1,10 @@
 """Test the Lovelace initialization."""
 
-from collections.abc import Generator
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -13,7 +13,7 @@ from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture
-def mock_onboarding_not_done() -> Generator[MagicMock, None, None]:
+def mock_onboarding_not_done() -> Generator[MagicMock]:
     """Mock that Home Assistant is currently onboarding."""
     with patch(
         "homeassistant.components.onboarding.async_is_onboarded",
@@ -23,7 +23,7 @@ def mock_onboarding_not_done() -> Generator[MagicMock, None, None]:
 
 
 @pytest.fixture
-def mock_onboarding_done() -> Generator[MagicMock, None, None]:
+def mock_onboarding_done() -> Generator[MagicMock]:
     """Mock that Home Assistant is currently onboarding."""
     with patch(
         "homeassistant.components.onboarding.async_is_onboarded",
@@ -33,7 +33,7 @@ def mock_onboarding_done() -> Generator[MagicMock, None, None]:
 
 
 @pytest.fixture
-def mock_add_onboarding_listener() -> Generator[MagicMock, None, None]:
+def mock_add_onboarding_listener() -> Generator[MagicMock]:
     """Mock that Home Assistant is currently onboarding."""
     with patch(
         "homeassistant.components.onboarding.async_add_listener",

--- a/tests/components/lovelace/test_system_health.py
+++ b/tests/components/lovelace/test_system_health.py
@@ -1,10 +1,10 @@
 """Tests for Lovelace system health."""
 
-from collections.abc import Generator
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.lovelace import dashboard
 from homeassistant.core import HomeAssistant
@@ -14,7 +14,7 @@ from tests.common import get_system_health_info
 
 
 @pytest.fixture(autouse=True)
-def mock_onboarding_done() -> Generator[MagicMock, None, None]:
+def mock_onboarding_done() -> Generator[MagicMock]:
     """Mock that Home Assistant is currently onboarding.
 
     Enabled to prevent creating default dashboards during test execution.

--- a/tests/components/luftdaten/conftest.py
+++ b/tests/components/luftdaten/conftest.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.luftdaten.const import CONF_SENSOR_ID, DOMAIN
 from homeassistant.const import CONF_SHOW_ON_MAP
@@ -26,7 +26,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[None, None, None]:
+def mock_setup_entry() -> Generator[None]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.luftdaten.async_setup_entry", return_value=True

--- a/tests/components/lutron/conftest.py
+++ b/tests/components/lutron/conftest.py
@@ -1,13 +1,13 @@
 """Provide common Lutron fixtures and mocks."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.lutron.async_setup_entry", return_value=True

--- a/tests/components/map/test_init.py
+++ b/tests/components/map/test_init.py
@@ -1,10 +1,10 @@
 """Test the Map initialization."""
 
-from collections.abc import Generator
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.map import DOMAIN
 from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
@@ -15,7 +15,7 @@ from tests.common import MockModule, mock_integration
 
 
 @pytest.fixture
-def mock_onboarding_not_done() -> Generator[MagicMock, None, None]:
+def mock_onboarding_not_done() -> Generator[MagicMock]:
     """Mock that Home Assistant is currently onboarding."""
     with patch(
         "homeassistant.components.onboarding.async_is_onboarded",
@@ -25,7 +25,7 @@ def mock_onboarding_not_done() -> Generator[MagicMock, None, None]:
 
 
 @pytest.fixture
-def mock_onboarding_done() -> Generator[MagicMock, None, None]:
+def mock_onboarding_done() -> Generator[MagicMock]:
     """Mock that Home Assistant is currently onboarding."""
     with patch(
         "homeassistant.components.onboarding.async_is_onboarded",
@@ -35,7 +35,7 @@ def mock_onboarding_done() -> Generator[MagicMock, None, None]:
 
 
 @pytest.fixture
-def mock_create_map_dashboard() -> Generator[MagicMock, None, None]:
+def mock_create_map_dashboard() -> Generator[MagicMock]:
     """Mock the create map dashboard function."""
     with patch(
         "homeassistant.components.map._create_map_dashboard",

--- a/tests/components/matter/conftest.py
+++ b/tests/components/matter/conftest.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncGenerator, Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from matter_server.client.models.node import MatterNode
 from matter_server.common.const import SCHEMA_VERSION
 from matter_server.common.models import ServerInfoMessage
 import pytest
+from typing_extensions import AsyncGenerator, Generator
 
 from homeassistant.core import HomeAssistant
 
@@ -22,7 +22,7 @@ MOCK_COMPR_FABRIC_ID = 1234
 
 
 @pytest.fixture(name="matter_client")
-async def matter_client_fixture() -> AsyncGenerator[MagicMock, None]:
+async def matter_client_fixture() -> AsyncGenerator[MagicMock]:
     """Fixture for a Matter client."""
     with patch(
         "homeassistant.components.matter.MatterClient", autospec=True
@@ -70,7 +70,7 @@ async def integration_fixture(
 
 
 @pytest.fixture(name="create_backup")
-def create_backup_fixture() -> Generator[AsyncMock, None, None]:
+def create_backup_fixture() -> Generator[AsyncMock]:
     """Mock Supervisor create backup of add-on."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_create_backup"
@@ -79,7 +79,7 @@ def create_backup_fixture() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture(name="addon_store_info")
-def addon_store_info_fixture() -> Generator[AsyncMock, None, None]:
+def addon_store_info_fixture() -> Generator[AsyncMock]:
     """Mock Supervisor add-on store info."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_get_addon_store_info"
@@ -94,7 +94,7 @@ def addon_store_info_fixture() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture(name="addon_info")
-def addon_info_fixture() -> Generator[AsyncMock, None, None]:
+def addon_info_fixture() -> Generator[AsyncMock]:
     """Mock Supervisor add-on info."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_get_addon_info",
@@ -158,7 +158,7 @@ def addon_running_fixture(
 @pytest.fixture(name="install_addon")
 def install_addon_fixture(
     addon_store_info: AsyncMock, addon_info: AsyncMock
-) -> Generator[AsyncMock, None, None]:
+) -> Generator[AsyncMock]:
     """Mock install add-on."""
 
     async def install_addon_side_effect(hass: HomeAssistant, slug: str) -> None:
@@ -181,7 +181,7 @@ def install_addon_fixture(
 
 
 @pytest.fixture(name="start_addon")
-def start_addon_fixture() -> Generator[AsyncMock, None, None]:
+def start_addon_fixture() -> Generator[AsyncMock]:
     """Mock start add-on."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_start_addon"
@@ -190,7 +190,7 @@ def start_addon_fixture() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture(name="stop_addon")
-def stop_addon_fixture() -> Generator[AsyncMock, None, None]:
+def stop_addon_fixture() -> Generator[AsyncMock]:
     """Mock stop add-on."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_stop_addon"
@@ -199,7 +199,7 @@ def stop_addon_fixture() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture(name="uninstall_addon")
-def uninstall_addon_fixture() -> Generator[AsyncMock, None, None]:
+def uninstall_addon_fixture() -> Generator[AsyncMock]:
     """Mock uninstall add-on."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_uninstall_addon"
@@ -208,7 +208,7 @@ def uninstall_addon_fixture() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture(name="update_addon")
-def update_addon_fixture() -> Generator[AsyncMock, None, None]:
+def update_addon_fixture() -> Generator[AsyncMock]:
     """Mock update add-on."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_update_addon"

--- a/tests/components/matter/test_binary_sensor.py
+++ b/tests/components/matter/test_binary_sensor.py
@@ -1,10 +1,10 @@
 """Test Matter binary sensors."""
 
-from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 from matter_server.client.models.node import MatterNode
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.matter.binary_sensor import (
     DISCOVERY_SCHEMAS as BINARY_SENSOR_SCHEMAS,
@@ -21,7 +21,7 @@ from .common import (
 
 
 @pytest.fixture(autouse=True)
-def binary_sensor_platform() -> Generator[None, None, None]:
+def binary_sensor_platform() -> Generator[None]:
     """Load only the binary sensor platform."""
     with patch(
         "homeassistant.components.matter.discovery.DISCOVERY_SCHEMAS",

--- a/tests/components/matter/test_config_flow.py
+++ b/tests/components/matter/test_config_flow.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from ipaddress import ip_address
 from typing import Any
 from unittest.mock import DEFAULT, AsyncMock, MagicMock, call, patch
 
 from matter_server.client.exceptions import CannotConnect, InvalidServerVersion
 import pytest
+from typing_extensions import Generator
 
 from homeassistant import config_entries
 from homeassistant.components.hassio import HassioAPIError, HassioServiceInfo
@@ -58,7 +58,7 @@ ZEROCONF_INFO_UDP = ZeroconfServiceInfo(
 
 
 @pytest.fixture(name="setup_entry", autouse=True)
-def setup_entry_fixture() -> Generator[AsyncMock, None, None]:
+def setup_entry_fixture() -> Generator[AsyncMock]:
     """Mock entry setup."""
     with patch(
         "homeassistant.components.matter.async_setup_entry", return_value=True
@@ -67,7 +67,7 @@ def setup_entry_fixture() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture(name="unload_entry", autouse=True)
-def unload_entry_fixture() -> Generator[AsyncMock, None, None]:
+def unload_entry_fixture() -> Generator[AsyncMock]:
     """Mock entry unload."""
     with patch(
         "homeassistant.components.matter.async_unload_entry", return_value=True
@@ -76,7 +76,7 @@ def unload_entry_fixture() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture(name="client_connect", autouse=True)
-def client_connect_fixture() -> Generator[AsyncMock, None, None]:
+def client_connect_fixture() -> Generator[AsyncMock]:
     """Mock server version."""
     with patch(
         "homeassistant.components.matter.config_flow.MatterClient.connect"
@@ -85,7 +85,7 @@ def client_connect_fixture() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture(name="supervisor")
-def supervisor_fixture() -> Generator[MagicMock, None, None]:
+def supervisor_fixture() -> Generator[MagicMock]:
     """Mock Supervisor."""
     with patch(
         "homeassistant.components.matter.config_flow.is_hassio", return_value=True
@@ -100,9 +100,7 @@ def discovery_info_fixture() -> Any:
 
 
 @pytest.fixture(name="get_addon_discovery_info", autouse=True)
-def get_addon_discovery_info_fixture(
-    discovery_info: Any,
-) -> Generator[AsyncMock, None, None]:
+def get_addon_discovery_info_fixture(discovery_info: Any) -> Generator[AsyncMock]:
     """Mock get add-on discovery info."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_get_addon_discovery_info",
@@ -112,7 +110,7 @@ def get_addon_discovery_info_fixture(
 
 
 @pytest.fixture(name="addon_setup_time", autouse=True)
-def addon_setup_time_fixture() -> Generator[int, None, None]:
+def addon_setup_time_fixture() -> Generator[int]:
     """Mock add-on setup sleep time."""
     with patch(
         "homeassistant.components.matter.config_flow.ADDON_SETUP_TIMEOUT", new=0
@@ -121,7 +119,7 @@ def addon_setup_time_fixture() -> Generator[int, None, None]:
 
 
 @pytest.fixture(name="not_onboarded")
-def mock_onboarded_fixture() -> Generator[MagicMock, None, None]:
+def mock_onboarded_fixture() -> Generator[MagicMock]:
     """Mock that Home Assistant is not yet onboarded."""
     with patch(
         "homeassistant.components.matter.config_flow.async_is_onboarded",

--- a/tests/components/matter/test_init.py
+++ b/tests/components/matter/test_init.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 from matter_server.client.exceptions import CannotConnect, InvalidServerVersion
@@ -12,6 +11,7 @@ from matter_server.common.errors import MatterError
 from matter_server.common.helpers.util import dataclass_from_dict
 from matter_server.common.models import MatterNodeData
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.hassio import HassioAPIError
 from homeassistant.components.matter.const import DOMAIN
@@ -32,14 +32,14 @@ from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture(name="connect_timeout")
-def connect_timeout_fixture() -> Generator[int, None, None]:
+def connect_timeout_fixture() -> Generator[int]:
     """Mock the connect timeout."""
     with patch("homeassistant.components.matter.CONNECT_TIMEOUT", new=0) as timeout:
         yield timeout
 
 
 @pytest.fixture(name="listen_ready_timeout")
-def listen_ready_timeout_fixture() -> Generator[int, None, None]:
+def listen_ready_timeout_fixture() -> Generator[int]:
     """Mock the listen ready timeout."""
     with patch(
         "homeassistant.components.matter.LISTEN_READY_TIMEOUT", new=0

--- a/tests/components/media_extractor/conftest.py
+++ b/tests/components/media_extractor/conftest.py
@@ -1,10 +1,10 @@
 """Common fixtures for the Media Extractor tests."""
 
-from collections.abc import Generator
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.media_extractor import DOMAIN
 from homeassistant.core import HomeAssistant, ServiceCall
@@ -57,7 +57,7 @@ def audio_media_extractor_config() -> dict[str, Any]:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.media_extractor.async_setup_entry", return_value=True

--- a/tests/components/media_source/test_local_source.py
+++ b/tests/components/media_source/test_local_source.py
@@ -1,6 +1,5 @@
 """Test Local Media Source."""
 
-from collections.abc import AsyncGenerator
 from http import HTTPStatus
 import io
 from pathlib import Path
@@ -8,6 +7,7 @@ from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 import pytest
+from typing_extensions import AsyncGenerator
 
 from homeassistant.components import media_source, websocket_api
 from homeassistant.components.media_source import const
@@ -20,7 +20,7 @@ from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 
 @pytest.fixture
-async def temp_dir(hass: HomeAssistant) -> AsyncGenerator[str, None]:
+async def temp_dir(hass: HomeAssistant) -> AsyncGenerator[str]:
     """Return a temp dir."""
     with TemporaryDirectory() as tmpdirname:
         target_dir = Path(tmpdirname) / "another_subdir"

--- a/tests/components/melnor/conftest.py
+++ b/tests/components/melnor/conftest.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from datetime import UTC, datetime, time, timedelta
 from unittest.mock import AsyncMock, _patch, patch
 
 from melnor_bluetooth.device import Device
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.bluetooth.models import BluetoothServiceInfoBleak
 from homeassistant.components.melnor.const import DOMAIN
@@ -245,7 +245,7 @@ def mock_melnor_device():
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Patch async setup entry to return True."""
     with patch(
         "homeassistant.components.melnor.async_setup_entry", return_value=True

--- a/tests/components/mjpeg/conftest.py
+++ b/tests/components/mjpeg/conftest.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from requests_mock import Mocker
+from typing_extensions import Generator
 
 from homeassistant.components.mjpeg.const import (
     CONF_MJPEG_URL,
@@ -44,7 +44,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.mjpeg.async_setup_entry", return_value=True
@@ -53,7 +53,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_reload_entry() -> Generator[AsyncMock, None, None]:
+def mock_reload_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch("homeassistant.components.mjpeg.async_reload_entry") as mock_reload:
         yield mock_reload

--- a/tests/components/moon/conftest.py
+++ b/tests/components/moon/conftest.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.moon.const import DOMAIN
 
@@ -22,7 +22,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[None, None, None]:
+def mock_setup_entry() -> Generator[None]:
     """Mock setting up a config entry."""
     with patch("homeassistant.components.moon.async_setup_entry", return_value=True):
         yield

--- a/tests/components/motionmount/conftest.py
+++ b/tests/components/motionmount/conftest.py
@@ -1,9 +1,9 @@
 """Fixtures for Vogel's MotionMount integration tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.motionmount.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PORT
@@ -25,7 +25,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.motionmount.async_setup_entry", return_value=True

--- a/tests/components/mqtt/test_config_flow.py
+++ b/tests/components/mqtt/test_config_flow.py
@@ -1,6 +1,6 @@
 """Test config flow."""
 
-from collections.abc import Generator, Iterator
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from ssl import SSLError
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
+from typing_extensions import Generator
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -33,7 +34,7 @@ MOCK_CLIENT_KEY = b"## mock key file ##"
 
 
 @pytest.fixture(autouse=True)
-def mock_finish_setup() -> Generator[MagicMock, None, None]:
+def mock_finish_setup() -> Generator[MagicMock]:
     """Mock out the finish setup method."""
     with patch(
         "homeassistant.components.mqtt.MQTT.async_connect", return_value=True
@@ -42,7 +43,7 @@ def mock_finish_setup() -> Generator[MagicMock, None, None]:
 
 
 @pytest.fixture
-def mock_client_cert_check_fail() -> Generator[MagicMock, None, None]:
+def mock_client_cert_check_fail() -> Generator[MagicMock]:
     """Mock the client certificate check."""
     with patch(
         "homeassistant.components.mqtt.config_flow.load_pem_x509_certificate",
@@ -52,7 +53,7 @@ def mock_client_cert_check_fail() -> Generator[MagicMock, None, None]:
 
 
 @pytest.fixture
-def mock_client_key_check_fail() -> Generator[MagicMock, None, None]:
+def mock_client_key_check_fail() -> Generator[MagicMock]:
     """Mock the client key file check."""
     with patch(
         "homeassistant.components.mqtt.config_flow.load_pem_private_key",
@@ -62,7 +63,7 @@ def mock_client_key_check_fail() -> Generator[MagicMock, None, None]:
 
 
 @pytest.fixture
-def mock_ssl_context() -> Generator[dict[str, MagicMock], None, None]:
+def mock_ssl_context() -> Generator[dict[str, MagicMock]]:
     """Mock the SSL context used to load the cert chain and to load verify locations."""
     with (
         patch("homeassistant.components.mqtt.config_flow.SSLContext") as mock_context,
@@ -81,7 +82,7 @@ def mock_ssl_context() -> Generator[dict[str, MagicMock], None, None]:
 
 
 @pytest.fixture
-def mock_reload_after_entry_update() -> Generator[MagicMock, None, None]:
+def mock_reload_after_entry_update() -> Generator[MagicMock]:
     """Mock out the reload after updating the entry."""
     with patch(
         "homeassistant.components.mqtt._async_config_entry_updated"
@@ -90,14 +91,14 @@ def mock_reload_after_entry_update() -> Generator[MagicMock, None, None]:
 
 
 @pytest.fixture
-def mock_try_connection() -> Generator[MagicMock, None, None]:
+def mock_try_connection() -> Generator[MagicMock]:
     """Mock the try connection method."""
     with patch("homeassistant.components.mqtt.config_flow.try_connection") as mock_try:
         yield mock_try
 
 
 @pytest.fixture
-def mock_try_connection_success() -> Generator[MqttMockPahoClient, None, None]:
+def mock_try_connection_success() -> Generator[MqttMockPahoClient]:
     """Mock the try connection method with success."""
 
     _mid = 1
@@ -132,7 +133,7 @@ def mock_try_connection_success() -> Generator[MqttMockPahoClient, None, None]:
 
 
 @pytest.fixture
-def mock_try_connection_time_out() -> Generator[MagicMock, None, None]:
+def mock_try_connection_time_out() -> Generator[MagicMock]:
     """Mock the try connection method with a time out."""
 
     # Patch prevent waiting 5 sec for a timeout
@@ -149,7 +150,7 @@ def mock_try_connection_time_out() -> Generator[MagicMock, None, None]:
 @pytest.fixture
 def mock_process_uploaded_file(
     tmp_path: Path, mock_temp_dir: str
-) -> Generator[MagicMock, None, None]:
+) -> Generator[MagicMock]:
     """Mock upload certificate files."""
     file_id_ca = str(uuid4())
     file_id_cert = str(uuid4())

--- a/tests/components/mqtt/test_tag.py
+++ b/tests/components/mqtt/test_tag.py
@@ -1,11 +1,11 @@
 """The tests for MQTT tag scanner."""
 
-from collections.abc import Generator
 import copy
 import json
 from unittest.mock import ANY, AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.mqtt.const import DOMAIN as MQTT_DOMAIN
@@ -47,7 +47,7 @@ DEFAULT_TAG_SCAN_JSON = (
 
 
 @pytest.fixture
-def tag_mock() -> Generator[AsyncMock, None, None]:
+def tag_mock() -> Generator[AsyncMock]:
     """Fixture to mock tag."""
     with patch("homeassistant.components.tag.async_scan_tag") as mock_tag:
         yield mock_tag

--- a/tests/components/mysensors/conftest.py
+++ b/tests/components/mysensors/conftest.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator, Callable, Generator
+from collections.abc import Callable
 from copy import deepcopy
 import json
 from typing import Any
@@ -12,6 +12,7 @@ from mysensors import BaseSyncGateway
 from mysensors.persistence import MySensorsJSONDecoder
 from mysensors.sensor import Sensor
 import pytest
+from typing_extensions import AsyncGenerator, Generator
 
 from homeassistant.components.mqtt import DOMAIN as MQTT_DOMAIN
 from homeassistant.components.mysensors.config_flow import DEFAULT_BAUD_RATE
@@ -36,7 +37,7 @@ def mock_mqtt_fixture(hass: HomeAssistant) -> None:
 
 
 @pytest.fixture(name="is_serial_port")
-def is_serial_port_fixture() -> Generator[MagicMock, None, None]:
+def is_serial_port_fixture() -> Generator[MagicMock]:
     """Patch the serial port check."""
     with patch("homeassistant.components.mysensors.gateway.cv.isdevice") as is_device:
         is_device.side_effect = lambda device: device
@@ -53,7 +54,7 @@ def gateway_nodes_fixture() -> dict[int, Sensor]:
 async def serial_transport_fixture(
     gateway_nodes: dict[int, Sensor],
     is_serial_port: MagicMock,
-) -> AsyncGenerator[dict[int, Sensor], None]:
+) -> AsyncGenerator[dict[int, Sensor]]:
     """Mock a serial transport."""
     with (
         patch(
@@ -136,7 +137,7 @@ def config_entry_fixture(serial_entry: MockConfigEntry) -> MockConfigEntry:
 @pytest.fixture(name="integration")
 async def integration_fixture(
     hass: HomeAssistant, transport: MagicMock, config_entry: MockConfigEntry
-) -> AsyncGenerator[MockConfigEntry, None]:
+) -> AsyncGenerator[MockConfigEntry]:
     """Set up the mysensors integration with a config entry."""
     config: dict[str, Any] = {}
     config_entry.add_to_hass(hass)

--- a/tests/components/mystrom/conftest.py
+++ b/tests/components/mystrom/conftest.py
@@ -1,9 +1,9 @@
 """Provide common mystrom fixtures and mocks."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.mystrom.const import DOMAIN
 from homeassistant.const import CONF_HOST
@@ -16,7 +16,7 @@ DEVICE_MAC = "6001940376EB"
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.mystrom.async_setup_entry", return_value=True

--- a/tests/components/myuplink/conftest.py
+++ b/tests/components/myuplink/conftest.py
@@ -1,6 +1,5 @@
 """Test helpers for myuplink."""
 
-from collections.abc import AsyncGenerator, Generator
 import time
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -8,6 +7,7 @@ from unittest.mock import MagicMock, patch
 from myuplink import Device, DevicePoint, System
 import orjson
 import pytest
+from typing_extensions import AsyncGenerator, Generator
 
 from homeassistant.components.application_credentials import (
     ClientCredential,
@@ -135,7 +135,7 @@ def mock_myuplink_client(
     device_points_fixture,
     system_fixture,
     load_systems_jv_file,
-) -> Generator[MagicMock, None, None]:
+) -> Generator[MagicMock]:
     """Mock a myuplink client."""
 
     with patch(
@@ -182,7 +182,7 @@ async def setup_platform(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     platforms,
-) -> AsyncGenerator[None, None]:
+) -> AsyncGenerator[None]:
     """Set up one or all platforms."""
 
     with patch(f"homeassistant.components.{DOMAIN}.PLATFORMS", platforms):

--- a/tests/components/nest/common.py
+++ b/tests/components/nest/common.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Generator
+from collections.abc import Awaitable, Callable
 import copy
 from dataclasses import dataclass, field
 import time
@@ -14,13 +14,14 @@ from google_nest_sdm.device_manager import DeviceManager
 from google_nest_sdm.event import EventMessage
 from google_nest_sdm.event_media import CachePolicy
 from google_nest_sdm.google_nest_subscriber import GoogleNestSubscriber
+from typing_extensions import Generator
 
 from homeassistant.components.application_credentials import ClientCredential
 from homeassistant.components.nest import DOMAIN
 
 # Typing helpers
 type PlatformSetup = Callable[[], Awaitable[None]]
-type YieldFixture[_T] = Generator[_T, None, None]
+type YieldFixture[_T] = Generator[_T]
 
 WEB_AUTH_DOMAIN = DOMAIN
 APP_AUTH_DOMAIN = f"{DOMAIN}.installed"

--- a/tests/components/nest/conftest.py
+++ b/tests/components/nest/conftest.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from asyncio import AbstractEventLoop
-from collections.abc import Generator
 import copy
 import shutil
 import time
@@ -16,6 +15,7 @@ from google_nest_sdm import diagnostics
 from google_nest_sdm.auth import AbstractAuth
 from google_nest_sdm.device_manager import DeviceManager
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.application_credentials import (
     async_import_client_credential,
@@ -298,7 +298,7 @@ async def setup_platform(
 
 
 @pytest.fixture(autouse=True)
-def reset_diagnostics() -> Generator[None, None, None]:
+def reset_diagnostics() -> Generator[None]:
     """Fixture to reset client library diagnostic counters."""
     yield
     diagnostics.reset()

--- a/tests/components/nest/test_init.py
+++ b/tests/components/nest/test_init.py
@@ -8,7 +8,6 @@ mode (e.g. yaml, ConfigEntry, etc) however some tests override and just run in
 relevant modes.
 """
 
-from collections.abc import Generator
 import logging
 from typing import Any
 from unittest.mock import patch
@@ -20,6 +19,7 @@ from google_nest_sdm.exceptions import (
     SubscriberException,
 )
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.nest import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -51,7 +51,7 @@ def platforms() -> list[str]:
 @pytest.fixture
 def error_caplog(
     caplog: pytest.LogCaptureFixture,
-) -> Generator[pytest.LogCaptureFixture, None, None]:
+) -> Generator[pytest.LogCaptureFixture]:
     """Fixture to capture nest init error messages."""
     with caplog.at_level(logging.ERROR, logger="homeassistant.components.nest"):
         yield caplog
@@ -60,7 +60,7 @@ def error_caplog(
 @pytest.fixture
 def warning_caplog(
     caplog: pytest.LogCaptureFixture,
-) -> Generator[pytest.LogCaptureFixture, None, None]:
+) -> Generator[pytest.LogCaptureFixture]:
     """Fixture to capture nest init warning messages."""
     with caplog.at_level(logging.WARNING, logger="homeassistant.components.nest"):
         yield caplog

--- a/tests/components/nest/test_media_source.py
+++ b/tests/components/nest/test_media_source.py
@@ -4,7 +4,6 @@ These tests simulate recent camera events received by the subscriber exposed
 as media in the media source.
 """
 
-from collections.abc import Generator
 import datetime
 from http import HTTPStatus
 import io
@@ -16,6 +15,7 @@ import av
 from google_nest_sdm.event import EventMessage
 import numpy as np
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.media_player.errors import BrowseError
 from homeassistant.components.media_source import (
@@ -1097,7 +1097,7 @@ async def test_multiple_devices(
 
 
 @pytest.fixture
-def event_store() -> Generator[None, None, None]:
+def event_store() -> Generator[None]:
     """Persist changes to event store immediately."""
     with patch(
         "homeassistant.components.nest.media_source.STORAGE_SAVE_DELAY_SECONDS",

--- a/tests/components/network/conftest.py
+++ b/tests/components/network/conftest.py
@@ -1,9 +1,9 @@
 """Tests for the Network Configuration integration."""
 
-from collections.abc import Generator
 from unittest.mock import _patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture(autouse=True)
@@ -14,7 +14,7 @@ def mock_network():
 @pytest.fixture(autouse=True)
 def override_mock_get_source_ip(
     mock_get_source_ip: _patch,
-) -> Generator[None, None, None]:
+) -> Generator[None]:
     """Override mock of network util's async_get_source_ip."""
     mock_get_source_ip.stop()
     yield

--- a/tests/components/nextbus/test_config_flow.py
+++ b/tests/components/nextbus/test_config_flow.py
@@ -1,9 +1,9 @@
 """Test the NextBus config flow."""
 
-from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant import config_entries, setup
 from homeassistant.components.nextbus.const import CONF_AGENCY, CONF_ROUTE, DOMAIN
@@ -13,7 +13,7 @@ from homeassistant.data_entry_flow import FlowResultType
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[MagicMock, None, None]:
+def mock_setup_entry() -> Generator[MagicMock]:
     """Create a mock for the nextbus component setup."""
     with patch(
         "homeassistant.components.nextbus.async_setup_entry",
@@ -23,7 +23,7 @@ def mock_setup_entry() -> Generator[MagicMock, None, None]:
 
 
 @pytest.fixture
-def mock_nextbus() -> Generator[MagicMock, None, None]:
+def mock_nextbus() -> Generator[MagicMock]:
     """Create a mock py_nextbus module."""
     with patch("homeassistant.components.nextbus.config_flow.NextBusClient") as client:
         yield client

--- a/tests/components/nextbus/test_sensor.py
+++ b/tests/components/nextbus/test_sensor.py
@@ -1,12 +1,12 @@
 """The tests for the nexbus sensor component."""
 
-from collections.abc import Generator
 from copy import deepcopy
 from unittest.mock import MagicMock, patch
 from urllib.error import HTTPError
 
 from py_nextbus.client import NextBusFormatError, NextBusHTTPError
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components import sensor
 from homeassistant.components.nextbus.const import CONF_AGENCY, CONF_ROUTE, DOMAIN
@@ -66,7 +66,7 @@ BASIC_RESULTS = {
 
 
 @pytest.fixture
-def mock_nextbus() -> Generator[MagicMock, None, None]:
+def mock_nextbus() -> Generator[MagicMock]:
     """Create a mock py_nextbus module."""
     with patch("homeassistant.components.nextbus.coordinator.NextBusClient") as client:
         yield client
@@ -75,7 +75,7 @@ def mock_nextbus() -> Generator[MagicMock, None, None]:
 @pytest.fixture
 def mock_nextbus_predictions(
     mock_nextbus: MagicMock,
-) -> Generator[MagicMock, None, None]:
+) -> Generator[MagicMock]:
     """Create a mock of NextBusClient predictions."""
     instance = mock_nextbus.return_value
     instance.get_predictions_for_multi_stops.return_value = BASIC_RESULTS

--- a/tests/components/nextcloud/conftest.py
+++ b/tests/components/nextcloud/conftest.py
@@ -1,9 +1,9 @@
 """Fixtrues for the Nextcloud integration tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
@@ -15,7 +15,7 @@ def mock_nextcloud_monitor() -> Mock:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.nextcloud.async_setup_entry", return_value=True

--- a/tests/components/nibe_heatpump/conftest.py
+++ b/tests/components/nibe_heatpump/conftest.py
@@ -1,12 +1,12 @@
 """Test configuration for Nibe Heat Pump."""
 
-from collections.abc import Generator
 from contextlib import ExitStack
 from unittest.mock import AsyncMock, Mock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 from nibe.exceptions import CoilNotFoundException
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.core import HomeAssistant
 
@@ -16,7 +16,7 @@ from tests.common import async_fire_time_changed
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Make sure we never actually run setup."""
     with patch(
         "homeassistant.components.nibe_heatpump.async_setup_entry", return_value=True

--- a/tests/components/notify/conftest.py
+++ b/tests/components/notify/conftest.py
@@ -1,8 +1,7 @@
 """Fixtures for Notify platform tests."""
 
-from collections.abc import Generator
-
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.core import HomeAssistant
@@ -15,7 +14,7 @@ class MockFlow(ConfigFlow):
 
 
 @pytest.fixture
-def config_flow_fixture(hass: HomeAssistant) -> Generator[None, None, None]:
+def config_flow_fixture(hass: HomeAssistant) -> Generator[None]:
     """Mock config flow."""
     mock_platform(hass, "test.config_flow")
 

--- a/tests/components/notion/conftest.py
+++ b/tests/components/notion/conftest.py
@@ -1,6 +1,5 @@
 """Define fixtures for Notion tests."""
 
-from collections.abc import Generator
 import json
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -9,6 +8,7 @@ from aionotion.listener.models import Listener
 from aionotion.sensor.models import Sensor
 from aionotion.user.models import UserPreferences
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.notion import CONF_REFRESH_TOKEN, CONF_USER_UUID, DOMAIN
 from homeassistant.const import CONF_USERNAME
@@ -23,7 +23,7 @@ TEST_USER_UUID = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.notion.async_setup_entry", return_value=True

--- a/tests/components/number/test_init.py
+++ b/tests/components/number/test_init.py
@@ -1,10 +1,10 @@
 """The tests for the Number component."""
 
-from collections.abc import Generator
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.number import (
     ATTR_MAX,
@@ -859,7 +859,7 @@ class MockFlow(ConfigFlow):
 
 
 @pytest.fixture(autouse=True)
-def config_flow_fixture(hass: HomeAssistant) -> Generator[None, None, None]:
+def config_flow_fixture(hass: HomeAssistant) -> Generator[None]:
     """Mock config flow."""
     mock_platform(hass, f"{TEST_DOMAIN}.config_flow")
 


### PR DESCRIPTION
## Proposed change
For details see: https://github.com/home-assistant/core/pull/118986

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
