### PR TITLE
Calculate attributes when entity information available in Group sensor

### DIFF
--- a/homeassistant/components/group/sensor.py
+++ b/homeassistant/components/group/sensor.py
@@ -359,7 +359,9 @@ class SensorGroup(GroupEntity, SensorEntity):
                 self.calculate_attributes_later = async_track_state_change_event(
                     self.hass, self._entity_ids, self.calculate_state_attributes
                 )
-        await self.calculate_state_attributes()
+                break
+        if not self.calculate_attributes_later:
+            await self.calculate_state_attributes()
         await super().async_added_to_hass()
 
     async def calculate_state_attributes(

--- a/homeassistant/components/group/sensor.py
+++ b/homeassistant/components/group/sensor.py
@@ -36,7 +36,14 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
-from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, State, callback
+from homeassistant.core import (
+    CALLBACK_TYPE,
+    Event,
+    EventStateChangedData,
+    HomeAssistant,
+    State,
+    callback,
+)
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.entity import (
@@ -355,7 +362,9 @@ class SensorGroup(GroupEntity, SensorEntity):
         await self.calculate_state_attributes()
         await super().async_added_to_hass()
 
-    async def calculate_state_attributes(self, event: Event | None = None) -> None:
+    async def calculate_state_attributes(
+        self, event: Event[EventStateChangedData] | None = None
+    ) -> None:
         """Calculate state attributes."""
         for entity_id in self._entity_ids:
             if self.hass.states.get(entity_id) is None:

--- a/homeassistant/components/group/sensor.py
+++ b/homeassistant/components/group/sensor.py
@@ -36,7 +36,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
-from homeassistant.core import HomeAssistant, State, callback
+from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, State, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.entity import (
@@ -45,6 +45,7 @@ from homeassistant.helpers.entity import (
     get_unit_of_measurement,
 )
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.issue_registry import (
     IssueSeverity,
     async_create_issue,
@@ -329,6 +330,7 @@ class SensorGroup(GroupEntity, SensorEntity):
         self._native_unit_of_measurement = unit_of_measurement
         self._valid_units: set[str | None] = set()
         self._can_convert: bool = False
+        self.calculate_attributes_later: CALLBACK_TYPE | None = None
         self._attr_name = name
         if name == DEFAULT_NAME:
             self._attr_name = f"{DEFAULT_NAME} {sensor_type}".capitalize()
@@ -345,13 +347,28 @@ class SensorGroup(GroupEntity, SensorEntity):
 
     async def async_added_to_hass(self) -> None:
         """When added to hass."""
+        for entity_id in self._entity_ids:
+            if self.hass.states.get(entity_id) is None:
+                self.calculate_attributes_later = async_track_state_change_event(
+                    self.hass, self._entity_ids, self.calculate_state_attributes
+                )
+        await self.calculate_state_attributes()
+        await super().async_added_to_hass()
+
+    async def calculate_state_attributes(self, event: Event | None = None) -> None:
+        """Calculate state attributes."""
+        for entity_id in self._entity_ids:
+            if self.hass.states.get(entity_id) is None:
+                return
+        if self.calculate_attributes_later:
+            self.calculate_attributes_later()
+            self.calculate_attributes_later = None
         self._attr_state_class = self._calculate_state_class(self._state_class)
         self._attr_device_class = self._calculate_device_class(self._device_class)
         self._attr_native_unit_of_measurement = self._calculate_unit_of_measurement(
             self._native_unit_of_measurement
         )
         self._valid_units = self._get_valid_units()
-        await super().async_added_to_hass()
 
     @callback
     def async_update_group_state(self) -> None:

--- a/tests/components/group/test_sensor.py
+++ b/tests/components/group/test_sensor.py
@@ -763,3 +763,52 @@ async def test_last_sensor(hass: HomeAssistant) -> None:
         state = hass.states.get("sensor.test_last")
         assert str(float(value)) == state.state
         assert entity_id == state.attributes.get("last_entity_id")
+
+
+async def test_sensors_attributes_added_when_entity_info_available(
+    hass: HomeAssistant,
+) -> None:
+    """Test the sensor calculate attributes once all entities attributes are available."""
+    config = {
+        SENSOR_DOMAIN: {
+            "platform": GROUP_DOMAIN,
+            "name": DEFAULT_NAME,
+            "type": "sum",
+            "entities": ["sensor.test_1", "sensor.test_2", "sensor.test_3"],
+            "unique_id": "very_unique_id",
+        }
+    }
+
+    entity_ids = config["sensor"]["entities"]
+
+    assert await async_setup_component(hass, "sensor", config)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.sensor_group_sum")
+
+    assert state.state == STATE_UNAVAILABLE
+    assert state.attributes.get(ATTR_ENTITY_ID) is None
+    assert state.attributes.get(ATTR_DEVICE_CLASS) is None
+    assert state.attributes.get(ATTR_STATE_CLASS) is None
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) is None
+
+    for entity_id, value in dict(zip(entity_ids, VALUES, strict=False)).items():
+        hass.states.async_set(
+            entity_id,
+            value,
+            {
+                ATTR_DEVICE_CLASS: SensorDeviceClass.VOLUME,
+                ATTR_STATE_CLASS: SensorStateClass.TOTAL,
+                ATTR_UNIT_OF_MEASUREMENT: "L",
+            },
+        )
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.sensor_group_sum")
+
+    assert float(state.state) == pytest.approx(float(SUM_VALUE))
+    assert state.attributes.get(ATTR_ENTITY_ID) == entity_ids
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.VOLUME
+    assert state.attributes.get(ATTR_ICON) is None
+    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.TOTAL
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "L"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Change that attributes device class, state class and unit of measurement is only calculated once all entitiy can provide details (state or entity registry).

Fixes if group starts before integration of consumed entities or other related things when entity data is not available during group sensor starts.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #114835
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 