### PR TITLE
Fix failing UniFi tests related to utcnow

### DIFF
--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -726,6 +726,7 @@ async def test_option_track_devices(
     ],
 )
 @pytest.mark.usefixtures("mock_device_registry")
+@pytest.mark.freeze_time(dt_util.utcnow())
 async def test_option_ssid_filter(
     hass: HomeAssistant,
     mock_unifi_websocket,
@@ -831,32 +832,29 @@ async def test_option_ssid_filter(
     assert hass.states.get("device_tracker.client_on_ssid2").state == STATE_NOT_HOME
 
 
-@pytest.mark.parametrize(
-    "client_payload",
-    [
-        [
-            {
-                "essid": "ssid",
-                "hostname": "client",
-                "ip": "10.0.0.1",
-                "is_wired": False,
-                "last_seen": dt_util.as_timestamp(dt_util.utcnow()),
-                "mac": "00:00:00:00:00:01",
-            }
-        ]
-    ],
-)
 @pytest.mark.usefixtures("mock_device_registry")
 async def test_wireless_client_go_wired_issue(
     hass: HomeAssistant,
     mock_unifi_websocket,
-    config_entry_setup: ConfigEntry,
+    config_entry_factory: Callable[[], ConfigEntry],
     client_payload: list[dict[str, Any]],
 ) -> None:
     """Test the solution to catch wireless device go wired UniFi issue.
 
     UniFi Network has a known issue that when a wireless device goes away it sometimes gets marked as wired.
     """
+    client_payload.append(
+        {
+            "essid": "ssid",
+            "hostname": "client",
+            "ip": "10.0.0.1",
+            "is_wired": False,
+            "last_seen": dt_util.as_timestamp(dt_util.utcnow()),
+            "mac": "00:00:00:00:00:01",
+        }
+    )
+    config_entry = await config_entry_factory()
+
     assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 1
 
     # Client is wireless
@@ -876,9 +874,7 @@ async def test_wireless_client_go_wired_issue(
 
     # Pass time
     new_time = dt_util.utcnow() + timedelta(
-        seconds=(
-            config_entry_setup.options.get(CONF_DETECTION_TIME, DEFAULT_DETECTION_TIME)
-        )
+        seconds=(config_entry.options.get(CONF_DETECTION_TIME, DEFAULT_DETECTION_TIME))
     )
     with freeze_time(new_time):
         async_fire_time_changed(hass, new_time)
@@ -909,30 +905,27 @@ async def test_wireless_client_go_wired_issue(
 
 
 @pytest.mark.parametrize("config_entry_options", [{CONF_IGNORE_WIRED_BUG: True}])
-@pytest.mark.parametrize(
-    "client_payload",
-    [
-        [
-            {
-                "ap_mac": "00:00:00:00:02:01",
-                "essid": "ssid",
-                "hostname": "client",
-                "ip": "10.0.0.1",
-                "is_wired": False,
-                "last_seen": dt_util.as_timestamp(dt_util.utcnow()),
-                "mac": "00:00:00:00:00:01",
-            }
-        ]
-    ],
-)
 @pytest.mark.usefixtures("mock_device_registry")
 async def test_option_ignore_wired_bug(
     hass: HomeAssistant,
     mock_unifi_websocket,
-    config_entry_setup: ConfigEntry,
+    config_entry_factory: Callable[[], ConfigEntry],
     client_payload: list[dict[str, Any]],
 ) -> None:
     """Test option to ignore wired bug."""
+    client_payload.append(
+        {
+            "ap_mac": "00:00:00:00:02:01",
+            "essid": "ssid",
+            "hostname": "client",
+            "ip": "10.0.0.1",
+            "is_wired": False,
+            "last_seen": dt_util.as_timestamp(dt_util.utcnow()),
+            "mac": "00:00:00:00:00:01",
+        }
+    )
+    config_entry = await config_entry_factory()
+
     assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 1
 
     # Client is wireless
@@ -951,9 +944,7 @@ async def test_option_ignore_wired_bug(
 
     # pass time
     new_time = dt_util.utcnow() + timedelta(
-        seconds=config_entry_setup.options.get(
-            CONF_DETECTION_TIME, DEFAULT_DETECTION_TIME
-        )
+        seconds=config_entry.options.get(CONF_DETECTION_TIME, DEFAULT_DETECTION_TIME)
     )
     with freeze_time(new_time):
         async_fire_time_changed(hass, new_time)

--- a/tests/components/unifi/test_hub.py
+++ b/tests/components/unifi/test_hub.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from copy import deepcopy
 from datetime import timedelta
 from http import HTTPStatus
+from typing import Any
 from unittest.mock import patch
 
 import aiounifi
@@ -313,27 +314,25 @@ async def test_reset_fails(
         assert config_entry.state is ConfigEntryState.LOADED
 
 
-@pytest.mark.parametrize(
-    "client_payload",
-    [
-        [
-            {
-                "hostname": "client",
-                "ip": "10.0.0.1",
-                "is_wired": True,
-                "last_seen": dt_util.as_timestamp(dt_util.utcnow()),
-                "mac": "00:00:00:00:00:01",
-            },
-        ]
-    ],
-)
 async def test_connection_state_signalling(
     hass: HomeAssistant,
     mock_device_registry,
-    config_entry_setup: ConfigEntry,
     websocket_mock,
+    config_entry_factory: Callable[[], ConfigEntry],
+    client_payload: list[dict[str, Any]],
 ) -> None:
     """Verify connection statesignalling and connection state are working."""
+    client_payload.append(
+        {
+            "hostname": "client",
+            "ip": "10.0.0.1",
+            "is_wired": True,
+            "last_seen": dt_util.as_timestamp(dt_util.utcnow()),
+            "mac": "00:00:00:00:00:01",
+        }
+    )
+    await config_entry_factory()
+
     # Controller is connected
     assert hass.states.get("device_tracker.client").state == "home"
 

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -682,43 +682,40 @@ async def test_poe_port_switches(
     assert hass.states.get("sensor.mock_name_port_1_poe_power")
 
 
-@pytest.mark.parametrize(
-    "client_payload",
-    [
-        [
-            {
-                "essid": "SSID 1",
-                "is_wired": False,
-                "last_seen": dt_util.as_timestamp(dt_util.utcnow()),
-                "mac": "00:00:00:00:00:01",
-                "name": "Wireless client",
-                "oui": "Producer",
-                "rx_bytes-r": 2345000000,
-                "tx_bytes-r": 6789000000,
-            },
-            {
-                "essid": "SSID 2",
-                "is_wired": False,
-                "last_seen": dt_util.as_timestamp(dt_util.utcnow()),
-                "mac": "00:00:00:00:00:02",
-                "name": "Wireless client2",
-                "oui": "Producer2",
-                "rx_bytes-r": 2345000000,
-                "tx_bytes-r": 6789000000,
-            },
-        ]
-    ],
-)
 @pytest.mark.parametrize("wlan_payload", [[WLAN]])
-@pytest.mark.usefixtures("config_entry_setup")
 async def test_wlan_client_sensors(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_unifi_websocket,
     websocket_mock,
+    config_entry_factory: Callable[[], ConfigEntry],
     client_payload: list[dict[str, Any]],
 ) -> None:
     """Verify that WLAN client sensors are working as expected."""
+    client_payload += [
+        {
+            "essid": "SSID 1",
+            "is_wired": False,
+            "last_seen": dt_util.as_timestamp(dt_util.utcnow()),
+            "mac": "00:00:00:00:00:01",
+            "name": "Wireless client",
+            "oui": "Producer",
+            "rx_bytes-r": 2345000000,
+            "tx_bytes-r": 6789000000,
+        },
+        {
+            "essid": "SSID 2",
+            "is_wired": False,
+            "last_seen": dt_util.as_timestamp(dt_util.utcnow()),
+            "mac": "00:00:00:00:00:02",
+            "name": "Wireless client2",
+            "oui": "Producer2",
+            "rx_bytes-r": 2345000000,
+            "tx_bytes-r": 6789000000,
+        },
+    ]
+    await config_entry_factory()
+
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 1
 
     ent_reg_entry = entity_registry.async_get("sensor.ssid_1")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The tests would break on a full CI run because `dt_util.utcnow` would generate a timestamp during collection of test names, but when running more than the time needed to mark entities as `NOT_HOME` has passed failing those tests. The solution is to not run `utcnow()` outside of the test.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
