### PR TITLE
New Integration - Leslie's Pool Test Results

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -771,6 +771,8 @@ build.json @home-assistant/supervisor
 /tests/components/leaone/ @bdraco
 /homeassistant/components/led_ble/ @bdraco
 /tests/components/led_ble/ @bdraco
+/homeassistant/components/leslies_pool/ @connorgallopo
+/tests/components/leslies_pool/ @connorgallopo
 /homeassistant/components/lg_netcast/ @Drafteed @splinter98
 /tests/components/lg_netcast/ @Drafteed @splinter98
 /homeassistant/components/lidarr/ @tkdrob

--- a/homeassistant/components/leslies_pool/__init__.py
+++ b/homeassistant/components/leslies_pool/__init__.py
@@ -1,0 +1,39 @@
+"""Initialize Leslie's Pool Water Tests integration."""
+
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from .api import LesliesPoolApi
+from .const import DOMAIN
+
+PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Leslie's Pool Water Tests from a config entry."""
+    data = entry.data
+    api = LesliesPoolApi(
+        data["username"], data["password"], data["pool_profile_id"], data["pool_name"]
+    )
+
+    # Run the authenticate method in the executor to avoid blocking the event loop
+    authenticated = await hass.async_add_executor_job(api.authenticate)
+    if not authenticated:
+        return False
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = api
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    if DOMAIN in hass.data:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/leslies_pool/api.py
+++ b/homeassistant/components/leslies_pool/api.py
@@ -1,0 +1,100 @@
+"""API client for Leslie's Pool Water Tests."""
+
+from bs4 import BeautifulSoup, Tag
+import requests
+
+
+class LesliesPoolApi:
+    """API class to interact with Leslie's Pool service."""
+
+    LOGIN_PAGE_URL = "https://lesliespool.com/on/demandware.store/Sites-lpm_site-Site/en_US/Account-Show"
+    LOGIN_URL = "https://lesliespool.com/on/demandware.store/Sites-lpm_site-Site/en_US/Account-Login"
+    WATER_TEST_URL = "https://lesliespool.com/on/demandware.store/Sites-lpm_site-Site/en_US/WaterTest-GetWaterTest"
+
+    def __init__(
+        self, username: str, password: str, pool_profile_id: str, pool_name: str
+    ) -> None:
+        """Initialize the API with user credentials and pool details."""
+        self.username = username
+        self.password = password
+        self.pool_profile_id = pool_profile_id
+        self.pool_name = pool_name
+        self.session = requests.Session()
+
+    def authenticate(self) -> bool:
+        """Authenticate the user and start a session."""
+        response = self.session.get(self.LOGIN_PAGE_URL)
+        soup = BeautifulSoup(response.text, "html.parser")
+        csrf_token_tag = soup.find("input", {"name": "csrf_token"})
+
+        csrf_token = None
+        if isinstance(csrf_token_tag, Tag) and csrf_token_tag.has_attr("value"):
+            csrf_token = csrf_token_tag["value"]
+
+        if not csrf_token:
+            return False
+
+        headers = {
+            "accept": "application/json, text/javascript, */*; q=0.01",
+            "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
+            "user-agent": "Mozilla/5.0",
+        }
+
+        payload = {
+            "loginEmail": self.username,
+            "loginPassword": self.password,
+            "csrf_token": csrf_token,
+        }
+
+        login_response = self.session.post(
+            self.LOGIN_URL, headers=headers, data=payload
+        )
+        return login_response.status_code == 200
+
+    def fetch_water_test_data(self) -> dict:
+        """Fetch water test data for the pool."""
+        self.session.get(
+            f"https://lesliespool.com/on/demandware.store/Sites-lpm_site-Site/en_US/WaterTest-Landing?poolProfileId={self.pool_profile_id}&poolName={self.pool_name}"
+        )
+        cookies = self.session.cookies.get_dict()
+        cookie_header = "; ".join([f"{key}={value}" for key, value in cookies.items()])
+
+        headers = {
+            "accept": "application/json, text/javascript, */*; q=0.01",
+            "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
+            "cookie": cookie_header,
+            "user-agent": "Mozilla/5.0",
+        }
+
+        payload = "poolProfileName=Pool&poolSanitizer=Salt+3000-4000"
+        response = self.session.post(self.WATER_TEST_URL, headers=headers, data=payload)
+        data = response.json()
+
+        html_content = data["response"]
+        soup = BeautifulSoup(html_content, "html.parser")
+        table = soup.find(
+            "table", class_="table table-striped table-bordered table-hover table-sm"
+        )
+
+        values = {}
+        if isinstance(table, Tag):
+            first_row_tag = table.find("tbody")
+            if isinstance(first_row_tag, Tag):
+                first_row = first_row_tag.find("tr")
+                if isinstance(first_row, Tag):
+                    columns = first_row.find_all("td")
+                    if len(columns) > 10:
+                        values = {
+                            "free_chlorine": columns[1].text.strip(),
+                            "total_chlorine": columns[2].text.strip(),
+                            "ph": columns[3].text.strip(),
+                            "alkalinity": columns[4].text.strip(),
+                            "calcium": columns[5].text.strip(),
+                            "cyanuric_acid": columns[6].text.strip(),
+                            "iron": columns[7].text.strip(),
+                            "copper": columns[8].text.strip(),
+                            "phosphates": columns[9].text.strip(),
+                            "salt": columns[10].text.strip(),
+                        }
+
+        return values

--- a/homeassistant/components/leslies_pool/config_flow.py
+++ b/homeassistant/components/leslies_pool/config_flow.py
@@ -1,0 +1,107 @@
+"""Config flow for Leslie's Pool Water Tests integration."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from .api import LesliesPoolApi
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+        vol.Required("water_test_url"): str,
+        vol.Optional(CONF_SCAN_INTERVAL, default=300): int,
+    }
+)
+
+
+async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
+    """Validate the user input allows us to connect."""
+    url = data["water_test_url"]
+    match = re.search(r"poolProfileId=(\d+)&poolName=([^&]+)", url)
+    if not match:
+        raise InvalidURL from None
+
+    pool_profile_id = match.group(1)
+    pool_name = match.group(2)
+
+    api = LesliesPoolApi(
+        data[CONF_USERNAME], data[CONF_PASSWORD], pool_profile_id, pool_name
+    )
+
+    # Run the authenticate method in the executor to avoid blocking the event loop
+    try:
+        authenticated = await hass.async_add_executor_job(api.authenticate)
+    except CannotConnect as err:
+        raise CannotConnect from err
+    except InvalidAuth as err:
+        raise InvalidAuth from err
+
+    if not authenticated:
+        raise InvalidAuth
+
+    return {
+        "title": "Leslie's Pool",
+        "username": data[CONF_USERNAME],
+        "password": data[CONF_PASSWORD],
+        "pool_profile_id": pool_profile_id,
+        "pool_name": pool_name,
+        "scan_interval": data[CONF_SCAN_INTERVAL],
+    }
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Leslie's Pool Water Tests."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            try:
+                info = await validate_input(self.hass, user_input)
+            except InvalidURL:
+                errors["base"] = "invalid_url"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                return self.async_create_entry(title=info["title"], data=info)
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+        )
+
+
+class InvalidURL(HomeAssistantError):
+    """Error to indicate the provided URL is invalid."""
+
+
+class InvalidAuth(HomeAssistantError):
+    """Error to indicate there is invalid auth."""
+
+
+class CannotConnect(HomeAssistantError):
+    """Error to indicate we cannot connect."""

--- a/homeassistant/components/leslies_pool/const.py
+++ b/homeassistant/components/leslies_pool/const.py
@@ -1,0 +1,4 @@
+"""Constants for the Leslie's Pool Water Tests integration."""
+
+DOMAIN = "leslies_pool"
+DATA_UPDATE_INTERVAL = 300

--- a/homeassistant/components/leslies_pool/manifest.json
+++ b/homeassistant/components/leslies_pool/manifest.json
@@ -1,0 +1,9 @@
+{
+  "domain": "leslies_pool",
+  "name": "Leslie's Pool Water Tests",
+  "codeowners": ["@connorgallopo"],
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/leslies_pool",
+  "iot_class": "cloud_polling",
+  "requirements": ["beautifulsoup4==4.12.3", "requests==2.31.0"]
+}

--- a/homeassistant/components/leslies_pool/sensor.py
+++ b/homeassistant/components/leslies_pool/sensor.py
@@ -1,0 +1,121 @@
+"""Sensor platform for Leslie's Pool Water Tests."""
+
+from datetime import timedelta
+import logging
+
+import requests
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+SENSOR_TYPES = {
+    "free_chlorine": ("Free Chlorine", "ppm"),
+    "total_chlorine": ("Total Chlorine", "ppm"),
+    "ph": ("pH", "pH"),
+    "alkalinity": ("Total Alkalinity", "ppm"),
+    "calcium": ("Calcium Hardness", "ppm"),
+    "cyanuric_acid": ("Cyanuric Acid", "ppm"),
+    "iron": ("Iron", "ppm"),
+    "copper": ("Copper", "ppm"),
+    "phosphates": ("Phosphates", "ppb"),
+    "salt": ("Salt", "ppm"),
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up Leslie's Pool Water Tests sensors from a config entry."""
+    api = hass.data[DOMAIN][entry.entry_id]
+
+    scan_interval = entry.data.get("scan_interval", 300)
+
+    async def async_update_data():
+        """Fetch data from API endpoint."""
+        try:
+            return await hass.async_add_executor_job(api.fetch_water_test_data)
+        except requests.RequestException as err:
+            raise UpdateFailed(f"Error fetching data: {err}") from err
+
+    coordinator = DataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        name="leslies_pool",
+        update_method=async_update_data,
+        update_interval=timedelta(seconds=scan_interval),
+    )
+
+    await coordinator.async_refresh()
+
+    sensors = [
+        LesliesPoolSensor(coordinator, entry, sensor_type, name, unit)
+        for sensor_type, (name, unit) in SENSOR_TYPES.items()
+    ]
+
+    async_add_entities(sensors, update_before_add=True)
+
+
+class LesliesPoolSensor(SensorEntity):
+    """Representation of a Leslie's Pool sensor."""
+
+    def __init__(self, coordinator, config_entry, sensor_type, name, unit):
+        """Initialize the sensor."""
+        self.coordinator = coordinator
+        self.config_entry = config_entry
+        self._sensor_type = sensor_type
+        self._name = name
+        self._unit = unit
+
+    @property
+    def unique_id(self):
+        """Return a unique ID for this sensor."""
+        return f"{self.config_entry.entry_id}_{self._sensor_type}"
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self.coordinator.data.get(self._sensor_type)
+
+    @property
+    def available(self):
+        """Return if the sensor is available."""
+        return self.coordinator.last_update_success
+
+    @property
+    def device_info(self):
+        """Return device information about this entity."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.config_entry.entry_id)},
+            name="Leslie's Pool",
+            manufacturer="Leslie's Pool",
+            model="Water Test",
+            entry_type=DeviceEntryType.SERVICE,
+        )
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity."""
+        return self._unit
+
+    async def async_update(self):
+        """Update the sensor."""
+        await self.coordinator.async_request_refresh()
+
+    async def async_added_to_hass(self):
+        """When entity is added to hass."""
+        self.async_on_remove(
+            self.coordinator.async_add_listener(self.async_write_ha_state)
+        )

--- a/homeassistant/components/leslies_pool/strings.json
+++ b/homeassistant/components/leslies_pool/strings.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connect to Leslie's Pool",
+        "data": {
+          "username": "Username",
+          "password": "Password",
+          "water_test_url": "Water Test URL",
+          "scan_interval": "Scan Interval"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -296,6 +296,7 @@ FLOWS = {
         "ld2410_ble",
         "leaone",
         "led_ble",
+        "leslies_pool",
         "lg_netcast",
         "lg_soundbar",
         "lidarr",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -3204,6 +3204,12 @@
       "integration_type": "virtual",
       "supported_by": "netatmo"
     },
+    "leslies_pool": {
+      "name": "Leslie's Pool Water Tests",
+      "integration_type": "hub",
+      "config_flow": true,
+      "iot_class": "cloud_polling"
+    },
     "leviton": {
       "name": "Leviton",
       "iot_standards": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -540,6 +540,7 @@ batinfo==0.4.2
 # homeassistant.components.eddystone_temperature
 # beacontools[scan]==2.1.0
 
+# homeassistant.components.leslies_pool
 # homeassistant.components.scrape
 beautifulsoup4==4.12.3
 
@@ -2458,6 +2459,9 @@ renson-endura-delta==1.7.1
 
 # homeassistant.components.reolink
 reolink-aio==0.9.1
+
+# homeassistant.components.leslies_pool
+requests==2.31.0
 
 # homeassistant.components.idteck_prox
 rfk101py==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -468,6 +468,7 @@ babel==2.13.1
 # homeassistant.components.homekit
 base36==0.1.1
 
+# homeassistant.components.leslies_pool
 # homeassistant.components.scrape
 beautifulsoup4==4.12.3
 
@@ -1919,6 +1920,9 @@ renson-endura-delta==1.7.1
 
 # homeassistant.components.reolink
 reolink-aio==0.9.1
+
+# homeassistant.components.leslies_pool
+requests==2.31.0
 
 # homeassistant.components.rflink
 rflink==0.0.66

--- a/tests/components/leslies_pool/__init__.py
+++ b/tests/components/leslies_pool/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Leslie's Pool Water Tests integration."""

--- a/tests/components/leslies_pool/conftest.py
+++ b/tests/components/leslies_pool/conftest.py
@@ -1,0 +1,15 @@
+"""Common fixtures for the Leslie's Pool Water Tests tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.leslies_pool.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry

--- a/tests/components/leslies_pool/test_api.py
+++ b/tests/components/leslies_pool/test_api.py
@@ -1,0 +1,96 @@
+"""Test the API for Leslie's Pool Water Tests."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from homeassistant.components.leslies_pool.api import LesliesPoolApi
+
+
+class TestLesliesPoolApi(unittest.TestCase):
+    """Test the Leslie's Pool API."""
+
+    def setUp(self):
+        """Set up the test."""
+        self.api = LesliesPoolApi("testuser", "testpassword", "123456", "TestPool")
+
+    @patch("homeassistant.components.leslies_pool.api.requests.Session.get")
+    @patch("homeassistant.components.leslies_pool.api.requests.Session.post")
+    def test_authenticate_success(self, mock_post, mock_get):
+        """Test successful authentication."""
+        login_page_html = '<input name="csrf_token" value="test_csrf_token">'
+        mock_get.return_value = MagicMock(status_code=200, text=login_page_html)
+        mock_post.return_value = MagicMock(status_code=200)
+
+        result = self.api.authenticate()
+
+        assert result
+        mock_get.assert_called_once_with(self.api.LOGIN_PAGE_URL)
+        mock_post.assert_called_once_with(
+            self.api.LOGIN_URL,
+            headers={
+                "accept": "application/json, text/javascript, */*; q=0.01",
+                "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
+                "user-agent": "Mozilla/5.0",
+            },
+            data={
+                "loginEmail": "testuser",
+                "loginPassword": "testpassword",
+                "csrf_token": "test_csrf_token",
+            },
+        )
+
+    @patch("homeassistant.components.leslies_pool.api.requests.Session.get")
+    @patch("homeassistant.components.leslies_pool.api.requests.Session.post")
+    def test_authenticate_fail(self, mock_post, mock_get):
+        """Test failed authentication."""
+        login_page_html = '<input name="csrf_token" value="test_csrf_token">'
+        mock_get.return_value = MagicMock(status_code=200, text=login_page_html)
+        mock_post.return_value = MagicMock(status_code=401)
+
+        result = self.api.authenticate()
+
+        assert not result
+
+    @patch("homeassistant.components.leslies_pool.api.requests.Session.get")
+    @patch("homeassistant.components.leslies_pool.api.requests.Session.post")
+    def test_fetch_water_test_data(self, mock_post, mock_get):
+        """Test fetching water test data."""
+        # Mock the response for the landing page request
+        mock_get.return_value = MagicMock(status_code=200)
+
+        # Mock the response for the water test data request
+        water_test_html = """
+        <table class="table table-striped table-bordered table-hover table-sm">
+            <tbody>
+                <tr>
+                    <td>Test</td>
+                    <td>1.0</td>
+                    <td>2.0</td>
+                    <td>7.0</td>
+                    <td>80</td>
+                    <td>200</td>
+                    <td>30</td>
+                    <td>0.1</td>
+                    <td>0.2</td>
+                    <td>300</td>
+                    <td>4000</td>
+                </tr>
+            </tbody>
+        </table>
+        """
+        mock_post.return_value = MagicMock(
+            status_code=200, json=MagicMock(return_value={"response": water_test_html})
+        )
+
+        data = self.api.fetch_water_test_data()
+
+        assert data["free_chlorine"] == "1.0"
+        assert data["total_chlorine"] == "2.0"
+        assert data["ph"] == "7.0"
+        assert data["alkalinity"] == "80"
+        assert data["calcium"] == "200"
+        assert data["cyanuric_acid"] == "30"
+        assert data["iron"] == "0.1"
+        assert data["copper"] == "0.2"
+        assert data["phosphates"] == "300"
+        assert data["salt"] == "4000"

--- a/tests/components/leslies_pool/test_config_flow.py
+++ b/tests/components/leslies_pool/test_config_flow.py
@@ -1,0 +1,211 @@
+"""Test the Leslie's Pool Water Tests config flow."""
+
+from unittest.mock import AsyncMock, patch
+
+from homeassistant import config_entries
+from homeassistant.components.leslies_pool.config_flow import (
+    CannotConnect,
+    InvalidAuth,
+    InvalidURL,
+)
+from homeassistant.components.leslies_pool.const import DOMAIN
+from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+WATER_TEST_URL = "https://lesliespool.com/on/demandware.store/Sites-lpm_site-Site/en_US/WaterTest-Landing?poolProfileId=5891278&poolName=Pool"
+
+
+async def test_form(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
+    """Test we get the form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.leslies_pool.api.LesliesPoolApi.authenticate",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "test-password",
+                "water_test_url": WATER_TEST_URL,
+                CONF_SCAN_INTERVAL: 300,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Leslie's Pool"
+    assert result["data"] == {
+        "title": "Leslie's Pool",
+        "username": "test-username",
+        "password": "test-password",
+        "pool_profile_id": "5891278",
+        "pool_name": "Pool",
+        "scan_interval": 300,
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_invalid_auth(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.leslies_pool.api.LesliesPoolApi.authenticate",
+        side_effect=InvalidAuth,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "test-password",
+                "water_test_url": WATER_TEST_URL,
+                CONF_SCAN_INTERVAL: 300,
+            },
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}
+
+    with patch(
+        "homeassistant.components.leslies_pool.api.LesliesPoolApi.authenticate",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "test-password",
+                "water_test_url": WATER_TEST_URL,
+                CONF_SCAN_INTERVAL: 300,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Leslie's Pool"
+    assert result["data"] == {
+        "title": "Leslie's Pool",
+        "username": "test-username",
+        "password": "test-password",
+        "pool_profile_id": "5891278",
+        "pool_name": "Pool",
+        "scan_interval": 300,
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_cannot_connect(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.leslies_pool.api.LesliesPoolApi.authenticate",
+        side_effect=CannotConnect,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "test-password",
+                "water_test_url": WATER_TEST_URL,
+                CONF_SCAN_INTERVAL: 300,
+            },
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+    with patch(
+        "homeassistant.components.leslies_pool.api.LesliesPoolApi.authenticate",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "test-password",
+                "water_test_url": WATER_TEST_URL,
+                CONF_SCAN_INTERVAL: 300,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Leslie's Pool"
+    assert result["data"] == {
+        "title": "Leslie's Pool",
+        "username": "test-username",
+        "password": "test-password",
+        "pool_profile_id": "5891278",
+        "pool_name": "Pool",
+        "scan_interval": 300,
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_invalid_url(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
+    """Test we handle invalid URL error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.leslies_pool.api.LesliesPoolApi.authenticate",
+        side_effect=InvalidURL,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "test-password",
+                "water_test_url": "invalid-url",
+                CONF_SCAN_INTERVAL: 300,
+            },
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_url"}
+
+    with patch(
+        "homeassistant.components.leslies_pool.api.LesliesPoolApi.authenticate",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "test-password",
+                "water_test_url": WATER_TEST_URL,
+                CONF_SCAN_INTERVAL: 300,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Leslie's Pool"
+    assert result["data"] == {
+        "title": "Leslie's Pool",
+        "username": "test-username",
+        "password": "test-password",
+        "pool_profile_id": "5891278",
+        "pool_name": "Pool",
+        "scan_interval": 300,
+    }
+    assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/leslies_pool/test_sensor.py
+++ b/tests/components/leslies_pool/test_sensor.py
@@ -1,0 +1,126 @@
+"""Test the Leslie's Pool Water Tests sensors."""
+
+from datetime import timedelta
+import logging
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.leslies_pool.const import DOMAIN
+from homeassistant.components.leslies_pool.sensor import (
+    LesliesPoolSensor,
+    async_setup_entry,
+)
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+SENSOR_TYPES = {
+    "free_chlorine": ("Free Chlorine", "ppm"),
+    "total_chlorine": ("Total Chlorine", "ppm"),
+    "ph": ("pH", "pH"),
+    "alkalinity": ("Total Alkalinity", "ppm"),
+    "calcium": ("Calcium Hardness", "ppm"),
+    "cyanuric_acid": ("Cyanuric Acid", "ppm"),
+    "iron": ("Iron", "ppm"),
+    "copper": ("Copper", "ppm"),
+    "phosphates": ("Phosphates", "ppb"),
+    "salt": ("Salt", "ppm"),
+}
+
+
+@pytest.fixture
+def mock_coordinator(hass):
+    """Mock a coordinator."""
+    coordinator = DataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        name="leslies_pool",
+        update_method=AsyncMock(return_value={sensor: 1 for sensor in SENSOR_TYPES}),
+        update_interval=timedelta(seconds=300),
+    )
+    coordinator.data = {sensor: 1 for sensor in SENSOR_TYPES}
+    coordinator.async_refresh = AsyncMock()
+    coordinator.async_add_listener = AsyncMock()
+    return coordinator
+
+
+async def test_async_setup_entry(hass, mock_coordinator):
+    """Test setting up the config entry."""
+    mock_entry = AsyncMock()
+    mock_entry.entry_id = "test_entry"
+    mock_entry.data = {
+        "username": "test-username",
+        "password": "test-password",
+        "scan_interval": 300,
+    }
+
+    hass.data = {DOMAIN: {mock_entry.entry_id: mock_coordinator}}
+
+    async_add_entities = AsyncMock()
+
+    with patch(
+        "homeassistant.components.leslies_pool.api.LesliesPoolApi",
+        return_value=AsyncMock(),
+    ):
+        await async_setup_entry(hass, mock_entry, async_add_entities)
+
+    assert async_add_entities.call_count == 1
+    assert len(async_add_entities.call_args[0][0]) == len(SENSOR_TYPES)
+
+
+async def test_sensor_properties(hass, mock_coordinator):
+    """Test sensor properties."""
+    mock_entry = AsyncMock()
+    mock_entry.entry_id = "test_entry"
+
+    sensor = LesliesPoolSensor(
+        mock_coordinator, mock_entry, "free_chlorine", "Free Chlorine", "ppm"
+    )
+
+    assert sensor.unique_id == "test_entry_free_chlorine"
+    assert sensor.name == "Free Chlorine"
+    assert sensor.state == 1
+    assert sensor.available
+    assert sensor.device_info == {
+        "identifiers": {(DOMAIN, "test_entry")},
+        "name": "Leslie's Pool",
+        "manufacturer": "Leslie's Pool",
+        "model": "Water Test",
+        "entry_type": "service",
+    }
+    assert sensor.unit_of_measurement == "ppm"
+
+
+async def test_sensor_update(hass, mock_coordinator):
+    """Test sensor update."""
+    mock_entry = AsyncMock()
+    mock_entry.entry_id = "test_entry"
+
+    sensor = LesliesPoolSensor(
+        mock_coordinator, mock_entry, "free_chlorine", "Free Chlorine", "ppm"
+    )
+
+    with patch.object(
+        sensor.coordinator, "async_request_refresh", AsyncMock()
+    ) as mock_refresh:
+        await sensor.async_update()
+        assert mock_refresh.call_count == 1
+
+
+async def test_sensor_added_to_hass(hass, mock_coordinator):
+    """Test sensor added to hass."""
+    mock_entry = AsyncMock()
+    mock_entry.entry_id = "test_entry"
+
+    sensor = LesliesPoolSensor(
+        mock_coordinator, mock_entry, "free_chlorine", "Free Chlorine", "ppm"
+    )
+
+    with patch.object(sensor, "async_write_ha_state", AsyncMock()):
+        await sensor.async_added_to_hass()
+        assert mock_coordinator.async_add_listener.call_count == 1
+        assert (
+            mock_coordinator.async_add_listener.call_args[0][0]
+            == sensor.async_write_ha_state
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

This PR adds a new integration for Leslie's Pool Tests. These tests come in two forms, in-store and with the AccuBlue Home tester.

Both of these report in the same way - and are currently only exposed in the mobile app or the web app. This integration uses their auth flow as well as API to retrieve the test results exposed by those tests and expose them to HomeAssistant!



## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ x ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
This is my first integration in HA! Super excited to be contributing. I am not a professional Python developer - but have professionally developing in Ruby/Rails for over 10 years. I am open to any and all feedback to ensure this integration is as maintainable as possible and meets all standards in both Python as well as the HA community.

## Checklist

- [ x ] The code change is tested and works locally.
- [ x ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ x ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ x ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ x ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure


[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
