### PR TITLE
Fix incorrect type hints in azure_data_explorer tests

### DIFF
--- a/tests/components/azure_data_explorer/conftest.py
+++ b/tests/components/azure_data_explorer/conftest.py
@@ -3,7 +3,7 @@
 from datetime import timedelta
 import logging
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from typing_extensions import Generator
@@ -94,7 +94,7 @@ async def mock_entry_with_one_event(
 
 # Fixtures for config_flow tests
 @pytest.fixture
-def mock_setup_entry() -> Generator[MockConfigEntry]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock the setup entry call, used for config flow tests."""
     with patch(
         f"{AZURE_DATA_EXPLORER_PATH}.async_setup_entry", return_value=True
@@ -104,7 +104,7 @@ def mock_setup_entry() -> Generator[MockConfigEntry]:
 
 # Fixtures for mocking the Azure Data Explorer SDK calls.
 @pytest.fixture(autouse=True)
-def mock_managed_streaming() -> Generator[mock_entry_fixture_managed, Any, Any]:
+def mock_managed_streaming() -> Generator[MagicMock]:
     """mock_azure_data_explorer_ManagedStreamingIngestClient_ingest_data."""
     with patch(
         "azure.kusto.ingest.ManagedStreamingIngestClient.ingest_from_stream",
@@ -114,7 +114,7 @@ def mock_managed_streaming() -> Generator[mock_entry_fixture_managed, Any, Any]:
 
 
 @pytest.fixture(autouse=True)
-def mock_queued_ingest() -> Generator[mock_entry_fixture_queued, Any, Any]:
+def mock_queued_ingest() -> Generator[MagicMock]:
     """mock_azure_data_explorer_QueuedIngestClient_ingest_data."""
     with patch(
         "azure.kusto.ingest.QueuedIngestClient.ingest_from_stream",
@@ -124,7 +124,7 @@ def mock_queued_ingest() -> Generator[mock_entry_fixture_queued, Any, Any]:
 
 
 @pytest.fixture(autouse=True)
-def mock_execute_query() -> Generator[Mock, Any, Any]:
+def mock_execute_query() -> Generator[MagicMock]:
     """Mock KustoClient execute_query."""
     with patch(
         "azure.kusto.data.KustoClient.execute_query",

--- a/tests/components/azure_data_explorer/test_config_flow.py
+++ b/tests/components/azure_data_explorer/test_config_flow.py
@@ -1,5 +1,7 @@
 """Test the Azure Data Explorer config flow."""
 
+from unittest.mock import AsyncMock, MagicMock
+
 from azure.kusto.data.exceptions import KustoAuthenticationError, KustoServiceError
 import pytest
 
@@ -10,7 +12,7 @@ from homeassistant.core import HomeAssistant
 from .const import BASE_CONFIG
 
 
-async def test_config_flow(hass, mock_setup_entry) -> None:
+async def test_config_flow(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}, data=None
@@ -36,10 +38,10 @@ async def test_config_flow(hass, mock_setup_entry) -> None:
     ],
 )
 async def test_config_flow_errors(
-    test_input,
-    expected,
+    test_input: Exception,
+    expected: str,
     hass: HomeAssistant,
-    mock_execute_query,
+    mock_execute_query: MagicMock,
 ) -> None:
     """Test we handle connection KustoServiceError."""
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/azure_data_explorer/test_init.py
+++ b/tests/components/azure_data_explorer/test_init.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timedelta
 import logging
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from azure.kusto.data.exceptions import KustoAuthenticationError, KustoServiceError
 from azure.kusto.ingest import StreamDescriptor
@@ -28,11 +28,9 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @pytest.mark.freeze_time("2024-01-01 00:00:00")
+@pytest.mark.usefixtures("entry_managed")
 async def test_put_event_on_queue_with_managed_client(
-    hass: HomeAssistant,
-    entry_managed,
-    mock_managed_streaming: Mock,
-    caplog: pytest.LogCaptureFixture,
+    hass: HomeAssistant, mock_managed_streaming: Mock
 ) -> None:
     """Test listening to events from Hass. and writing to ADX with managed client."""
 
@@ -59,12 +57,12 @@ async def test_put_event_on_queue_with_managed_client(
     ],
     ids=["KustoServiceError", "KustoAuthenticationError"],
 )
+@pytest.mark.usefixtures("entry_managed")
 async def test_put_event_on_queue_with_managed_client_with_errors(
     hass: HomeAssistant,
-    entry_managed,
     mock_managed_streaming: Mock,
-    sideeffect,
-    log_message,
+    sideeffect: Exception,
+    log_message: str,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test listening to events from Hass. and writing to ADX with managed client."""
@@ -83,7 +81,7 @@ async def test_put_event_on_queue_with_managed_client_with_errors(
 
 async def test_put_event_on_queue_with_queueing_client(
     hass: HomeAssistant,
-    entry_queued,
+    entry_queued: MockConfigEntry,
     mock_queued_ingest: Mock,
 ) -> None:
     """Test listening to events from Hass. and writing to ADX with managed client."""
@@ -124,7 +122,7 @@ async def test_import(hass: HomeAssistant) -> None:
 
 async def test_unload_entry(
     hass: HomeAssistant,
-    entry_managed,
+    entry_managed: MockConfigEntry,
     mock_managed_streaming: Mock,
 ) -> None:
     """Test being able to unload an entry.
@@ -140,11 +138,8 @@ async def test_unload_entry(
 
 
 @pytest.mark.freeze_time("2024-01-01 00:00:00")
-async def test_late_event(
-    hass: HomeAssistant,
-    entry_with_one_event,
-    mock_managed_streaming: Mock,
-) -> None:
+@pytest.mark.usefixtures("entry_with_one_event")
+async def test_late_event(hass: HomeAssistant, mock_managed_streaming: Mock) -> None:
     """Test the check on late events."""
     with patch(
         f"{AZURE_DATA_EXPLORER_PATH}.utcnow",
@@ -225,8 +220,8 @@ async def test_late_event(
 )
 async def test_filter(
     hass: HomeAssistant,
-    entry_managed,
-    tests,
+    entry_managed: MockConfigEntry,
+    tests: list[FilterTest],
     mock_managed_streaming: Mock,
 ) -> None:
     """Test different filters.
@@ -254,9 +249,9 @@ async def test_filter(
 )
 async def test_event(
     hass: HomeAssistant,
-    entry_managed,
+    entry_managed: MockConfigEntry,
     mock_managed_streaming: Mock,
-    event,
+    event: str | None,
 ) -> None:
     """Test listening to events from Hass. and getting an event with a newline in the state."""
 
@@ -279,7 +274,9 @@ async def test_event(
     ],
     ids=["KustoServiceError", "KustoAuthenticationError", "Exception"],
 )
-async def test_connection(hass, mock_execute_query, sideeffect) -> None:
+async def test_connection(
+    hass: HomeAssistant, mock_execute_query: MagicMock, sideeffect: Exception
+) -> None:
     """Test Error when no getting proper connection with Exception."""
     entry = MockConfigEntry(
         domain=azure_data_explorer.DOMAIN,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
