### PR TITLE
Move mock_async_zeroconf to decorator in homekit tests

### DIFF
--- a/tests/components/homekit/conftest.py
+++ b/tests/components/homekit/conftest.py
@@ -5,7 +5,7 @@ from collections.abc import Generator
 from contextlib import suppress
 import os
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -88,7 +88,7 @@ def mock_hap(
     hass: HomeAssistant,
     event_loop: AbstractEventLoop,
     iid_storage: AccessoryIIDStorage,
-    mock_zeroconf: None,
+    mock_zeroconf: MagicMock,
 ) -> Generator[HomeDriver, Any, None]:
     """Return a custom AccessoryDriver instance for HomeKit accessory init."""
     with (

--- a/tests/components/homekit/test_config_flow.py
+++ b/tests/components/homekit/test_config_flow.py
@@ -15,7 +15,7 @@ from homeassistant.config_entries import SOURCE_IGNORE, SOURCE_IMPORT
 from homeassistant.const import CONF_NAME, CONF_PORT, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entityfilter import CONF_INCLUDE_DOMAINS
 from homeassistant.setup import async_setup_component
 
@@ -405,13 +405,12 @@ async def test_options_flow_exclude_mode_basic(hass: HomeAssistant) -> None:
 
 
 @patch(f"{PATH_HOMEKIT}.async_port_is_available", return_value=True)
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_options_flow_devices(
     port_mock,
     hass: HomeAssistant,
     demo_cleanup,
-    device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    mock_async_zeroconf: None,
 ) -> None:
     """Test devices can be bridged."""
     config_entry = MockConfigEntry(
@@ -502,8 +501,9 @@ async def test_options_flow_devices(
 
 
 @patch(f"{PATH_HOMEKIT}.async_port_is_available", return_value=True)
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_options_flow_devices_preserved_when_advanced_off(
-    port_mock, hass: HomeAssistant, mock_async_zeroconf: None
+    port_mock, hass: HomeAssistant
 ) -> None:
     """Test devices are preserved if they were added in advanced mode but it was turned off."""
     config_entry = MockConfigEntry(
@@ -1161,11 +1161,11 @@ async def test_options_flow_blocked_when_from_yaml(hass: HomeAssistant) -> None:
 
 
 @patch(f"{PATH_HOMEKIT}.async_port_is_available", return_value=True)
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_options_flow_include_mode_basic_accessory(
     port_mock,
     hass: HomeAssistant,
     hk_driver,
-    mock_async_zeroconf: None,
 ) -> None:
     """Test config flow options in include mode with a single accessory."""
     config_entry = _mock_config_entry_with_options_populated()
@@ -1387,11 +1387,11 @@ def _get_schema_default(schema, key_name):
 
 
 @patch(f"{PATH_HOMEKIT}.async_port_is_available", return_value=True)
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_options_flow_exclude_mode_skips_category_entities(
     port_mock,
     hass: HomeAssistant,
     hk_driver,
-    mock_async_zeroconf: None,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Ensure exclude mode does not offer category entities."""
@@ -1491,11 +1491,11 @@ async def test_options_flow_exclude_mode_skips_category_entities(
 
 
 @patch(f"{PATH_HOMEKIT}.async_port_is_available", return_value=True)
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_options_flow_exclude_mode_skips_hidden_entities(
     port_mock,
     hass: HomeAssistant,
     hk_driver,
-    mock_async_zeroconf: None,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Ensure exclude mode does not offer hidden entities."""
@@ -1575,11 +1575,11 @@ async def test_options_flow_exclude_mode_skips_hidden_entities(
 
 
 @patch(f"{PATH_HOMEKIT}.async_port_is_available", return_value=True)
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_options_flow_include_mode_allows_hidden_entities(
     port_mock,
     hass: HomeAssistant,
     hk_driver,
-    mock_async_zeroconf: None,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Ensure include mode does not offer hidden entities."""

--- a/tests/components/homekit/test_diagnostics.py
+++ b/tests/components/homekit/test_diagnostics.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import ANY, MagicMock, patch
 
+import pytest
+
 from homeassistant.components.homekit.const import (
     CONF_DEVICES,
     CONF_HOMEKIT_MODE,
@@ -20,11 +22,11 @@ from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_config_entry_not_running(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     hk_driver,
-    mock_async_zeroconf: None,
 ) -> None:
     """Test generating diagnostics for a config entry."""
     entry = await async_init_integration(hass)
@@ -40,11 +42,11 @@ async def test_config_entry_not_running(
     }
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_config_entry_running(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     hk_driver,
-    mock_async_zeroconf: None,
 ) -> None:
     """Test generating diagnostics for a bridge config entry."""
     entry = MockConfigEntry(
@@ -152,11 +154,11 @@ async def test_config_entry_running(
         await hass.async_block_till_done()
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_config_entry_accessory(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     hk_driver,
-    mock_async_zeroconf: None,
 ) -> None:
     """Test generating diagnostics for an accessory config entry."""
     hass.states.async_set("light.demo", "on")
@@ -314,11 +316,11 @@ async def test_config_entry_accessory(
         await hass.async_block_till_done()
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_config_entry_with_trigger_accessory(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     hk_driver,
-    mock_async_zeroconf: None,
     events,
     demo_cleanup,
     device_registry: dr.DeviceRegistry,

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -154,7 +154,8 @@ def _mock_pyhap_bridge():
     )
 
 
-async def test_setup_min(hass: HomeAssistant, mock_async_zeroconf: None) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_setup_min(hass: HomeAssistant) -> None:
     """Test async_setup with min config options."""
 
     entry = MockConfigEntry(
@@ -198,9 +199,8 @@ async def test_setup_min(hass: HomeAssistant, mock_async_zeroconf: None) -> None
 
 
 @patch(f"{PATH_HOMEKIT}.async_port_is_available", return_value=True)
-async def test_removing_entry(
-    port_mock, hass: HomeAssistant, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_removing_entry(port_mock, hass: HomeAssistant) -> None:
     """Test removing a config entry."""
 
     entry = MockConfigEntry(
@@ -246,9 +246,8 @@ async def test_removing_entry(
     await hass.async_block_till_done()
 
 
-async def test_homekit_setup(
-    hass: HomeAssistant, hk_driver, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_homekit_setup(hass: HomeAssistant, hk_driver) -> None:
     """Test setup of bridge and driver."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -415,9 +414,8 @@ async def test_homekit_with_many_advertise_ips(
     )
 
 
-async def test_homekit_setup_advertise_ips(
-    hass: HomeAssistant, hk_driver, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_homekit_setup_advertise_ips(hass: HomeAssistant, hk_driver) -> None:
     """Test setup with given IP address to advertise."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -461,9 +459,8 @@ async def test_homekit_setup_advertise_ips(
     )
 
 
-async def test_homekit_add_accessory(
-    hass: HomeAssistant, mock_async_zeroconf: None, mock_hap
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_homekit_add_accessory(hass: HomeAssistant, mock_hap) -> None:
     """Add accessory if config exists and get_acc returns an accessory."""
 
     entry = MockConfigEntry(
@@ -501,10 +498,10 @@ async def test_homekit_add_accessory(
 
 
 @pytest.mark.parametrize("acc_category", [CATEGORY_TELEVISION, CATEGORY_CAMERA])
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_homekit_warn_add_accessory_bridge(
     hass: HomeAssistant,
     acc_category,
-    mock_async_zeroconf: None,
     mock_hap,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -535,9 +532,8 @@ async def test_homekit_warn_add_accessory_bridge(
     assert "accessory mode" in caplog.text
 
 
-async def test_homekit_remove_accessory(
-    hass: HomeAssistant, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_homekit_remove_accessory(hass: HomeAssistant) -> None:
     """Remove accessory from bridge."""
     entry = await async_init_integration(hass)
 
@@ -554,9 +550,8 @@ async def test_homekit_remove_accessory(
     assert len(homekit.bridge.accessories) == 0
 
 
-async def test_homekit_entity_filter(
-    hass: HomeAssistant, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_homekit_entity_filter(hass: HomeAssistant) -> None:
     """Test the entity filter."""
     entry = await async_init_integration(hass)
 
@@ -575,9 +570,8 @@ async def test_homekit_entity_filter(
     assert hass.states.get("light.demo") not in filtered_states
 
 
-async def test_homekit_entity_glob_filter(
-    hass: HomeAssistant, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_homekit_entity_glob_filter(hass: HomeAssistant) -> None:
     """Test the entity filter."""
     entry = await async_init_integration(hass)
 
@@ -601,8 +595,9 @@ async def test_homekit_entity_glob_filter(
     assert hass.states.get("light.included_test") in filtered_states
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_homekit_entity_glob_filter_with_config_entities(
-    hass: HomeAssistant, mock_async_zeroconf: None, entity_registry: er.EntityRegistry
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test the entity filter with configuration entities."""
     entry = await async_init_integration(hass)
@@ -654,8 +649,9 @@ async def test_homekit_entity_glob_filter_with_config_entities(
     assert hass.states.get("select.keep") in filtered_states
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_homekit_entity_glob_filter_with_hidden_entities(
-    hass: HomeAssistant, mock_async_zeroconf: None, entity_registry: er.EntityRegistry
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test the entity filter with hidden entities."""
     entry = await async_init_integration(hass)
@@ -707,10 +703,10 @@ async def test_homekit_entity_glob_filter_with_hidden_entities(
     assert hass.states.get("select.keep") in filtered_states
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_homekit_start(
     hass: HomeAssistant,
     hk_driver,
-    mock_async_zeroconf: None,
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test HomeKit start method."""
@@ -794,8 +790,9 @@ async def test_homekit_start(
     assert homekit.driver.state.config_version == 1
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_homekit_start_with_a_broken_accessory(
-    hass: HomeAssistant, hk_driver, mock_async_zeroconf: None
+    hass: HomeAssistant, hk_driver
 ) -> None:
     """Test HomeKit start method."""
     entry = MockConfigEntry(
@@ -835,10 +832,10 @@ async def test_homekit_start_with_a_broken_accessory(
     assert not hk_driver_start.called
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_homekit_start_with_a_device(
     hass: HomeAssistant,
     hk_driver,
-    mock_async_zeroconf: None,
     demo_cleanup,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
@@ -908,9 +905,8 @@ async def test_homekit_stop(hass: HomeAssistant) -> None:
     assert homekit.driver.async_stop.called is True
 
 
-async def test_homekit_reset_accessories(
-    hass: HomeAssistant, mock_async_zeroconf: None, mock_hap
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_homekit_reset_accessories(hass: HomeAssistant, mock_hap) -> None:
     """Test resetting HomeKit accessories."""
 
     entry = MockConfigEntry(
@@ -946,8 +942,9 @@ async def test_homekit_reset_accessories(
         await homekit.async_stop()
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_homekit_reload_accessory_can_change_class(
-    hass: HomeAssistant, mock_async_zeroconf: None, mock_hap
+    hass: HomeAssistant, mock_hap
 ) -> None:
     """Test reloading a HomeKit Accessory in brdige mode.
 
@@ -981,8 +978,9 @@ async def test_homekit_reload_accessory_can_change_class(
         await homekit.async_stop()
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_homekit_reload_accessory_in_accessory_mode(
-    hass: HomeAssistant, mock_async_zeroconf: None, mock_hap
+    hass: HomeAssistant, mock_hap
 ) -> None:
     """Test reloading a HomeKit Accessory in accessory mode.
 
@@ -1016,8 +1014,9 @@ async def test_homekit_reload_accessory_in_accessory_mode(
         await homekit.async_stop()
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_homekit_reload_accessory_same_class(
-    hass: HomeAssistant, mock_async_zeroconf: None, mock_hap
+    hass: HomeAssistant, mock_hap
 ) -> None:
     """Test reloading a HomeKit Accessory in bridge mode.
 
@@ -1060,8 +1059,9 @@ async def test_homekit_reload_accessory_same_class(
         await homekit.async_stop()
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_homekit_unpair(
-    hass: HomeAssistant, device_registry: dr.DeviceRegistry, mock_async_zeroconf: None
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
 ) -> None:
     """Test unpairing HomeKit accessories."""
 
@@ -1110,9 +1110,8 @@ async def test_homekit_unpair(
         homekit.status = STATUS_STOPPED
 
 
-async def test_homekit_unpair_missing_device_id(
-    hass: HomeAssistant, device_registry: dr.DeviceRegistry, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_homekit_unpair_missing_device_id(hass: HomeAssistant) -> None:
     """Test unpairing HomeKit accessories with invalid device id."""
 
     entry = MockConfigEntry(
@@ -1152,8 +1151,9 @@ async def test_homekit_unpair_missing_device_id(
         homekit.status = STATUS_STOPPED
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_homekit_unpair_not_homekit_device(
-    hass: HomeAssistant, device_registry: dr.DeviceRegistry, mock_async_zeroconf: None
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
 ) -> None:
     """Test unpairing HomeKit accessories with a non-homekit device id."""
 
@@ -1205,9 +1205,8 @@ async def test_homekit_unpair_not_homekit_device(
         homekit.status = STATUS_STOPPED
 
 
-async def test_homekit_reset_accessories_not_supported(
-    hass: HomeAssistant, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_homekit_reset_accessories_not_supported(hass: HomeAssistant) -> None:
     """Test resetting HomeKit accessories with an unsupported entity."""
 
     entry = MockConfigEntry(
@@ -1251,9 +1250,8 @@ async def test_homekit_reset_accessories_not_supported(
         homekit.status = STATUS_STOPPED
 
 
-async def test_homekit_reset_accessories_state_missing(
-    hass: HomeAssistant, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_homekit_reset_accessories_state_missing(hass: HomeAssistant) -> None:
     """Test resetting HomeKit accessories when the state goes missing."""
 
     entry = MockConfigEntry(
@@ -1295,9 +1293,8 @@ async def test_homekit_reset_accessories_state_missing(
         homekit.status = STATUS_STOPPED
 
 
-async def test_homekit_reset_accessories_not_bridged(
-    hass: HomeAssistant, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_homekit_reset_accessories_not_bridged(hass: HomeAssistant) -> None:
     """Test resetting HomeKit accessories when the state is not bridged."""
 
     entry = MockConfigEntry(
@@ -1342,9 +1339,8 @@ async def test_homekit_reset_accessories_not_bridged(
         homekit.status = STATUS_STOPPED
 
 
-async def test_homekit_reset_single_accessory(
-    hass: HomeAssistant, mock_hap, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_homekit_reset_single_accessory(hass: HomeAssistant, mock_hap) -> None:
     """Test resetting HomeKit single accessory."""
 
     entry = MockConfigEntry(
@@ -1381,9 +1377,8 @@ async def test_homekit_reset_single_accessory(
         await homekit.async_stop()
 
 
-async def test_homekit_reset_single_accessory_unsupported(
-    hass: HomeAssistant, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_homekit_reset_single_accessory_unsupported(hass: HomeAssistant) -> None:
     """Test resetting HomeKit single accessory with an unsupported entity."""
 
     entry = MockConfigEntry(
@@ -1422,8 +1417,9 @@ async def test_homekit_reset_single_accessory_unsupported(
         homekit.status = STATUS_STOPPED
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_homekit_reset_single_accessory_state_missing(
-    hass: HomeAssistant, mock_async_zeroconf: None
+    hass: HomeAssistant,
 ) -> None:
     """Test resetting HomeKit single accessory when the state goes missing."""
 
@@ -1462,9 +1458,8 @@ async def test_homekit_reset_single_accessory_state_missing(
         homekit.status = STATUS_STOPPED
 
 
-async def test_homekit_reset_single_accessory_no_match(
-    hass: HomeAssistant, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_homekit_reset_single_accessory_no_match(hass: HomeAssistant) -> None:
     """Test resetting HomeKit single accessory when the entity id does not match."""
 
     entry = MockConfigEntry(
@@ -1502,11 +1497,11 @@ async def test_homekit_reset_single_accessory_no_match(
         homekit.status = STATUS_STOPPED
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_homekit_too_many_accessories(
     hass: HomeAssistant,
     hk_driver,
     caplog: pytest.LogCaptureFixture,
-    mock_async_zeroconf: None,
 ) -> None:
     """Test adding too many accessories to HomeKit."""
     entry = await async_init_integration(hass)
@@ -1538,12 +1533,12 @@ async def test_homekit_too_many_accessories(
         assert "would exceed" in caplog.text
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_homekit_finds_linked_batteries(
     hass: HomeAssistant,
     hk_driver,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    mock_async_zeroconf: None,
 ) -> None:
     """Test HomeKit start method."""
     entry = await async_init_integration(hass)
@@ -1617,12 +1612,12 @@ async def test_homekit_finds_linked_batteries(
     )
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_homekit_async_get_integration_fails(
     hass: HomeAssistant,
     hk_driver,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    mock_async_zeroconf: None,
 ) -> None:
     """Test that we continue if async_get_integration fails."""
     entry = await async_init_integration(hass)
@@ -1692,9 +1687,8 @@ async def test_homekit_async_get_integration_fails(
     )
 
 
-async def test_yaml_updates_update_config_entry_for_name(
-    hass: HomeAssistant, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_yaml_updates_update_config_entry_for_name(hass: HomeAssistant) -> None:
     """Test async_setup with imported config."""
 
     entry = MockConfigEntry(
@@ -1742,9 +1736,8 @@ async def test_yaml_updates_update_config_entry_for_name(
     mock_homekit().async_start.assert_called()
 
 
-async def test_yaml_can_link_with_default_name(
-    hass: HomeAssistant, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_yaml_can_link_with_default_name(hass: HomeAssistant) -> None:
     """Test async_setup with imported config linked by default name."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1776,9 +1769,8 @@ async def test_yaml_can_link_with_default_name(
     assert entry.options["entity_config"]["camera.back_camera"]["stream_count"] == 3
 
 
-async def test_yaml_can_link_with_port(
-    hass: HomeAssistant, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_yaml_can_link_with_port(hass: HomeAssistant) -> None:
     """Test async_setup with imported config linked by port."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1830,9 +1822,8 @@ async def test_yaml_can_link_with_port(
     assert entry3.options == {}
 
 
-async def test_homekit_uses_system_zeroconf(
-    hass: HomeAssistant, hk_driver, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_homekit_uses_system_zeroconf(hass: HomeAssistant, hk_driver) -> None:
     """Test HomeKit uses system zeroconf."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1856,12 +1847,12 @@ async def test_homekit_uses_system_zeroconf(
         await hass.async_block_till_done()
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_homekit_ignored_missing_devices(
     hass: HomeAssistant,
     hk_driver,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    mock_async_zeroconf: None,
 ) -> None:
     """Test HomeKit handles a device in the entity registry but missing from the device registry."""
 
@@ -1947,12 +1938,12 @@ async def test_homekit_ignored_missing_devices(
     )
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_homekit_finds_linked_motion_sensors(
     hass: HomeAssistant,
     hk_driver,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    mock_async_zeroconf: None,
 ) -> None:
     """Test HomeKit start method."""
     entry = await async_init_integration(hass)
@@ -2014,12 +2005,12 @@ async def test_homekit_finds_linked_motion_sensors(
     )
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_homekit_finds_linked_humidity_sensors(
     hass: HomeAssistant,
     hk_driver,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    mock_async_zeroconf: None,
 ) -> None:
     """Test HomeKit start method."""
     entry = await async_init_integration(hass)
@@ -2084,7 +2075,8 @@ async def test_homekit_finds_linked_humidity_sensors(
     )
 
 
-async def test_reload(hass: HomeAssistant, mock_async_zeroconf: None) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_reload(hass: HomeAssistant) -> None:
     """Test we can reload from yaml."""
 
     entry = MockConfigEntry(
@@ -2166,10 +2158,10 @@ async def test_reload(hass: HomeAssistant, mock_async_zeroconf: None) -> None:
     )
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_homekit_start_in_accessory_mode(
     hass: HomeAssistant,
     hk_driver,
-    mock_async_zeroconf: None,
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test HomeKit start method in accessory mode."""
@@ -2210,11 +2202,10 @@ async def test_homekit_start_in_accessory_mode(
     assert len(device_registry.devices) == 1
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_homekit_start_in_accessory_mode_unsupported_entity(
     hass: HomeAssistant,
     hk_driver,
-    mock_async_zeroconf: None,
-    device_registry: dr.DeviceRegistry,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test HomeKit start method in accessory mode with an unsupported entity."""
@@ -2244,11 +2235,10 @@ async def test_homekit_start_in_accessory_mode_unsupported_entity(
     assert "entity not supported" in caplog.text
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_homekit_start_in_accessory_mode_missing_entity(
     hass: HomeAssistant,
     hk_driver,
-    mock_async_zeroconf: None,
-    device_registry: dr.DeviceRegistry,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test HomeKit start method in accessory mode when entity is not available."""
@@ -2275,10 +2265,10 @@ async def test_homekit_start_in_accessory_mode_missing_entity(
     assert "entity not available" in caplog.text
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_wait_for_port_to_free(
     hass: HomeAssistant,
     hk_driver,
-    mock_async_zeroconf: None,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test we wait for the port to free before declaring unload success."""

--- a/tests/components/homekit/test_init.py
+++ b/tests/components/homekit/test_init.py
@@ -70,10 +70,10 @@ async def test_humanify_homekit_changed_event(hass: HomeAssistant, hk_driver) ->
     assert event2["entity_id"] == "cover.window"
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_bridge_with_triggers(
     hass: HomeAssistant,
     hk_driver,
-    mock_async_zeroconf: None,
     entity_registry: er.EntityRegistry,
     caplog: pytest.LogCaptureFixture,
 ) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
