### PR TITLE
Remove `async_late_forward_entry_setups` and instead implicitly hold the lock

### DIFF
--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -182,7 +182,7 @@ class AmbientStation:
             # already been done):
             if not self._entry_setup_complete:
                 self._hass.async_create_task(
-                    self._hass.config_entries.async_late_forward_entry_setups(
+                    self._hass.config_entries.async_forward_entry_setups(
                         self._entry, PLATFORMS
                     ),
                     eager_start=True,

--- a/homeassistant/components/cert_expiry/__init__.py
+++ b/homeassistant/components/cert_expiry/__init__.py
@@ -28,7 +28,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: CertExpiryConfigEntry) -
 
     async def _async_finish_startup(_: HomeAssistant) -> None:
         await coordinator.async_refresh()
-        await hass.config_entries.async_late_forward_entry_setups(entry, PLATFORMS)
+        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     async_at_started(hass, _async_finish_startup)
     return True

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -248,16 +248,10 @@ class RuntimeEntryData:
         hass: HomeAssistant,
         entry: ConfigEntry,
         platforms: set[Platform],
-        late: bool,
     ) -> None:
         async with self.platform_load_lock:
             if needed := platforms - self.loaded_platforms:
-                if late:
-                    await hass.config_entries.async_late_forward_entry_setups(
-                        entry, needed
-                    )
-                else:
-                    await hass.config_entries.async_forward_entry_setups(entry, needed)
+                await hass.config_entries.async_forward_entry_setups(entry, needed)
             self.loaded_platforms |= needed
 
     async def async_update_static_infos(
@@ -266,7 +260,6 @@ class RuntimeEntryData:
         entry: ConfigEntry,
         infos: list[EntityInfo],
         mac: str,
-        late: bool = False,
     ) -> None:
         """Distribute an update of static infos to all platforms."""
         # First, load all platforms
@@ -296,7 +289,7 @@ class RuntimeEntryData:
             ):
                 ent_reg.async_update_entity(old_entry, new_unique_id=new_unique_id)
 
-        await self._ensure_platforms_loaded(hass, entry, needed_platforms, late)
+        await self._ensure_platforms_loaded(hass, entry, needed_platforms)
 
         # Make a dict of the EntityInfo by type and send
         # them to the listeners for each specific EntityInfo type

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -491,7 +491,7 @@ class ESPHomeManager:
 
         entry_data.async_update_device_state()
         await entry_data.async_update_static_infos(
-            hass, entry, entity_infos, device_info.mac_address, late=True
+            hass, entry, entity_infos, device_info.mac_address
         )
         _setup_services(hass, entry_data, services)
 

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -379,9 +379,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         new_config: list[ConfigType] = config_yaml.get(DOMAIN, [])
         platforms_used = platforms_from_config(new_config)
         new_platforms = platforms_used - mqtt_data.platforms_loaded
-        await async_forward_entry_setup_and_setup_discovery(
-            hass, entry, new_platforms, late=True
-        )
+        await async_forward_entry_setup_and_setup_discovery(hass, entry, new_platforms)
         # Check the schema before continuing reload
         await async_check_config_schema(hass, config_yaml)
 

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -211,7 +211,7 @@ async def async_start(  # noqa: C901
         async with platform_setup_lock.setdefault(component, asyncio.Lock()):
             if component not in mqtt_data.platforms_loaded:
                 await async_forward_entry_setup_and_setup_discovery(
-                    hass, config_entry, {component}, late=True
+                    hass, config_entry, {component}
                 )
         _async_add_component(discovery_payload)
 

--- a/homeassistant/components/mqtt/util.py
+++ b/homeassistant/components/mqtt/util.py
@@ -72,11 +72,13 @@ async def async_forward_entry_setup_and_setup_discovery(
 
         tasks.append(create_eager_task(tag.async_setup_entry(hass, config_entry)))
     if new_entity_platforms := (new_platforms - {"tag", "device_automation"}):
-        if late:
-            coro = hass.config_entries.async_forward_entry_setups
-        else:
-            coro = hass.config_entries.async_forward_entry_setups
-        tasks.append(create_eager_task(coro(config_entry, new_entity_platforms)))
+        tasks.append(
+            create_eager_task(
+                hass.config_entries.async_forward_entry_setups(
+                    config_entry, new_entity_platforms
+                )
+            )
+        )
     if not tasks:
         return
     await asyncio.gather(*tasks)

--- a/homeassistant/components/mqtt/util.py
+++ b/homeassistant/components/mqtt/util.py
@@ -73,7 +73,7 @@ async def async_forward_entry_setup_and_setup_discovery(
         tasks.append(create_eager_task(tag.async_setup_entry(hass, config_entry)))
     if new_entity_platforms := (new_platforms - {"tag", "device_automation"}):
         if late:
-            coro = hass.config_entries.async_late_forward_entry_setups
+            coro = hass.config_entries.async_forward_entry_setups
         else:
             coro = hass.config_entries.async_forward_entry_setups
         tasks.append(create_eager_task(coro(config_entry, new_entity_platforms)))

--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -200,9 +200,7 @@ class ShellyCoordinatorBase[_DeviceT: BlockDevice | RpcDevice](
             self.hass.config_entries.async_update_entry(self.entry, data=data)
 
         # Resume platform setup
-        await self.hass.config_entries.async_late_forward_entry_setups(
-            self.entry, platforms
-        )
+        await self.hass.config_entries.async_forward_entry_setups(self.entry, platforms)
 
         return True
 

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -324,7 +324,7 @@ class DriverEvents:
         """Set up platform if needed."""
         if platform not in self.platform_setup_tasks:
             self.platform_setup_tasks[platform] = self.hass.async_create_task(
-                self.hass.config_entries.async_late_forward_entry_setups(
+                self.hass.config_entries.async_forward_entry_setups(
                     self.config_entry, [platform]
                 )
             )

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1175,7 +1175,7 @@ def _report_non_awaited_platform_forwards(entry: ConfigEntry, what: str) -> None
     report(
         f"calls {what} for integration {entry.domain} with "
         f"title: {entry.title} and entry_id: {entry.entry_id}, "
-        f"during without awaiting {what}, which can cause "
+        f"during setup without awaiting {what}, which can cause "
         "the setup lock to be released before the setup is done. "
         "This will stop working in Home Assistant 2025.1",
         error_if_integration=False,

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1170,24 +1170,6 @@ class FlowCancelledError(Exception):
     """Error to indicate that a flow has been cancelled."""
 
 
-def _report_non_locked_platform_forwards(entry: ConfigEntry) -> None:
-    """Report non awaited and non-locked platform forwards."""
-    report(
-        f"calls async_forward_entry_setup after the entry for "
-        f"integration, {entry.domain} with title: {entry.title} "
-        f"and entry_id: {entry.entry_id}, has been set up, "
-        "without holding the setup lock that prevents the config "
-        "entry from being set up multiple times. "
-        "Instead await hass.config_entries.async_forward_entry_setup "
-        "during setup of the config entry or call "
-        "hass.config_entries.async_late_forward_entry_setups "
-        "in a tracked task. "
-        "This will stop working in Home Assistant 2025.1",
-        error_if_integration=False,
-        error_if_core=False,
-    )
-
-
 class ConfigEntriesFlowManager(data_entry_flow.FlowManager[ConfigFlowResult]):
     """Manage all the config entry flows that are in progress."""
 
@@ -2041,9 +2023,6 @@ class ConfigEntries:
         before the entry is set up. This ensures that the config entry cannot
         be unloaded before all platforms are loaded.
 
-        If platforms must be loaded late (after the config entry is setup),
-        use async_late_forward_entry_setup instead.
-
         This method is more efficient than async_forward_entry_setup as
         it can load multiple platforms at once and does not require a separate
         import executor job for each platform.
@@ -2052,14 +2031,26 @@ class ConfigEntries:
         if not integration.platforms_are_loaded(platforms):
             with async_pause_setup(self.hass, SetupPhases.WAIT_IMPORT_PLATFORMS):
                 await integration.async_get_platforms(platforms)
-        if non_locked_platform_forwards := not entry.setup_lock.locked():
-            _report_non_locked_platform_forwards(entry)
+
+        if not entry.setup_lock.locked():
+            async with entry.setup_lock:
+                if entry.state is not ConfigEntryState.LOADED:
+                    raise OperationNotAllowed(
+                        f"The config entry {entry.title} ({entry.domain}) with entry_id"
+                        f" {entry.entry_id} cannot forward setup for {platforms} because it"
+                        f" is not loaded in the {entry.state} state"
+                    )
+                await self._async_forward_entry_setups_locked(entry, platforms)
+        else:
+            await self._async_forward_entry_setups_locked(entry, platforms)
+
+    async def _async_forward_entry_setups_locked(
+        self, entry: ConfigEntry, platforms: Iterable[Platform | str]
+    ) -> None:
         await asyncio.gather(
             *(
                 create_eager_task(
-                    self._async_forward_entry_setup(
-                        entry, platform, False, non_locked_platform_forwards
-                    ),
+                    self._async_forward_entry_setup(entry, platform, False),
                     name=(
                         f"config entry forward setup {entry.title} "
                         f"{entry.domain} {entry.entry_id} {platform}"
@@ -2069,25 +2060,6 @@ class ConfigEntries:
                 for platform in platforms
             )
         )
-
-    async def async_late_forward_entry_setups(
-        self, entry: ConfigEntry, platforms: Iterable[Platform | str]
-    ) -> None:
-        """Forward the setup of an entry to platforms after setup.
-
-        If platforms must be loaded late (after the config entry is setup),
-        use this method instead of async_forward_entry_setups as it holds
-        the setup lock until the platforms are loaded to ensure that the
-        config entry cannot be unloaded while platforms are loaded.
-        """
-        async with entry.setup_lock:
-            if entry.state is not ConfigEntryState.LOADED:
-                raise OperationNotAllowed(
-                    f"The config entry {entry.title} ({entry.domain}) with entry_id"
-                    f" {entry.entry_id} cannot forward setup for {platforms} "
-                    f"because it is not loaded in the {entry.state} state"
-                )
-            await self.async_forward_entry_setups(entry, platforms)
 
     async def async_forward_entry_setup(
         self, entry: ConfigEntry, domain: Platform | str
@@ -2103,32 +2075,32 @@ class ConfigEntries:
         Instead, await async_forward_entry_setups as it can load
         multiple platforms at once and is more efficient since it
         does not require a separate import executor job for each platform.
-
-        If platforms must be loaded late (after the config entry is setup),
-        use async_late_forward_entry_setup instead.
         """
-        if non_locked_platform_forwards := not entry.setup_lock.locked():
-            _report_non_locked_platform_forwards(entry)
-        else:
-            report(
-                "calls async_forward_entry_setup for "
-                f"integration, {entry.domain} with title: {entry.title} "
-                f"and entry_id: {entry.entry_id}, which is deprecated and "
-                "will stop working in Home Assistant 2025.6, "
-                "await async_forward_entry_setups instead",
-                error_if_core=False,
-                error_if_integration=False,
-            )
-        return await self._async_forward_entry_setup(
-            entry, domain, True, non_locked_platform_forwards
+        report(
+            "calls async_forward_entry_setup for "
+            f"integration, {entry.domain} with title: {entry.title} "
+            f"and entry_id: {entry.entry_id}, which is deprecated and "
+            "will stop working in Home Assistant 2025.6, "
+            "await async_forward_entry_setups instead",
+            error_if_core=False,
+            error_if_integration=False,
         )
+        if not entry.setup_lock.locked():
+            async with entry.setup_lock:
+                if entry.state is not ConfigEntryState.LOADED:
+                    raise OperationNotAllowed(
+                        f"The config entry {entry.title} ({entry.domain}) with entry_id"
+                        f" {entry.entry_id} cannot forward setup for {domain} because it"
+                        f" is not loaded in the {entry.state} state"
+                    )
+                return await self._async_forward_entry_setup(entry, domain, True)
+        return await self._async_forward_entry_setup(entry, domain, True)
 
     async def _async_forward_entry_setup(
         self,
         entry: ConfigEntry,
         domain: Platform | str,
         preload_platform: bool,
-        non_locked_platform_forwards: bool,
     ) -> bool:
         """Forward the setup of an entry to a different component."""
         # Setup Component if not set up yet
@@ -2152,12 +2124,6 @@ class ConfigEntries:
 
         integration = loader.async_get_loaded_integration(self.hass, domain)
         await entry.async_setup(self.hass, integration=integration)
-
-        # Check again after setup to make sure the lock
-        # is still there because it could have been released
-        # unless we already reported it.
-        if not non_locked_platform_forwards and not entry.setup_lock.locked():
-            _report_non_locked_platform_forwards(entry)
         return True
 
     async def async_unload_platforms(
@@ -2221,7 +2187,7 @@ class ConfigEntries:
         # The component was not loaded.
         if entry.domain not in self.hass.config.components:
             return False
-        return entry.state == ConfigEntryState.LOADED
+        return entry.state is ConfigEntryState.LOADED
 
 
 @callback

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1173,9 +1173,8 @@ class FlowCancelledError(Exception):
 def _report_non_awaited_platform_forwards(entry: ConfigEntry, what: str) -> None:
     """Report non awaited platform forwards."""
     report(
-        f"calls {what} for "
-        f"integration, {entry.domain} with title: {entry.title} "
-        f"and entry_id: {entry.entry_id}, "
+        f"calls {what} for integration {entry.domain} with "
+        f"title: {entry.title} and entry_id: {entry.entry_id}, "
         f"during without awaiting {what}, which can cause "
         "the setup lock to be released before the setup is done. "
         "This will stop working in Home Assistant 2025.1",

--- a/tests/components/assist_pipeline/test_select.py
+++ b/tests/components/assist_pipeline/test_select.py
@@ -53,7 +53,7 @@ async def init_select(hass: HomeAssistant, init_components) -> ConfigEntry:
         domain="assist_pipeline", state=ConfigEntryState.LOADED
     )
     config_entry.add_to_hass(hass)
-    await hass.config_entries.async_late_forward_entry_setups(config_entry, ["select"])
+    await hass.config_entries.async_forward_entry_setups(config_entry, ["select"])
     return config_entry
 
 
@@ -161,7 +161,7 @@ async def test_select_entity_changing_pipelines(
 
     # Reload config entry to test selected option persists
     assert await hass.config_entries.async_forward_entry_unload(config_entry, "select")
-    await hass.config_entries.async_late_forward_entry_setups(config_entry, ["select"])
+    await hass.config_entries.async_forward_entry_setups(config_entry, ["select"])
 
     state = hass.states.get("select.assist_pipeline_test_prefix_pipeline")
     assert state is not None
@@ -209,7 +209,7 @@ async def test_select_entity_changing_vad_sensitivity(
 
     # Reload config entry to test selected option persists
     assert await hass.config_entries.async_forward_entry_unload(config_entry, "select")
-    await hass.config_entries.async_late_forward_entry_setups(config_entry, ["select"])
+    await hass.config_entries.async_forward_entry_setups(config_entry, ["select"])
 
     state = hass.states.get("select.assist_pipeline_test_vad_sensitivity")
     assert state is not None

--- a/tests/components/hue/conftest.py
+++ b/tests/components/hue/conftest.py
@@ -277,7 +277,7 @@ async def setup_platform(
     await hass.async_block_till_done()
 
     config_entry.mock_state(hass, ConfigEntryState.LOADED)
-    await hass.config_entries.async_late_forward_entry_setups(config_entry, platforms)
+    await hass.config_entries.async_forward_entry_setups(config_entry, platforms)
 
     # and make sure it completes before going further
     await hass.async_block_till_done()

--- a/tests/components/hue/test_light_v1.py
+++ b/tests/components/hue/test_light_v1.py
@@ -186,7 +186,7 @@ async def setup_bridge(hass: HomeAssistant, mock_bridge_v1):
     config_entry.mock_state(hass, ConfigEntryState.LOADED)
     mock_bridge_v1.config_entry = config_entry
     hass.data[hue.DOMAIN] = {config_entry.entry_id: mock_bridge_v1}
-    await hass.config_entries.async_late_forward_entry_setups(config_entry, ["light"])
+    await hass.config_entries.async_forward_entry_setups(config_entry, ["light"])
     # To flush out the service call to update the group
     await hass.async_block_till_done()
 

--- a/tests/components/hue/test_sensor_v2.py
+++ b/tests/components/hue/test_sensor_v2.py
@@ -75,7 +75,7 @@ async def test_enable_sensor(
 
     assert await async_setup_component(hass, hue.DOMAIN, {}) is True
     await hass.async_block_till_done()
-    await hass.config_entries.async_late_forward_entry_setups(
+    await hass.config_entries.async_forward_entry_setups(
         mock_config_entry_v2, ["sensor"]
     )
 
@@ -95,7 +95,7 @@ async def test_enable_sensor(
 
     # reload platform and check if entity is correctly there
     await hass.config_entries.async_forward_entry_unload(mock_config_entry_v2, "sensor")
-    await hass.config_entries.async_late_forward_entry_setups(
+    await hass.config_entries.async_forward_entry_setups(
         mock_config_entry_v2, ["sensor"]
     )
     await hass.async_block_till_done()

--- a/tests/components/mobile_app/test_device_tracker.py
+++ b/tests/components/mobile_app/test_device_tracker.py
@@ -104,7 +104,7 @@ async def test_restoring_location(
 
     # mobile app doesn't support unloading, so we just reload device tracker
     await hass.config_entries.async_forward_entry_unload(config_entry, "device_tracker")
-    await hass.config_entries.async_late_forward_entry_setups(
+    await hass.config_entries.async_forward_entry_setups(
         config_entry, ["device_tracker"]
     )
     await hass.async_block_till_done()

--- a/tests/components/smartthings/conftest.py
+++ b/tests/components/smartthings/conftest.py
@@ -71,7 +71,7 @@ async def setup_platform(hass, platform: str, *, devices=None, scenes=None):
 
     hass.data[DOMAIN] = {DATA_BROKERS: {config_entry.entry_id: broker}}
     config_entry.mock_state(hass, ConfigEntryState.LOADED)
-    await hass.config_entries.async_late_forward_entry_setups(config_entry, [platform])
+    await hass.config_entries.async_forward_entry_setups(config_entry, [platform])
     await hass.async_block_till_done()
     return config_entry
 

--- a/tests/ignore_uncaught_exceptions.py
+++ b/tests/ignore_uncaught_exceptions.py
@@ -17,6 +17,12 @@ IGNORE_UNCAUGHT_EXCEPTIONS = [
         # This test explicitly throws an uncaught exception
         # and should not be removed.
         "tests.test_config_entries",
+        "test_config_entry_unloaded_during_platform_setups",
+    ),
+    (
+        # This test explicitly throws an uncaught exception
+        # and should not be removed.
+        "tests.test_config_entries",
         "test_config_entry_unloaded_during_platform_setup",
     ),
     (

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -5664,7 +5664,7 @@ async def test_non_awaited_async_forward_entry_setups(
 
     assert (
         "Detected code that calls async_forward_entry_setups for integration "
-        "test with title: Mock Title and entry_id: test2, during without "
+        "test with title: Mock Title and entry_id: test2, during setup without "
         "awaiting async_forward_entry_setups, which can cause the setup lock "
         "to be released before the setup is done. This will stop working in "
         "Home Assistant 2025.1. Please report this issue."
@@ -5730,7 +5730,7 @@ async def test_non_awaited_async_forward_entry_setup(
 
     assert (
         "Detected code that calls async_forward_entry_setup for integration "
-        "test with title: Mock Title and entry_id: test2, during without "
+        "test with title: Mock Title and entry_id: test2, during setup without "
         "awaiting async_forward_entry_setup, which can cause the setup lock "
         "to be released before the setup is done. This will stop working in "
         "Home Assistant 2025.1. Please report this issue."

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -5677,3 +5677,76 @@ async def test_config_entry_unloaded_during_platform_setup(
         "entry_id test2 cannot forward setup for light because it is "
         "not loaded in the ConfigEntryState.NOT_LOADED state"
     ) in caplog.text
+
+
+async def test_config_entry_late_platform_setup(
+    hass: HomeAssistant,
+    manager: config_entries.ConfigEntries,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test async_forward_entry_setup not being awaited."""
+    task = None
+
+    async def mock_setup_entry(
+        hass: HomeAssistant, entry: config_entries.ConfigEntry
+    ) -> bool:
+        """Mock setting up entry."""
+
+        # Call async_forward_entry_setup in a non-tracked task
+        # so we can unload the config entry during the setup
+        def _late_setup():
+            nonlocal task
+            task = asyncio.create_task(
+                hass.config_entries.async_forward_entry_setup(entry, "light")
+            )
+
+        hass.loop.call_soon(_late_setup)
+        return True
+
+    async def mock_unload_entry(
+        hass: HomeAssistant, entry: config_entries.ConfigEntry
+    ) -> bool:
+        """Mock unloading an entry."""
+        result = await hass.config_entries.async_unload_platforms(entry, ["light"])
+        assert result
+        return result
+
+    mock_remove_entry = AsyncMock(return_value=None)
+
+    async def mock_setup_entry_platform(
+        hass: HomeAssistant,
+        entry: config_entries.ConfigEntry,
+        async_add_entities: AddEntitiesCallback,
+    ) -> None:
+        """Mock setting up platform."""
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    mock_integration(
+        hass,
+        MockModule(
+            "test",
+            async_setup_entry=mock_setup_entry,
+            async_unload_entry=mock_unload_entry,
+            async_remove_entry=mock_remove_entry,
+        ),
+    )
+    mock_platform(
+        hass, "test.light", MockPlatform(async_setup_entry=mock_setup_entry_platform)
+    )
+    mock_platform(hass, "test.config_flow", None)
+
+    entry = MockConfigEntry(domain="test", entry_id="test2")
+    entry.add_to_manager(manager)
+
+    # Setup entry
+    await manager.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    await task
+    await hass.async_block_till_done()
+
+    assert (
+        "OperationNotAllowed: The config entry Mock Title (test) with "
+        "entry_id test2 cannot forward setup for light because it is "
+        "not loaded in the ConfigEntryState.NOT_LOADED state"
+    ) not in caplog.text

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -5605,6 +5605,138 @@ async def test_config_entry_unloaded_during_platform_setups(
     ) in caplog.text
 
 
+async def test_non_awaited_async_forward_entry_setups(
+    hass: HomeAssistant,
+    manager: config_entries.ConfigEntries,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test async_forward_entry_setups not being awaited."""
+
+    async def mock_setup_entry(
+        hass: HomeAssistant, entry: config_entries.ConfigEntry
+    ) -> bool:
+        """Mock setting up entry."""
+        # Call async_forward_entry_setups without awaiting it
+        # This is not allowed and will raise a warning
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setups(entry, ["light"])
+        )
+        return True
+
+    async def mock_unload_entry(
+        hass: HomeAssistant, entry: config_entries.ConfigEntry
+    ) -> bool:
+        """Mock unloading an entry."""
+        result = await hass.config_entries.async_unload_platforms(entry, ["light"])
+        assert result
+        return result
+
+    mock_remove_entry = AsyncMock(return_value=None)
+
+    async def mock_setup_entry_platform(
+        hass: HomeAssistant,
+        entry: config_entries.ConfigEntry,
+        async_add_entities: AddEntitiesCallback,
+    ) -> None:
+        """Mock setting up platform."""
+        await asyncio.sleep(0)
+
+    mock_integration(
+        hass,
+        MockModule(
+            "test",
+            async_setup_entry=mock_setup_entry,
+            async_unload_entry=mock_unload_entry,
+            async_remove_entry=mock_remove_entry,
+        ),
+    )
+    mock_platform(
+        hass, "test.light", MockPlatform(async_setup_entry=mock_setup_entry_platform)
+    )
+    mock_platform(hass, "test.config_flow", None)
+
+    entry = MockConfigEntry(domain="test", entry_id="test2")
+    entry.add_to_manager(manager)
+
+    # Setup entry
+    await manager.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        "Detected code that calls async_forward_entry_setups for integration, "
+        "test with title: Mock Title and entry_id: test2, during without "
+        "awaiting async_forward_entry_setups, which can cause the setup lock "
+        "to be released before the setup is done. This will stop working in "
+        "Home Assistant 2025.1. Please report this issue."
+    ) in caplog.text
+
+
+async def test_non_awaited_async_forward_entry_setup(
+    hass: HomeAssistant,
+    manager: config_entries.ConfigEntries,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test async_forward_entry_setup not being awaited."""
+
+    async def mock_setup_entry(
+        hass: HomeAssistant, entry: config_entries.ConfigEntry
+    ) -> bool:
+        """Mock setting up entry."""
+        # Call async_forward_entry_setups without awaiting it
+        # This is not allowed and will raise a warning
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, "light")
+        )
+        return True
+
+    async def mock_unload_entry(
+        hass: HomeAssistant, entry: config_entries.ConfigEntry
+    ) -> bool:
+        """Mock unloading an entry."""
+        result = await hass.config_entries.async_unload_platforms(entry, ["light"])
+        assert result
+        return result
+
+    mock_remove_entry = AsyncMock(return_value=None)
+
+    async def mock_setup_entry_platform(
+        hass: HomeAssistant,
+        entry: config_entries.ConfigEntry,
+        async_add_entities: AddEntitiesCallback,
+    ) -> None:
+        """Mock setting up platform."""
+        await asyncio.sleep(0)
+
+    mock_integration(
+        hass,
+        MockModule(
+            "test",
+            async_setup_entry=mock_setup_entry,
+            async_unload_entry=mock_unload_entry,
+            async_remove_entry=mock_remove_entry,
+        ),
+    )
+    mock_platform(
+        hass, "test.light", MockPlatform(async_setup_entry=mock_setup_entry_platform)
+    )
+    mock_platform(hass, "test.config_flow", None)
+
+    entry = MockConfigEntry(domain="test", entry_id="test2")
+    entry.add_to_manager(manager)
+
+    # Setup entry
+    await manager.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        "Detected code that calls async_forward_entry_setup for integration, "
+        "test with title: Mock Title and entry_id: test2, during without "
+        "awaiting async_forward_entry_setup, which can cause the setup lock "
+        "to be released before the setup is done. This will stop working in "
+        "Home Assistant 2025.1. Please report this issue."
+    ) in caplog.text
+
+
 async def test_config_entry_unloaded_during_platform_setup(
     hass: HomeAssistant,
     manager: config_entries.ConfigEntries,

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -5663,7 +5663,7 @@ async def test_non_awaited_async_forward_entry_setups(
     await hass.async_block_till_done()
 
     assert (
-        "Detected code that calls async_forward_entry_setups for integration, "
+        "Detected code that calls async_forward_entry_setups for integration "
         "test with title: Mock Title and entry_id: test2, during without "
         "awaiting async_forward_entry_setups, which can cause the setup lock "
         "to be released before the setup is done. This will stop working in "
@@ -5729,7 +5729,7 @@ async def test_non_awaited_async_forward_entry_setup(
     await hass.async_block_till_done()
 
     assert (
-        "Detected code that calls async_forward_entry_setup for integration, "
+        "Detected code that calls async_forward_entry_setup for integration "
         "test with title: Mock Title and entry_id: test2, during without "
         "awaiting async_forward_entry_setup, which can cause the setup lock "
         "to be released before the setup is done. This will stop working in "


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Removes `async_late_forward_entry_setups` and instead implicitly holds the lock if it was not obtained. @emontnemery came up with a suggestion to keep the check for [non-awaited platform forwards](https://developers.home-assistant.io/blog/2022/07/08/config_entry_forwards/) working while not needing `async_late_forward_entry_setups`

This change continues ensures that integrations cannot be unloaded while their platforms are being setup without the need to switch to `async_late_forward_entry_setups`.

blog post https://github.com/home-assistant/developers.home-assistant/pull/2203 has been adjusted to reflect this change as well


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
