### PR TITLE
Remove unused request fixtures

### DIFF
--- a/tests/components/backup/test_websocket.py
+++ b/tests/components/backup/test_websocket.py
@@ -120,7 +120,6 @@ async def test_backup_end(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     snapshot: SnapshotAssertion,
-    request: pytest.FixtureRequest,
     sync_access_token_proxy: str,
     *,
     access_token_fixture_name: str,

--- a/tests/components/bmw_connected_drive/conftest.py
+++ b/tests/components/bmw_connected_drive/conftest.py
@@ -9,9 +9,7 @@ from typing_extensions import Generator
 
 
 @pytest.fixture
-def bmw_fixture(
-    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
-) -> Generator[respx.MockRouter]:
+def bmw_fixture(monkeypatch: pytest.MonkeyPatch) -> Generator[respx.MockRouter]:
     """Patch MyBMW login API calls."""
 
     # we use the library's mock router to mock the API calls, but only with a subset of vehicles

--- a/tests/components/bsblan/conftest.py
+++ b/tests/components/bsblan/conftest.py
@@ -40,7 +40,7 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_bsblan(request: pytest.FixtureRequest) -> Generator[MagicMock]:
+def mock_bsblan() -> Generator[MagicMock]:
     """Return a mocked BSBLAN client."""
 
     with (

--- a/tests/components/ipp/conftest.py
+++ b/tests/components/ipp/conftest.py
@@ -72,9 +72,7 @@ def mock_ipp_config_flow(mock_printer: Printer) -> Generator[MagicMock]:
 
 
 @pytest.fixture
-def mock_ipp(
-    request: pytest.FixtureRequest, mock_printer: Printer
-) -> Generator[MagicMock]:
+def mock_ipp(mock_printer: Printer) -> Generator[MagicMock]:
     """Return a mocked IPP client."""
 
     with patch(

--- a/tests/components/lamarzocco/conftest.py
+++ b/tests/components/lamarzocco/conftest.py
@@ -57,9 +57,7 @@ def device_fixture() -> LaMarzoccoModel:
 
 
 @pytest.fixture
-def mock_lamarzocco(
-    request: pytest.FixtureRequest, device_fixture: LaMarzoccoModel
-) -> Generator[MagicMock]:
+def mock_lamarzocco(device_fixture: LaMarzoccoModel) -> Generator[MagicMock]:
     """Return a mocked LM client."""
     model_name = device_fixture
 

--- a/tests/components/openexchangerates/conftest.py
+++ b/tests/components/openexchangerates/conftest.py
@@ -29,9 +29,7 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_latest_rates_config_flow(
-    request: pytest.FixtureRequest,
-) -> Generator[AsyncMock]:
+def mock_latest_rates_config_flow() -> Generator[AsyncMock]:
     """Return a mocked WLED client."""
     with patch(
         "homeassistant.components.openexchangerates.config_flow.Client.get_latest",

--- a/tests/components/pure_energie/conftest.py
+++ b/tests/components/pure_energie/conftest.py
@@ -35,9 +35,7 @@ def mock_setup_entry() -> Generator[None]:
 
 
 @pytest.fixture
-def mock_pure_energie_config_flow(
-    request: pytest.FixtureRequest,
-) -> Generator[MagicMock]:
+def mock_pure_energie_config_flow() -> Generator[MagicMock]:
     """Return a mocked Pure Energie client."""
     with patch(
         "homeassistant.components.pure_energie.config_flow.GridNet", autospec=True

--- a/tests/components/roku/conftest.py
+++ b/tests/components/roku/conftest.py
@@ -64,9 +64,7 @@ def mock_roku_config_flow(mock_device: RokuDevice) -> Generator[MagicMock]:
 
 
 @pytest.fixture
-def mock_roku(
-    request: pytest.FixtureRequest, mock_device: RokuDevice
-) -> Generator[MagicMock]:
+def mock_roku(mock_device: RokuDevice) -> Generator[MagicMock]:
     """Return a mocked Roku client."""
 
     with patch(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #119018
`request: pytest.FixtureRequest` is only ever needed if it is used inside the function.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
