### PR TITLE
Improve type hints in kaleidescape tests

### DIFF
--- a/tests/components/kaleidescape/conftest.py
+++ b/tests/components/kaleidescape/conftest.py
@@ -1,6 +1,6 @@
 """Fixtures for Kaleidescape integration."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import MagicMock, patch
 
 from kaleidescape import Dispatcher
 from kaleidescape.device import Automation, Movie, Power, System
@@ -17,7 +17,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture(name="mock_device")
-def fixture_mock_device() -> Generator[AsyncMock]:
+def fixture_mock_device() -> Generator[MagicMock]:
     """Return a mocked Kaleidescape device."""
     with patch(
         "homeassistant.components.kaleidescape.KaleidescapeDevice", autospec=True

--- a/tests/components/kaleidescape/conftest.py
+++ b/tests/components/kaleidescape/conftest.py
@@ -64,6 +64,7 @@ def fixture_mock_config_entry() -> MockConfigEntry:
 @pytest.fixture(name="mock_integration")
 async def fixture_mock_integration(
     hass: HomeAssistant,
+    mock_device: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> MockConfigEntry:
     """Return a mock ConfigEntry setup for Kaleidescape integration."""

--- a/tests/components/kaleidescape/test_config_flow.py
+++ b/tests/components/kaleidescape/test_config_flow.py
@@ -1,7 +1,9 @@
 """Tests for Kaleidescape config flow."""
 
 import dataclasses
-from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
 
 from homeassistant.components.kaleidescape.const import DOMAIN
 from homeassistant.config_entries import SOURCE_SSDP, SOURCE_USER
@@ -11,12 +13,9 @@ from homeassistant.data_entry_flow import FlowResultType
 
 from . import MOCK_HOST, MOCK_SSDP_DISCOVERY_INFO
 
-from tests.common import MockConfigEntry
 
-
-async def test_user_config_flow_success(
-    hass: HomeAssistant, mock_device: AsyncMock
-) -> None:
+@pytest.mark.usefixtures("mock_device")
+async def test_user_config_flow_success(hass: HomeAssistant) -> None:
     """Test user config flow success."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -35,7 +34,7 @@ async def test_user_config_flow_success(
 
 
 async def test_user_config_flow_bad_connect_errors(
-    hass: HomeAssistant, mock_device: AsyncMock
+    hass: HomeAssistant, mock_device: MagicMock
 ) -> None:
     """Test errors when connection error occurs."""
     mock_device.connect.side_effect = ConnectionError
@@ -50,7 +49,7 @@ async def test_user_config_flow_bad_connect_errors(
 
 
 async def test_user_config_flow_unsupported_device_errors(
-    hass: HomeAssistant, mock_device: AsyncMock
+    hass: HomeAssistant, mock_device: MagicMock
 ) -> None:
     """Test errors when connecting to unsupported device."""
     mock_device.is_server_only = True
@@ -64,9 +63,8 @@ async def test_user_config_flow_unsupported_device_errors(
     assert result["errors"] == {"base": "unsupported"}
 
 
-async def test_user_config_flow_device_exists_abort(
-    hass: HomeAssistant, mock_device: AsyncMock, mock_integration: MockConfigEntry
-) -> None:
+@pytest.mark.usefixtures("mock_device", "mock_integration")
+async def test_user_config_flow_device_exists_abort(hass: HomeAssistant) -> None:
     """Test flow aborts when device already configured."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: MOCK_HOST}
@@ -75,9 +73,8 @@ async def test_user_config_flow_device_exists_abort(
     assert result["reason"] == "already_configured"
 
 
-async def test_ssdp_config_flow_success(
-    hass: HomeAssistant, mock_device: AsyncMock
-) -> None:
+@pytest.mark.usefixtures("mock_device")
+async def test_ssdp_config_flow_success(hass: HomeAssistant) -> None:
     """Test ssdp config flow success."""
     discovery_info = dataclasses.replace(MOCK_SSDP_DISCOVERY_INFO)
     result = await hass.config_entries.flow.async_init(
@@ -97,7 +94,7 @@ async def test_ssdp_config_flow_success(
 
 
 async def test_ssdp_config_flow_bad_connect_aborts(
-    hass: HomeAssistant, mock_device: AsyncMock
+    hass: HomeAssistant, mock_device: MagicMock
 ) -> None:
     """Test abort when connection error occurs."""
     mock_device.connect.side_effect = ConnectionError
@@ -112,7 +109,7 @@ async def test_ssdp_config_flow_bad_connect_aborts(
 
 
 async def test_ssdp_config_flow_unsupported_device_aborts(
-    hass: HomeAssistant, mock_device: AsyncMock
+    hass: HomeAssistant, mock_device: MagicMock
 ) -> None:
     """Test abort when connecting to unsupported device."""
     mock_device.is_server_only = True

--- a/tests/components/kaleidescape/test_init.py
+++ b/tests/components/kaleidescape/test_init.py
@@ -1,6 +1,8 @@
 """Tests for Kaleidescape config entry."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
 
 from homeassistant.components.kaleidescape.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -14,7 +16,7 @@ from tests.common import MockConfigEntry
 
 async def test_unload_config_entry(
     hass: HomeAssistant,
-    mock_device: AsyncMock,
+    mock_device: MagicMock,
     mock_integration: MockConfigEntry,
 ) -> None:
     """Test config entry loading and unloading."""
@@ -32,7 +34,7 @@ async def test_unload_config_entry(
 
 async def test_config_entry_not_ready(
     hass: HomeAssistant,
-    mock_device: AsyncMock,
+    mock_device: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test config entry not ready."""
@@ -45,12 +47,8 @@ async def test_config_entry_not_ready(
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_device(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    mock_device: AsyncMock,
-    mock_integration: MockConfigEntry,
-) -> None:
+@pytest.mark.usefixtures("mock_device", "mock_integration")
+async def test_device(device_registry: dr.DeviceRegistry) -> None:
     """Test device."""
     device = device_registry.async_get_device(
         identifiers={("kaleidescape", MOCK_SERIAL)}

--- a/tests/components/kaleidescape/test_media_player.py
+++ b/tests/components/kaleidescape/test_media_player.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 from kaleidescape import const as kaleidescape_const
 from kaleidescape.device import Movie
+import pytest
 
 from homeassistant.components.media_player import DOMAIN as MEDIA_PLAYER_DOMAIN
 from homeassistant.const import (
@@ -25,17 +26,12 @@ from homeassistant.helpers import device_registry as dr
 
 from . import MOCK_SERIAL
 
-from tests.common import MockConfigEntry
-
 ENTITY_ID = f"media_player.kaleidescape_device_{MOCK_SERIAL}"
 FRIENDLY_NAME = f"Kaleidescape Device {MOCK_SERIAL}"
 
 
-async def test_entity(
-    hass: HomeAssistant,
-    mock_device: MagicMock,
-    mock_integration: MockConfigEntry,
-) -> None:
+@pytest.mark.usefixtures("mock_device", "mock_integration")
+async def test_entity(hass: HomeAssistant) -> None:
     """Test entity attributes."""
     entity = hass.states.get(ENTITY_ID)
     assert entity is not None
@@ -43,11 +39,8 @@ async def test_entity(
     assert entity.attributes["friendly_name"] == FRIENDLY_NAME
 
 
-async def test_update_state(
-    hass: HomeAssistant,
-    mock_device: MagicMock,
-    mock_integration: MockConfigEntry,
-) -> None:
+@pytest.mark.usefixtures("mock_integration")
+async def test_update_state(hass: HomeAssistant, mock_device: MagicMock) -> None:
     """Tests dispatched signals update player."""
     entity = hass.states.get(ENTITY_ID)
     assert entity is not None
@@ -105,11 +98,8 @@ async def test_update_state(
     assert entity.state == STATE_PAUSED
 
 
-async def test_services(
-    hass: HomeAssistant,
-    mock_device: MagicMock,
-    mock_integration: MockConfigEntry,
-) -> None:
+@pytest.mark.usefixtures("mock_integration")
+async def test_services(hass: HomeAssistant, mock_device: MagicMock) -> None:
     """Test service calls."""
     await hass.services.async_call(
         MEDIA_PLAYER_DOMAIN,
@@ -168,12 +158,8 @@ async def test_services(
     assert mock_device.previous.call_count == 1
 
 
-async def test_device(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    mock_device: MagicMock,
-    mock_integration: MockConfigEntry,
-) -> None:
+@pytest.mark.usefixtures("mock_device", "mock_integration")
+async def test_device(device_registry: dr.DeviceRegistry) -> None:
     """Test device attributes."""
     device = device_registry.async_get_device(
         identifiers={("kaleidescape", MOCK_SERIAL)}

--- a/tests/components/kaleidescape/test_remote.py
+++ b/tests/components/kaleidescape/test_remote.py
@@ -15,25 +15,17 @@ from homeassistant.exceptions import HomeAssistantError
 
 from . import MOCK_SERIAL
 
-from tests.common import MockConfigEntry
-
 ENTITY_ID = f"remote.kaleidescape_device_{MOCK_SERIAL}"
 
 
-async def test_entity(
-    hass: HomeAssistant,
-    mock_device: MagicMock,
-    mock_integration: MockConfigEntry,
-) -> None:
+@pytest.mark.usefixtures("mock_device", "mock_integration")
+async def test_entity(hass: HomeAssistant) -> None:
     """Test entity attributes."""
     assert hass.states.get(ENTITY_ID)
 
 
-async def test_commands(
-    hass: HomeAssistant,
-    mock_device: MagicMock,
-    mock_integration: MockConfigEntry,
-) -> None:
+@pytest.mark.usefixtures("mock_integration")
+async def test_commands(hass: HomeAssistant, mock_device: MagicMock) -> None:
     """Test service calls."""
     await hass.services.async_call(
         REMOTE_DOMAIN,
@@ -140,11 +132,8 @@ async def test_commands(
     assert mock_device.menu_toggle.call_count == 1
 
 
-async def test_unknown_command(
-    hass: HomeAssistant,
-    mock_device: MagicMock,
-    mock_integration: MockConfigEntry,
-) -> None:
+@pytest.mark.usefixtures("mock_device", "mock_integration")
+async def test_unknown_command(hass: HomeAssistant) -> None:
     """Test service calls."""
     with pytest.raises(HomeAssistantError) as err:
         await hass.services.async_call(

--- a/tests/components/kaleidescape/test_sensor.py
+++ b/tests/components/kaleidescape/test_sensor.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock
 
 from kaleidescape import const as kaleidescape_const
+import pytest
 
 from homeassistant.const import ATTR_FRIENDLY_NAME
 from homeassistant.core import HomeAssistant
@@ -10,17 +11,13 @@ from homeassistant.helpers import entity_registry as er
 
 from . import MOCK_SERIAL
 
-from tests.common import MockConfigEntry
-
 ENTITY_ID = f"sensor.kaleidescape_device_{MOCK_SERIAL}"
 FRIENDLY_NAME = f"Kaleidescape Device {MOCK_SERIAL}"
 
 
+@pytest.mark.usefixtures("mock_integration")
 async def test_sensors(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-    mock_device: MagicMock,
-    mock_integration: MockConfigEntry,
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_device: MagicMock
 ) -> None:
     """Test sensors."""
     entity = hass.states.get(f"{ENTITY_ID}_media_location")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, follow-up to #119018

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
