### PR TITLE
Import Generator from typing_extensions (4)

### DIFF
--- a/tests/components/obihai/conftest.py
+++ b/tests/components/obihai/conftest.py
@@ -1,14 +1,14 @@
 """Define test fixtures for Obihai."""
 
-from collections.abc import Generator
 from socket import gaierror
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
 
     with patch(
@@ -18,7 +18,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_gaierror() -> Generator[AsyncMock, None, None]:
+def mock_gaierror() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
 
     with patch(

--- a/tests/components/onboarding/test_views.py
+++ b/tests/components/onboarding/test_views.py
@@ -1,13 +1,13 @@
 """Test the onboarding views."""
 
 import asyncio
-from collections.abc import AsyncGenerator
 from http import HTTPStatus
 import os
 from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
+from typing_extensions import AsyncGenerator
 
 from homeassistant.components import onboarding
 from homeassistant.components.onboarding import const, views
@@ -70,7 +70,7 @@ async def no_rpi_fixture(
 @pytest.fixture(name="mock_supervisor")
 async def mock_supervisor_fixture(
     aioclient_mock: AiohttpClientMocker,
-) -> AsyncGenerator[None, None]:
+) -> AsyncGenerator[None]:
     """Mock supervisor."""
     aioclient_mock.post("http://127.0.0.1/homeassistant/options", json={"result": "ok"})
     aioclient_mock.post("http://127.0.0.1/supervisor/options", json={"result": "ok"})

--- a/tests/components/ondilo_ico/conftest.py
+++ b/tests/components/ondilo_ico/conftest.py
@@ -1,10 +1,10 @@
 """Provide basic Ondilo fixture."""
 
-from collections.abc import Generator
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.ondilo_ico.const import DOMAIN
 
@@ -31,7 +31,7 @@ def mock_ondilo_client(
     ico_details1: dict[str, Any],
     ico_details2: dict[str, Any],
     last_measures: list[dict[str, Any]],
-) -> Generator[MagicMock, None, None]:
+) -> Generator[MagicMock]:
     """Mock a Homeassistant Ondilo client."""
     with (
         patch(

--- a/tests/components/onewire/conftest.py
+++ b/tests/components/onewire/conftest.py
@@ -1,10 +1,10 @@
 """Provide common 1-Wire fixtures."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from pyownet.protocol import ConnError
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.onewire.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER, ConfigEntry
@@ -17,7 +17,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.onewire.async_setup_entry", return_value=True

--- a/tests/components/onewire/test_binary_sensor.py
+++ b/tests/components/onewire/test_binary_sensor.py
@@ -1,10 +1,10 @@
 """Tests for 1-Wire binary sensors."""
 
-from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from typing_extensions import Generator
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -15,7 +15,7 @@ from . import setup_owproxy_mock_devices
 
 
 @pytest.fixture(autouse=True)
-def override_platforms() -> Generator[None, None, None]:
+def override_platforms() -> Generator[None]:
     """Override PLATFORMS."""
     with patch("homeassistant.components.onewire.PLATFORMS", [Platform.BINARY_SENSOR]):
         yield

--- a/tests/components/onewire/test_diagnostics.py
+++ b/tests/components/onewire/test_diagnostics.py
@@ -1,10 +1,10 @@
 """Test 1-Wire diagnostics."""
 
-from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from typing_extensions import Generator
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -17,7 +17,7 @@ from tests.typing import ClientSessionGenerator
 
 
 @pytest.fixture(autouse=True)
-def override_platforms() -> Generator[None, None, None]:
+def override_platforms() -> Generator[None]:
     """Override PLATFORMS."""
     with patch("homeassistant.components.onewire.PLATFORMS", [Platform.SWITCH]):
         yield

--- a/tests/components/onewire/test_sensor.py
+++ b/tests/components/onewire/test_sensor.py
@@ -1,6 +1,5 @@
 """Tests for 1-Wire sensors."""
 
-from collections.abc import Generator
 from copy import deepcopy
 import logging
 from unittest.mock import MagicMock, _patch_dict, patch
@@ -8,6 +7,7 @@ from unittest.mock import MagicMock, _patch_dict, patch
 from pyownet.protocol import OwnetError
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from typing_extensions import Generator
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -19,7 +19,7 @@ from .const import ATTR_INJECT_READS, MOCK_OWPROXY_DEVICES
 
 
 @pytest.fixture(autouse=True)
-def override_platforms() -> Generator[None, None, None]:
+def override_platforms() -> Generator[None]:
     """Override PLATFORMS."""
     with patch("homeassistant.components.onewire.PLATFORMS", [Platform.SENSOR]):
         yield

--- a/tests/components/onewire/test_switch.py
+++ b/tests/components/onewire/test_switch.py
@@ -1,10 +1,10 @@
 """Tests for 1-Wire switches."""
 
-from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from typing_extensions import Generator
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntry
@@ -22,7 +22,7 @@ from . import setup_owproxy_mock_devices
 
 
 @pytest.fixture(autouse=True)
-def override_platforms() -> Generator[None, None, None]:
+def override_platforms() -> Generator[None]:
     """Override PLATFORMS."""
     with patch("homeassistant.components.onewire.PLATFORMS", [Platform.SWITCH]):
         yield

--- a/tests/components/open_meteo/conftest.py
+++ b/tests/components/open_meteo/conftest.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 from open_meteo import Forecast
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.open_meteo.const import DOMAIN
 from homeassistant.const import CONF_ZONE
@@ -26,7 +26,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[None, None, None]:
+def mock_setup_entry() -> Generator[None]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.open_meteo.async_setup_entry", return_value=True

--- a/tests/components/openexchangerates/conftest.py
+++ b/tests/components/openexchangerates/conftest.py
@@ -1,9 +1,9 @@
 """Provide common fixtures for tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.openexchangerates.const import DOMAIN
 
@@ -19,7 +19,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.openexchangerates.async_setup_entry",
@@ -31,7 +31,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 @pytest.fixture
 def mock_latest_rates_config_flow(
     request: pytest.FixtureRequest,
-) -> Generator[AsyncMock, None, None]:
+) -> Generator[AsyncMock]:
     """Return a mocked WLED client."""
     with patch(
         "homeassistant.components.openexchangerates.config_flow.Client.get_latest",

--- a/tests/components/openexchangerates/test_config_flow.py
+++ b/tests/components/openexchangerates/test_config_flow.py
@@ -1,7 +1,6 @@
 """Test the Open Exchange Rates config flow."""
 
 import asyncio
-from collections.abc import Generator
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -10,6 +9,7 @@ from aioopenexchangerates import (
     OpenExchangeRatesClientError,
 )
 import pytest
+from typing_extensions import Generator
 
 from homeassistant import config_entries
 from homeassistant.components.openexchangerates.const import DOMAIN
@@ -20,7 +20,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture(name="currencies", autouse=True)
-def currencies_fixture(hass: HomeAssistant) -> Generator[AsyncMock, None, None]:
+def currencies_fixture(hass: HomeAssistant) -> Generator[AsyncMock]:
     """Mock currencies."""
     with patch(
         "homeassistant.components.openexchangerates.config_flow.Client.get_currencies",

--- a/tests/components/opengarage/conftest.py
+++ b/tests/components/opengarage/conftest.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.opengarage.const import CONF_DEVICE_KEY, DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_VERIFY_SSL
@@ -31,7 +31,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_opengarage() -> Generator[MagicMock, None, None]:
+def mock_opengarage() -> Generator[MagicMock]:
     """Return a mocked OpenGarage client."""
     with patch(
         "homeassistant.components.opengarage.opengarage.OpenGarage",

--- a/tests/components/openuv/conftest.py
+++ b/tests/components/openuv/conftest.py
@@ -1,10 +1,10 @@
 """Define test fixtures for OpenUV."""
 
-from collections.abc import Generator
 import json
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.openuv import CONF_FROM_WINDOW, CONF_TO_WINDOW, DOMAIN
 from homeassistant.const import (
@@ -23,7 +23,7 @@ TEST_LONGITUDE = -0.3817765
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.openuv.async_setup_entry", return_value=True

--- a/tests/components/opower/test_config_flow.py
+++ b/tests/components/opower/test_config_flow.py
@@ -1,10 +1,10 @@
 """Test the Opower config flow."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 from opower import CannotConnect, InvalidAuth
 import pytest
+from typing_extensions import Generator
 
 from homeassistant import config_entries
 from homeassistant.components.opower.const import DOMAIN
@@ -17,7 +17,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture(autouse=True, name="mock_setup_entry")
-def override_async_setup_entry() -> Generator[AsyncMock, None, None]:
+def override_async_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.opower.async_setup_entry", return_value=True
@@ -26,7 +26,7 @@ def override_async_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_unload_entry() -> Generator[AsyncMock, None, None]:
+def mock_unload_entry() -> Generator[AsyncMock]:
     """Mock unloading a config entry."""
     with patch(
         "homeassistant.components.opower.async_unload_entry",

--- a/tests/components/oralb/conftest.py
+++ b/tests/components/oralb/conftest.py
@@ -1,9 +1,9 @@
 """OralB session fixtures."""
 
-from collections.abc import Generator
 from unittest import mock
 
 import pytest
+from typing_extensions import Generator
 
 
 class MockServices:
@@ -45,7 +45,7 @@ class MockBleakClientBattery49(MockBleakClient):
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth: None) -> Generator[None, None, None]:
+def mock_bluetooth(enable_bluetooth: None) -> Generator[None]:
     """Auto mock bluetooth."""
 
     with mock.patch(

--- a/tests/components/ourgroceries/conftest.py
+++ b/tests/components/ourgroceries/conftest.py
@@ -1,9 +1,9 @@
 """Common fixtures for the OurGroceries tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.ourgroceries import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
@@ -19,7 +19,7 @@ PASSWORD = "test-password"
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.ourgroceries.async_setup_entry", return_value=True

--- a/tests/components/overkiz/conftest.py
+++ b/tests/components/overkiz/conftest.py
@@ -1,9 +1,9 @@
 """Configuration for overkiz tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.overkiz.const import DOMAIN
 from homeassistant.core import HomeAssistant
@@ -32,7 +32,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.overkiz.async_setup_entry", return_value=True

--- a/tests/components/permobil/conftest.py
+++ b/tests/components/permobil/conftest.py
@@ -1,16 +1,16 @@
 """Common fixtures for the MyPermobil tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, Mock, patch
 
 from mypermobil import MyPermobil
 import pytest
+from typing_extensions import Generator
 
 from .const import MOCK_REGION_NAME, MOCK_TOKEN, MOCK_URL
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.permobil.async_setup_entry", return_value=True

--- a/tests/components/philips_js/conftest.py
+++ b/tests/components/philips_js/conftest.py
@@ -1,10 +1,10 @@
 """Standard setup for tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, create_autospec, patch
 
 from haphilipsjs import PhilipsTV
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.philips_js.const import DOMAIN
 
@@ -14,7 +14,7 @@ from tests.common import MockConfigEntry, mock_device_registry
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Disable component setup."""
     with (
         patch(

--- a/tests/components/ping/test_device_tracker.py
+++ b/tests/components/ping/test_device_tracker.py
@@ -1,12 +1,12 @@
 """Test the binary sensor platform of ping."""
 
-from collections.abc import Generator
 from datetime import timedelta
 from unittest.mock import patch
 
 from freezegun.api import FrozenDateTimeFactory
 from icmplib import Host
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.device_tracker import legacy
 from homeassistant.components.ping.const import DOMAIN
@@ -20,7 +20,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed, patch_yaml_fi
 
 
 @pytest.fixture
-def entity_registry_enabled_by_default() -> Generator[None, None, None]:
+def entity_registry_enabled_by_default() -> Generator[None]:
     """Test fixture that ensures ping device_tracker entities are enabled in the registry."""
     with patch(
         "homeassistant.components.ping.device_tracker.PingDeviceTracker.entity_registry_enabled_default",

--- a/tests/components/plex/conftest.py
+++ b/tests/components/plex/conftest.py
@@ -1,10 +1,10 @@
 """Fixtures for Plex tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
 import requests_mock
+from typing_extensions import Generator
 
 from homeassistant.components.plex.const import DOMAIN, PLEX_SERVER_CONFIG, SERVERS
 from homeassistant.const import CONF_URL
@@ -22,7 +22,7 @@ def plex_server_url(entry):
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.plex.async_setup_entry", return_value=True

--- a/tests/components/plugwise/conftest.py
+++ b/tests/components/plugwise/conftest.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from plugwise import PlugwiseData
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.plugwise.const import DOMAIN
 from homeassistant.const import (
@@ -47,7 +47,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.plugwise.async_setup_entry", return_value=True

--- a/tests/components/poolsense/conftest.py
+++ b/tests/components/poolsense/conftest.py
@@ -1,10 +1,10 @@
 """Common fixtures for the Poolsense tests."""
 
-from collections.abc import Generator
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.poolsense.const import DOMAIN
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
@@ -13,7 +13,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.poolsense.async_setup_entry",
@@ -23,7 +23,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_poolsense_client() -> Generator[AsyncMock, None, None]:
+def mock_poolsense_client() -> Generator[AsyncMock]:
     """Mock a PoolSense client."""
     with (
         patch(

--- a/tests/components/prosegur/test_alarm_control_panel.py
+++ b/tests/components/prosegur/test_alarm_control_panel.py
@@ -1,10 +1,10 @@
 """Tests for the Prosegur alarm control panel device."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 from pyprosegur.installation import Status
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.alarm_control_panel import DOMAIN as ALARM_DOMAIN
 from homeassistant.const import (
@@ -36,7 +36,7 @@ def mock_auth():
 
 
 @pytest.fixture(params=list(Status))
-def mock_status(request: pytest.FixtureRequest) -> Generator[None, None, None]:
+def mock_status(request: pytest.FixtureRequest) -> Generator[None]:
     """Mock the status of the alarm."""
 
     install = AsyncMock()

--- a/tests/components/ps4/conftest.py
+++ b/tests/components/ps4/conftest.py
@@ -1,14 +1,14 @@
 """Test configuration for PS4."""
 
-from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 from pyps4_2ndscreen.ddp import DEFAULT_UDP_PORT, DDPProtocol
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def patch_load_json_object() -> Generator[MagicMock, None, None]:
+def patch_load_json_object() -> Generator[MagicMock]:
     """Prevent load JSON being used."""
     with patch(
         "homeassistant.components.ps4.load_json_object", return_value={}
@@ -17,21 +17,21 @@ def patch_load_json_object() -> Generator[MagicMock, None, None]:
 
 
 @pytest.fixture
-def patch_save_json() -> Generator[MagicMock, None, None]:
+def patch_save_json() -> Generator[MagicMock]:
     """Prevent save JSON being used."""
     with patch("homeassistant.components.ps4.save_json") as mock_save:
         yield mock_save
 
 
 @pytest.fixture
-def patch_get_status() -> Generator[MagicMock, None, None]:
+def patch_get_status() -> Generator[MagicMock]:
     """Prevent save JSON being used."""
     with patch("pyps4_2ndscreen.ps4.get_status", return_value=None) as mock_get_status:
         yield mock_get_status
 
 
 @pytest.fixture
-def mock_ddp_endpoint() -> Generator[None, None, None]:
+def mock_ddp_endpoint() -> Generator[None]:
     """Mock pyps4_2ndscreen.ddp.async_create_ddp_endpoint."""
     protocol = DDPProtocol()
     protocol._local_port = DEFAULT_UDP_PORT

--- a/tests/components/pure_energie/conftest.py
+++ b/tests/components/pure_energie/conftest.py
@@ -1,11 +1,11 @@
 """Fixtures for Pure Energie integration tests."""
 
-from collections.abc import Generator
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from gridnet import Device as GridNetDevice, SmartBridge
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.pure_energie.const import DOMAIN
 from homeassistant.const import CONF_HOST
@@ -26,7 +26,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[None, None, None]:
+def mock_setup_entry() -> Generator[None]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.pure_energie.async_setup_entry", return_value=True

--- a/tests/components/pvoutput/conftest.py
+++ b/tests/components/pvoutput/conftest.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from pvo import Status, System
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.pvoutput.const import CONF_SYSTEM_ID, DOMAIN
 from homeassistant.const import CONF_API_KEY
@@ -27,7 +27,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.pvoutput.async_setup_entry", return_value=True

--- a/tests/components/qbittorrent/conftest.py
+++ b/tests/components/qbittorrent/conftest.py
@@ -1,14 +1,14 @@
 """Fixtures for testing qBittorrent component."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
 import requests_mock
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock qbittorrent entry setup."""
     with patch(
         "homeassistant.components.qbittorrent.async_setup_entry", return_value=True
@@ -17,7 +17,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_api() -> Generator[requests_mock.Mocker, None, None]:
+def mock_api() -> Generator[requests_mock.Mocker]:
     """Mock the qbittorrent API."""
     with requests_mock.Mocker() as mocker:
         mocker.get("http://localhost:8080/api/v2/app/preferences", status_code=403)

--- a/tests/components/qnap/conftest.py
+++ b/tests/components/qnap/conftest.py
@@ -1,9 +1,9 @@
 """Setup the QNAP tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 TEST_HOST = "1.2.3.4"
 TEST_USERNAME = "admin"
@@ -15,7 +15,7 @@ TEST_SYSTEM_STATS = {"system": {"serial_number": TEST_SERIAL, "name": TEST_NAS_N
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.qnap.async_setup_entry", return_value=True
@@ -24,7 +24,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def qnap_connect() -> Generator[MagicMock, None, None]:
+def qnap_connect() -> Generator[MagicMock]:
     """Mock qnap connection."""
     with patch(
         "homeassistant.components.qnap.config_flow.QNAPStats", autospec=True

--- a/tests/components/rabbitair/test_config_flow.py
+++ b/tests/components/rabbitair/test_config_flow.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from ipaddress import ip_address
 from unittest.mock import Mock, patch
 
 import pytest
 from rabbitair import Mode, Model, Speed
+from typing_extensions import Generator
 
 from homeassistant import config_entries
 from homeassistant.components import zeroconf
@@ -43,7 +43,7 @@ def use_mocked_zeroconf(mock_async_zeroconf):
 
 
 @pytest.fixture
-def rabbitair_connect() -> Generator[None, None, None]:
+def rabbitair_connect() -> Generator[None]:
     """Mock connection."""
     with (
         patch("rabbitair.UdpClient.get_info", return_value=get_mock_info()),

--- a/tests/components/radio_browser/conftest.py
+++ b/tests/components/radio_browser/conftest.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.radio_browser.const import DOMAIN
 
@@ -23,7 +23,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.radio_browser.async_setup_entry", return_value=True

--- a/tests/components/rainbird/conftest.py
+++ b/tests/components/rainbird/conftest.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from http import HTTPStatus
 import json
 from typing import Any
@@ -10,6 +9,7 @@ from unittest.mock import patch
 
 from pyrainbird import encryption
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.rainbird import DOMAIN
 from homeassistant.components.rainbird.const import (
@@ -157,7 +157,7 @@ def setup_platforms(
 
 
 @pytest.fixture(autouse=True)
-def aioclient_mock(hass: HomeAssistant) -> Generator[AiohttpClientMocker, None, None]:
+def aioclient_mock(hass: HomeAssistant) -> Generator[AiohttpClientMocker]:
     """Context manager to mock aiohttp client."""
     mocker = AiohttpClientMocker()
 

--- a/tests/components/rainforest_raven/conftest.py
+++ b/tests/components/rainforest_raven/conftest.py
@@ -1,9 +1,9 @@
 """Fixtures for the Rainforest RAVEn tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.core import HomeAssistant
 
@@ -13,7 +13,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def mock_device() -> Generator[AsyncMock, None, None]:
+def mock_device() -> Generator[AsyncMock]:
     """Mock a functioning RAVEn device."""
     mock_device = create_mock_device()
     with patch(

--- a/tests/components/rainforest_raven/test_config_flow.py
+++ b/tests/components/rainforest_raven/test_config_flow.py
@@ -1,11 +1,11 @@
 """Test Rainforest RAVEn config flow."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 from aioraven.device import RAVEnConnectionError
 import pytest
 from serial.tools.list_ports_common import ListPortInfo
+from typing_extensions import Generator
 
 from homeassistant.components.rainforest_raven.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USB, SOURCE_USER
@@ -20,7 +20,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def mock_device() -> Generator[AsyncMock, None, None]:
+def mock_device() -> Generator[AsyncMock]:
     """Mock a functioning RAVEn device."""
     device = create_mock_device()
     with patch(
@@ -55,7 +55,7 @@ def mock_device_timeout(mock_device: AsyncMock) -> AsyncMock:
 
 
 @pytest.fixture
-def mock_comports() -> Generator[list[ListPortInfo], None, None]:
+def mock_comports() -> Generator[list[ListPortInfo]]:
     """Mock serial port list."""
     port = ListPortInfo(DISCOVERY_INFO.device)
     port.serial_number = DISCOVERY_INFO.serial_number

--- a/tests/components/rdw/conftest.py
+++ b/tests/components/rdw/conftest.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 from vehicle import Vehicle
 
 from homeassistant.components.rdw.const import CONF_LICENSE_PLATE, DOMAIN
@@ -26,7 +26,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[None, None, None]:
+def mock_setup_entry() -> Generator[None]:
     """Mock setting up a config entry."""
     with patch("homeassistant.components.rdw.async_setup_entry", return_value=True):
         yield

--- a/tests/components/recorder/conftest.py
+++ b/tests/components/recorder/conftest.py
@@ -1,18 +1,16 @@
 """Fixtures for the recorder component tests."""
 
-from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components import recorder
 from homeassistant.core import HomeAssistant
 
 
 @pytest.fixture
-def recorder_dialect_name(
-    hass: HomeAssistant, db_engine: str
-) -> Generator[None, None, None]:
+def recorder_dialect_name(hass: HomeAssistant, db_engine: str) -> Generator[None]:
     """Patch the recorder dialect."""
     if instance := hass.data.get(recorder.DATA_INSTANCE):
         instance.__dict__.pop("dialect_name", None)

--- a/tests/components/recorder/test_filters_with_entityfilter_schema_37.py
+++ b/tests/components/recorder/test_filters_with_entityfilter_schema_37.py
@@ -1,12 +1,12 @@
 """The tests for the recorder filter matching the EntityFilter component."""
 
-from collections.abc import AsyncGenerator
 import json
 from unittest.mock import patch
 
 import pytest
 from sqlalchemy import select
 from sqlalchemy.engine.row import Row
+from typing_extensions import AsyncGenerator
 
 from homeassistant.components.recorder import Recorder, get_instance
 from homeassistant.components.recorder.db_schema import EventData, Events, States
@@ -41,7 +41,7 @@ def db_schema_32():
 @pytest.fixture(name="legacy_recorder_mock")
 async def legacy_recorder_mock_fixture(
     recorder_mock: Recorder,
-) -> AsyncGenerator[Recorder, None]:
+) -> AsyncGenerator[Recorder]:
     """Fixture for legacy recorder mock."""
     with patch.object(recorder_mock.states_meta_manager, "active", False):
         yield recorder_mock

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Generator
 from datetime import datetime, timedelta
 from pathlib import Path
 import sqlite3
@@ -15,6 +14,7 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from sqlalchemy.exc import DatabaseError, OperationalError, SQLAlchemyError
 from sqlalchemy.pool import QueuePool
+from typing_extensions import Generator
 
 from homeassistant.components import recorder
 from homeassistant.components.recorder import (
@@ -115,7 +115,7 @@ def setup_recorder(recorder_mock: Recorder) -> None:
 
 
 @pytest.fixture
-def small_cache_size() -> Generator[None, None, None]:
+def small_cache_size() -> Generator[None]:
     """Patch the default cache size to 8."""
     with (
         patch.object(state_attributes_table_manager, "CACHE_SIZE", 8),

--- a/tests/components/recorder/test_migration_from_schema_32.py
+++ b/tests/components/recorder/test_migration_from_schema_32.py
@@ -1,6 +1,5 @@
 """The tests for the recorder filter matching the EntityFilter component."""
 
-from collections.abc import AsyncGenerator
 import datetime
 import importlib
 import sys
@@ -13,6 +12,7 @@ import pytest
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
+from typing_extensions import AsyncGenerator
 
 from homeassistant.components import recorder
 from homeassistant.components.recorder import (
@@ -119,7 +119,7 @@ def db_schema_32():
 @pytest.fixture(name="legacy_recorder_mock")
 async def legacy_recorder_mock_fixture(
     recorder_mock: Recorder,
-) -> AsyncGenerator[Recorder, None]:
+) -> AsyncGenerator[Recorder]:
     """Fixture for legacy recorder mock."""
     with patch.object(recorder_mock.states_meta_manager, "active", False):
         yield recorder_mock

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -1,6 +1,5 @@
 """Test data purging."""
 
-from collections.abc import Generator
 from datetime import datetime, timedelta
 import json
 import sqlite3
@@ -10,6 +9,7 @@ from freezegun import freeze_time
 import pytest
 from sqlalchemy.exc import DatabaseError, OperationalError
 from sqlalchemy.orm.session import Session
+from typing_extensions import Generator
 from voluptuous.error import MultipleInvalid
 
 from homeassistant.components import recorder
@@ -59,7 +59,7 @@ TEST_EVENT_TYPES = (
 
 
 @pytest.fixture(name="use_sqlite")
-def mock_use_sqlite(request: pytest.FixtureRequest) -> Generator[None, None, None]:
+def mock_use_sqlite(request: pytest.FixtureRequest) -> Generator[None]:
     """Pytest fixture to switch purge method."""
     with patch(
         "homeassistant.components.recorder.core.Recorder.dialect_name",

--- a/tests/components/recorder/test_purge_v32_schema.py
+++ b/tests/components/recorder/test_purge_v32_schema.py
@@ -1,6 +1,5 @@
 """Test data purging."""
 
-from collections.abc import Generator
 from datetime import datetime, timedelta
 import json
 import sqlite3
@@ -11,6 +10,7 @@ import pytest
 from sqlalchemy import text, update
 from sqlalchemy.exc import DatabaseError, OperationalError
 from sqlalchemy.orm.session import Session
+from typing_extensions import Generator
 
 from homeassistant.components import recorder
 from homeassistant.components.recorder import migration
@@ -55,7 +55,7 @@ def db_schema_32():
 
 
 @pytest.fixture(name="use_sqlite")
-def mock_use_sqlite(request: pytest.FixtureRequest) -> Generator[None, None, None]:
+def mock_use_sqlite(request: pytest.FixtureRequest) -> Generator[None]:
     """Pytest fixture to switch purge method."""
     with patch(
         "homeassistant.components.recorder.core.Recorder.dialect_name",

--- a/tests/components/refoss/conftest.py
+++ b/tests/components/refoss/conftest.py
@@ -1,13 +1,13 @@
 """Pytest module configuration."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.refoss.async_setup_entry", return_value=True

--- a/tests/components/renault/conftest.py
+++ b/tests/components/renault/conftest.py
@@ -1,6 +1,5 @@
 """Provide common Renault fixtures."""
 
-from collections.abc import Generator
 import contextlib
 from types import MappingProxyType
 from typing import Any
@@ -9,6 +8,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from renault_api.kamereon import exceptions, schemas
 from renault_api.renault_account import RenaultAccount
+from typing_extensions import Generator
 
 from homeassistant.components.renault.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER, ConfigEntry
@@ -21,7 +21,7 @@ from tests.common import MockConfigEntry, load_fixture
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.renault.async_setup_entry", return_value=True

--- a/tests/components/renault/test_binary_sensor.py
+++ b/tests/components/renault/test_binary_sensor.py
@@ -1,10 +1,10 @@
 """Tests for Renault binary sensors."""
 
-from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from typing_extensions import Generator
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.usefixtures("patch_renault_account", "patch_get_vehicle
 
 
 @pytest.fixture(autouse=True)
-def override_platforms() -> Generator[None, None, None]:
+def override_platforms() -> Generator[None]:
     """Override PLATFORMS."""
     with patch("homeassistant.components.renault.PLATFORMS", [Platform.BINARY_SENSOR]):
         yield

--- a/tests/components/renault/test_button.py
+++ b/tests/components/renault/test_button.py
@@ -1,11 +1,11 @@
 """Tests for Renault sensors."""
 
-from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
 from renault_api.kamereon import schemas
 from syrupy.assertion import SnapshotAssertion
+from typing_extensions import Generator
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
 from homeassistant.config_entries import ConfigEntry
@@ -22,7 +22,7 @@ pytestmark = pytest.mark.usefixtures("patch_renault_account", "patch_get_vehicle
 
 
 @pytest.fixture(autouse=True)
-def override_platforms() -> Generator[None, None, None]:
+def override_platforms() -> Generator[None]:
     """Override PLATFORMS."""
     with patch("homeassistant.components.renault.PLATFORMS", [Platform.BUTTON]):
         yield

--- a/tests/components/renault/test_device_tracker.py
+++ b/tests/components/renault/test_device_tracker.py
@@ -1,10 +1,10 @@
 """Tests for Renault sensors."""
 
-from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from typing_extensions import Generator
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.usefixtures("patch_renault_account", "patch_get_vehicle
 
 
 @pytest.fixture(autouse=True)
-def override_platforms() -> Generator[None, None, None]:
+def override_platforms() -> Generator[None]:
     """Override PLATFORMS."""
     with patch("homeassistant.components.renault.PLATFORMS", [Platform.DEVICE_TRACKER]):
         yield

--- a/tests/components/renault/test_init.py
+++ b/tests/components/renault/test_init.py
@@ -1,12 +1,12 @@
 """Tests for Renault setup process."""
 
-from collections.abc import Generator
 from typing import Any
 from unittest.mock import Mock, patch
 
 import aiohttp
 import pytest
 from renault_api.gigya.exceptions import GigyaException, InvalidCredentialsException
+from typing_extensions import Generator
 
 from homeassistant.components.renault.const import DOMAIN
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
@@ -18,7 +18,7 @@ from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture(autouse=True)
-def override_platforms() -> Generator[None, None, None]:
+def override_platforms() -> Generator[None]:
     """Override PLATFORMS."""
     with patch("homeassistant.components.renault.PLATFORMS", []):
         yield

--- a/tests/components/renault/test_select.py
+++ b/tests/components/renault/test_select.py
@@ -1,11 +1,11 @@
 """Tests for Renault selects."""
 
-from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
 from renault_api.kamereon import schemas
 from syrupy.assertion import SnapshotAssertion
+from typing_extensions import Generator
 
 from homeassistant.components.select import (
     ATTR_OPTION,
@@ -26,7 +26,7 @@ pytestmark = pytest.mark.usefixtures("patch_renault_account", "patch_get_vehicle
 
 
 @pytest.fixture(autouse=True)
-def override_platforms() -> Generator[None, None, None]:
+def override_platforms() -> Generator[None]:
     """Override PLATFORMS."""
     with patch("homeassistant.components.renault.PLATFORMS", [Platform.SELECT]):
         yield

--- a/tests/components/renault/test_sensor.py
+++ b/tests/components/renault/test_sensor.py
@@ -1,10 +1,10 @@
 """Tests for Renault sensors."""
 
-from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from typing_extensions import Generator
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.usefixtures("patch_renault_account", "patch_get_vehicle
 
 
 @pytest.fixture(autouse=True)
-def override_platforms() -> Generator[None, None, None]:
+def override_platforms() -> Generator[None]:
     """Override PLATFORMS."""
     with patch("homeassistant.components.renault.PLATFORMS", [Platform.SENSOR]):
         yield

--- a/tests/components/renault/test_services.py
+++ b/tests/components/renault/test_services.py
@@ -1,6 +1,5 @@
 """Tests for Renault sensors."""
 
-from collections.abc import Generator
 from datetime import datetime
 from unittest.mock import patch
 
@@ -8,6 +7,7 @@ import pytest
 from renault_api.exceptions import RenaultException
 from renault_api.kamereon import schemas
 from renault_api.kamereon.models import ChargeSchedule
+from typing_extensions import Generator
 
 from homeassistant.components.renault.const import DOMAIN
 from homeassistant.components.renault.services import (
@@ -39,7 +39,7 @@ pytestmark = pytest.mark.usefixtures("patch_renault_account", "patch_get_vehicle
 
 
 @pytest.fixture(autouse=True)
-def override_platforms() -> Generator[None, None, None]:
+def override_platforms() -> Generator[None]:
     """Override PLATFORMS."""
     with patch("homeassistant.components.renault.PLATFORMS", []):
         yield

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -1,9 +1,9 @@
 """Setup the Reolink tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.reolink import const
 from homeassistant.components.reolink.config_flow import DEFAULT_PROTOCOL
@@ -38,7 +38,7 @@ TEST_CAM_MODEL = "RLC-123"
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.reolink.async_setup_entry", return_value=True
@@ -47,7 +47,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def reolink_connect_class() -> Generator[MagicMock, None, None]:
+def reolink_connect_class() -> Generator[MagicMock]:
     """Mock reolink connection and return both the host_mock and host_mock_class."""
     with (
         patch(
@@ -105,13 +105,13 @@ def reolink_connect_class() -> Generator[MagicMock, None, None]:
 @pytest.fixture
 def reolink_connect(
     reolink_connect_class: MagicMock,
-) -> Generator[MagicMock, None, None]:
+) -> Generator[MagicMock]:
     """Mock reolink connection."""
     return reolink_connect_class.return_value
 
 
 @pytest.fixture
-def reolink_platforms() -> Generator[None, None, None]:
+def reolink_platforms() -> Generator[None]:
     """Mock reolink entry setup."""
     with patch("homeassistant.components.reolink.PLATFORMS", return_value=[]):
         yield

--- a/tests/components/ring/conftest.py
+++ b/tests/components/ring/conftest.py
@@ -1,11 +1,11 @@
 """Configuration for Ring tests."""
 
-from collections.abc import Generator
 import re
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 import requests_mock
+from typing_extensions import Generator
 
 from homeassistant.components.ring import DOMAIN
 from homeassistant.const import CONF_USERNAME
@@ -16,7 +16,7 @@ from tests.components.light.conftest import mock_light_profiles  # noqa: F401
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.ring.async_setup_entry", return_value=True

--- a/tests/components/roku/conftest.py
+++ b/tests/components/roku/conftest.py
@@ -1,11 +1,11 @@
 """Fixtures for Roku integration tests."""
 
-from collections.abc import Generator
 import json
 from unittest.mock import MagicMock, patch
 
 import pytest
 from rokuecp import Device as RokuDevice
+from typing_extensions import Generator
 
 from homeassistant.components.roku.const import DOMAIN
 from homeassistant.const import CONF_HOST
@@ -32,7 +32,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[None, None, None]:
+def mock_setup_entry() -> Generator[None]:
     """Mock setting up a config entry."""
     with patch("homeassistant.components.roku.async_setup_entry", return_value=True):
         yield

--- a/tests/components/rtsp_to_webrtc/conftest.py
+++ b/tests/components/rtsp_to_webrtc/conftest.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator, Awaitable, Callable
+from collections.abc import Awaitable, Callable
 from typing import Any
 from unittest.mock import patch
 
 import pytest
 import rtsp_to_webrtc
+from typing_extensions import AsyncGenerator
 
 from homeassistant.components import camera
 from homeassistant.components.rtsp_to_webrtc import DOMAIN
@@ -24,7 +25,7 @@ CONFIG_ENTRY_DATA = {"server_url": SERVER_URL}
 
 # Typing helpers
 type ComponentSetup = Callable[[], Awaitable[None]]
-type AsyncYieldFixture[_T] = AsyncGenerator[_T, None]
+type AsyncYieldFixture[_T] = AsyncGenerator[_T]
 
 
 @pytest.fixture(autouse=True)
@@ -38,7 +39,7 @@ async def webrtc_server() -> None:
 
 
 @pytest.fixture
-async def mock_camera(hass) -> AsyncGenerator[None, None]:
+async def mock_camera(hass) -> AsyncGenerator[None]:
     """Initialize a demo camera platform."""
     assert await async_setup_component(
         hass, "camera", {camera.DOMAIN: {"platform": "demo"}}

--- a/tests/components/sabnzbd/conftest.py
+++ b/tests/components/sabnzbd/conftest.py
@@ -1,13 +1,13 @@
 """Configuration for Sabnzbd tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.sabnzbd.async_setup_entry", return_value=True

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Generator
+from collections.abc import Awaitable, Callable
 from datetime import datetime
 from socket import AddressFamily
 from typing import Any
@@ -19,6 +19,7 @@ from samsungtvws.encrypted.remote import SamsungTVEncryptedWSAsyncRemote
 from samsungtvws.event import ED_INSTALLED_APP_EVENT
 from samsungtvws.exceptions import ResponseError
 from samsungtvws.remote import ChannelEmitCommand
+from typing_extensions import Generator
 
 from homeassistant.components.samsungtv.const import WEBSOCKET_SSL_PORT
 from homeassistant.core import HomeAssistant, ServiceCall
@@ -30,7 +31,7 @@ from tests.common import async_mock_service
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.samsungtv.async_setup_entry", return_value=True

--- a/tests/components/sanix/conftest.py
+++ b/tests/components/sanix/conftest.py
@@ -1,6 +1,5 @@
 """Sanix tests configuration."""
 
-from collections.abc import Generator
 from datetime import datetime
 from unittest.mock import AsyncMock, patch
 from zoneinfo import ZoneInfo
@@ -17,6 +16,7 @@ from sanix import (
     ATTR_API_TIME,
 )
 from sanix.models import Measurement
+from typing_extensions import Generator
 
 from homeassistant.components.sanix.const import CONF_SERIAL_NUMBER, DOMAIN
 from homeassistant.const import CONF_TOKEN
@@ -67,7 +67,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.sanix.async_setup_entry",

--- a/tests/components/schlage/conftest.py
+++ b/tests/components/schlage/conftest.py
@@ -1,10 +1,10 @@
 """Common fixtures for the Schlage tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, Mock, create_autospec, patch
 
 from pyschlage.lock import Lock
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.schlage.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
@@ -46,7 +46,7 @@ async def mock_added_config_entry(
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.schlage.async_setup_entry", return_value=True

--- a/tests/components/scrape/conftest.py
+++ b/tests/components/scrape/conftest.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from typing import Any
 from unittest.mock import AsyncMock, patch
 import uuid
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.rest.data import DEFAULT_TIMEOUT
 from homeassistant.components.rest.schema import DEFAULT_METHOD, DEFAULT_VERIFY_SSL
@@ -35,7 +35,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Automatically path uuid generator."""
     with patch(
         "homeassistant.components.scrape.async_setup_entry",

--- a/tests/components/screenlogic/test_services.py
+++ b/tests/components/screenlogic/test_services.py
@@ -1,12 +1,12 @@
 """Tests for ScreenLogic integration service calls."""
 
-from collections.abc import AsyncGenerator
 from typing import Any
 from unittest.mock import DEFAULT, AsyncMock, patch
 
 import pytest
 from screenlogicpy import ScreenLogicGateway
 from screenlogicpy.device_const.system import COLOR_MODE
+from typing_extensions import AsyncGenerator
 
 from homeassistant.components.screenlogic import DOMAIN
 from homeassistant.components.screenlogic.const import (
@@ -53,7 +53,7 @@ async def setup_screenlogic_services_fixture(
     request: pytest.FixtureRequest,
     device_registry: dr.DeviceRegistry,
     mock_config_entry: MockConfigEntry,
-) -> AsyncGenerator[dict[str, Any], None]:
+) -> AsyncGenerator[dict[str, Any]]:
     """Define the setup for a patched screenlogic integration."""
     data = (
         marker.args[0]

--- a/tests/components/season/conftest.py
+++ b/tests/components/season/conftest.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.season.const import DOMAIN, TYPE_ASTRONOMICAL
 from homeassistant.const import CONF_TYPE
@@ -25,7 +25,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[None, None, None]:
+def mock_setup_entry() -> Generator[None]:
     """Mock setting up a config entry."""
     with patch("homeassistant.components.season.async_setup_entry", return_value=True):
         yield

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from datetime import UTC, date, datetime
 from decimal import Decimal
 import logging
@@ -10,6 +9,7 @@ from types import ModuleType
 from typing import Any
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components import sensor
 from homeassistant.components.number import NumberDeviceClass
@@ -2384,7 +2384,7 @@ class MockFlow(ConfigFlow):
 
 
 @pytest.fixture(autouse=True)
-def config_flow_fixture(hass: HomeAssistant) -> Generator[None, None, None]:
+def config_flow_fixture(hass: HomeAssistant) -> Generator[None]:
     """Mock config flow."""
     mock_platform(hass, f"{TEST_DOMAIN}.config_flow")
 

--- a/tests/components/seventeentrack/conftest.py
+++ b/tests/components/seventeentrack/conftest.py
@@ -1,10 +1,10 @@
 """Configuration for 17Track tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 from py17track.package import Package
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.seventeentrack.const import (
     CONF_SHOW_ARCHIVED,
@@ -69,7 +69,7 @@ VALID_PLATFORM_CONFIG_FULL = {
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.seventeentrack.async_setup_entry", return_value=True

--- a/tests/components/sfr_box/conftest.py
+++ b/tests/components/sfr_box/conftest.py
@@ -1,11 +1,11 @@
 """Provide common SFR Box fixtures."""
 
-from collections.abc import Generator
 import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from sfrbox_api.models import DslInfo, FtthInfo, SystemInfo, WanInfo
+from typing_extensions import Generator
 
 from homeassistant.components.sfr_box.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER, ConfigEntry
@@ -16,7 +16,7 @@ from tests.common import MockConfigEntry, load_fixture
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.sfr_box.async_setup_entry", return_value=True
@@ -59,7 +59,7 @@ def get_config_entry_with_auth(hass: HomeAssistant) -> ConfigEntry:
 
 
 @pytest.fixture
-def dsl_get_info() -> Generator[DslInfo, None, None]:
+def dsl_get_info() -> Generator[DslInfo]:
     """Fixture for SFRBox.dsl_get_info."""
     dsl_info = DslInfo(**json.loads(load_fixture("dsl_getInfo.json", DOMAIN)))
     with patch(
@@ -70,7 +70,7 @@ def dsl_get_info() -> Generator[DslInfo, None, None]:
 
 
 @pytest.fixture
-def ftth_get_info() -> Generator[FtthInfo, None, None]:
+def ftth_get_info() -> Generator[FtthInfo]:
     """Fixture for SFRBox.ftth_get_info."""
     info = FtthInfo(**json.loads(load_fixture("ftth_getInfo.json", DOMAIN)))
     with patch(
@@ -81,7 +81,7 @@ def ftth_get_info() -> Generator[FtthInfo, None, None]:
 
 
 @pytest.fixture
-def system_get_info() -> Generator[SystemInfo, None, None]:
+def system_get_info() -> Generator[SystemInfo]:
     """Fixture for SFRBox.system_get_info."""
     info = SystemInfo(**json.loads(load_fixture("system_getInfo.json", DOMAIN)))
     with patch(
@@ -92,7 +92,7 @@ def system_get_info() -> Generator[SystemInfo, None, None]:
 
 
 @pytest.fixture
-def wan_get_info() -> Generator[WanInfo, None, None]:
+def wan_get_info() -> Generator[WanInfo]:
     """Fixture for SFRBox.wan_get_info."""
     info = WanInfo(**json.loads(load_fixture("wan_getInfo.json", DOMAIN)))
     with patch(

--- a/tests/components/sfr_box/test_binary_sensor.py
+++ b/tests/components/sfr_box/test_binary_sensor.py
@@ -1,11 +1,11 @@
 """Test the SFR Box binary sensors."""
 
-from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
 from sfrbox_api.models import SystemInfo
 from syrupy.assertion import SnapshotAssertion
+from typing_extensions import Generator
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.usefixtures(
 
 
 @pytest.fixture(autouse=True)
-def override_platforms() -> Generator[None, None, None]:
+def override_platforms() -> Generator[None]:
     """Override PLATFORMS."""
     with patch("homeassistant.components.sfr_box.PLATFORMS", [Platform.BINARY_SENSOR]):
         yield

--- a/tests/components/sfr_box/test_button.py
+++ b/tests/components/sfr_box/test_button.py
@@ -1,11 +1,11 @@
 """Test the SFR Box buttons."""
 
-from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
 from sfrbox_api.exceptions import SFRBoxError
 from syrupy.assertion import SnapshotAssertion
+from typing_extensions import Generator
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
 from homeassistant.config_entries import ConfigEntry
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.usefixtures("system_get_info", "dsl_get_info", "wan_get
 
 
 @pytest.fixture(autouse=True)
-def override_platforms() -> Generator[None, None, None]:
+def override_platforms() -> Generator[None]:
     """Override PLATFORMS_WITH_AUTH."""
     with (
         patch(

--- a/tests/components/sfr_box/test_diagnostics.py
+++ b/tests/components/sfr_box/test_diagnostics.py
@@ -1,11 +1,11 @@
 """Test the SFR Box diagnostics."""
 
-from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
 from sfrbox_api.models import SystemInfo
 from syrupy.assertion import SnapshotAssertion
+from typing_extensions import Generator
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -19,7 +19,7 @@ pytestmark = pytest.mark.usefixtures(
 
 
 @pytest.fixture(autouse=True)
-def override_platforms() -> Generator[None, None, None]:
+def override_platforms() -> Generator[None]:
     """Override PLATFORMS."""
     with patch("homeassistant.components.sfr_box.PLATFORMS", []):
         yield

--- a/tests/components/sfr_box/test_init.py
+++ b/tests/components/sfr_box/test_init.py
@@ -1,10 +1,10 @@
 """Test the SFR Box setup process."""
 
-from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
 from sfrbox_api.exceptions import SFRBoxAuthenticationError, SFRBoxError
+from typing_extensions import Generator
 
 from homeassistant.components.sfr_box.const import DOMAIN
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant
 
 
 @pytest.fixture(autouse=True)
-def override_platforms() -> Generator[None, None, None]:
+def override_platforms() -> Generator[None]:
     """Override PLATFORMS."""
     with patch("homeassistant.components.sfr_box.PLATFORMS", []):
         yield

--- a/tests/components/sfr_box/test_sensor.py
+++ b/tests/components/sfr_box/test_sensor.py
@@ -1,10 +1,10 @@
 """Test the SFR Box sensors."""
 
-from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from typing_extensions import Generator
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -15,7 +15,7 @@ pytestmark = pytest.mark.usefixtures("system_get_info", "dsl_get_info", "wan_get
 
 
 @pytest.fixture(autouse=True)
-def override_platforms() -> Generator[None, None, None]:
+def override_platforms() -> Generator[None]:
     """Override PLATFORMS."""
     with patch("homeassistant.components.sfr_box.PLATFORMS", [Platform.SENSOR]):
         yield

--- a/tests/components/sleepiq/conftest.py
+++ b/tests/components/sleepiq/conftest.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
 from asyncsleepiq import (
@@ -18,6 +17,7 @@ from asyncsleepiq import (
     SleepIQSleeper,
 )
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.sleepiq import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
@@ -46,7 +46,7 @@ SLEEPIQ_CONFIG = {
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.sleepiq.async_setup_entry", return_value=True
@@ -97,7 +97,7 @@ def mock_bed() -> MagicMock:
 @pytest.fixture
 def mock_asyncsleepiq_single_foundation(
     mock_bed: MagicMock,
-) -> Generator[MagicMock, None, None]:
+) -> Generator[MagicMock]:
     """Mock an AsyncSleepIQ object with a single foundation."""
     with patch("homeassistant.components.sleepiq.AsyncSleepIQ", autospec=True) as mock:
         client = mock.return_value
@@ -131,7 +131,7 @@ def mock_asyncsleepiq_single_foundation(
 
 
 @pytest.fixture
-def mock_asyncsleepiq(mock_bed: MagicMock) -> Generator[MagicMock, None, None]:
+def mock_asyncsleepiq(mock_bed: MagicMock) -> Generator[MagicMock]:
     """Mock an AsyncSleepIQ object with a split foundation."""
     with patch("homeassistant.components.sleepiq.AsyncSleepIQ", autospec=True) as mock:
         client = mock.return_value

--- a/tests/components/slimproto/conftest.py
+++ b/tests/components/slimproto/conftest.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.slimproto.const import DOMAIN
 
@@ -23,7 +23,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.slimproto.async_setup_entry",

--- a/tests/components/snapcast/conftest.py
+++ b/tests/components/snapcast/conftest.py
@@ -1,13 +1,13 @@
 """Test the snapcast config flow."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.snapcast.async_setup_entry", return_value=True
@@ -16,7 +16,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_create_server() -> Generator[AsyncMock, None, None]:
+def mock_create_server() -> Generator[AsyncMock]:
     """Create mock snapcast connection."""
     mock_connection = AsyncMock()
     mock_connection.start = AsyncMock(return_value=None)

--- a/tests/components/sonarr/conftest.py
+++ b/tests/components/sonarr/conftest.py
@@ -1,6 +1,5 @@
 """Fixtures for Sonarr integration tests."""
 
-from collections.abc import Generator
 import json
 from unittest.mock import MagicMock, patch
 
@@ -14,6 +13,7 @@ from aiopyarr import (
     SystemStatus,
 )
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.sonarr.const import (
     CONF_BASE_PATH,
@@ -102,7 +102,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[None, None, None]:
+def mock_setup_entry() -> Generator[None]:
     """Mock setting up a config entry."""
     with patch("homeassistant.components.sonarr.async_setup_entry", return_value=True):
         yield

--- a/tests/components/stream/conftest.py
+++ b/tests/components/stream/conftest.py
@@ -13,13 +13,13 @@ so that it can inspect the output.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Generator
 import logging
 import threading
 from unittest.mock import Mock, patch
 
 from aiohttp import web
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.stream.core import StreamOutput
 from homeassistant.components.stream.worker import StreamState
@@ -175,7 +175,7 @@ def hls_sync():
 
 
 @pytest.fixture(autouse=True)
-def should_retry() -> Generator[Mock, None, None]:
+def should_retry() -> Generator[Mock]:
     """Fixture to disable stream worker retries in tests by default."""
     with patch(
         "homeassistant.components.stream._should_retry", return_value=False

--- a/tests/components/streamlabswater/conftest.py
+++ b/tests/components/streamlabswater/conftest.py
@@ -1,10 +1,10 @@
 """Common fixtures for the StreamLabs tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from streamlabswater.streamlabswater import StreamlabsClient
+from typing_extensions import Generator
 
 from homeassistant.components.streamlabswater import DOMAIN
 from homeassistant.const import CONF_API_KEY
@@ -13,7 +13,7 @@ from tests.common import MockConfigEntry, load_json_object_fixture
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.streamlabswater.async_setup_entry", return_value=True
@@ -32,7 +32,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture(name="streamlabswater")
-def mock_streamlabswater() -> Generator[AsyncMock, None, None]:
+def mock_streamlabswater() -> Generator[AsyncMock]:
     """Mock the StreamLabs client."""
 
     locations = load_json_object_fixture("streamlabswater/get_locations.json")

--- a/tests/components/stt/test_init.py
+++ b/tests/components/stt/test_init.py
@@ -1,11 +1,12 @@
 """Test STT component setup."""
 
-from collections.abc import AsyncIterable, Generator
+from collections.abc import AsyncIterable
 from http import HTTPStatus
 from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.stt import (
     DOMAIN,
@@ -131,7 +132,7 @@ def config_flow_test_domain_fixture() -> str:
 @pytest.fixture(autouse=True)
 def config_flow_fixture(
     hass: HomeAssistant, config_flow_test_domain: str
-) -> Generator[None, None, None]:
+) -> Generator[None]:
     """Mock config flow."""
     mock_platform(hass, f"{config_flow_test_domain}.config_flow")
 

--- a/tests/components/suez_water/conftest.py
+++ b/tests/components/suez_water/conftest.py
@@ -1,13 +1,13 @@
 """Common fixtures for the Suez Water tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.suez_water.async_setup_entry", return_value=True

--- a/tests/components/swiss_public_transport/conftest.py
+++ b/tests/components/swiss_public_transport/conftest.py
@@ -1,13 +1,13 @@
 """Common fixtures for the swiss_public_transport tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.swiss_public_transport.async_setup_entry",

--- a/tests/components/switch_as_x/conftest.py
+++ b/tests/components/switch_as_x/conftest.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -18,7 +18,7 @@ async def setup_homeassistant(hass: HomeAssistant):
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.switch_as_x.async_setup_entry", return_value=True

--- a/tests/components/switchbot_cloud/conftest.py
+++ b/tests/components/switchbot_cloud/conftest.py
@@ -1,13 +1,13 @@
 """Common fixtures for the SwitchBot via API tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.switchbot_cloud.async_setup_entry",

--- a/tests/components/switcher_kis/conftest.py
+++ b/tests/components/switcher_kis/conftest.py
@@ -1,13 +1,13 @@
 """Common fixtures and objects for the Switcher integration tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.switcher_kis.async_setup_entry", return_value=True
@@ -16,7 +16,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_bridge(request: pytest.FixtureRequest) -> Generator[MagicMock, None, None]:
+def mock_bridge(request: pytest.FixtureRequest) -> Generator[MagicMock]:
     """Return a mocked SwitcherBridge."""
     with (
         patch(

--- a/tests/components/synology_dsm/conftest.py
+++ b/tests/components/synology_dsm/conftest.py
@@ -1,16 +1,16 @@
 """Configure Synology DSM tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.synology_dsm.async_setup_entry", return_value=True

--- a/tests/components/systemmonitor/conftest.py
+++ b/tests/components/systemmonitor/conftest.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 import socket
 from unittest.mock import AsyncMock, Mock, NonCallableMock, patch
 
 from psutil import NoSuchProcess, Process
 from psutil._common import sdiskpart, sdiskusage, shwtemp, snetio, snicaddr, sswap
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.systemmonitor.const import DOMAIN
 from homeassistant.components.systemmonitor.coordinator import VirtualMemory
@@ -18,7 +18,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture(autouse=True)
-def mock_sys_platform() -> Generator[None, None, None]:
+def mock_sys_platform() -> Generator[None]:
     """Mock sys platform to Linux."""
     with patch("sys.platform", "linux"):
         yield
@@ -42,7 +42,7 @@ class MockProcess(Process):
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setup entry."""
     with patch(
         "homeassistant.components.systemmonitor.async_setup_entry",


### PR DESCRIPTION
## Proposed change
For details see: https://github.com/home-assistant/core/pull/118986

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
