### PR TITLE
Fix Generator annotations in tests (1)

### DIFF
--- a/tests/components/androidtv/conftest.py
+++ b/tests/components/androidtv/conftest.py
@@ -1,15 +1,15 @@
 """Fixtures for the Android TV integration tests."""
 
-from collections.abc import Generator
 from unittest.mock import Mock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from . import patchers
 
 
 @pytest.fixture(autouse=True)
-def adb_device_tcp_fixture() -> Generator[None, patchers.AdbDeviceTcpAsyncFake, None]:
+def adb_device_tcp_fixture() -> Generator[None]:
     """Patch ADB Device TCP."""
     with patch(
         "androidtv.adb_manager.adb_manager_async.AdbDeviceTcpAsync",
@@ -19,7 +19,7 @@ def adb_device_tcp_fixture() -> Generator[None, patchers.AdbDeviceTcpAsyncFake, 
 
 
 @pytest.fixture(autouse=True)
-def load_adbkey_fixture() -> Generator[None, str, None]:
+def load_adbkey_fixture() -> Generator[None]:
     """Patch load_adbkey."""
     with patch(
         "homeassistant.components.androidtv.ADBPythonSync.load_adbkey",
@@ -29,7 +29,7 @@ def load_adbkey_fixture() -> Generator[None, str, None]:
 
 
 @pytest.fixture(autouse=True)
-def keygen_fixture() -> Generator[None, Mock, None]:
+def keygen_fixture() -> Generator[None]:
     """Patch keygen."""
     with patch(
         "homeassistant.components.androidtv.keygen",

--- a/tests/components/androidtv_remote/conftest.py
+++ b/tests/components/androidtv_remote/conftest.py
@@ -33,7 +33,7 @@ def mock_unload_entry() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_api() -> Generator[None, MagicMock, None]:
+def mock_api() -> Generator[MagicMock]:
     """Return a mocked AndroidTVRemote."""
     with patch(
         "homeassistant.components.androidtv_remote.helpers.AndroidTVRemote",

--- a/tests/components/bsblan/conftest.py
+++ b/tests/components/bsblan/conftest.py
@@ -40,7 +40,7 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_bsblan(request: pytest.FixtureRequest) -> Generator[None, MagicMock, None]:
+def mock_bsblan(request: pytest.FixtureRequest) -> Generator[MagicMock]:
     """Return a mocked BSBLAN client."""
 
     with (

--- a/tests/components/co2signal/conftest.py
+++ b/tests/components/co2signal/conftest.py
@@ -1,9 +1,9 @@
 """Fixtures for Electricity maps integration tests."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.co2signal import DOMAIN
 from homeassistant.const import CONF_API_KEY
@@ -15,7 +15,7 @@ from tests.components.co2signal import VALID_RESPONSE
 
 
 @pytest.fixture(name="electricity_maps")
-def mock_electricity_maps() -> Generator[None, MagicMock, None]:
+def mock_electricity_maps() -> Generator[MagicMock]:
     """Mock the ElectricityMaps client."""
 
     with (

--- a/tests/components/elgato/conftest.py
+++ b/tests/components/elgato/conftest.py
@@ -51,7 +51,7 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_onboarding() -> Generator[None, MagicMock, None]:
+def mock_onboarding() -> Generator[MagicMock]:
     """Mock that Home Assistant is currently onboarding."""
     with patch(
         "homeassistant.components.onboarding.async_is_onboarded",
@@ -61,9 +61,7 @@ def mock_onboarding() -> Generator[None, MagicMock, None]:
 
 
 @pytest.fixture
-def mock_elgato(
-    device_fixtures: str, state_variant: str
-) -> Generator[None, MagicMock, None]:
+def mock_elgato(device_fixtures: str, state_variant: str) -> Generator[MagicMock]:
     """Return a mocked Elgato client."""
     with (
         patch(

--- a/tests/components/forecast_solar/conftest.py
+++ b/tests/components/forecast_solar/conftest.py
@@ -57,7 +57,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_forecast_solar(hass) -> Generator[None, MagicMock, None]:
+def mock_forecast_solar(hass: HomeAssistant) -> Generator[MagicMock]:
     """Return a mocked Forecast.Solar client.
 
     hass fixture included because it sets the time zone.

--- a/tests/components/geocaching/conftest.py
+++ b/tests/components/geocaching/conftest.py
@@ -37,7 +37,7 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_geocaching_config_flow() -> Generator[None, MagicMock, None]:
+def mock_geocaching_config_flow() -> Generator[MagicMock]:
     """Return a mocked Geocaching API client."""
 
     mock_status = GeocachingStatus()

--- a/tests/components/homeworks/conftest.py
+++ b/tests/components/homeworks/conftest.py
@@ -88,7 +88,7 @@ def mock_empty_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_homeworks() -> Generator[None, MagicMock, None]:
+def mock_homeworks() -> Generator[MagicMock]:
     """Return a mocked Homeworks client."""
     with (
         patch(

--- a/tests/components/intellifire/conftest.py
+++ b/tests/components/intellifire/conftest.py
@@ -17,7 +17,7 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_fireplace_finder_none() -> Generator[None, MagicMock, None]:
+def mock_fireplace_finder_none() -> Generator[MagicMock]:
     """Mock fireplace finder."""
     mock_found_fireplaces = Mock()
     mock_found_fireplaces.ips = []
@@ -28,7 +28,7 @@ def mock_fireplace_finder_none() -> Generator[None, MagicMock, None]:
 
 
 @pytest.fixture
-def mock_fireplace_finder_single() -> Generator[None, MagicMock, None]:
+def mock_fireplace_finder_single() -> Generator[MagicMock]:
     """Mock fireplace finder."""
     mock_found_fireplaces = Mock()
     mock_found_fireplaces.ips = ["192.168.1.69"]
@@ -39,7 +39,7 @@ def mock_fireplace_finder_single() -> Generator[None, MagicMock, None]:
 
 
 @pytest.fixture
-def mock_intellifire_config_flow() -> Generator[None, MagicMock, None]:
+def mock_intellifire_config_flow() -> Generator[MagicMock]:
     """Return a mocked IntelliFire client."""
     data_mock = Mock()
     data_mock.serial = "12345"

--- a/tests/components/ipp/conftest.py
+++ b/tests/components/ipp/conftest.py
@@ -60,9 +60,7 @@ async def mock_printer(
 
 
 @pytest.fixture
-def mock_ipp_config_flow(
-    mock_printer: Printer,
-) -> Generator[None, MagicMock, None]:
+def mock_ipp_config_flow(mock_printer: Printer) -> Generator[MagicMock]:
     """Return a mocked IPP client."""
 
     with patch(
@@ -76,7 +74,7 @@ def mock_ipp_config_flow(
 @pytest.fixture
 def mock_ipp(
     request: pytest.FixtureRequest, mock_printer: Printer
-) -> Generator[None, MagicMock, None]:
+) -> Generator[MagicMock]:
     """Return a mocked IPP client."""
 
     with patch(

--- a/tests/components/jellyfin/conftest.py
+++ b/tests/components/jellyfin/conftest.py
@@ -46,7 +46,7 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_client_device_id() -> Generator[None, MagicMock, None]:
+def mock_client_device_id() -> Generator[MagicMock]:
     """Mock generating device id."""
     with patch(
         "homeassistant.components.jellyfin.config_flow._generate_client_device_id"
@@ -108,7 +108,7 @@ def mock_client(
 
 
 @pytest.fixture
-def mock_jellyfin(mock_client: MagicMock) -> Generator[None, MagicMock, None]:
+def mock_jellyfin(mock_client: MagicMock) -> Generator[MagicMock]:
     """Return a mocked Jellyfin."""
     with patch(
         "homeassistant.components.jellyfin.client_wrapper.Jellyfin", autospec=True

--- a/tests/components/kaleidescape/conftest.py
+++ b/tests/components/kaleidescape/conftest.py
@@ -1,11 +1,11 @@
 """Fixtures for Kaleidescape integration."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 from kaleidescape import Dispatcher
 from kaleidescape.device import Automation, Movie, Power, System
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.kaleidescape.const import DOMAIN
 from homeassistant.const import CONF_HOST
@@ -17,7 +17,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture(name="mock_device")
-def fixture_mock_device() -> Generator[None, AsyncMock, None]:
+def fixture_mock_device() -> Generator[AsyncMock]:
     """Return a mocked Kaleidescape device."""
     with patch(
         "homeassistant.components.kaleidescape.KaleidescapeDevice", autospec=True

--- a/tests/components/luftdaten/conftest.py
+++ b/tests/components/luftdaten/conftest.py
@@ -35,7 +35,7 @@ def mock_setup_entry() -> Generator[None]:
 
 
 @pytest.fixture
-def mock_luftdaten() -> Generator[None, MagicMock, None]:
+def mock_luftdaten() -> Generator[MagicMock]:
     """Return a mocked Luftdaten client."""
     with (
         patch(

--- a/tests/components/motionmount/conftest.py
+++ b/tests/components/motionmount/conftest.py
@@ -34,7 +34,7 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_motionmount_config_flow() -> Generator[None, MagicMock, None]:
+def mock_motionmount_config_flow() -> Generator[MagicMock]:
     """Return a mocked MotionMount config flow."""
 
     with patch(

--- a/tests/components/mqtt/conftest.py
+++ b/tests/components/mqtt/conftest.py
@@ -1,10 +1,10 @@
 """Test fixtures for mqtt component."""
 
-from collections.abc import Generator
 from random import getrandbits
 from unittest.mock import patch
 
 import pytest
+from typing_extensions import Generator
 
 from tests.components.light.conftest import mock_light_profiles  # noqa: F401
 
@@ -21,7 +21,7 @@ def temp_dir_prefix() -> str:
 
 
 @pytest.fixture
-def mock_temp_dir(temp_dir_prefix: str) -> Generator[None, None, str]:
+def mock_temp_dir(temp_dir_prefix: str) -> Generator[str]:
     """Mock the certificate temp directory."""
     with patch(
         # Patch temp dir name to avoid tests fail running in parallel

--- a/tests/components/open_meteo/conftest.py
+++ b/tests/components/open_meteo/conftest.py
@@ -35,7 +35,7 @@ def mock_setup_entry() -> Generator[None]:
 
 
 @pytest.fixture
-def mock_open_meteo(request: pytest.FixtureRequest) -> Generator[None, MagicMock, None]:
+def mock_open_meteo(request: pytest.FixtureRequest) -> Generator[MagicMock]:
     """Return a mocked Open-Meteo client."""
     fixture: str = "forecast.json"
     if hasattr(request, "param") and request.param:

--- a/tests/components/plugwise/conftest.py
+++ b/tests/components/plugwise/conftest.py
@@ -56,7 +56,7 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_smile_config_flow() -> Generator[None, MagicMock, None]:
+def mock_smile_config_flow() -> Generator[MagicMock]:
     """Return a mocked Smile client."""
     with patch(
         "homeassistant.components.plugwise.config_flow.Smile",
@@ -71,7 +71,7 @@ def mock_smile_config_flow() -> Generator[None, MagicMock, None]:
 
 
 @pytest.fixture
-def mock_smile_adam() -> Generator[None, MagicMock, None]:
+def mock_smile_adam() -> Generator[MagicMock]:
     """Create a Mock Adam environment for testing exceptions."""
     chosen_env = "adam_multiple_devices_per_zone"
 
@@ -97,7 +97,7 @@ def mock_smile_adam() -> Generator[None, MagicMock, None]:
 
 
 @pytest.fixture
-def mock_smile_adam_2() -> Generator[None, MagicMock, None]:
+def mock_smile_adam_2() -> Generator[MagicMock]:
     """Create a 2nd Mock Adam environment for testing exceptions."""
     chosen_env = "m_adam_heating"
 
@@ -123,7 +123,7 @@ def mock_smile_adam_2() -> Generator[None, MagicMock, None]:
 
 
 @pytest.fixture
-def mock_smile_adam_3() -> Generator[None, MagicMock, None]:
+def mock_smile_adam_3() -> Generator[MagicMock]:
     """Create a 3rd Mock Adam environment for testing exceptions."""
     chosen_env = "m_adam_cooling"
 
@@ -149,7 +149,7 @@ def mock_smile_adam_3() -> Generator[None, MagicMock, None]:
 
 
 @pytest.fixture
-def mock_smile_adam_4() -> Generator[None, MagicMock, None]:
+def mock_smile_adam_4() -> Generator[MagicMock]:
     """Create a 4th Mock Adam environment for testing exceptions."""
     chosen_env = "m_adam_jip"
 
@@ -175,7 +175,7 @@ def mock_smile_adam_4() -> Generator[None, MagicMock, None]:
 
 
 @pytest.fixture
-def mock_smile_anna() -> Generator[None, MagicMock, None]:
+def mock_smile_anna() -> Generator[MagicMock]:
     """Create a Mock Anna environment for testing exceptions."""
     chosen_env = "anna_heatpump_heating"
     with patch(
@@ -200,7 +200,7 @@ def mock_smile_anna() -> Generator[None, MagicMock, None]:
 
 
 @pytest.fixture
-def mock_smile_anna_2() -> Generator[None, MagicMock, None]:
+def mock_smile_anna_2() -> Generator[MagicMock]:
     """Create a 2nd Mock Anna environment for testing exceptions."""
     chosen_env = "m_anna_heatpump_cooling"
     with patch(
@@ -225,7 +225,7 @@ def mock_smile_anna_2() -> Generator[None, MagicMock, None]:
 
 
 @pytest.fixture
-def mock_smile_anna_3() -> Generator[None, MagicMock, None]:
+def mock_smile_anna_3() -> Generator[MagicMock]:
     """Create a 3rd Mock Anna environment for testing exceptions."""
     chosen_env = "m_anna_heatpump_idle"
     with patch(
@@ -250,7 +250,7 @@ def mock_smile_anna_3() -> Generator[None, MagicMock, None]:
 
 
 @pytest.fixture
-def mock_smile_p1() -> Generator[None, MagicMock, None]:
+def mock_smile_p1() -> Generator[MagicMock]:
     """Create a Mock P1 DSMR environment for testing exceptions."""
     chosen_env = "p1v4_442_single"
     with patch(
@@ -275,7 +275,7 @@ def mock_smile_p1() -> Generator[None, MagicMock, None]:
 
 
 @pytest.fixture
-def mock_smile_p1_2() -> Generator[None, MagicMock, None]:
+def mock_smile_p1_2() -> Generator[MagicMock]:
     """Create a Mock P1 3-phase DSMR environment for testing exceptions."""
     chosen_env = "p1v4_442_triple"
     with patch(
@@ -300,7 +300,7 @@ def mock_smile_p1_2() -> Generator[None, MagicMock, None]:
 
 
 @pytest.fixture
-def mock_stretch() -> Generator[None, MagicMock, None]:
+def mock_stretch() -> Generator[MagicMock]:
     """Create a Mock Stretch environment for testing exceptions."""
     chosen_env = "stretch_v31"
     with patch(

--- a/tests/components/pure_energie/conftest.py
+++ b/tests/components/pure_energie/conftest.py
@@ -37,7 +37,7 @@ def mock_setup_entry() -> Generator[None]:
 @pytest.fixture
 def mock_pure_energie_config_flow(
     request: pytest.FixtureRequest,
-) -> Generator[None, MagicMock, None]:
+) -> Generator[MagicMock]:
     """Return a mocked Pure Energie client."""
     with patch(
         "homeassistant.components.pure_energie.config_flow.GridNet", autospec=True

--- a/tests/components/pvoutput/conftest.py
+++ b/tests/components/pvoutput/conftest.py
@@ -36,7 +36,7 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_pvoutput() -> Generator[None, MagicMock, None]:
+def mock_pvoutput() -> Generator[MagicMock]:
     """Return a mocked PVOutput client."""
     with (
         patch(

--- a/tests/components/rdw/conftest.py
+++ b/tests/components/rdw/conftest.py
@@ -33,7 +33,7 @@ def mock_setup_entry() -> Generator[None]:
 
 
 @pytest.fixture
-def mock_rdw_config_flow() -> Generator[None, MagicMock, None]:
+def mock_rdw_config_flow() -> Generator[MagicMock]:
     """Return a mocked RDW client."""
     with patch(
         "homeassistant.components.rdw.config_flow.RDW", autospec=True
@@ -44,7 +44,7 @@ def mock_rdw_config_flow() -> Generator[None, MagicMock, None]:
 
 
 @pytest.fixture
-def mock_rdw(request: pytest.FixtureRequest) -> Generator[None, MagicMock, None]:
+def mock_rdw(request: pytest.FixtureRequest) -> Generator[MagicMock]:
     """Return a mocked WLED client."""
     fixture: str = "rdw/11ZKZ3.json"
     if hasattr(request, "param") and request.param:

--- a/tests/components/roku/conftest.py
+++ b/tests/components/roku/conftest.py
@@ -51,9 +51,7 @@ async def mock_device(
 
 
 @pytest.fixture
-def mock_roku_config_flow(
-    mock_device: RokuDevice,
-) -> Generator[None, MagicMock, None]:
+def mock_roku_config_flow(mock_device: RokuDevice) -> Generator[MagicMock]:
     """Return a mocked Roku client."""
 
     with patch(
@@ -68,7 +66,7 @@ def mock_roku_config_flow(
 @pytest.fixture
 def mock_roku(
     request: pytest.FixtureRequest, mock_device: RokuDevice
-) -> Generator[None, MagicMock, None]:
+) -> Generator[MagicMock]:
     """Return a mocked Roku client."""
 
     with patch(

--- a/tests/components/sonarr/conftest.py
+++ b/tests/components/sonarr/conftest.py
@@ -109,7 +109,7 @@ def mock_setup_entry() -> Generator[None]:
 
 
 @pytest.fixture
-def mock_sonarr_config_flow() -> Generator[None, MagicMock, None]:
+def mock_sonarr_config_flow() -> Generator[MagicMock]:
     """Return a mocked Sonarr client."""
     with patch(
         "homeassistant.components.sonarr.config_flow.SonarrClient", autospec=True
@@ -127,7 +127,7 @@ def mock_sonarr_config_flow() -> Generator[None, MagicMock, None]:
 
 
 @pytest.fixture
-def mock_sonarr() -> Generator[None, MagicMock, None]:
+def mock_sonarr() -> Generator[MagicMock]:
     """Return a mocked Sonarr client."""
     with patch(
         "homeassistant.components.sonarr.SonarrClient", autospec=True

--- a/tests/components/srp_energy/conftest.py
+++ b/tests/components/srp_energy/conftest.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 import datetime as dt
 from unittest.mock import MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.srp_energy.const import DOMAIN, PHOENIX_TIME_ZONE
 from homeassistant.const import CONF_ID
@@ -48,7 +48,7 @@ def fixture_mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture(name="mock_srp_energy")
-def fixture_mock_srp_energy() -> Generator[None, MagicMock, None]:
+def fixture_mock_srp_energy() -> Generator[MagicMock]:
     """Return a mocked SrpEnergyClient client."""
     with patch(
         "homeassistant.components.srp_energy.SrpEnergyClient", autospec=True
@@ -60,7 +60,7 @@ def fixture_mock_srp_energy() -> Generator[None, MagicMock, None]:
 
 
 @pytest.fixture(name="mock_srp_energy_config_flow")
-def fixture_mock_srp_energy_config_flow() -> Generator[None, MagicMock, None]:
+def fixture_mock_srp_energy_config_flow() -> Generator[MagicMock]:
     """Return a mocked config_flow SrpEnergyClient client."""
     with patch(
         "homeassistant.components.srp_energy.config_flow.SrpEnergyClient", autospec=True

--- a/tests/components/tailscale/conftest.py
+++ b/tests/components/tailscale/conftest.py
@@ -36,7 +36,7 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_tailscale_config_flow() -> Generator[None, MagicMock, None]:
+def mock_tailscale_config_flow() -> Generator[MagicMock]:
     """Return a mocked Tailscale client."""
     with patch(
         "homeassistant.components.tailscale.config_flow.Tailscale", autospec=True
@@ -49,7 +49,7 @@ def mock_tailscale_config_flow() -> Generator[None, MagicMock, None]:
 
 
 @pytest.fixture
-def mock_tailscale(request: pytest.FixtureRequest) -> Generator[None, MagicMock, None]:
+def mock_tailscale(request: pytest.FixtureRequest) -> Generator[MagicMock]:
     """Return a mocked Tailscale client."""
     fixture: str = "tailscale/devices.json"
     if hasattr(request, "param") and request.param:

--- a/tests/components/ukraine_alarm/test_config_flow.py
+++ b/tests/components/ukraine_alarm/test_config_flow.py
@@ -1,10 +1,10 @@
 """Test the Ukraine Alarm config flow."""
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 from aiohttp import ClientConnectionError, ClientError, ClientResponseError, RequestInfo
 import pytest
+from typing_extensions import Generator
 from yarl import URL
 
 from homeassistant import config_entries
@@ -41,7 +41,7 @@ REGIONS = {
 
 
 @pytest.fixture(autouse=True)
-def mock_get_regions() -> Generator[None, AsyncMock, None]:
+def mock_get_regions() -> Generator[AsyncMock]:
     """Mock the get_regions method."""
 
     with patch(

--- a/tests/components/verisure/conftest.py
+++ b/tests/components/verisure/conftest.py
@@ -38,7 +38,7 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_verisure_config_flow() -> Generator[None, MagicMock, None]:
+def mock_verisure_config_flow() -> Generator[MagicMock]:
     """Return a mocked Tailscale client."""
     with patch(
         "homeassistant.components.verisure.config_flow.Verisure", autospec=True

--- a/tests/components/wake_on_lan/conftest.py
+++ b/tests/components/wake_on_lan/conftest.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
@@ -22,9 +22,7 @@ def subprocess_call_return_value() -> int | None:
 
 
 @pytest.fixture(autouse=True)
-def mock_subprocess_call(
-    subprocess_call_return_value: int,
-) -> Generator[None, None, MagicMock]:
+def mock_subprocess_call(subprocess_call_return_value: int) -> Generator[MagicMock]:
     """Mock magic packet."""
     with patch("homeassistant.components.wake_on_lan.switch.sp.call") as mock_sp:
         mock_sp.return_value = subprocess_call_return_value

--- a/tests/components/zamg/conftest.py
+++ b/tests/components/zamg/conftest.py
@@ -37,9 +37,7 @@ def mock_setup_entry() -> Generator[None]:
 
 
 @pytest.fixture
-def mock_zamg_config_flow(
-    request: pytest.FixtureRequest,
-) -> Generator[None, MagicMock, None]:
+def mock_zamg_config_flow(request: pytest.FixtureRequest) -> Generator[MagicMock]:
     """Return a mocked Zamg client."""
     with patch(
         "homeassistant.components.zamg.sensor.ZamgData", autospec=True
@@ -53,7 +51,7 @@ def mock_zamg_config_flow(
 
 
 @pytest.fixture
-def mock_zamg(request: pytest.FixtureRequest) -> Generator[None, MagicMock, None]:
+def mock_zamg(request: pytest.FixtureRequest) -> Generator[MagicMock]:
     """Return a mocked Zamg client."""
 
     with patch(
@@ -72,9 +70,7 @@ def mock_zamg(request: pytest.FixtureRequest) -> Generator[None, MagicMock, None
 
 
 @pytest.fixture
-def mock_zamg_coordinator(
-    request: pytest.FixtureRequest,
-) -> Generator[None, MagicMock, None]:
+def mock_zamg_coordinator(request: pytest.FixtureRequest) -> Generator[MagicMock]:
     """Return a mocked Zamg client."""
 
     with patch(
@@ -93,9 +89,7 @@ def mock_zamg_coordinator(
 
 
 @pytest.fixture
-def mock_zamg_stations(
-    request: pytest.FixtureRequest,
-) -> Generator[None, MagicMock, None]:
+def mock_zamg_stations(request: pytest.FixtureRequest) -> Generator[MagicMock]:
     """Return a mocked Zamg client."""
     with patch(
         "homeassistant.components.zamg.config_flow.ZamgData.zamg_stations"


### PR DESCRIPTION
## Proposed change
The Generator TypeVars are defined as follows
1. Yield type
2. Send type
3. Return type

The `send` and `return` TypeVar default to `None` if `Generator` is imported from `typing_extensions` or for Python 3.13.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
