### PR TITLE
Improve type hints in assist_pipeline tests

### DIFF
--- a/tests/components/assist_pipeline/conftest.py
+++ b/tests/components/assist_pipeline/conftest.py
@@ -154,7 +154,7 @@ class MockTTSPlatform(MockPlatform):
 
 
 @pytest.fixture
-async def mock_tts_provider(hass) -> MockTTSProvider:
+async def mock_tts_provider() -> MockTTSProvider:
     """Mock TTS provider."""
     return MockTTSProvider()
 
@@ -257,13 +257,13 @@ class MockWakeWordEntity2(wake_word.WakeWordDetectionEntity):
 
 
 @pytest.fixture
-async def mock_wake_word_provider_entity(hass) -> MockWakeWordEntity:
+async def mock_wake_word_provider_entity() -> MockWakeWordEntity:
     """Mock wake word provider."""
     return MockWakeWordEntity()
 
 
 @pytest.fixture
-async def mock_wake_word_provider_entity2(hass) -> MockWakeWordEntity2:
+async def mock_wake_word_provider_entity2() -> MockWakeWordEntity2:
     """Mock wake word provider."""
     return MockWakeWordEntity2()
 

--- a/tests/components/assist_pipeline/test_pipeline.py
+++ b/tests/components/assist_pipeline/test_pipeline.py
@@ -39,12 +39,13 @@ async def delay_save_fixture() -> AsyncGenerator[None]:
 
 
 @pytest.fixture(autouse=True)
-async def load_homeassistant(hass) -> None:
+async def load_homeassistant(hass: HomeAssistant) -> None:
     """Load the homeassistant integration."""
     assert await async_setup_component(hass, "homeassistant", {})
 
 
-async def test_load_pipelines(hass: HomeAssistant, init_components) -> None:
+@pytest.mark.usefixtures("init_components")
+async def test_load_pipelines(hass: HomeAssistant) -> None:
     """Make sure that we can load/save data correctly."""
 
     pipelines = [
@@ -247,9 +248,8 @@ async def test_migrate_pipeline_store(
     assert store.async_get_preferred_item() == "01GX8ZWBAQYWNB1XV3EXEZ75DY"
 
 
-async def test_create_default_pipeline(
-    hass: HomeAssistant, init_supporting_components
-) -> None:
+@pytest.mark.usefixtures("init_supporting_components")
+async def test_create_default_pipeline(hass: HomeAssistant) -> None:
     """Test async_create_default_pipeline."""
     assert await async_setup_component(hass, "assist_pipeline", {})
 
@@ -395,9 +395,9 @@ async def test_default_pipeline_no_stt_tts(
         ("pt", "br", "pt-br", "pt", "pt-br", "pt-br"),
     ],
 )
+@pytest.mark.usefixtures("init_supporting_components")
 async def test_default_pipeline(
     hass: HomeAssistant,
-    init_supporting_components,
     mock_stt_provider: MockSttProvider,
     mock_tts_provider: MockTTSProvider,
     ha_language: str,
@@ -439,10 +439,9 @@ async def test_default_pipeline(
     )
 
 
+@pytest.mark.usefixtures("init_supporting_components")
 async def test_default_pipeline_unsupported_stt_language(
-    hass: HomeAssistant,
-    init_supporting_components,
-    mock_stt_provider: MockSttProvider,
+    hass: HomeAssistant, mock_stt_provider: MockSttProvider
 ) -> None:
     """Test async_get_pipeline."""
     with patch.object(mock_stt_provider, "_supported_languages", ["smurfish"]):
@@ -470,10 +469,9 @@ async def test_default_pipeline_unsupported_stt_language(
     )
 
 
+@pytest.mark.usefixtures("init_supporting_components")
 async def test_default_pipeline_unsupported_tts_language(
-    hass: HomeAssistant,
-    init_supporting_components,
-    mock_tts_provider: MockTTSProvider,
+    hass: HomeAssistant, mock_tts_provider: MockTTSProvider
 ) -> None:
     """Test async_get_pipeline."""
     with patch.object(mock_tts_provider, "_supported_languages", ["smurfish"]):
@@ -502,8 +500,7 @@ async def test_default_pipeline_unsupported_tts_language(
 
 
 async def test_update_pipeline(
-    hass: HomeAssistant,
-    hass_storage: dict[str, Any],
+    hass: HomeAssistant, hass_storage: dict[str, Any]
 ) -> None:
     """Test async_update_pipeline."""
     assert await async_setup_component(hass, "assist_pipeline", {})
@@ -623,9 +620,8 @@ async def test_update_pipeline(
     }
 
 
-async def test_migrate_after_load(
-    hass: HomeAssistant, init_supporting_components
-) -> None:
+@pytest.mark.usefixtures("init_supporting_components")
+async def test_migrate_after_load(hass: HomeAssistant) -> None:
     """Test migrating an engine after done loading."""
     assert await async_setup_component(hass, "assist_pipeline", {})
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
