### PR TITLE
Add type hint to mock_async_zeroconf in test fixtures

### DIFF
--- a/tests/components/bosch_shc/conftest.py
+++ b/tests/components/bosch_shc/conftest.py
@@ -1,8 +1,10 @@
 """bosch_shc session fixtures."""
 
+from unittest.mock import MagicMock
+
 import pytest
 
 
 @pytest.fixture(autouse=True)
-def bosch_shc_mock_async_zeroconf(mock_async_zeroconf):
+def bosch_shc_mock_async_zeroconf(mock_async_zeroconf: MagicMock) -> None:
     """Auto mock zeroconf."""

--- a/tests/components/default_config/conftest.py
+++ b/tests/components/default_config/conftest.py
@@ -1,8 +1,10 @@
 """default_config session fixtures."""
 
+from unittest.mock import MagicMock
+
 import pytest
 
 
 @pytest.fixture(autouse=True)
-def default_config_mock_async_zeroconf(mock_async_zeroconf):
+def default_config_mock_async_zeroconf(mock_async_zeroconf: MagicMock) -> None:
     """Auto mock zeroconf."""

--- a/tests/components/devolo_home_control/conftest.py
+++ b/tests/components/devolo_home_control/conftest.py
@@ -1,6 +1,6 @@
 """Fixtures for tests."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from typing_extensions import Generator
@@ -39,5 +39,5 @@ def patch_mydevolo(credentials_valid: bool, maintenance: bool) -> Generator[None
 
 
 @pytest.fixture(autouse=True)
-def devolo_home_control_mock_async_zeroconf(mock_async_zeroconf):
+def devolo_home_control_mock_async_zeroconf(mock_async_zeroconf: MagicMock) -> None:
     """Auto mock zeroconf."""

--- a/tests/components/devolo_home_network/conftest.py
+++ b/tests/components/devolo_home_network/conftest.py
@@ -1,7 +1,7 @@
 """Fixtures for tests."""
 
 from itertools import cycle
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -50,5 +50,5 @@ def mock_validate_input():
 
 
 @pytest.fixture(autouse=True)
-def devolo_home_network_mock_async_zeroconf(mock_async_zeroconf):
+def devolo_home_network_mock_async_zeroconf(mock_async_zeroconf: MagicMock) -> None:
     """Auto mock zeroconf."""

--- a/tests/components/esphome/conftest.py
+++ b/tests/components/esphome/conftest.py
@@ -7,7 +7,7 @@ from asyncio import Event
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from aioesphomeapi import (
     APIClient,
@@ -47,7 +47,7 @@ def mock_bluetooth(enable_bluetooth: None) -> None:
 
 
 @pytest.fixture(autouse=True)
-def esphome_mock_async_zeroconf(mock_async_zeroconf):
+def esphome_mock_async_zeroconf(mock_async_zeroconf: MagicMock) -> None:
     """Auto mock zeroconf."""
 
 

--- a/tests/components/otbr/conftest.py
+++ b/tests/components/otbr/conftest.py
@@ -1,6 +1,6 @@
 """Test fixtures for the Open Thread Border Router integration."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
@@ -73,7 +73,7 @@ async def otbr_config_entry_thread_fixture(hass):
 
 
 @pytest.fixture(autouse=True)
-def use_mocked_zeroconf(mock_async_zeroconf):
+def use_mocked_zeroconf(mock_async_zeroconf: MagicMock) -> None:
     """Mock zeroconf in all tests."""
 
 

--- a/tests/components/rabbitair/test_config_flow.py
+++ b/tests/components/rabbitair/test_config_flow.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from ipaddress import ip_address
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from rabbitair import Mode, Model, Speed
@@ -38,7 +38,7 @@ ZEROCONF_DATA = zeroconf.ZeroconfServiceInfo(
 
 
 @pytest.fixture(autouse=True)
-def use_mocked_zeroconf(mock_async_zeroconf):
+def use_mocked_zeroconf(mock_async_zeroconf: MagicMock) -> None:
     """Mock zeroconf in all tests."""
 
 

--- a/tests/components/thread/conftest.py
+++ b/tests/components/thread/conftest.py
@@ -1,5 +1,7 @@
 """Test fixtures for the Thread integration."""
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from homeassistant.components import thread
@@ -24,5 +26,5 @@ async def thread_config_entry_fixture(hass: HomeAssistant):
 
 
 @pytest.fixture(autouse=True)
-def use_mocked_zeroconf(mock_async_zeroconf):
+def use_mocked_zeroconf(mock_async_zeroconf: MagicMock) -> None:
     """Mock zeroconf in all tests."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
