### PR TITLE
Improve type hints in airvisual test fixtures

### DIFF
--- a/tests/components/airvisual/conftest.py
+++ b/tests/components/airvisual/conftest.py
@@ -1,10 +1,10 @@
 """Define test fixtures for AirVisual."""
 
-import json
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from typing_extensions import Generator
+from typing_extensions import AsyncGenerator, Generator
 
 from homeassistant.components.airvisual import (
     CONF_CITY,
@@ -21,8 +21,10 @@ from homeassistant.const import (
     CONF_SHOW_ON_MAP,
     CONF_STATE,
 )
+from homeassistant.core import HomeAssistant
+from homeassistant.util.json import JsonObjectType
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, load_json_object_fixture
 
 TEST_API_KEY = "abcde12345"
 TEST_LATITUDE = 51.528308
@@ -55,7 +57,7 @@ NAME_CONFIG = {
 
 
 @pytest.fixture(name="cloud_api")
-def cloud_api_fixture(data_cloud):
+def cloud_api_fixture(data_cloud: JsonObjectType) -> Mock:
     """Define a mock CloudAPI object."""
     return Mock(
         air_quality=Mock(
@@ -66,7 +68,12 @@ def cloud_api_fixture(data_cloud):
 
 
 @pytest.fixture(name="config_entry")
-def config_entry_fixture(hass, config, config_entry_version, integration_type):
+def config_entry_fixture(
+    hass: HomeAssistant,
+    config: dict[str, Any],
+    config_entry_version: int,
+    integration_type: str,
+) -> MockConfigEntry:
     """Define a config entry fixture."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -81,37 +88,39 @@ def config_entry_fixture(hass, config, config_entry_version, integration_type):
 
 
 @pytest.fixture(name="config_entry_version")
-def config_entry_version_fixture():
+def config_entry_version_fixture() -> int:
     """Define a config entry version fixture."""
     return 2
 
 
 @pytest.fixture(name="config")
-def config_fixture():
+def config_fixture() -> dict[str, Any]:
     """Define a config entry data fixture."""
     return COORDS_CONFIG
 
 
 @pytest.fixture(name="data_cloud", scope="package")
-def data_cloud_fixture():
+def data_cloud_fixture() -> JsonObjectType:
     """Define an update coordinator data example."""
-    return json.loads(load_fixture("data.json", "airvisual"))
+    return load_json_object_fixture("data.json", "airvisual")
 
 
 @pytest.fixture(name="data_pro", scope="package")
-def data_pro_fixture():
+def data_pro_fixture() -> JsonObjectType:
     """Define an update coordinator data example for the Pro."""
-    return json.loads(load_fixture("data.json", "airvisual_pro"))
+    return load_json_object_fixture("data.json", "airvisual_pro")
 
 
 @pytest.fixture(name="integration_type")
-def integration_type_fixture():
+def integration_type_fixture() -> str:
     """Define an integration type."""
     return INTEGRATION_TYPE_GEOGRAPHY_COORDS
 
 
 @pytest.fixture(name="mock_pyairvisual")
-async def mock_pyairvisual_fixture(cloud_api, node_samba):
+async def mock_pyairvisual_fixture(
+    cloud_api: Mock, node_samba: Mock
+) -> AsyncGenerator[None]:
     """Define a fixture to patch pyairvisual."""
     with (
         patch(
@@ -135,7 +144,7 @@ async def mock_pyairvisual_fixture(cloud_api, node_samba):
 
 
 @pytest.fixture(name="node_samba")
-def node_samba_fixture(data_pro):
+def node_samba_fixture(data_pro: JsonObjectType) -> Mock:
     """Define a mock NodeSamba object."""
     return Mock(
         async_connect=AsyncMock(),
@@ -145,7 +154,9 @@ def node_samba_fixture(data_pro):
 
 
 @pytest.fixture(name="setup_config_entry")
-async def setup_config_entry_fixture(hass, config_entry, mock_pyairvisual):
+async def setup_config_entry_fixture(
+    hass: HomeAssistant, config_entry: MockConfigEntry, mock_pyairvisual: None
+) -> None:
     """Define a fixture to set up airvisual."""
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/airvisual_pro/conftest.py
+++ b/tests/components/airvisual_pro/conftest.py
@@ -1,16 +1,18 @@
 """Define test fixtures for AirVisual Pro."""
 
-import json
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from typing_extensions import Generator
+from typing_extensions import AsyncGenerator, Generator
 
 from homeassistant.components.airvisual_pro.const import DOMAIN
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+from homeassistant.util.json import JsonObjectType
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, load_json_object_fixture
 
 
 @pytest.fixture
@@ -23,7 +25,9 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 
 
 @pytest.fixture(name="config_entry")
-def config_entry_fixture(hass, config):
+def config_entry_fixture(
+    hass: HomeAssistant, config: dict[str, Any]
+) -> MockConfigEntry:
     """Define a config entry fixture."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -36,7 +40,7 @@ def config_entry_fixture(hass, config):
 
 
 @pytest.fixture(name="config")
-def config_fixture(hass):
+def config_fixture() -> dict[str, Any]:
     """Define a config entry data fixture."""
     return {
         CONF_IP_ADDRESS: "192.168.1.101",
@@ -45,25 +49,27 @@ def config_fixture(hass):
 
 
 @pytest.fixture(name="connect")
-def connect_fixture():
+def connect_fixture() -> AsyncMock:
     """Define a mocked async_connect method."""
     return AsyncMock(return_value=True)
 
 
 @pytest.fixture(name="disconnect")
-def disconnect_fixture():
+def disconnect_fixture() -> AsyncMock:
     """Define a mocked async_connect method."""
     return AsyncMock()
 
 
 @pytest.fixture(name="data", scope="package")
-def data_fixture():
+def data_fixture() -> JsonObjectType:
     """Define an update coordinator data example."""
-    return json.loads(load_fixture("data.json", "airvisual_pro"))
+    return load_json_object_fixture("data.json", "airvisual_pro")
 
 
 @pytest.fixture(name="pro")
-def pro_fixture(connect, data, disconnect):
+def pro_fixture(
+    connect: AsyncMock, data: JsonObjectType, disconnect: AsyncMock
+) -> Mock:
     """Define a mocked NodeSamba object."""
     return Mock(
         async_connect=connect,
@@ -73,7 +79,9 @@ def pro_fixture(connect, data, disconnect):
 
 
 @pytest.fixture(name="setup_airvisual_pro")
-async def setup_airvisual_pro_fixture(hass, config, pro):
+async def setup_airvisual_pro_fixture(
+    hass: HomeAssistant, config, pro
+) -> AsyncGenerator[None]:
     """Define a fixture to set up AirVisual Pro."""
     with (
         patch(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA
```
************* Module tests.components.airvisual.conftest
tests/components/airvisual/conftest.py:69:25: W7431: Argument hass should be of type HomeAssistant in config_entry_fixture (hass-argument-type)
tests/components/airvisual/conftest.py:69:25: W7431: Argument hass should be of type HomeAssistant in config_entry_fixture (hass-argument-type)
tests/components/airvisual/conftest.py:148:37: W7431: Argument hass should be of type HomeAssistant in setup_config_entry_fixture (hass-argument-type)
tests/components/airvisual/conftest.py:148:37: W7431: Argument hass should be of type HomeAssistant in setup_config_entry_fixture (hass-argument-type)
************* Module tests.components.airvisual_pro.conftest
tests/components/airvisual_pro/conftest.py:26:25: W7431: Argument hass should be of type HomeAssistant in config_entry_fixture (hass-argument-type)
tests/components/airvisual_pro/conftest.py:26:25: W7431: Argument hass should be of type HomeAssistant in config_entry_fixture (hass-argument-type)
tests/components/airvisual_pro/conftest.py:39:19: W7431: Argument hass should be of type HomeAssistant in config_fixture (hass-argument-type)
tests/components/airvisual_pro/conftest.py:39:19: W7431: Argument hass should be of type HomeAssistant in config_fixture (hass-argument-type)
tests/components/airvisual_pro/conftest.py:76:38: W7431: Argument hass should be of type HomeAssistant in setup_airvisual_pro_fixture (hass-argument-type)
tests/components/airvisual_pro/conftest.py:76:38: W7431: Argument hass should be of type HomeAssistant in setup_airvisual_pro_fixture (hass-argument-type)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
