### PR TITLE
Fix KNX `climate.set_hvac_mode` not turning `on`

### DIFF
--- a/homeassistant/components/knx/climate.py
+++ b/homeassistant/components/knx/climate.py
@@ -283,16 +283,13 @@ class KNXClimate(KnxEntity, ClimateEntity):
             )
             if knx_controller_mode in self._device.mode.controller_modes:
                 await self._device.mode.set_controller_mode(knx_controller_mode)
-                self.async_write_ha_state()
-                return
 
         if self._device.supports_on_off:
             if hvac_mode == HVACMode.OFF:
                 await self._device.turn_off()
             elif not self._device.is_on:
-                # for default hvac mode, otherwise above would have triggered
                 await self._device.turn_on()
-            self.async_write_ha_state()
+        self.async_write_ha_state()
 
     @property
     def preset_mode(self) -> str | None:

--- a/tests/components/knx/test_climate.py
+++ b/tests/components/knx/test_climate.py
@@ -128,6 +128,7 @@ async def test_climate_on_off(
         blocking=True,
     )
     await knx.assert_write(on_off_ga, 0)
+    assert hass.states.get("climate.test").state == "off"
 
     # set hvac mode to heat
     await hass.services.async_call(
@@ -137,10 +138,11 @@ async def test_climate_on_off(
         blocking=True,
     )
     if heat_cool_ga:
-        # only set new hvac_mode without changing on/off - actuator shall handle that
         await knx.assert_write(heat_cool_ga, 1)
+        await knx.assert_write(on_off_ga, 1)
     else:
         await knx.assert_write(on_off_ga, 1)
+    assert hass.states.get("climate.test").state == "heat"
 
 
 @pytest.mark.parametrize("on_off_ga", [None, "4/4/4"])
@@ -190,6 +192,9 @@ async def test_climate_hvac_mode(
         blocking=True,
     )
     await knx.assert_write(controller_mode_ga, (0x06,))
+    if on_off_ga:
+        await knx.assert_write(on_off_ga, 0)
+    assert hass.states.get("climate.test").state == "off"
 
     # set hvac to non default mode
     await hass.services.async_call(
@@ -199,6 +204,9 @@ async def test_climate_hvac_mode(
         blocking=True,
     )
     await knx.assert_write(controller_mode_ga, (0x03,))
+    if on_off_ga:
+        await knx.assert_write(on_off_ga, 1)
+    assert hass.states.get("climate.test").state == "cool"
 
     # turn off
     await hass.services.async_call(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
UI doesn't seem to support independent `climate.turn_on` and `climate.set_hvac_mode`. 
So - if both, a `mode` and `on_off` addresses are configured - we now always set the mode **and** turn on/off when `climate.set_hvac_mode` is called, not only set the mode. This means a `off` climate entity can't be switched from heat to cool and vice versa by a climate service (if needed it can be done by sending to the `heat_cool` address manually eg. with `knx.send` in an automation).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #118982
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
