### PR TITLE
Remove unused caplog fixtures in tests

### DIFF
--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -2940,9 +2940,7 @@ def test_deprecated_constants(
     )
 
 
-async def test_automation_turns_off_other_automation(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
-) -> None:
+async def test_automation_turns_off_other_automation(hass: HomeAssistant) -> None:
     """Test an automation that turns off another automation."""
     hass.set_state(CoreState.not_running)
     calls = async_mock_service(hass, "persistent_notification", "create")
@@ -3021,7 +3019,7 @@ async def test_automation_turns_off_other_automation(
 
 
 async def test_two_automations_call_restart_script_same_time(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
 ) -> None:
     """Test two automations that call a restart mode script at the same."""
     hass.states.async_set("binary_sensor.presence", "off")

--- a/tests/components/ring/test_init.py
+++ b/tests/components/ring/test_init.py
@@ -38,7 +38,6 @@ async def test_setup_entry_device_update(
     mock_ring_devices,
     freezer: FrozenDateTimeFactory,
     mock_added_config_entry: MockConfigEntry,
-    caplog,
 ) -> None:
     """Test devices are updating after setup entry."""
 

--- a/tests/test_block_async_io.py
+++ b/tests/test_block_async_io.py
@@ -43,7 +43,7 @@ async def test_protect_loop_debugger_sleep(caplog: pytest.LogCaptureFixture) -> 
     assert "Detected blocking call inside the event loop" not in caplog.text
 
 
-async def test_protect_loop_sleep(caplog: pytest.LogCaptureFixture) -> None:
+async def test_protect_loop_sleep() -> None:
     """Test time.sleep not injected by the debugger raises."""
     block_async_io.enable()
     frames = extract_stack_to_frame(
@@ -71,9 +71,7 @@ async def test_protect_loop_sleep(caplog: pytest.LogCaptureFixture) -> None:
         time.sleep(0)
 
 
-async def test_protect_loop_sleep_get_current_frame_raises(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
+async def test_protect_loop_sleep_get_current_frame_raises() -> None:
     """Test time.sleep when get_current_frame raises ValueError."""
     block_async_io.enable()
     frames = extract_stack_to_frame(

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1171,9 +1171,7 @@ async def test_bootstrap_is_cancellation_safe(
 
 
 @pytest.mark.parametrize("load_registries", [False])
-async def test_bootstrap_empty_integrations(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
-) -> None:
+async def test_bootstrap_empty_integrations(hass: HomeAssistant) -> None:
     """Test setting up an empty integrations does not raise."""
     await bootstrap.async_setup_multi_components(hass, set(), {})
     await hass.async_block_till_done()

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1034,9 +1034,7 @@ async def test_get_custom_components_recovery_mode(hass: HomeAssistant) -> None:
     assert await loader.async_get_custom_components(hass) == {}
 
 
-async def test_custom_integration_missing_version(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
-) -> None:
+async def test_custom_integration_missing_version(hass: HomeAssistant) -> None:
     """Test trying to load a custom integration without a version twice does not deadlock."""
     with pytest.raises(loader.IntegrationNotFound):
         await loader.async_get_integration(hass, "test_no_version")
@@ -1045,9 +1043,7 @@ async def test_custom_integration_missing_version(
         await loader.async_get_integration(hass, "test_no_version")
 
 
-async def test_custom_integration_missing(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
-) -> None:
+async def test_custom_integration_missing(hass: HomeAssistant) -> None:
     """Test trying to load a custom integration that is missing twice not deadlock."""
     with patch("homeassistant.loader.async_get_custom_components") as mock_get:
         mock_get.return_value = {}
@@ -1296,7 +1292,7 @@ async def test_hass_components_use_reported(
 
 
 async def test_async_get_component_preloads_config_and_config_flow(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
 ) -> None:
     """Verify async_get_component will try to preload the config and config_flow platform."""
     executor_import_integration = _get_test_integration(
@@ -1407,7 +1403,6 @@ async def test_async_get_component_loads_loop_if_already_in_sys_modules(
 
 async def test_async_get_component_concurrent_loads(
     hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
     enable_custom_integrations: None,
 ) -> None:
     """Verify async_get_component waits if the first load if called again when still in progress."""
@@ -1882,7 +1877,6 @@ async def test_async_get_platforms_loads_loop_if_already_in_sys_modules(
 
 async def test_async_get_platforms_concurrent_loads(
     hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
     enable_custom_integrations: None,
 ) -> None:
     """Verify async_get_platforms waits if the first load if called again.


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA
Spotted whilst looking at
```
************* Module tests.components.ring.test_init
tests/components/ring/test_init.py:41:4: W7431: Argument caplog should be of type pytest.LogCaptureFixture in test_setup_entry_device_update (hass-argument-type)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
