### PR TITLE
Improve type hints in motionblinds_ble tests

### DIFF
--- a/tests/components/motionblinds_ble/conftest.py
+++ b/tests/components/motionblinds_ble/conftest.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from typing_extensions import Generator
 
 TEST_MAC = "abcd"
 TEST_NAME = f"MOTION_{TEST_MAC.upper()}"
@@ -10,7 +11,9 @@ TEST_ADDRESS = "test_adress"
 
 
 @pytest.fixture(name="motionblinds_ble_connect", autouse=True)
-def motion_blinds_connect_fixture(enable_bluetooth):
+def motion_blinds_connect_fixture(
+    enable_bluetooth: None,
+) -> Generator[tuple[AsyncMock, Mock]]:
     """Mock motion blinds ble connection and entry setup."""
     device = Mock()
     device.name = TEST_NAME

--- a/tests/components/motionblinds_ble/test_config_flow.py
+++ b/tests/components/motionblinds_ble/test_config_flow.py
@@ -1,8 +1,9 @@
 """Test the Motionblinds Bluetooth config flow."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from motionblindsble.const import MotionBlindType
+import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.bluetooth.models import BluetoothServiceInfoBleak
@@ -43,9 +44,8 @@ BLIND_SERVICE_INFO = BluetoothServiceInfoBleak(
 )
 
 
-async def test_config_flow_manual_success(
-    hass: HomeAssistant, motionblinds_ble_connect
-) -> None:
+@pytest.mark.usefixtures("motionblinds_ble_connect")
+async def test_config_flow_manual_success(hass: HomeAssistant) -> None:
     """Successful flow manually initialized by the user."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -76,9 +76,8 @@ async def test_config_flow_manual_success(
     assert result["options"] == {}
 
 
-async def test_config_flow_manual_error_invalid_mac(
-    hass: HomeAssistant, motionblinds_ble_connect
-) -> None:
+@pytest.mark.usefixtures("motionblinds_ble_connect")
+async def test_config_flow_manual_error_invalid_mac(hass: HomeAssistant) -> None:
     """Invalid MAC code error flow manually initialized by the user."""
 
     # Initialize
@@ -122,8 +121,9 @@ async def test_config_flow_manual_error_invalid_mac(
     assert result["options"] == {}
 
 
+@pytest.mark.usefixtures("motionblinds_ble_connect")
 async def test_config_flow_manual_error_no_bluetooth_adapter(
-    hass: HomeAssistant, motionblinds_ble_connect
+    hass: HomeAssistant,
 ) -> None:
     """No Bluetooth adapter error flow manually initialized by the user."""
 
@@ -159,7 +159,7 @@ async def test_config_flow_manual_error_no_bluetooth_adapter(
 
 
 async def test_config_flow_manual_error_could_not_find_motor(
-    hass: HomeAssistant, motionblinds_ble_connect
+    hass: HomeAssistant, motionblinds_ble_connect: tuple[AsyncMock, Mock]
 ) -> None:
     """Could not find motor error flow manually initialized by the user."""
 
@@ -207,7 +207,7 @@ async def test_config_flow_manual_error_could_not_find_motor(
 
 
 async def test_config_flow_manual_error_no_devices_found(
-    hass: HomeAssistant, motionblinds_ble_connect
+    hass: HomeAssistant, motionblinds_ble_connect: tuple[AsyncMock, Mock]
 ) -> None:
     """No devices found error flow manually initialized by the user."""
 
@@ -229,9 +229,8 @@ async def test_config_flow_manual_error_no_devices_found(
     assert result["reason"] == const.ERROR_NO_DEVICES_FOUND
 
 
-async def test_config_flow_bluetooth_success(
-    hass: HomeAssistant, motionblinds_ble_connect
-) -> None:
+@pytest.mark.usefixtures("motionblinds_ble_connect")
+async def test_config_flow_bluetooth_success(hass: HomeAssistant) -> None:
     """Successful bluetooth discovery flow."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
