### PR TITLE
Check aliases in get_by_name functions for areas/floors

### DIFF
--- a/homeassistant/helpers/floor_registry.py
+++ b/homeassistant/helpers/floor_registry.py
@@ -93,8 +93,19 @@ class FloorRegistry(BaseRegistry[FloorRegistryStoreData]):
 
     @callback
     def async_get_floor_by_name(self, name: str) -> FloorEntry | None:
-        """Get floor by name."""
-        return self.floors.get_by_name(name)
+        """Get floor by name or alias."""
+        if floor := self.floors.get_by_name(name):
+            return floor
+
+        # Check aliases
+        normalized_name = normalize_name(name)
+        for floor in self.async_list_floors():
+            for alias in floor.aliases:
+                normalized_alias = normalize_name(alias)
+                if normalized_name == normalized_alias:
+                    return floor
+
+        return None
 
     @callback
     def async_list_floors(self) -> Iterable[FloorEntry]:

--- a/tests/components/config/test_area_registry.py
+++ b/tests/components/config/test_area_registry.py
@@ -260,3 +260,9 @@ async def test_update_area_with_name_already_in_use(
     assert msg["error"]["code"] == "invalid_info"
     assert msg["error"]["message"] == "The name mock 2 (mock2) is already in use"
     assert len(area_registry.areas) == 2
+
+
+async def test_get_area_by_alias(area_registry: ar.AreaRegistry) -> None:
+    """Test async_get_area_by_name also works with aliases."""
+    area = area_registry.async_create("area 1", aliases={"alias 1"})
+    assert area_registry.async_get_area_by_name("alias 1") == area

--- a/tests/components/config/test_floor_registry.py
+++ b/tests/components/config/test_floor_registry.py
@@ -239,3 +239,9 @@ async def test_update_with_name_already_in_use(
         == "The name Second floor (secondfloor) is already in use"
     )
     assert len(floor_registry.floors) == 2
+
+
+async def test_get_floor_by_alias(floor_registry: fr.FloorRegistry) -> None:
+    """Test async_get_floor_by_name also works with aliases."""
+    floor = floor_registry.async_create("floor 1", aliases={"alias 1"})
+    assert floor_registry.async_get_floor_by_name("alias 1") == floor


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The `async_get_area_by_name` and `async_get_floor_by_name` functions on their respective registries do not currently check for aliases. Because of this, working with area/floor aliases in templates is not possible (the `area_id` and `floor_id` template functions use `get_*_by_name`).

This PR extends the two `get_*_by_name` functions to also check aliases. The `normalize_name` function from `normalized_name_base_registry` is reused.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/intents/issues/2212
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
