### PR TITLE
Move mock_zeroconf to decorator in tests

### DIFF
--- a/tests/components/bosch_shc/test_config_flow.py
+++ b/tests/components/bosch_shc/test_config_flow.py
@@ -10,6 +10,7 @@ from boschshcpy.exceptions import (
     SHCSessionError,
 )
 from boschshcpy.information import SHCInformation
+import pytest
 
 from homeassistant import config_entries
 from homeassistant.components import zeroconf
@@ -35,7 +36,8 @@ DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
 )
 
 
-async def test_form_user(hass: HomeAssistant, mock_zeroconf: None) -> None:
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_form_user(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -107,9 +109,8 @@ async def test_form_user(hass: HomeAssistant, mock_zeroconf: None) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_get_info_connection_error(
-    hass: HomeAssistant, mock_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_form_get_info_connection_error(hass: HomeAssistant) -> None:
     """Test we handle connection error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -153,7 +154,8 @@ async def test_form_get_info_exception(hass: HomeAssistant) -> None:
     assert result2["errors"] == {"base": "unknown"}
 
 
-async def test_form_pairing_error(hass: HomeAssistant, mock_zeroconf: None) -> None:
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_form_pairing_error(hass: HomeAssistant) -> None:
     """Test we handle pairing error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -199,7 +201,8 @@ async def test_form_pairing_error(hass: HomeAssistant, mock_zeroconf: None) -> N
     assert result3["errors"] == {"base": "pairing_failed"}
 
 
-async def test_form_user_invalid_auth(hass: HomeAssistant, mock_zeroconf: None) -> None:
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_form_user_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -257,9 +260,8 @@ async def test_form_user_invalid_auth(hass: HomeAssistant, mock_zeroconf: None) 
     assert result3["errors"] == {"base": "invalid_auth"}
 
 
-async def test_form_validate_connection_error(
-    hass: HomeAssistant, mock_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_form_validate_connection_error(hass: HomeAssistant) -> None:
     """Test we handle connection error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -317,9 +319,8 @@ async def test_form_validate_connection_error(
     assert result3["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_validate_session_error(
-    hass: HomeAssistant, mock_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_form_validate_session_error(hass: HomeAssistant) -> None:
     """Test we handle session error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -377,9 +378,8 @@ async def test_form_validate_session_error(
     assert result3["errors"] == {"base": "session_error"}
 
 
-async def test_form_validate_exception(
-    hass: HomeAssistant, mock_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_form_validate_exception(hass: HomeAssistant) -> None:
     """Test we handle exception."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -437,9 +437,8 @@ async def test_form_validate_exception(
     assert result3["errors"] == {"base": "unknown"}
 
 
-async def test_form_already_configured(
-    hass: HomeAssistant, mock_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_form_already_configured(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     entry = MockConfigEntry(
@@ -479,7 +478,8 @@ async def test_form_already_configured(
     assert entry.data["host"] == "1.1.1.1"
 
 
-async def test_zeroconf(hass: HomeAssistant, mock_zeroconf: None) -> None:
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_zeroconf(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     with (
@@ -557,9 +557,8 @@ async def test_zeroconf(hass: HomeAssistant, mock_zeroconf: None) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_zeroconf_already_configured(
-    hass: HomeAssistant, mock_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_zeroconf_already_configured(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     entry = MockConfigEntry(
@@ -596,9 +595,8 @@ async def test_zeroconf_already_configured(
     assert entry.data["host"] == "1.1.1.1"
 
 
-async def test_zeroconf_cannot_connect(
-    hass: HomeAssistant, mock_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_zeroconf_cannot_connect(hass: HomeAssistant) -> None:
     """Test we get the form."""
     with patch(
         "boschshcpy.session.SHCSession.mdns_info", side_effect=SHCConnectionError
@@ -612,7 +610,8 @@ async def test_zeroconf_cannot_connect(
         assert result["reason"] == "cannot_connect"
 
 
-async def test_zeroconf_not_bosch_shc(hass: HomeAssistant, mock_zeroconf: None) -> None:
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_zeroconf_not_bosch_shc(hass: HomeAssistant) -> None:
     """Test we filter out non-bosch_shc devices."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -631,7 +630,8 @@ async def test_zeroconf_not_bosch_shc(hass: HomeAssistant, mock_zeroconf: None) 
     assert result["reason"] == "not_bosch_shc"
 
 
-async def test_reauth(hass: HomeAssistant, mock_zeroconf: None) -> None:
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_reauth(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     mock_config = MockConfigEntry(

--- a/tests/components/cast/test_home_assistant_cast.py
+++ b/tests/components/cast/test_home_assistant_cast.py
@@ -12,7 +12,8 @@ from homeassistant.exceptions import HomeAssistantError
 from tests.common import MockConfigEntry, async_mock_signal
 
 
-async def test_service_show_view(hass: HomeAssistant, mock_zeroconf: None) -> None:
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_service_show_view(hass: HomeAssistant) -> None:
     """Test showing a view."""
     entry = MockConfigEntry(domain=DOMAIN)
     entry.add_to_hass(hass)
@@ -51,9 +52,8 @@ async def test_service_show_view(hass: HomeAssistant, mock_zeroconf: None) -> No
     assert url_path is None
 
 
-async def test_service_show_view_dashboard(
-    hass: HomeAssistant, mock_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_service_show_view_dashboard(hass: HomeAssistant) -> None:
     """Test casting a specific dashboard."""
     await async_process_ha_core_config(
         hass,
@@ -82,7 +82,8 @@ async def test_service_show_view_dashboard(
     assert url_path == "mock-dashboard"
 
 
-async def test_use_cloud_url(hass: HomeAssistant, mock_zeroconf: None) -> None:
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_use_cloud_url(hass: HomeAssistant) -> None:
     """Test that we fall back to cloud url."""
     await async_process_ha_core_config(
         hass,
@@ -111,7 +112,8 @@ async def test_use_cloud_url(hass: HomeAssistant, mock_zeroconf: None) -> None:
     assert controller_data["hass_url"] == "https://something.nabu.casa"
 
 
-async def test_remove_entry(hass: HomeAssistant, mock_zeroconf: None) -> None:
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_remove_entry(hass: HomeAssistant) -> None:
     """Test removing config entry removes user."""
     entry = MockConfigEntry(
         data={},

--- a/tests/components/devolo_home_control/test_init.py
+++ b/tests/components/devolo_home_control/test_init.py
@@ -19,7 +19,8 @@ from .mocks import HomeControlMock, HomeControlMockBinarySensor
 from tests.typing import WebSocketGenerator
 
 
-async def test_setup_entry(hass: HomeAssistant, mock_zeroconf: None) -> None:
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_setup_entry(hass: HomeAssistant) -> None:
     """Test setup entry."""
     entry = configure_integration(hass)
     with patch("homeassistant.components.devolo_home_control.HomeControl"):
@@ -43,7 +44,8 @@ async def test_setup_entry_maintenance(hass: HomeAssistant) -> None:
     assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_setup_gateway_offline(hass: HomeAssistant, mock_zeroconf: None) -> None:
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_setup_gateway_offline(hass: HomeAssistant) -> None:
     """Test setup entry fails on gateway offline."""
     entry = configure_integration(hass)
     with patch(

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -47,8 +47,9 @@ def mock_setup_entry():
         yield
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_user_connection_works(
-    hass: HomeAssistant, mock_client, mock_zeroconf: None, mock_setup_entry: None
+    hass: HomeAssistant, mock_client, mock_setup_entry: None
 ) -> None:
     """Test we can finish a config flow."""
     result = await hass.config_entries.flow.async_init(
@@ -89,8 +90,9 @@ async def test_user_connection_works(
     assert mock_client.noise_psk is None
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_user_connection_updates_host(
-    hass: HomeAssistant, mock_client, mock_zeroconf: None, mock_setup_entry: None
+    hass: HomeAssistant, mock_client, mock_setup_entry: None
 ) -> None:
     """Test setup up the same name updates the host."""
     entry = MockConfigEntry(
@@ -118,8 +120,9 @@ async def test_user_connection_updates_host(
     assert entry.data[CONF_HOST] == "127.0.0.1"
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_user_sets_unique_id(
-    hass: HomeAssistant, mock_client, mock_zeroconf: None, mock_setup_entry: None
+    hass: HomeAssistant, mock_client, mock_setup_entry: None
 ) -> None:
     """Test that the user flow sets the unique id."""
     service_info = zeroconf.ZeroconfServiceInfo(
@@ -170,8 +173,9 @@ async def test_user_sets_unique_id(
     assert result["reason"] == "already_configured"
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_user_resolve_error(
-    hass: HomeAssistant, mock_client, mock_zeroconf: None, mock_setup_entry: None
+    hass: HomeAssistant, mock_client, mock_setup_entry: None
 ) -> None:
     """Test user step with IP resolve error."""
 
@@ -195,8 +199,9 @@ async def test_user_resolve_error(
     assert len(mock_client.disconnect.mock_calls) == 1
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_user_causes_zeroconf_to_abort(
-    hass: HomeAssistant, mock_client, mock_zeroconf: None, mock_setup_entry: None
+    hass: HomeAssistant, mock_client, mock_setup_entry: None
 ) -> None:
     """Test that the user flow sets the unique id and aborts the zeroconf flow."""
     service_info = zeroconf.ZeroconfServiceInfo(
@@ -242,8 +247,9 @@ async def test_user_causes_zeroconf_to_abort(
     assert not hass.config_entries.flow.async_progress_by_handler(DOMAIN)
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_user_connection_error(
-    hass: HomeAssistant, mock_client, mock_zeroconf: None, mock_setup_entry: None
+    hass: HomeAssistant, mock_client, mock_setup_entry: None
 ) -> None:
     """Test user step with connection error."""
     mock_client.device_info.side_effect = APIConnectionError
@@ -263,8 +269,9 @@ async def test_user_connection_error(
     assert len(mock_client.disconnect.mock_calls) == 1
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_user_with_password(
-    hass: HomeAssistant, mock_client, mock_zeroconf: None, mock_setup_entry: None
+    hass: HomeAssistant, mock_client, mock_setup_entry: None
 ) -> None:
     """Test user step with password."""
     mock_client.device_info.return_value = DeviceInfo(uses_password=True, name="test")
@@ -293,9 +300,8 @@ async def test_user_with_password(
     assert mock_client.password == "password1"
 
 
-async def test_user_invalid_password(
-    hass: HomeAssistant, mock_client, mock_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_user_invalid_password(hass: HomeAssistant, mock_client) -> None:
     """Test user step with invalid password."""
     mock_client.device_info.return_value = DeviceInfo(uses_password=True, name="test")
 
@@ -319,11 +325,11 @@ async def test_user_invalid_password(
     assert result["errors"] == {"base": "invalid_auth"}
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_user_dashboard_has_wrong_key(
     hass: HomeAssistant,
     mock_client,
     mock_dashboard,
-    mock_zeroconf: None,
     mock_setup_entry: None,
 ) -> None:
     """Test user step with key from dashboard that is incorrect."""
@@ -366,11 +372,11 @@ async def test_user_dashboard_has_wrong_key(
     assert mock_client.noise_psk == VALID_NOISE_PSK
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_user_discovers_name_and_gets_key_from_dashboard(
     hass: HomeAssistant,
     mock_client,
     mock_dashboard,
-    mock_zeroconf: None,
     mock_setup_entry: None,
 ) -> None:
     """Test user step can discover the name and get the key from the dashboard."""
@@ -418,12 +424,12 @@ async def test_user_discovers_name_and_gets_key_from_dashboard(
     "dashboard_exception",
     [aiohttp.ClientError(), json.JSONDecodeError("test", "test", 0)],
 )
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_user_discovers_name_and_gets_key_from_dashboard_fails(
     hass: HomeAssistant,
     dashboard_exception: Exception,
     mock_client,
     mock_dashboard,
-    mock_zeroconf: None,
     mock_setup_entry: None,
 ) -> None:
     """Test user step can discover the name and get the key from the dashboard."""
@@ -474,11 +480,11 @@ async def test_user_discovers_name_and_gets_key_from_dashboard_fails(
     assert mock_client.noise_psk == VALID_NOISE_PSK
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_user_discovers_name_and_dashboard_is_unavailable(
     hass: HomeAssistant,
     mock_client,
     mock_dashboard,
-    mock_zeroconf: None,
     mock_setup_entry: None,
 ) -> None:
     """Test user step can discover the name but the dashboard is unavailable."""
@@ -529,8 +535,9 @@ async def test_user_discovers_name_and_dashboard_is_unavailable(
     assert mock_client.noise_psk == VALID_NOISE_PSK
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_login_connection_error(
-    hass: HomeAssistant, mock_client, mock_zeroconf: None, mock_setup_entry: None
+    hass: HomeAssistant, mock_client, mock_setup_entry: None
 ) -> None:
     """Test user step with connection error on login attempt."""
     mock_client.device_info.return_value = DeviceInfo(uses_password=True, name="test")
@@ -555,8 +562,9 @@ async def test_login_connection_error(
     assert result["errors"] == {"base": "connection_error"}
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_discovery_initiation(
-    hass: HomeAssistant, mock_client, mock_zeroconf: None, mock_setup_entry: None
+    hass: HomeAssistant, mock_client, mock_setup_entry: None
 ) -> None:
     """Test discovery importing works."""
     service_info = zeroconf.ZeroconfServiceInfo(
@@ -587,8 +595,9 @@ async def test_discovery_initiation(
     assert result["result"].unique_id == "11:22:33:44:55:aa"
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_discovery_no_mac(
-    hass: HomeAssistant, mock_client, mock_zeroconf: None, mock_setup_entry: None
+    hass: HomeAssistant, mock_client, mock_setup_entry: None
 ) -> None:
     """Test discovery aborted if old ESPHome without mac in zeroconf."""
     service_info = zeroconf.ZeroconfServiceInfo(
@@ -694,8 +703,9 @@ async def test_discovery_updates_unique_id(
     assert entry.unique_id == "11:22:33:44:55:aa"
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_user_requires_psk(
-    hass: HomeAssistant, mock_client, mock_zeroconf: None, mock_setup_entry: None
+    hass: HomeAssistant, mock_client, mock_setup_entry: None
 ) -> None:
     """Test user step with requiring encryption key."""
     mock_client.device_info.side_effect = RequiresEncryptionAPIError
@@ -715,8 +725,9 @@ async def test_user_requires_psk(
     assert len(mock_client.disconnect.mock_calls) == 2
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_encryption_key_valid_psk(
-    hass: HomeAssistant, mock_client, mock_zeroconf: None, mock_setup_entry: None
+    hass: HomeAssistant, mock_client, mock_setup_entry: None
 ) -> None:
     """Test encryption key step with valid key."""
 
@@ -749,8 +760,9 @@ async def test_encryption_key_valid_psk(
     assert mock_client.noise_psk == VALID_NOISE_PSK
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_encryption_key_invalid_psk(
-    hass: HomeAssistant, mock_client, mock_zeroconf: None, mock_setup_entry: None
+    hass: HomeAssistant, mock_client, mock_setup_entry: None
 ) -> None:
     """Test encryption key step with invalid key."""
 
@@ -776,9 +788,8 @@ async def test_encryption_key_invalid_psk(
     assert mock_client.noise_psk == INVALID_NOISE_PSK
 
 
-async def test_reauth_initiation(
-    hass: HomeAssistant, mock_client, mock_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_reauth_initiation(hass: HomeAssistant, mock_client) -> None:
     """Test reauth initiation shows form."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -798,8 +809,9 @@ async def test_reauth_initiation(
     assert result["step_id"] == "reauth_confirm"
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_reauth_confirm_valid(
-    hass: HomeAssistant, mock_client, mock_zeroconf: None, mock_setup_entry: None
+    hass: HomeAssistant, mock_client, mock_setup_entry: None
 ) -> None:
     """Test reauth initiation with valid PSK."""
     entry = MockConfigEntry(
@@ -827,10 +839,10 @@ async def test_reauth_confirm_valid(
     assert entry.data[CONF_NOISE_PSK] == VALID_NOISE_PSK
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_reauth_fixed_via_dashboard(
     hass: HomeAssistant,
     mock_client,
-    mock_zeroconf: None,
     mock_dashboard,
     mock_setup_entry: None,
 ) -> None:
@@ -878,10 +890,10 @@ async def test_reauth_fixed_via_dashboard(
     assert len(mock_get_encryption_key.mock_calls) == 1
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_reauth_fixed_via_dashboard_add_encryption_remove_password(
     hass: HomeAssistant,
     mock_client,
-    mock_zeroconf: None,
     mock_dashboard,
     mock_config_entry,
     mock_setup_entry: None,
@@ -946,10 +958,10 @@ async def test_reauth_fixed_via_remove_password(
     assert mock_config_entry.data[CONF_PASSWORD] == ""
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_reauth_fixed_via_dashboard_at_confirm(
     hass: HomeAssistant,
     mock_client,
-    mock_zeroconf: None,
     mock_dashboard,
     mock_setup_entry: None,
 ) -> None:
@@ -1003,8 +1015,9 @@ async def test_reauth_fixed_via_dashboard_at_confirm(
     assert len(mock_get_encryption_key.mock_calls) == 1
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_reauth_confirm_invalid(
-    hass: HomeAssistant, mock_client, mock_zeroconf: None, mock_setup_entry: None
+    hass: HomeAssistant, mock_client, mock_setup_entry: None
 ) -> None:
     """Test reauth initiation with invalid PSK."""
     entry = MockConfigEntry(
@@ -1044,8 +1057,9 @@ async def test_reauth_confirm_invalid(
     assert entry.data[CONF_NOISE_PSK] == VALID_NOISE_PSK
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_reauth_confirm_invalid_with_unique_id(
-    hass: HomeAssistant, mock_client, mock_zeroconf: None, mock_setup_entry: None
+    hass: HomeAssistant, mock_client, mock_setup_entry: None
 ) -> None:
     """Test reauth initiation with invalid PSK."""
     entry = MockConfigEntry(
@@ -1166,10 +1180,10 @@ async def test_discovery_hassio(hass: HomeAssistant, mock_dashboard) -> None:
     assert dash.addon_slug == "mock-slug"
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_zeroconf_encryption_key_via_dashboard(
     hass: HomeAssistant,
     mock_client,
-    mock_zeroconf: None,
     mock_dashboard,
     mock_setup_entry: None,
 ) -> None:
@@ -1232,10 +1246,10 @@ async def test_zeroconf_encryption_key_via_dashboard(
     assert mock_client.noise_psk == VALID_NOISE_PSK
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_zeroconf_encryption_key_via_dashboard_with_api_encryption_prop(
     hass: HomeAssistant,
     mock_client,
-    mock_zeroconf: None,
     mock_dashboard,
     mock_setup_entry: None,
 ) -> None:
@@ -1298,10 +1312,10 @@ async def test_zeroconf_encryption_key_via_dashboard_with_api_encryption_prop(
     assert mock_client.noise_psk == VALID_NOISE_PSK
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_zeroconf_no_encryption_key_via_dashboard(
     hass: HomeAssistant,
     mock_client,
-    mock_zeroconf: None,
     mock_dashboard,
     mock_setup_entry: None,
 ) -> None:
@@ -1375,10 +1389,10 @@ async def test_option_flow(
     assert len(mock_reload.mock_calls) == int(option_value)
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_user_discovers_name_no_dashboard(
     hass: HomeAssistant,
     mock_client,
-    mock_zeroconf: None,
     mock_setup_entry: None,
 ) -> None:
     """Test user step can discover the name and the there is not dashboard."""
@@ -1434,22 +1448,25 @@ async def mqtt_discovery_test_abort(hass: HomeAssistant, payload: str, reason: s
     assert flow["reason"] == reason
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_discovery_mqtt_no_mac(
-    hass: HomeAssistant, mock_client, mock_zeroconf: None, mock_setup_entry: None
+    hass: HomeAssistant, mock_client, mock_setup_entry: None
 ) -> None:
     """Test discovery aborted if mac is missing in MQTT payload."""
     await mqtt_discovery_test_abort(hass, "{}", "mqtt_missing_mac")
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_discovery_mqtt_no_api(
-    hass: HomeAssistant, mock_client, mock_zeroconf: None, mock_setup_entry: None
+    hass: HomeAssistant, mock_client, mock_setup_entry: None
 ) -> None:
     """Test discovery aborted if api/port is missing in MQTT payload."""
     await mqtt_discovery_test_abort(hass, '{"mac":"abcdef123456"}', "mqtt_missing_api")
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_discovery_mqtt_no_ip(
-    hass: HomeAssistant, mock_client, mock_zeroconf: None, mock_setup_entry: None
+    hass: HomeAssistant, mock_client, mock_setup_entry: None
 ) -> None:
     """Test discovery aborted if ip is missing in MQTT payload."""
     await mqtt_discovery_test_abort(
@@ -1457,8 +1474,9 @@ async def test_discovery_mqtt_no_ip(
     )
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_discovery_mqtt_initiation(
-    hass: HomeAssistant, mock_client, mock_zeroconf: None, mock_setup_entry: None
+    hass: HomeAssistant, mock_client, mock_setup_entry: None
 ) -> None:
     """Test discovery importing works."""
     service_info = MqttServiceInfo(

--- a/tests/components/esphome/test_init.py
+++ b/tests/components/esphome/test_init.py
@@ -1,5 +1,7 @@
 """ESPHome set up tests."""
 
+import pytest
+
 from homeassistant.components.esphome import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
 from homeassistant.core import HomeAssistant
@@ -7,9 +9,8 @@ from homeassistant.core import HomeAssistant
 from tests.common import MockConfigEntry
 
 
-async def test_delete_entry(
-    hass: HomeAssistant, mock_client, mock_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_delete_entry(hass: HomeAssistant, mock_client) -> None:
     """Test we can delete an entry with error."""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -354,9 +354,8 @@ async def test_esphome_device_with_current_bluetooth(
     )
 
 
-async def test_unique_id_updated_to_mac(
-    hass: HomeAssistant, mock_client, mock_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_unique_id_updated_to_mac(hass: HomeAssistant, mock_client) -> None:
     """Test we update config entry unique ID to MAC address."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -384,8 +383,9 @@ async def test_unique_id_updated_to_mac(
     assert entry.unique_id == "11:22:33:44:55:aa"
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_unique_id_not_updated_if_name_same_and_already_mac(
-    hass: HomeAssistant, mock_client: APIClient, mock_zeroconf: None
+    hass: HomeAssistant, mock_client: APIClient
 ) -> None:
     """Test we never update the entry unique ID event if the name is the same."""
     entry = MockConfigEntry(
@@ -418,8 +418,9 @@ async def test_unique_id_not_updated_if_name_same_and_already_mac(
     assert entry.unique_id == "11:22:33:44:55:aa"
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_unique_id_updated_if_name_unset_and_already_mac(
-    hass: HomeAssistant, mock_client: APIClient, mock_zeroconf: None
+    hass: HomeAssistant, mock_client: APIClient
 ) -> None:
     """Test we never update config entry unique ID even if the name is unset."""
     entry = MockConfigEntry(
@@ -447,8 +448,9 @@ async def test_unique_id_updated_if_name_unset_and_already_mac(
     assert entry.unique_id == "11:22:33:44:55:aa"
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_unique_id_not_updated_if_name_different_and_already_mac(
-    hass: HomeAssistant, mock_client: APIClient, mock_zeroconf: None
+    hass: HomeAssistant, mock_client: APIClient
 ) -> None:
     """Test we do not update config entry unique ID if the name is different."""
     entry = MockConfigEntry(
@@ -483,8 +485,9 @@ async def test_unique_id_not_updated_if_name_different_and_already_mac(
     assert entry.data[CONF_DEVICE_NAME] == "test"
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_name_updated_only_if_mac_matches(
-    hass: HomeAssistant, mock_client: APIClient, mock_zeroconf: None
+    hass: HomeAssistant, mock_client: APIClient
 ) -> None:
     """Test we update config entry name only if the mac matches."""
     entry = MockConfigEntry(
@@ -517,8 +520,9 @@ async def test_name_updated_only_if_mac_matches(
     assert entry.data[CONF_DEVICE_NAME] == "new"
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_name_updated_only_if_mac_was_unset(
-    hass: HomeAssistant, mock_client: APIClient, mock_zeroconf: None
+    hass: HomeAssistant, mock_client: APIClient
 ) -> None:
     """Test we update config entry name if the old unique id was not a mac."""
     entry = MockConfigEntry(
@@ -551,10 +555,10 @@ async def test_name_updated_only_if_mac_was_unset(
     assert entry.data[CONF_DEVICE_NAME] == "new"
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_connection_aborted_wrong_device(
     hass: HomeAssistant,
     mock_client: APIClient,
-    mock_zeroconf: None,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test we abort the connection if the unique id is a mac and neither name or mac match."""
@@ -615,10 +619,10 @@ async def test_connection_aborted_wrong_device(
     assert "Unexpected device found at" not in caplog.text
 
 
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_failure_during_connect(
     hass: HomeAssistant,
     mock_client: APIClient,
-    mock_zeroconf: None,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test we disconnect when there is a failure during connection setup."""

--- a/tests/components/zeroconf/test_usage.py
+++ b/tests/components/zeroconf/test_usage.py
@@ -15,11 +15,9 @@ from tests.common import extract_stack_to_frame
 DOMAIN = "zeroconf"
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf", "mock_zeroconf")
 async def test_multiple_zeroconf_instances(
-    hass: HomeAssistant,
-    mock_async_zeroconf: None,
-    mock_zeroconf: None,
-    caplog: pytest.LogCaptureFixture,
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test creating multiple zeroconf throws without an integration."""
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
@@ -34,11 +32,9 @@ async def test_multiple_zeroconf_instances(
     assert "Zeroconf" in caplog.text
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf", "mock_zeroconf")
 async def test_multiple_zeroconf_instances_gives_shared(
-    hass: HomeAssistant,
-    mock_async_zeroconf: None,
-    mock_zeroconf: None,
-    caplog: pytest.LogCaptureFixture,
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test creating multiple zeroconf gives the shared instance to an integration."""
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
