### PR TITLE
Improve type hints in airnow tests

### DIFF
--- a/tests/components/airnow/conftest.py
+++ b/tests/components/airnow/conftest.py
@@ -1,18 +1,23 @@
 """Define fixtures for AirNow tests."""
 
-import json
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.airnow import DOMAIN
 from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_RADIUS
+from homeassistant.core import HomeAssistant
+from homeassistant.util.json import JsonArrayType
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, load_json_array_fixture
 
 
 @pytest.fixture(name="config_entry")
-def config_entry_fixture(hass, config, options):
+def config_entry_fixture(
+    hass: HomeAssistant, config: dict[str, Any], options: dict[str, Any]
+) -> MockConfigEntry:
     """Define a config entry fixture."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -27,7 +32,7 @@ def config_entry_fixture(hass, config, options):
 
 
 @pytest.fixture(name="config")
-def config_fixture(hass):
+def config_fixture() -> dict[str, Any]:
     """Define a config entry data fixture."""
     return {
         CONF_API_KEY: "abc123",
@@ -37,7 +42,7 @@ def config_fixture(hass):
 
 
 @pytest.fixture(name="options")
-def options_fixture(hass):
+def options_fixture() -> dict[str, Any]:
     """Define a config options data fixture."""
     return {
         CONF_RADIUS: 150,
@@ -45,19 +50,19 @@ def options_fixture(hass):
 
 
 @pytest.fixture(name="data", scope="package")
-def data_fixture():
+def data_fixture() -> JsonArrayType:
     """Define a fixture for response data."""
-    return json.loads(load_fixture("response.json", "airnow"))
+    return load_json_array_fixture("response.json", "airnow")
 
 
 @pytest.fixture(name="mock_api_get")
-def mock_api_get_fixture(data):
+def mock_api_get_fixture(data: JsonArrayType) -> AsyncMock:
     """Define a fixture for a mock "get" coroutine function."""
     return AsyncMock(return_value=data)
 
 
 @pytest.fixture(name="setup_airnow")
-async def setup_airnow_fixture(hass, config, mock_api_get):
+def setup_airnow_fixture(mock_api_get: AsyncMock) -> Generator[None]:
     """Define a fixture to set up AirNow."""
     with (
         patch("pyairnow.WebServiceAPI._get", mock_api_get),

--- a/tests/components/airnow/test_config_flow.py
+++ b/tests/components/airnow/test_config_flow.py
@@ -1,5 +1,6 @@
 """Test the AirNow config flow."""
 
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 from pyairnow.errors import AirNowError, EmptyResponseError, InvalidKeyError
@@ -14,7 +15,10 @@ from homeassistant.data_entry_flow import FlowResultType
 from tests.common import MockConfigEntry
 
 
-async def test_form(hass: HomeAssistant, config, options, setup_airnow) -> None:
+@pytest.mark.usefixtures("setup_airnow")
+async def test_form(
+    hass: HomeAssistant, config: dict[str, Any], options: dict[str, Any]
+) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -29,7 +33,8 @@ async def test_form(hass: HomeAssistant, config, options, setup_airnow) -> None:
 
 
 @pytest.mark.parametrize("mock_api_get", [AsyncMock(side_effect=InvalidKeyError)])
-async def test_form_invalid_auth(hass: HomeAssistant, config, setup_airnow) -> None:
+@pytest.mark.usefixtures("setup_airnow")
+async def test_form_invalid_auth(hass: HomeAssistant, config: dict[str, Any]) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -40,7 +45,10 @@ async def test_form_invalid_auth(hass: HomeAssistant, config, setup_airnow) -> N
 
 
 @pytest.mark.parametrize("data", [{}])
-async def test_form_invalid_location(hass: HomeAssistant, config, setup_airnow) -> None:
+@pytest.mark.usefixtures("setup_airnow")
+async def test_form_invalid_location(
+    hass: HomeAssistant, config: dict[str, Any]
+) -> None:
     """Test we handle invalid location."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -51,7 +59,8 @@ async def test_form_invalid_location(hass: HomeAssistant, config, setup_airnow) 
 
 
 @pytest.mark.parametrize("mock_api_get", [AsyncMock(side_effect=AirNowError)])
-async def test_form_cannot_connect(hass: HomeAssistant, config, setup_airnow) -> None:
+@pytest.mark.usefixtures("setup_airnow")
+async def test_form_cannot_connect(hass: HomeAssistant, config: dict[str, Any]) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -62,7 +71,8 @@ async def test_form_cannot_connect(hass: HomeAssistant, config, setup_airnow) ->
 
 
 @pytest.mark.parametrize("mock_api_get", [AsyncMock(side_effect=EmptyResponseError)])
-async def test_form_empty_result(hass: HomeAssistant, config, setup_airnow) -> None:
+@pytest.mark.usefixtures("setup_airnow")
+async def test_form_empty_result(hass: HomeAssistant, config: dict[str, Any]) -> None:
     """Test we handle empty response error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -73,7 +83,8 @@ async def test_form_empty_result(hass: HomeAssistant, config, setup_airnow) -> N
 
 
 @pytest.mark.parametrize("mock_api_get", [AsyncMock(side_effect=RuntimeError)])
-async def test_form_unexpected(hass: HomeAssistant, config, setup_airnow) -> None:
+@pytest.mark.usefixtures("setup_airnow")
+async def test_form_unexpected(hass: HomeAssistant, config: dict[str, Any]) -> None:
     """Test we handle an unexpected error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -83,7 +94,10 @@ async def test_form_unexpected(hass: HomeAssistant, config, setup_airnow) -> Non
     assert result2["errors"] == {"base": "unknown"}
 
 
-async def test_entry_already_exists(hass: HomeAssistant, config, config_entry) -> None:
+@pytest.mark.usefixtures("config_entry")
+async def test_entry_already_exists(
+    hass: HomeAssistant, config: dict[str, Any]
+) -> None:
     """Test that the form aborts if the Lat/Lng is already configured."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -93,7 +107,8 @@ async def test_entry_already_exists(hass: HomeAssistant, config, config_entry) -
     assert result2["reason"] == "already_configured"
 
 
-async def test_config_migration_v2(hass: HomeAssistant, setup_airnow) -> None:
+@pytest.mark.usefixtures("setup_airnow")
+async def test_config_migration_v2(hass: HomeAssistant) -> None:
     """Test that the config migration from Version 1 to Version 2 works."""
     config_entry = MockConfigEntry(
         version=1,
@@ -119,7 +134,8 @@ async def test_config_migration_v2(hass: HomeAssistant, setup_airnow) -> None:
     assert config_entry.options.get(CONF_RADIUS) == 25
 
 
-async def test_options_flow(hass: HomeAssistant, setup_airnow) -> None:
+@pytest.mark.usefixtures("setup_airnow")
+async def test_options_flow(hass: HomeAssistant) -> None:
     """Test that the options flow works."""
     config_entry = MockConfigEntry(
         version=2,

--- a/tests/components/airnow/test_diagnostics.py
+++ b/tests/components/airnow/test_diagnostics.py
@@ -1,18 +1,20 @@
 """Test AirNow diagnostics."""
 
+import pytest
 from syrupy import SnapshotAssertion
 
 from homeassistant.core import HomeAssistant
 
+from tests.common import MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
 
 
+@pytest.mark.usefixtures("setup_airnow")
 async def test_entry_diagnostics(
     hass: HomeAssistant,
-    config_entry,
+    config_entry: MockConfigEntry,
     hass_client: ClientSessionGenerator,
-    setup_airnow,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test config entry diagnostics."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
