### PR TITLE
Import Generator from typing_extensions (5)

### DIFF
--- a/tests/components/tailscale/conftest.py
+++ b/tests/components/tailscale/conftest.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from tailscale.models import Devices
+from typing_extensions import Generator
 
 from homeassistant.components.tailscale.const import CONF_TAILNET, DOMAIN
 from homeassistant.const import CONF_API_KEY
@@ -27,7 +27,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.tailscale.async_setup_entry", return_value=True

--- a/tests/components/tailwind/conftest.py
+++ b/tests/components/tailwind/conftest.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from gotailwind import TailwindDeviceStatus
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.tailwind.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_TOKEN
@@ -36,7 +36,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.tailwind.async_setup_entry", return_value=True
@@ -45,7 +45,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_tailwind(device_fixture: str) -> Generator[MagicMock, None, None]:
+def mock_tailwind(device_fixture: str) -> Generator[MagicMock]:
     """Return a mocked Tailwind client."""
     with (
         patch(

--- a/tests/components/tami4/conftest.py
+++ b/tests/components/tami4/conftest.py
@@ -1,12 +1,12 @@
 """Common fixutres with default mocks as well as common test helper methods."""
 
-from collections.abc import Generator
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from Tami4EdgeAPI.device import Device
 from Tami4EdgeAPI.water_quality import UV, Filter, WaterQuality
+from typing_extensions import Generator
 
 from homeassistant.components.tami4.const import CONF_REFRESH_TOKEN, DOMAIN
 from homeassistant.core import HomeAssistant
@@ -37,7 +37,7 @@ def mock_api(mock__get_devices, mock_get_water_quality):
 
 
 @pytest.fixture
-def mock__get_devices(request: pytest.FixtureRequest) -> Generator[None, None, None]:
+def mock__get_devices(request: pytest.FixtureRequest) -> Generator[None]:
     """Fixture to mock _get_devices which makes a call to the API."""
 
     side_effect = getattr(request, "param", None)
@@ -62,7 +62,7 @@ def mock__get_devices(request: pytest.FixtureRequest) -> Generator[None, None, N
 @pytest.fixture
 def mock_get_water_quality(
     request: pytest.FixtureRequest,
-) -> Generator[None, None, None]:
+) -> Generator[None]:
     """Fixture to mock get_water_quality which makes a call to the API."""
 
     side_effect = getattr(request, "param", None)
@@ -90,7 +90,7 @@ def mock_get_water_quality(
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
 
     with patch(
@@ -102,7 +102,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 @pytest.fixture
 def mock_request_otp(
     request: pytest.FixtureRequest,
-) -> Generator[MagicMock, None, None]:
+) -> Generator[MagicMock]:
     """Mock request_otp."""
 
     side_effect = getattr(request, "param", None)
@@ -116,7 +116,7 @@ def mock_request_otp(
 
 
 @pytest.fixture
-def mock_submit_otp(request: pytest.FixtureRequest) -> Generator[MagicMock, None, None]:
+def mock_submit_otp(request: pytest.FixtureRequest) -> Generator[MagicMock]:
     """Mock submit_otp."""
 
     side_effect = getattr(request, "param", None)

--- a/tests/components/tankerkoenig/conftest.py
+++ b/tests/components/tankerkoenig/conftest.py
@@ -1,9 +1,9 @@
 """Fixtures for Tankerkoenig integration tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.tankerkoenig import DOMAIN
 from homeassistant.const import CONF_SHOW_ON_MAP
@@ -16,7 +16,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture(name="tankerkoenig")
-def mock_tankerkoenig() -> Generator[AsyncMock, None, None]:
+def mock_tankerkoenig() -> Generator[AsyncMock]:
     """Mock the aiotankerkoenig client."""
     with (
         patch(

--- a/tests/components/technove/conftest.py
+++ b/tests/components/technove/conftest.py
@@ -1,10 +1,10 @@
 """Fixtures for TechnoVE integration tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from technove import Station as TechnoVEStation
+from typing_extensions import Generator
 
 from homeassistant.components.technove.const import DOMAIN
 from homeassistant.const import CONF_HOST
@@ -24,7 +24,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.technove.async_setup_entry", return_value=True
@@ -33,7 +33,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_onboarding() -> Generator[MagicMock, None, None]:
+def mock_onboarding() -> Generator[MagicMock]:
     """Mock that Home Assistant is currently onboarding."""
     with patch(
         "homeassistant.components.onboarding.async_is_onboarded",
@@ -49,7 +49,7 @@ def device_fixture() -> TechnoVEStation:
 
 
 @pytest.fixture
-def mock_technove(device_fixture: TechnoVEStation) -> Generator[MagicMock, None, None]:
+def mock_technove(device_fixture: TechnoVEStation) -> Generator[MagicMock]:
     """Return a mocked TechnoVE client."""
     with (
         patch(

--- a/tests/components/tedee/conftest.py
+++ b/tests/components/tedee/conftest.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from pytedee_async.bridge import TedeeBridge
 from pytedee_async.lock import TedeeLock
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.tedee.const import CONF_LOCAL_ACCESS_TOKEN, DOMAIN
 from homeassistant.const import CONF_HOST, CONF_WEBHOOK_ID
@@ -37,7 +37,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.tedee.async_setup_entry", return_value=True
@@ -46,7 +46,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_tedee() -> Generator[MagicMock, None, None]:
+def mock_tedee() -> Generator[MagicMock]:
     """Return a mocked Tedee client."""
     with (
         patch(

--- a/tests/components/time_date/conftest.py
+++ b/tests/components/time_date/conftest.py
@@ -1,13 +1,13 @@
 """Fixtures for Time & Date integration tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.time_date.async_setup_entry", return_value=True

--- a/tests/components/todo/test_init.py
+++ b/tests/components/todo/test_init.py
@@ -1,12 +1,12 @@
 """Tests for the todo integration."""
 
-from collections.abc import Generator
 import datetime
 from typing import Any
 from unittest.mock import AsyncMock
 import zoneinfo
 
 import pytest
+from typing_extensions import Generator
 import voluptuous as vol
 
 from homeassistant.components.todo import (
@@ -75,7 +75,7 @@ class MockTodoListEntity(TodoListEntity):
 
 
 @pytest.fixture(autouse=True)
-def config_flow_fixture(hass: HomeAssistant) -> Generator[None, None, None]:
+def config_flow_fixture(hass: HomeAssistant) -> Generator[None]:
     """Mock config flow."""
     mock_platform(hass, f"{TEST_DOMAIN}.config_flow")
 

--- a/tests/components/todoist/conftest.py
+++ b/tests/components/todoist/conftest.py
@@ -1,6 +1,5 @@
 """Common fixtures for the todoist tests."""
 
-from collections.abc import Generator
 from http import HTTPStatus
 from unittest.mock import AsyncMock, patch
 
@@ -8,6 +7,7 @@ import pytest
 from requests.exceptions import HTTPError
 from requests.models import Response
 from todoist_api_python.models import Collaborator, Due, Label, Project, Task
+from typing_extensions import Generator
 
 from homeassistant.components.todoist import DOMAIN
 from homeassistant.const import CONF_TOKEN, Platform
@@ -24,7 +24,7 @@ TODAY = dt_util.now().strftime("%Y-%m-%d")
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.todoist.async_setup_entry", return_value=True

--- a/tests/components/tplink/conftest.py
+++ b/tests/components/tplink/conftest.py
@@ -1,10 +1,10 @@
 """tplink conftest."""
 
-from collections.abc import Generator
 import copy
 from unittest.mock import DEFAULT, AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.tplink import DOMAIN
 from homeassistant.core import HomeAssistant
@@ -85,7 +85,7 @@ def entity_reg_fixture(hass):
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch.multiple(
         async_setup=DEFAULT,
@@ -97,7 +97,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_init() -> Generator[AsyncMock, None, None]:
+def mock_init() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch.multiple(
         "homeassistant.components.tplink",

--- a/tests/components/tplink_omada/conftest.py
+++ b/tests/components/tplink_omada/conftest.py
@@ -1,6 +1,5 @@
 """Test fixtures for TP-Link Omada integration."""
 
-from collections.abc import Generator
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -11,6 +10,7 @@ from tplink_omada_client.devices import (
     OmadaSwitch,
     OmadaSwitchPortDetails,
 )
+from typing_extensions import Generator
 
 from homeassistant.components.tplink_omada.config_flow import CONF_SITE
 from homeassistant.components.tplink_omada.const import DOMAIN
@@ -38,7 +38,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.tplink_omada.async_setup_entry", return_value=True
@@ -47,7 +47,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_omada_site_client() -> Generator[AsyncMock, None, None]:
+def mock_omada_site_client() -> Generator[AsyncMock]:
     """Mock Omada site client."""
     site_client = AsyncMock()
 
@@ -73,9 +73,7 @@ def mock_omada_site_client() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_omada_client(
-    mock_omada_site_client: AsyncMock,
-) -> Generator[MagicMock, None, None]:
+def mock_omada_client(mock_omada_site_client: AsyncMock) -> Generator[MagicMock]:
     """Mock Omada client."""
     with patch(
         "homeassistant.components.tplink_omada.create_omada_client",

--- a/tests/components/traccar_server/conftest.py
+++ b/tests/components/traccar_server/conftest.py
@@ -1,10 +1,10 @@
 """Common fixtures for the Traccar Server tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from pytraccar import ApiClient, SubscriptionStatus
+from typing_extensions import Generator
 
 from homeassistant.components.traccar_server.const import (
     CONF_CUSTOM_ATTRIBUTES,
@@ -30,7 +30,7 @@ from tests.common import (
 
 
 @pytest.fixture
-def mock_traccar_api_client() -> Generator[AsyncMock, None, None]:
+def mock_traccar_api_client() -> Generator[AsyncMock]:
     """Mock a Traccar ApiClient client."""
     with (
         patch(

--- a/tests/components/traccar_server/test_config_flow.py
+++ b/tests/components/traccar_server/test_config_flow.py
@@ -1,11 +1,11 @@
 """Test the Traccar Server config flow."""
 
-from collections.abc import Generator
 from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
 from pytraccar import TraccarException
+from typing_extensions import Generator
 
 from homeassistant import config_entries
 from homeassistant.components.traccar.device_tracker import PLATFORM_SCHEMA
@@ -34,7 +34,7 @@ from tests.common import MockConfigEntry
 
 async def test_form(
     hass: HomeAssistant,
-    mock_traccar_api_client: Generator[AsyncMock, None, None],
+    mock_traccar_api_client: Generator[AsyncMock],
 ) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
@@ -77,7 +77,7 @@ async def test_form_cannot_connect(
     hass: HomeAssistant,
     side_effect: Exception,
     error: str,
-    mock_traccar_api_client: Generator[AsyncMock, None, None],
+    mock_traccar_api_client: Generator[AsyncMock],
 ) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
@@ -127,7 +127,7 @@ async def test_form_cannot_connect(
 async def test_options(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_traccar_api_client: Generator[AsyncMock, None, None],
+    mock_traccar_api_client: Generator[AsyncMock],
 ) -> None:
     """Test options flow."""
     mock_config_entry.add_to_hass(hass)
@@ -231,7 +231,7 @@ async def test_import_from_yaml(
     imported: dict[str, Any],
     data: dict[str, Any],
     options: dict[str, Any],
-    mock_traccar_api_client: Generator[AsyncMock, None, None],
+    mock_traccar_api_client: Generator[AsyncMock],
 ) -> None:
     """Test importing configuration from YAML."""
     result = await hass.config_entries.flow.async_init(
@@ -277,7 +277,7 @@ async def test_abort_import_already_configured(hass: HomeAssistant) -> None:
 async def test_abort_already_configured(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_traccar_api_client: Generator[AsyncMock, None, None],
+    mock_traccar_api_client: Generator[AsyncMock],
 ) -> None:
     """Test abort for existing server."""
     mock_config_entry.add_to_hass(hass)

--- a/tests/components/traccar_server/test_diagnostics.py
+++ b/tests/components/traccar_server/test_diagnostics.py
@@ -1,9 +1,9 @@
 """Test Traccar Server diagnostics."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock
 
 from syrupy import SnapshotAssertion
+from typing_extensions import Generator
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -21,7 +21,7 @@ from tests.typing import ClientSessionGenerator
 async def test_entry_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
-    mock_traccar_api_client: Generator[AsyncMock, None, None],
+    mock_traccar_api_client: Generator[AsyncMock],
     mock_config_entry: MockConfigEntry,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -44,7 +44,7 @@ async def test_entry_diagnostics(
 async def test_device_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
-    mock_traccar_api_client: Generator[AsyncMock, None, None],
+    mock_traccar_api_client: Generator[AsyncMock],
     mock_config_entry: MockConfigEntry,
     snapshot: SnapshotAssertion,
     device_registry: dr.DeviceRegistry,
@@ -86,7 +86,7 @@ async def test_device_diagnostics(
 async def test_device_diagnostics_with_disabled_entity(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
-    mock_traccar_api_client: Generator[AsyncMock, None, None],
+    mock_traccar_api_client: Generator[AsyncMock],
     mock_config_entry: MockConfigEntry,
     snapshot: SnapshotAssertion,
     device_registry: dr.DeviceRegistry,

--- a/tests/components/tractive/conftest.py
+++ b/tests/components/tractive/conftest.py
@@ -1,12 +1,12 @@
 """Common fixtures for the Tractive tests."""
 
-from collections.abc import Generator
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 from aiotractive.trackable_object import TrackableObject
 from aiotractive.tracker import Tracker
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.tractive.const import DOMAIN, SERVER_UNAVAILABLE
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
@@ -16,7 +16,7 @@ from tests.common import MockConfigEntry, load_json_object_fixture
 
 
 @pytest.fixture
-def mock_tractive_client() -> Generator[AsyncMock, None, None]:
+def mock_tractive_client() -> Generator[AsyncMock]:
     """Mock a Tractive client."""
 
     def send_hardware_event(

--- a/tests/components/tradfri/conftest.py
+++ b/tests/components/tradfri/conftest.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Generator
+from collections.abc import Callable
 import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -12,6 +12,7 @@ from pytradfri.command import Command
 from pytradfri.const import ATTR_FIRMWARE_VERSION, ATTR_GATEWAY_ID
 from pytradfri.device import Device
 from pytradfri.gateway import Gateway
+from typing_extensions import Generator
 
 from homeassistant.components.tradfri.const import DOMAIN
 
@@ -22,7 +23,7 @@ from tests.common import load_fixture
 
 
 @pytest.fixture
-def mock_entry_setup() -> Generator[AsyncMock, None, None]:
+def mock_entry_setup() -> Generator[AsyncMock]:
     """Mock entry setup."""
     with patch(f"{TRADFRI_PATH}.async_setup_entry") as mock_setup:
         mock_setup.return_value = True
@@ -76,7 +77,7 @@ def mock_api_fixture(
 @pytest.fixture(autouse=True)
 def mock_api_factory(
     mock_api: Callable[[Command | list[Command], float | None], Any | None],
-) -> Generator[MagicMock, None, None]:
+) -> Generator[MagicMock]:
     """Mock pytradfri api factory."""
     with patch(f"{TRADFRI_PATH}.APIFactory", autospec=True) as factory_class:
         factory = factory_class.return_value

--- a/tests/components/tts/common.py
+++ b/tests/components/tts/common.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from http import HTTPStatus
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 import voluptuous as vol
 
 from homeassistant.components import media_source
@@ -42,7 +42,7 @@ SUPPORT_LANGUAGES = ["de_CH", "de_DE", "en_GB", "en_US"]
 TEST_DOMAIN = "test"
 
 
-def mock_tts_get_cache_files_fixture_helper() -> Generator[MagicMock, None, None]:
+def mock_tts_get_cache_files_fixture_helper() -> Generator[MagicMock]:
     """Mock the list TTS cache function."""
     with patch(
         "homeassistant.components.tts._get_cache_files", return_value={}
@@ -52,7 +52,7 @@ def mock_tts_get_cache_files_fixture_helper() -> Generator[MagicMock, None, None
 
 def mock_tts_init_cache_dir_fixture_helper(
     init_tts_cache_dir_side_effect: Any,
-) -> Generator[MagicMock, None, None]:
+) -> Generator[MagicMock]:
     """Mock the TTS cache dir in memory."""
     with patch(
         "homeassistant.components.tts._init_tts_cache_dir",
@@ -71,7 +71,7 @@ def mock_tts_cache_dir_fixture_helper(
     mock_tts_init_cache_dir: MagicMock,
     mock_tts_get_cache_files: MagicMock,
     request: pytest.FixtureRequest,
-) -> Generator[Path, None, None]:
+) -> Generator[Path]:
     """Mock the TTS cache dir with empty dir."""
     mock_tts_init_cache_dir.return_value = str(tmp_path)
 
@@ -92,7 +92,7 @@ def mock_tts_cache_dir_fixture_helper(
     pytest.fail("Test failed, see log for details")
 
 
-def tts_mutagen_mock_fixture_helper() -> Generator[MagicMock, None, None]:
+def tts_mutagen_mock_fixture_helper() -> Generator[MagicMock]:
     """Mock writing tags."""
     with patch(
         "homeassistant.components.tts.SpeechManager.write_tags",

--- a/tests/components/tts/conftest.py
+++ b/tests/components/tts/conftest.py
@@ -3,11 +3,11 @@
 From http://doc.pytest.org/en/latest/example/simple.html#making-test-result-information-available-in-fixtures
 """
 
-from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.config_entries import ConfigFlow
@@ -82,7 +82,7 @@ class TTSFlow(ConfigFlow):
 
 
 @pytest.fixture(autouse=True)
-def config_flow_fixture(hass: HomeAssistant) -> Generator[None, None, None]:
+def config_flow_fixture(hass: HomeAssistant) -> Generator[None]:
     """Mock config flow."""
     mock_platform(hass, f"{TEST_DOMAIN}.config_flow")
 

--- a/tests/components/tuya/conftest.py
+++ b/tests/components/tuya/conftest.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.tuya.const import CONF_APP_TYPE, CONF_USER_CODE, DOMAIN
 
@@ -35,14 +35,14 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch("homeassistant.components.tuya.async_setup_entry", return_value=True):
         yield
 
 
 @pytest.fixture
-def mock_tuya_login_control() -> Generator[MagicMock, None, None]:
+def mock_tuya_login_control() -> Generator[MagicMock]:
     """Return a mocked Tuya login control."""
     with patch(
         "homeassistant.components.tuya.config_flow.LoginControl", autospec=True

--- a/tests/components/twentemilieu/conftest.py
+++ b/tests/components/twentemilieu/conftest.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from datetime import date
 from unittest.mock import MagicMock, patch
 
 import pytest
 from twentemilieu import WasteType
+from typing_extensions import Generator
 
 from homeassistant.components.twentemilieu.const import (
     CONF_HOUSE_LETTER,
@@ -38,7 +38,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[None, None, None]:
+def mock_setup_entry() -> Generator[None]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.twentemilieu.async_setup_entry", return_value=True
@@ -47,7 +47,7 @@ def mock_setup_entry() -> Generator[None, None, None]:
 
 
 @pytest.fixture
-def mock_twentemilieu() -> Generator[MagicMock, None, None]:
+def mock_twentemilieu() -> Generator[MagicMock]:
     """Return a mocked Twente Milieu client."""
     with (
         patch(

--- a/tests/components/twitch/__init__.py
+++ b/tests/components/twitch/__init__.py
@@ -1,9 +1,10 @@
 """Tests for the Twitch component."""
 
-from collections.abc import AsyncGenerator, AsyncIterator
+from collections.abc import AsyncIterator
 from typing import Any, Generic, TypeVar
 
 from twitchAPI.object.base import TwitchObject
+from typing_extensions import AsyncGenerator
 
 from homeassistant.components.twitch import DOMAIN
 from homeassistant.core import HomeAssistant
@@ -40,7 +41,7 @@ class TwitchIterObject(Generic[TwitchType]):
 
 async def get_generator(
     fixture: str, target_type: type[TwitchType]
-) -> AsyncGenerator[TwitchType, None]:
+) -> AsyncGenerator[TwitchType]:
     """Return async generator."""
     data = load_json_array_fixture(fixture, DOMAIN)
     async for item in get_generator_from_data(data, target_type):
@@ -49,7 +50,7 @@ async def get_generator(
 
 async def get_generator_from_data(
     items: list[dict[str, Any]], target_type: type[TwitchType]
-) -> AsyncGenerator[TwitchType, None]:
+) -> AsyncGenerator[TwitchType]:
     """Return async generator."""
     for item in items:
         yield target_type(**item)

--- a/tests/components/twitch/conftest.py
+++ b/tests/components/twitch/conftest.py
@@ -1,11 +1,11 @@
 """Configure tests for the Twitch integration."""
 
-from collections.abc import Generator
 import time
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from twitchAPI.object.api import FollowedChannel, Stream, TwitchUser, UserSubscription
+from typing_extensions import Generator
 
 from homeassistant.components.application_credentials import (
     ClientCredential,
@@ -26,7 +26,7 @@ TITLE = "Test"
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.twitch.async_setup_entry", return_value=True
@@ -93,7 +93,7 @@ def mock_connection(aioclient_mock: AiohttpClientMocker) -> None:
 
 
 @pytest.fixture
-def twitch_mock() -> Generator[AsyncMock, None, None]:
+def twitch_mock() -> Generator[AsyncMock]:
     """Return as fixture to inject other mocks."""
     with (
         patch(

--- a/tests/components/update/test_init.py
+++ b/tests/components/update/test_init.py
@@ -1,9 +1,9 @@
 """The tests for the Update component."""
 
-from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.update import (
     ATTR_BACKUP,
@@ -767,7 +767,7 @@ class MockFlow(ConfigFlow):
 
 
 @pytest.fixture(autouse=True)
-def config_flow_fixture(hass: HomeAssistant) -> Generator[None, None, None]:
+def config_flow_fixture(hass: HomeAssistant) -> Generator[None]:
     """Mock config flow."""
     mock_platform(hass, f"{TEST_DOMAIN}.config_flow")
 

--- a/tests/components/uptime/conftest.py
+++ b/tests/components/uptime/conftest.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.uptime.const import DOMAIN
 from homeassistant.core import HomeAssistant
@@ -23,7 +23,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[None, None, None]:
+def mock_setup_entry() -> Generator[None]:
     """Mock setting up a config entry."""
     with patch("homeassistant.components.uptime.async_setup_entry", return_value=True):
         yield

--- a/tests/components/v2c/conftest.py
+++ b/tests/components/v2c/conftest.py
@@ -1,10 +1,10 @@
 """Common fixtures for the V2C tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from pytrydan.models.trydan import TrydanData
+from typing_extensions import Generator
 
 from homeassistant.components.v2c import DOMAIN
 from homeassistant.const import CONF_HOST
@@ -14,7 +14,7 @@ from tests.common import MockConfigEntry, load_json_object_fixture
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.v2c.async_setup_entry", return_value=True
@@ -34,7 +34,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_v2c_client() -> Generator[AsyncMock, None, None]:
+def mock_v2c_client() -> Generator[AsyncMock]:
     """Mock a V2C client."""
     with (
         patch(

--- a/tests/components/vacuum/conftest.py
+++ b/tests/components/vacuum/conftest.py
@@ -1,8 +1,7 @@
 """Fixtures for Vacuum platform tests."""
 
-from collections.abc import Generator
-
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.core import HomeAssistant
@@ -15,7 +14,7 @@ class MockFlow(ConfigFlow):
 
 
 @pytest.fixture
-def config_flow_fixture(hass: HomeAssistant) -> Generator[None, None, None]:
+def config_flow_fixture(hass: HomeAssistant) -> Generator[None]:
     """Mock config flow."""
     mock_platform(hass, "test.config_flow")
 

--- a/tests/components/valve/test_init.py
+++ b/tests/components/valve/test_init.py
@@ -1,9 +1,8 @@
 """The tests for Valve."""
 
-from collections.abc import Generator
-
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from typing_extensions import Generator
 
 from homeassistant.components.valve import (
     DOMAIN,
@@ -123,7 +122,7 @@ class MockBinaryValveEntity(ValveEntity):
 
 
 @pytest.fixture(autouse=True)
-def config_flow_fixture(hass: HomeAssistant) -> Generator[None, None, None]:
+def config_flow_fixture(hass: HomeAssistant) -> Generator[None]:
     """Mock config flow."""
     mock_platform(hass, f"{TEST_DOMAIN}.config_flow")
 

--- a/tests/components/velbus/conftest.py
+++ b/tests/components/velbus/conftest.py
@@ -1,9 +1,9 @@
 """Fixtures for the Velbus tests."""
 
-from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.velbus.const import DOMAIN
 from homeassistant.config_entries import ConfigEntry
@@ -16,7 +16,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture(name="controller")
-def mock_controller() -> Generator[MagicMock, None, None]:
+def mock_controller() -> Generator[MagicMock]:
     """Mock a successful velbus controller."""
     with patch("homeassistant.components.velbus.Velbus", autospec=True) as controller:
         yield controller

--- a/tests/components/velbus/test_config_flow.py
+++ b/tests/components/velbus/test_config_flow.py
@@ -1,10 +1,10 @@
 """Tests for the Velbus config flow."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import serial.tools.list_ports
+from typing_extensions import Generator
 from velbusaio.exceptions import VelbusConnectionFailed
 
 from homeassistant.components import usb
@@ -39,7 +39,7 @@ def com_port():
 
 
 @pytest.fixture(name="controller")
-def mock_controller() -> Generator[MagicMock, None, None]:
+def mock_controller() -> Generator[MagicMock]:
     """Mock a successful velbus controller."""
     with patch(
         "homeassistant.components.velbus.config_flow.velbusaio.controller.Velbus",
@@ -49,7 +49,7 @@ def mock_controller() -> Generator[MagicMock, None, None]:
 
 
 @pytest.fixture(autouse=True)
-def override_async_setup_entry() -> Generator[AsyncMock, None, None]:
+def override_async_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.velbus.async_setup_entry", return_value=True

--- a/tests/components/velux/conftest.py
+++ b/tests/components/velux/conftest.py
@@ -1,13 +1,13 @@
 """Configuration for Velux tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.velux.async_setup_entry", return_value=True

--- a/tests/components/verisure/conftest.py
+++ b/tests/components/verisure/conftest.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.verisure.const import CONF_GIID, DOMAIN
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
@@ -29,7 +29,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.verisure.async_setup_entry", return_value=True

--- a/tests/components/vicare/conftest.py
+++ b/tests/components/vicare/conftest.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator, Generator
 from dataclasses import dataclass
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from PyViCare.PyViCareDeviceConfig import PyViCareDeviceConfig
 from PyViCare.PyViCareService import ViCareDeviceAccessor, readFeature
+from typing_extensions import AsyncGenerator, Generator
 
 from homeassistant.components.vicare.const import DOMAIN
 from homeassistant.core import HomeAssistant
@@ -80,7 +80,7 @@ def mock_config_entry() -> MockConfigEntry:
 @pytest.fixture
 async def mock_vicare_gas_boiler(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
-) -> AsyncGenerator[MockConfigEntry, None]:
+) -> AsyncGenerator[MockConfigEntry]:
     """Return a mocked ViCare API representing a single gas boiler device."""
     fixtures: list[Fixture] = [Fixture({"type:boiler"}, "vicare/Vitodens300W.json")]
     with patch(
@@ -96,7 +96,7 @@ async def mock_vicare_gas_boiler(
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(f"{MODULE}.async_setup_entry", return_value=True) as mock_setup_entry:
         yield mock_setup_entry

--- a/tests/components/vilfo/conftest.py
+++ b/tests/components/vilfo/conftest.py
@@ -1,9 +1,9 @@
 """Vilfo tests conftest."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.vilfo import DOMAIN
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_HOST
@@ -12,7 +12,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.vilfo.async_setup_entry",
@@ -22,7 +22,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_vilfo_client() -> Generator[AsyncMock, None, None]:
+def mock_vilfo_client() -> Generator[AsyncMock]:
     """Mock a Vilfo client."""
     with patch(
         "homeassistant.components.vilfo.config_flow.VilfoClient",
@@ -38,7 +38,7 @@ def mock_vilfo_client() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_is_valid_host() -> Generator[AsyncMock, None, None]:
+def mock_is_valid_host() -> Generator[AsyncMock]:
     """Mock is_valid_host."""
     with patch(
         "homeassistant.components.vilfo.config_flow.is_host_valid",

--- a/tests/components/wake_word/test_init.py
+++ b/tests/components/wake_word/test_init.py
@@ -1,13 +1,14 @@
 """Test wake_word component setup."""
 
 import asyncio
-from collections.abc import AsyncIterable, Generator
+from collections.abc import AsyncIterable
 from functools import partial
 from pathlib import Path
 from unittest.mock import patch
 
 from freezegun import freeze_time
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components import wake_word
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState, ConfigFlow
@@ -88,7 +89,7 @@ class WakeWordFlow(ConfigFlow):
 
 
 @pytest.fixture(autouse=True)
-def config_flow_fixture(hass: HomeAssistant) -> Generator[None, None, None]:
+def config_flow_fixture(hass: HomeAssistant) -> Generator[None]:
     """Mock config flow."""
     mock_platform(hass, f"{TEST_DOMAIN}.config_flow")
 

--- a/tests/components/waqi/conftest.py
+++ b/tests/components/waqi/conftest.py
@@ -1,9 +1,9 @@
 """Common fixtures for the World Air Quality Index (WAQI) tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.waqi.const import CONF_STATION_NUMBER, DOMAIN
 from homeassistant.const import CONF_API_KEY
@@ -12,7 +12,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.waqi.async_setup_entry", return_value=True

--- a/tests/components/water_heater/conftest.py
+++ b/tests/components/water_heater/conftest.py
@@ -1,8 +1,7 @@
 """Fixtures for water heater platform tests."""
 
-from collections.abc import Generator
-
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.core import HomeAssistant
@@ -15,7 +14,7 @@ class MockFlow(ConfigFlow):
 
 
 @pytest.fixture
-def config_flow_fixture(hass: HomeAssistant) -> Generator[None, None, None]:
+def config_flow_fixture(hass: HomeAssistant) -> Generator[None]:
     """Mock config flow."""
     mock_platform(hass, "test.config_flow")
 

--- a/tests/components/weather/conftest.py
+++ b/tests/components/weather/conftest.py
@@ -1,8 +1,7 @@
 """Fixtures for Weather platform tests."""
 
-from collections.abc import Generator
-
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.core import HomeAssistant
@@ -15,7 +14,7 @@ class MockFlow(ConfigFlow):
 
 
 @pytest.fixture
-def config_flow_fixture(hass: HomeAssistant) -> Generator[None, None, None]:
+def config_flow_fixture(hass: HomeAssistant) -> Generator[None]:
     """Mock config flow."""
     mock_platform(hass, "test.config_flow")
 

--- a/tests/components/weatherflow/conftest.py
+++ b/tests/components/weatherflow/conftest.py
@@ -1,12 +1,12 @@
 """Fixtures for Weatherflow integration tests."""
 
 import asyncio
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from pyweatherflowudp.client import EVENT_DEVICE_DISCOVERED
 from pyweatherflowudp.device import WeatherFlowDevice
+from typing_extensions import Generator
 
 from homeassistant.components.weatherflow.const import DOMAIN
 
@@ -14,7 +14,7 @@ from tests.common import MockConfigEntry, load_json_object_fixture
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.weatherflow.async_setup_entry", return_value=True
@@ -29,7 +29,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_has_devices() -> Generator[AsyncMock, None, None]:
+def mock_has_devices() -> Generator[AsyncMock]:
     """Return a mock has_devices function."""
     with patch(
         "homeassistant.components.weatherflow.config_flow.WeatherFlowListener.on",
@@ -39,7 +39,7 @@ def mock_has_devices() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_stop() -> Generator[AsyncMock, None, None]:
+def mock_stop() -> Generator[AsyncMock]:
     """Return a fixture to handle the stop of udp."""
 
     async def mock_stop_listening(self):
@@ -54,7 +54,7 @@ def mock_stop() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_start() -> Generator[AsyncMock, None, None]:
+def mock_start() -> Generator[AsyncMock]:
     """Return fixture for starting upd."""
 
     device = WeatherFlowDevice(

--- a/tests/components/weatherflow_cloud/conftest.py
+++ b/tests/components/weatherflow_cloud/conftest.py
@@ -1,14 +1,14 @@
 """Common fixtures for the WeatherflowCloud tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, Mock, patch
 
 from aiohttp import ClientResponseError
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.weatherflow_cloud.async_setup_entry",
@@ -18,7 +18,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_get_stations() -> Generator[AsyncMock, None, None]:
+def mock_get_stations() -> Generator[AsyncMock]:
     """Mock get_stations with a sequence of responses."""
     side_effects = [
         True,
@@ -32,7 +32,7 @@ def mock_get_stations() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_get_stations_500_error() -> Generator[AsyncMock, None, None]:
+def mock_get_stations_500_error() -> Generator[AsyncMock]:
     """Mock get_stations with a sequence of responses."""
     side_effects = [
         ClientResponseError(Mock(), (), status=500),
@@ -47,7 +47,7 @@ def mock_get_stations_500_error() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_get_stations_401_error() -> Generator[AsyncMock, None, None]:
+def mock_get_stations_401_error() -> Generator[AsyncMock]:
     """Mock get_stations with a sequence of responses."""
     side_effects = [ClientResponseError(Mock(), (), status=401), True, True, True]
 

--- a/tests/components/weatherkit/conftest.py
+++ b/tests/components/weatherkit/conftest.py
@@ -1,13 +1,13 @@
 """Common fixtures for the Apple WeatherKit tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.weatherkit.async_setup_entry", return_value=True

--- a/tests/components/webmin/conftest.py
+++ b/tests/components/webmin/conftest.py
@@ -1,9 +1,9 @@
 """Fixtures for Webmin integration tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.webmin.const import DEFAULT_PORT, DOMAIN
 from homeassistant.const import (
@@ -29,7 +29,7 @@ TEST_USER_INPUT = {
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.webmin.async_setup_entry", return_value=True

--- a/tests/components/webostv/conftest.py
+++ b/tests/components/webostv/conftest.py
@@ -1,9 +1,9 @@
 """Common fixtures and objects for the LG webOS integration tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.webostv.const import LIVE_TV_APP_ID
 from homeassistant.core import HomeAssistant, ServiceCall
@@ -14,7 +14,7 @@ from tests.common import async_mock_service
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.webostv.async_setup_entry", return_value=True

--- a/tests/components/whois/conftest.py
+++ b/tests/components/whois/conftest.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.whois.const import DOMAIN
 from homeassistant.const import CONF_DOMAIN
@@ -30,7 +30,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.whois.async_setup_entry", return_value=True
@@ -39,7 +39,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_whois() -> Generator[MagicMock, None, None]:
+def mock_whois() -> Generator[MagicMock]:
     """Return a mocked query."""
     with (
         patch(
@@ -68,7 +68,7 @@ def mock_whois() -> Generator[MagicMock, None, None]:
 
 
 @pytest.fixture
-def mock_whois_missing_some_attrs() -> Generator[Mock, None, None]:
+def mock_whois_missing_some_attrs() -> Generator[Mock]:
     """Return a mocked query that only sets admin."""
 
     class LimitedWhoisMock:

--- a/tests/components/wiffi/conftest.py
+++ b/tests/components/wiffi/conftest.py
@@ -1,13 +1,13 @@
 """Configuration for Wiffi tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.wiffi.async_setup_entry", return_value=True

--- a/tests/components/wled/conftest.py
+++ b/tests/components/wled/conftest.py
@@ -1,10 +1,10 @@
 """Fixtures for WLED integration tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
+from typing_extensions import Generator
 from wled import Device as WLEDDevice
 
 from homeassistant.components.wled.const import DOMAIN
@@ -26,7 +26,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.wled.async_setup_entry", return_value=True
@@ -35,7 +35,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_onboarding() -> Generator[MagicMock, None, None]:
+def mock_onboarding() -> Generator[MagicMock]:
     """Mock that Home Assistant is currently onboarding."""
     with patch(
         "homeassistant.components.onboarding.async_is_onboarded",
@@ -51,7 +51,7 @@ def device_fixture() -> str:
 
 
 @pytest.fixture
-def mock_wled(device_fixture: str) -> Generator[MagicMock, None, None]:
+def mock_wled(device_fixture: str) -> Generator[MagicMock]:
     """Return a mocked WLED client."""
     with (
         patch(

--- a/tests/components/workday/conftest.py
+++ b/tests/components/workday/conftest.py
@@ -1,13 +1,13 @@
 """Fixtures for Workday integration tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.workday.async_setup_entry", return_value=True

--- a/tests/components/wyoming/conftest.py
+++ b/tests/components/wyoming/conftest.py
@@ -1,10 +1,10 @@
 """Common fixtures for the Wyoming tests."""
 
-from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components import stt
 from homeassistant.components.wyoming import DOMAIN
@@ -31,7 +31,7 @@ async def init_components(hass: HomeAssistant):
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.wyoming.async_setup_entry", return_value=True

--- a/tests/components/xiaomi_ble/conftest.py
+++ b/tests/components/xiaomi_ble/conftest.py
@@ -1,9 +1,9 @@
 """Session fixtures."""
 
-from collections.abc import Generator
 from unittest import mock
 
 import pytest
+from typing_extensions import Generator
 
 
 class MockServices:
@@ -45,7 +45,7 @@ class MockBleakClientBattery5(MockBleakClient):
 
 
 @pytest.fixture(autouse=True)
-def mock_bluetooth(enable_bluetooth: None) -> Generator[None, None, None]:
+def mock_bluetooth(enable_bluetooth: None) -> Generator[None]:
     """Auto mock bluetooth."""
 
     with mock.patch("xiaomi_ble.parser.BleakClient", MockBleakClientBattery5):

--- a/tests/components/xiaomi_miio/test_vacuum.py
+++ b/tests/components/xiaomi_miio/test_vacuum.py
@@ -1,12 +1,12 @@
 """The tests for the Xiaomi vacuum platform."""
 
-from collections.abc import Generator
 from datetime import datetime, time, timedelta
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
 from miio import DeviceException
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.vacuum import (
     ATTR_BATTERY_ICON,
@@ -143,7 +143,7 @@ new_fanspeeds = {
 @pytest.fixture(name="mock_mirobo_fanspeeds", params=[old_fanspeeds, new_fanspeeds])
 def mirobo_old_speeds_fixture(
     request: pytest.FixtureRequest,
-) -> Generator[MagicMock, None, None]:
+) -> Generator[MagicMock]:
     """Fixture for testing both types of fanspeeds."""
     mock_vacuum = MagicMock()
     mock_vacuum.status().battery = 32

--- a/tests/components/yardian/conftest.py
+++ b/tests/components/yardian/conftest.py
@@ -1,13 +1,13 @@
 """Common fixtures for the Yardian tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.yardian.async_setup_entry", return_value=True

--- a/tests/components/youtube/__init__.py
+++ b/tests/components/youtube/__init__.py
@@ -1,8 +1,8 @@
 """Tests for the YouTube integration."""
 
-from collections.abc import AsyncGenerator
 import json
 
+from typing_extensions import AsyncGenerator
 from youtubeaio.models import YouTubeChannel, YouTubePlaylistItem, YouTubeSubscription
 from youtubeaio.types import AuthScope
 
@@ -30,7 +30,7 @@ class MockYouTube:
     ) -> None:
         """Authenticate the user."""
 
-    async def get_user_channels(self) -> AsyncGenerator[YouTubeChannel, None]:
+    async def get_user_channels(self) -> AsyncGenerator[YouTubeChannel]:
         """Get channels for authenticated user."""
         channels = json.loads(load_fixture(self._channel_fixture))
         for item in channels["items"]:
@@ -38,7 +38,7 @@ class MockYouTube:
 
     async def get_channels(
         self, channel_ids: list[str]
-    ) -> AsyncGenerator[YouTubeChannel, None]:
+    ) -> AsyncGenerator[YouTubeChannel]:
         """Get channels."""
         if self._thrown_error is not None:
             raise self._thrown_error
@@ -48,13 +48,13 @@ class MockYouTube:
 
     async def get_playlist_items(
         self, playlist_id: str, amount: int
-    ) -> AsyncGenerator[YouTubePlaylistItem, None]:
+    ) -> AsyncGenerator[YouTubePlaylistItem]:
         """Get channels."""
         channels = json.loads(load_fixture(self._playlist_items_fixture))
         for item in channels["items"]:
             yield YouTubePlaylistItem(**item)
 
-    async def get_user_subscriptions(self) -> AsyncGenerator[YouTubeSubscription, None]:
+    async def get_user_subscriptions(self) -> AsyncGenerator[YouTubeSubscription]:
         """Get channels for authenticated user."""
         channels = json.loads(load_fixture(self._subscriptions_fixture))
         for item in channels["items"]:

--- a/tests/components/zamg/conftest.py
+++ b/tests/components/zamg/conftest.py
@@ -1,10 +1,10 @@
 """Fixtures for Zamg integration tests."""
 
-from collections.abc import Generator
 import json
 from unittest.mock import MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 from zamg import ZamgData as ZamgDevice
 
 from homeassistant.components.zamg.const import CONF_STATION_ID, DOMAIN
@@ -30,7 +30,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[None, None, None]:
+def mock_setup_entry() -> Generator[None]:
     """Mock setting up a config entry."""
     with patch("homeassistant.components.zamg.async_setup_entry", return_value=True):
         yield

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -1,6 +1,6 @@
 """Test configuration for the ZHA component."""
 
-from collections.abc import Callable, Generator
+from collections.abc import Callable
 import itertools
 import time
 from typing import Any
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 import warnings
 
 import pytest
+from typing_extensions import Generator
 import zigpy
 from zigpy.application import ControllerApplication
 import zigpy.backups
@@ -225,7 +226,7 @@ async def config_entry_fixture(hass) -> MockConfigEntry:
 @pytest.fixture
 def mock_zigpy_connect(
     zigpy_app_controller: ControllerApplication,
-) -> Generator[ControllerApplication, None, None]:
+) -> Generator[ControllerApplication]:
     """Patch the zigpy radio connection with our mock application."""
     with (
         patch(

--- a/tests/components/zha/test_radio_manager.py
+++ b/tests/components/zha/test_radio_manager.py
@@ -1,10 +1,10 @@
 """Tests for ZHA config flow."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
 import pytest
 import serial.tools.list_ports
+from typing_extensions import Generator
 from zigpy.backups import BackupManager
 import zigpy.config
 from zigpy.config import CONF_DEVICE_PATH
@@ -87,7 +87,7 @@ def com_port(device="/dev/ttyUSB1234"):
 
 
 @pytest.fixture
-def mock_connect_zigpy_app() -> Generator[MagicMock, None, None]:
+def mock_connect_zigpy_app() -> Generator[MagicMock]:
     """Mock the radio connection."""
 
     mock_connect_app = MagicMock()

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -1,7 +1,6 @@
 """Test the Z-Wave JS config flow."""
 
 import asyncio
-from collections.abc import Generator
 from copy import copy
 from ipaddress import ip_address
 from unittest.mock import DEFAULT, MagicMock, call, patch
@@ -9,6 +8,7 @@ from unittest.mock import DEFAULT, MagicMock, call, patch
 import aiohttp
 import pytest
 from serial.tools.list_ports_common import ListPortInfo
+from typing_extensions import Generator
 from zwave_js_server.version import VersionInfo
 
 from homeassistant import config_entries
@@ -159,7 +159,7 @@ def serial_port_fixture() -> ListPortInfo:
 
 
 @pytest.fixture(name="mock_list_ports", autouse=True)
-def mock_list_ports_fixture(serial_port) -> Generator[MagicMock, None, None]:
+def mock_list_ports_fixture(serial_port) -> Generator[MagicMock]:
     """Mock list ports."""
     with patch(
         "homeassistant.components.zwave_js.config_flow.list_ports.comports"
@@ -179,7 +179,7 @@ def mock_list_ports_fixture(serial_port) -> Generator[MagicMock, None, None]:
 
 
 @pytest.fixture(name="mock_usb_serial_by_id", autouse=True)
-def mock_usb_serial_by_id_fixture() -> Generator[MagicMock, None, None]:
+def mock_usb_serial_by_id_fixture() -> Generator[MagicMock]:
     """Mock usb serial by id."""
     with patch(
         "homeassistant.components.zwave_js.config_flow.usb.get_serial_by_id"


### PR DESCRIPTION
## Proposed change
For details see: https://github.com/home-assistant/core/pull/118986

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
