### PR TITLE
Improve type hints in arcam_fmj tests

### DIFF
--- a/tests/components/arcam_fmj/conftest.py
+++ b/tests/components/arcam_fmj/conftest.py
@@ -5,10 +5,12 @@ from unittest.mock import Mock, patch
 from arcam.fmj.client import Client
 from arcam.fmj.state import State
 import pytest
+from typing_extensions import AsyncGenerator
 
 from homeassistant.components.arcam_fmj.const import DEFAULT_NAME
 from homeassistant.components.arcam_fmj.media_player import ArcamFmj
 from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, MockEntityPlatform
@@ -27,7 +29,7 @@ MOCK_CONFIG_ENTRY = {CONF_HOST: MOCK_HOST, CONF_PORT: MOCK_PORT}
 
 
 @pytest.fixture(name="client")
-def client_fixture():
+def client_fixture() -> Mock:
     """Get a mocked client."""
     client = Mock(Client)
     client.host = MOCK_HOST
@@ -36,7 +38,7 @@ def client_fixture():
 
 
 @pytest.fixture(name="state_1")
-def state_1_fixture(client):
+def state_1_fixture(client: Mock) -> State:
     """Get a mocked state."""
     state = Mock(State)
     state.client = client
@@ -51,7 +53,7 @@ def state_1_fixture(client):
 
 
 @pytest.fixture(name="state_2")
-def state_2_fixture(client):
+def state_2_fixture(client: Mock) -> State:
     """Get a mocked state."""
     state = Mock(State)
     state.client = client
@@ -66,13 +68,13 @@ def state_2_fixture(client):
 
 
 @pytest.fixture(name="state")
-def state_fixture(state_1):
+def state_fixture(state_1: State) -> State:
     """Get a mocked state."""
     return state_1
 
 
 @pytest.fixture(name="player")
-def player_fixture(hass, state):
+def player_fixture(hass: HomeAssistant, state: State) -> ArcamFmj:
     """Get standard player."""
     player = ArcamFmj(MOCK_NAME, state, MOCK_UUID)
     player.entity_id = MOCK_ENTITY_ID
@@ -83,7 +85,9 @@ def player_fixture(hass, state):
 
 
 @pytest.fixture(name="player_setup")
-async def player_setup_fixture(hass, state_1, state_2, client):
+async def player_setup_fixture(
+    hass: HomeAssistant, state_1: State, state_2: State, client: Mock
+) -> AsyncGenerator[str]:
     """Get standard player."""
     config_entry = MockConfigEntry(
         domain="arcam_fmj", data=MOCK_CONFIG_ENTRY, title=MOCK_NAME


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA
```
************* Module tests.components.arcam_fmj.conftest
tests/components/arcam_fmj/conftest.py:75:19: W7431: Argument hass should be of type HomeAssistant in player_fixture (hass-argument-type)
tests/components/arcam_fmj/conftest.py:75:19: W7431: Argument hass should be of type HomeAssistant in player_fixture (hass-argument-type)
tests/components/arcam_fmj/conftest.py:86:31: W7431: Argument hass should be of type HomeAssistant in player_setup_fixture (hass-argument-type)
tests/components/arcam_fmj/conftest.py:86:31: W7431: Argument hass should be of type HomeAssistant in player_setup_fixture (hass-argument-type)
************* Module tests.components.arcam_fmj.test_config_flow
tests/components/arcam_fmj/test_config_flow.py:56:25: W7431: Argument hass should be of type HomeAssistant in dummy_client_fixture (hass-argument-type)
tests/components/arcam_fmj/test_config_flow.py:56:25: W7431: Argument hass should be of type HomeAssistant in dummy_client_fixture (hass-argument-type)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
