### PR TITLE
Move mock_async_zeroconf to decorator in zeroconf tests

### DIFF
--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -194,8 +194,9 @@ async def test_setup(hass: HomeAssistant, mock_async_zeroconf: MagicMock) -> Non
     assert await zeroconf.async_get_async_instance(hass) is mock_async_zeroconf
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_setup_with_overly_long_url_and_name(
-    hass: HomeAssistant, mock_async_zeroconf: None, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test we still setup with long urls and names."""
     with (
@@ -237,8 +238,9 @@ async def test_setup_with_overly_long_url_and_name(
     assert "German Umlaut" in caplog.text
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_setup_with_defaults(
-    hass: HomeAssistant, mock_zeroconf: MagicMock, mock_async_zeroconf: None
+    hass: HomeAssistant, mock_zeroconf: MagicMock
 ) -> None:
     """Test default interface config."""
     with (
@@ -258,9 +260,8 @@ async def test_setup_with_defaults(
     )
 
 
-async def test_zeroconf_match_macaddress(
-    hass: HomeAssistant, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_zeroconf_match_macaddress(hass: HomeAssistant) -> None:
     """Test configured options for a device are loaded via config entry."""
 
     def http_only_service_update_mock(zeroconf, services, handlers):
@@ -305,9 +306,8 @@ async def test_zeroconf_match_macaddress(
     assert mock_config_flow.mock_calls[0][2]["context"] == {"source": "zeroconf"}
 
 
-async def test_zeroconf_match_manufacturer(
-    hass: HomeAssistant, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_zeroconf_match_manufacturer(hass: HomeAssistant) -> None:
     """Test configured options for a device are loaded via config entry."""
 
     def http_only_service_update_mock(zeroconf, services, handlers):
@@ -347,9 +347,8 @@ async def test_zeroconf_match_manufacturer(
     assert mock_config_flow.mock_calls[0][1][0] == "samsungtv"
 
 
-async def test_zeroconf_match_model(
-    hass: HomeAssistant, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_zeroconf_match_model(hass: HomeAssistant) -> None:
     """Test matching a specific model in zeroconf."""
 
     def http_only_service_update_mock(zeroconf, services, handlers):
@@ -389,9 +388,8 @@ async def test_zeroconf_match_model(
     assert mock_config_flow.mock_calls[0][1][0] == "appletv"
 
 
-async def test_zeroconf_match_manufacturer_not_present(
-    hass: HomeAssistant, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_zeroconf_match_manufacturer_not_present(hass: HomeAssistant) -> None:
     """Test matchers reject when a property is missing."""
 
     def http_only_service_update_mock(zeroconf, services, handlers):
@@ -430,9 +428,8 @@ async def test_zeroconf_match_manufacturer_not_present(
     assert len(mock_config_flow.mock_calls) == 0
 
 
-async def test_zeroconf_no_match(
-    hass: HomeAssistant, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_zeroconf_no_match(hass: HomeAssistant) -> None:
     """Test configured options for a device are loaded via config entry."""
 
     def http_only_service_update_mock(zeroconf, services, handlers):
@@ -467,9 +464,8 @@ async def test_zeroconf_no_match(
     assert len(mock_config_flow.mock_calls) == 0
 
 
-async def test_zeroconf_no_match_manufacturer(
-    hass: HomeAssistant, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_zeroconf_no_match_manufacturer(hass: HomeAssistant) -> None:
     """Test configured options for a device are loaded via config entry."""
 
     def http_only_service_update_mock(zeroconf, services, handlers):
@@ -508,9 +504,8 @@ async def test_zeroconf_no_match_manufacturer(
     assert len(mock_config_flow.mock_calls) == 0
 
 
-async def test_homekit_match_partial_space(
-    hass: HomeAssistant, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_homekit_match_partial_space(hass: HomeAssistant) -> None:
     """Test configured options for a device are loaded via config entry."""
     with (
         patch.dict(
@@ -550,8 +545,9 @@ async def test_homekit_match_partial_space(
     }
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_device_with_invalid_name(
-    hass: HomeAssistant, mock_async_zeroconf: None, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test we ignore devices with an invalid name."""
     with (
@@ -587,9 +583,8 @@ async def test_device_with_invalid_name(
     assert "Bad name in zeroconf record" in caplog.text
 
 
-async def test_homekit_match_partial_dash(
-    hass: HomeAssistant, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_homekit_match_partial_dash(hass: HomeAssistant) -> None:
     """Test configured options for a device are loaded via config entry."""
     with (
         patch.dict(
@@ -626,9 +621,8 @@ async def test_homekit_match_partial_dash(
     assert mock_config_flow.mock_calls[0][1][0] == "lutron_caseta"
 
 
-async def test_homekit_match_partial_fnmatch(
-    hass: HomeAssistant, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_homekit_match_partial_fnmatch(hass: HomeAssistant) -> None:
     """Test matching homekit devices with fnmatch."""
     with (
         patch.dict(
@@ -663,9 +657,8 @@ async def test_homekit_match_partial_fnmatch(
     assert mock_config_flow.mock_calls[0][1][0] == "yeelight"
 
 
-async def test_homekit_match_full(
-    hass: HomeAssistant, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_homekit_match_full(hass: HomeAssistant) -> None:
     """Test configured options for a device are loaded via config entry."""
     with (
         patch.dict(
@@ -700,9 +693,8 @@ async def test_homekit_match_full(
     assert mock_config_flow.mock_calls[0][1][0] == "hue"
 
 
-async def test_homekit_already_paired(
-    hass: HomeAssistant, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_homekit_already_paired(hass: HomeAssistant) -> None:
     """Test that an already paired device is sent to homekit_controller."""
     with (
         patch.dict(
@@ -741,9 +733,8 @@ async def test_homekit_already_paired(
     assert mock_config_flow.mock_calls[1][1][0] == "homekit_controller"
 
 
-async def test_homekit_invalid_paring_status(
-    hass: HomeAssistant, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_homekit_invalid_paring_status(hass: HomeAssistant) -> None:
     """Test that missing paring data is not sent to homekit_controller."""
     with (
         patch.dict(
@@ -778,9 +769,8 @@ async def test_homekit_invalid_paring_status(
     assert mock_config_flow.mock_calls[0][1][0] == "lutron_caseta"
 
 
-async def test_homekit_not_paired(
-    hass: HomeAssistant, mock_async_zeroconf: None
-) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_homekit_not_paired(hass: HomeAssistant) -> None:
     """Test that an not paired device is sent to homekit_controller."""
     with (
         patch.dict(
@@ -808,8 +798,9 @@ async def test_homekit_not_paired(
     assert mock_config_flow.mock_calls[0][1][0] == "homekit_controller"
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_homekit_controller_still_discovered_unpaired_for_cloud(
-    hass: HomeAssistant, mock_async_zeroconf: None
+    hass: HomeAssistant,
 ) -> None:
     """Test discovery is still passed to homekit controller when unpaired.
 
@@ -852,8 +843,9 @@ async def test_homekit_controller_still_discovered_unpaired_for_cloud(
     assert mock_config_flow.mock_calls[1][1][0] == "homekit_controller"
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_homekit_controller_still_discovered_unpaired_for_polling(
-    hass: HomeAssistant, mock_async_zeroconf: None
+    hass: HomeAssistant,
 ) -> None:
     """Test discovery is still passed to homekit controller when unpaired.
 
@@ -1010,7 +1002,8 @@ async def test_get_instance(
     assert len(mock_async_zeroconf.ha_async_close.mock_calls) == 1
 
 
-async def test_removed_ignored(hass: HomeAssistant, mock_async_zeroconf: None) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_removed_ignored(hass: HomeAssistant) -> None:
     """Test we remove it when a zeroconf entry is removed."""
 
     def service_update_mock(zeroconf, services, handlers):
@@ -1062,8 +1055,9 @@ _ADAPTER_WITH_DEFAULT_ENABLED = [
 ]
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_async_detect_interfaces_setting_non_loopback_route(
-    hass: HomeAssistant, mock_async_zeroconf: None
+    hass: HomeAssistant,
 ) -> None:
     """Test without default interface and the route returns a non-loopback address."""
     with (
@@ -1148,8 +1142,9 @@ _ADAPTERS_WITH_MANUAL_CONFIG = [
 ]
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_async_detect_interfaces_setting_empty_route_linux(
-    hass: HomeAssistant, mock_async_zeroconf: None
+    hass: HomeAssistant,
 ) -> None:
     """Test without default interface config and the route returns nothing on linux."""
     with (
@@ -1181,8 +1176,9 @@ async def test_async_detect_interfaces_setting_empty_route_linux(
     )
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_async_detect_interfaces_setting_empty_route_freebsd(
-    hass: HomeAssistant, mock_async_zeroconf: None
+    hass: HomeAssistant,
 ) -> None:
     """Test without default interface and the route returns nothing on freebsd."""
     with (
@@ -1231,8 +1227,9 @@ _ADAPTER_WITH_DEFAULT_ENABLED_AND_IPV6 = [
 ]
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_async_detect_interfaces_explicitly_set_ipv6_linux(
-    hass: HomeAssistant, mock_async_zeroconf: None
+    hass: HomeAssistant,
 ) -> None:
     """Test interfaces are explicitly set when IPv6 is present on linux."""
     with (
@@ -1259,8 +1256,9 @@ async def test_async_detect_interfaces_explicitly_set_ipv6_linux(
     )
 
 
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_async_detect_interfaces_explicitly_set_ipv6_freebsd(
-    hass: HomeAssistant, mock_async_zeroconf: None
+    hass: HomeAssistant,
 ) -> None:
     """Test interfaces are explicitly set when IPv6 is present on freebsd."""
     with (
@@ -1336,7 +1334,8 @@ async def test_start_with_frontend(
     mock_async_zeroconf.async_register_service.assert_called_once()
 
 
-async def test_zeroconf_removed(hass: HomeAssistant, mock_async_zeroconf: None) -> None:
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_zeroconf_removed(hass: HomeAssistant) -> None:
     """Test we dismiss flows when a PTR record is removed."""
 
     def _device_removed_mock(zeroconf, services, handlers):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
