### PR TITLE
Improve type hints in zamg tests

### DIFF
--- a/tests/components/zamg/conftest.py
+++ b/tests/components/zamg/conftest.py
@@ -1,7 +1,7 @@
 """Fixtures for Zamg integration tests."""
 
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from typing_extensions import Generator
@@ -37,7 +37,7 @@ def mock_setup_entry() -> Generator[None]:
 
 
 @pytest.fixture
-def mock_zamg_config_flow(request: pytest.FixtureRequest) -> Generator[MagicMock]:
+def mock_zamg_config_flow() -> Generator[MagicMock]:
     """Return a mocked Zamg client."""
     with patch(
         "homeassistant.components.zamg.sensor.ZamgData", autospec=True
@@ -51,7 +51,7 @@ def mock_zamg_config_flow(request: pytest.FixtureRequest) -> Generator[MagicMock
 
 
 @pytest.fixture
-def mock_zamg(request: pytest.FixtureRequest) -> Generator[MagicMock]:
+def mock_zamg() -> Generator[MagicMock]:
     """Return a mocked Zamg client."""
 
     with patch(
@@ -70,7 +70,7 @@ def mock_zamg(request: pytest.FixtureRequest) -> Generator[MagicMock]:
 
 
 @pytest.fixture
-def mock_zamg_coordinator(request: pytest.FixtureRequest) -> Generator[MagicMock]:
+def mock_zamg_coordinator() -> Generator[MagicMock]:
     """Return a mocked Zamg client."""
 
     with patch(
@@ -89,7 +89,7 @@ def mock_zamg_coordinator(request: pytest.FixtureRequest) -> Generator[MagicMock
 
 
 @pytest.fixture
-def mock_zamg_stations(request: pytest.FixtureRequest) -> Generator[MagicMock]:
+def mock_zamg_stations() -> Generator[AsyncMock]:
     """Return a mocked Zamg client."""
     with patch(
         "homeassistant.components.zamg.config_flow.ZamgData.zamg_stations"
@@ -102,9 +102,7 @@ def mock_zamg_stations(request: pytest.FixtureRequest) -> Generator[MagicMock]:
 
 
 @pytest.fixture
-async def init_integration(
-    hass: HomeAssistant,
-) -> MockConfigEntry:
+async def init_integration(hass: HomeAssistant) -> MockConfigEntry:
     """Set up the Zamg integration for testing."""
     mock_config_entry.add_to_hass(hass)
 

--- a/tests/components/zamg/conftest.py
+++ b/tests/components/zamg/conftest.py
@@ -1,7 +1,7 @@
 """Fixtures for Zamg integration tests."""
 
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from typing_extensions import Generator
@@ -86,19 +86,6 @@ def mock_zamg_coordinator() -> Generator[MagicMock]:
         zamg.get_data.return_value = TEST_STATION_ID
         zamg.get_station_name = TEST_STATION_NAME
         yield zamg
-
-
-@pytest.fixture
-def mock_zamg_stations() -> Generator[AsyncMock]:
-    """Return a mocked Zamg client."""
-    with patch(
-        "homeassistant.components.zamg.config_flow.ZamgData.zamg_stations"
-    ) as zamg_mock:
-        zamg_mock.return_value = {
-            "11240": (46.99305556, 15.43916667, "GRAZ-FLUGHAFEN"),
-            "11244": (46.87222222, 15.90361111, "BAD GLEICHENBERG"),
-        }
-        yield zamg_mock
 
 
 @pytest.fixture

--- a/tests/components/zamg/test_config_flow.py
+++ b/tests/components/zamg/test_config_flow.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock
 
+import pytest
 from zamg.exceptions import ZamgApiError
 
 from homeassistant.components.zamg.const import CONF_STATION_ID, DOMAIN, LOGGER
@@ -12,11 +13,8 @@ from homeassistant.data_entry_flow import FlowResultType
 from .conftest import TEST_STATION_ID
 
 
-async def test_full_user_flow_implementation(
-    hass: HomeAssistant,
-    mock_zamg: MagicMock,
-    mock_setup_entry: None,
-) -> None:
+@pytest.mark.usefixtures("mock_zamg", "mock_setup_entry")
+async def test_full_user_flow_implementation(hass: HomeAssistant) -> None:
     """Test the full manual user flow from start to finish."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -37,11 +35,8 @@ async def test_full_user_flow_implementation(
     assert result["result"].unique_id == TEST_STATION_ID
 
 
-async def test_error_closest_station(
-    hass: HomeAssistant,
-    mock_zamg: MagicMock,
-    mock_setup_entry: None,
-) -> None:
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_error_closest_station(hass: HomeAssistant, mock_zamg: MagicMock) -> None:
     """Test with error of reading from Zamg."""
     mock_zamg.closest_station.side_effect = ZamgApiError
     result = await hass.config_entries.flow.async_init(
@@ -52,11 +47,8 @@ async def test_error_closest_station(
     assert result.get("reason") == "cannot_connect"
 
 
-async def test_error_update(
-    hass: HomeAssistant,
-    mock_zamg: MagicMock,
-    mock_setup_entry: None,
-) -> None:
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_error_update(hass: HomeAssistant, mock_zamg: MagicMock) -> None:
     """Test with error of reading from Zamg."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -75,11 +67,8 @@ async def test_error_update(
     assert result.get("reason") == "cannot_connect"
 
 
-async def test_user_flow_duplicate(
-    hass: HomeAssistant,
-    mock_zamg: MagicMock,
-    mock_setup_entry: None,
-) -> None:
+@pytest.mark.usefixtures("mock_zamg", "mock_setup_entry")
+async def test_user_flow_duplicate(hass: HomeAssistant) -> None:
     """Test the full manual user flow from start to finish."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/zamg/test_init.py
+++ b/tests/components/zamg/test_init.py
@@ -1,7 +1,5 @@
 """Test Zamg component init."""
 
-from unittest.mock import MagicMock
-
 import pytest
 
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
@@ -62,10 +60,10 @@ from tests.common import MockConfigEntry
         ),
     ],
 )
+@pytest.mark.usefixtures("mock_zamg_coordinator")
 async def test_migrate_unique_ids(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    mock_zamg_coordinator: MagicMock,
     entitydata: dict,
     old_unique_id: str,
     new_unique_id: str,
@@ -108,10 +106,10 @@ async def test_migrate_unique_ids(
         ),
     ],
 )
+@pytest.mark.usefixtures("mock_zamg_coordinator")
 async def test_dont_migrate_unique_ids(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    mock_zamg_coordinator: MagicMock,
     entitydata: dict,
     old_unique_id: str,
     new_unique_id: str,
@@ -167,10 +165,10 @@ async def test_dont_migrate_unique_ids(
         ),
     ],
 )
+@pytest.mark.usefixtures("mock_zamg_coordinator")
 async def test_unload_entry(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    mock_zamg_coordinator: MagicMock,
     entitydata: dict,
     unique_id: str,
 ) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #119018

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
