### PR TITLE
Update airgradient names to NOx index and VOC index

### DIFF
--- a/homeassistant/components/airgradient/strings.json
+++ b/homeassistant/components/airgradient/strings.json
@@ -42,19 +42,19 @@
     },
     "sensor": {
       "total_volatile_organic_component_index": {
-        "name": "Total VOC index"
+        "name": "VOC index"
       },
       "nitrogen_index": {
-        "name": "Nitrogen index"
+        "name": "NOx index"
       },
       "pm003_count": {
         "name": "PM0.3"
       },
       "raw_total_volatile_organic_component": {
-        "name": "Raw total VOC"
+        "name": "Raw VOC"
       },
       "raw_nitrogen": {
-        "name": "Raw nitrogen"
+        "name": "Raw NOx"
       }
     }
   },

--- a/tests/components/airgradient/snapshots/test_sensor.ambr
+++ b/tests/components/airgradient/snapshots/test_sensor.ambr
@@ -150,6 +150,55 @@
     'state': '1',
   })
 # ---
+# name: test_all_entities[sensor.airgradient_nox_index-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.airgradient_nox_index',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'NOx index',
+    'platform': 'airgradient',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'nitrogen_index',
+    'unique_id': '84fce612f5b8-nitrogen_index',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.airgradient_nox_index-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Airgradient NOx index',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.airgradient_nox_index',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1',
+  })
+# ---
 # name: test_all_entities[sensor.airgradient_pm0_3-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -403,6 +452,56 @@
     'state': '16931',
   })
 # ---
+# name: test_all_entities[sensor.airgradient_raw_nox-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.airgradient_raw_nox',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Raw NOx',
+    'platform': 'airgradient',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'raw_nitrogen',
+    'unique_id': '84fce612f5b8-nox_raw',
+    'unit_of_measurement': 'ticks',
+  })
+# ---
+# name: test_all_entities[sensor.airgradient_raw_nox-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Airgradient Raw NOx',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'ticks',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.airgradient_raw_nox',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '16931',
+  })
+# ---
 # name: test_all_entities[sensor.airgradient_raw_total_voc-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -447,6 +546,56 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.airgradient_raw_total_voc',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '31792',
+  })
+# ---
+# name: test_all_entities[sensor.airgradient_raw_voc-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.airgradient_raw_voc',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Raw VOC',
+    'platform': 'airgradient',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'raw_total_volatile_organic_component',
+    'unique_id': '84fce612f5b8-tvoc_raw',
+    'unit_of_measurement': 'ticks',
+  })
+# ---
+# name: test_all_entities[sensor.airgradient_raw_voc-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Airgradient Raw VOC',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'ticks',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.airgradient_raw_voc',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -598,6 +747,55 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.airgradient_total_voc_index',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '99',
+  })
+# ---
+# name: test_all_entities[sensor.airgradient_voc_index-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.airgradient_voc_index',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'VOC index',
+    'platform': 'airgradient',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'total_volatile_organic_component_index',
+    'unique_id': '84fce612f5b8-tvoc',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.airgradient_voc_index-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Airgradient VOC index',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.airgradient_voc_index',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/airgradient/snapshots/test_sensor.ambr
+++ b/tests/components/airgradient/snapshots/test_sensor.ambr
@@ -101,55 +101,6 @@
     'state': '48.0',
   })
 # ---
-# name: test_all_entities[sensor.airgradient_nitrogen_index-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.airgradient_nitrogen_index',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Nitrogen index',
-    'platform': 'airgradient',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': 'nitrogen_index',
-    'unique_id': '84fce612f5b8-nitrogen_index',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_entities[sensor.airgradient_nitrogen_index-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Airgradient Nitrogen index',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.airgradient_nitrogen_index',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '1',
-  })
-# ---
 # name: test_all_entities[sensor.airgradient_nox_index-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -402,56 +353,6 @@
     'state': '34',
   })
 # ---
-# name: test_all_entities[sensor.airgradient_raw_nitrogen-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.airgradient_raw_nitrogen',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Raw nitrogen',
-    'platform': 'airgradient',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': 'raw_nitrogen',
-    'unique_id': '84fce612f5b8-nox_raw',
-    'unit_of_measurement': 'ticks',
-  })
-# ---
-# name: test_all_entities[sensor.airgradient_raw_nitrogen-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Airgradient Raw nitrogen',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'ticks',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.airgradient_raw_nitrogen',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '16931',
-  })
-# ---
 # name: test_all_entities[sensor.airgradient_raw_nox-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -500,56 +401,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '16931',
-  })
-# ---
-# name: test_all_entities[sensor.airgradient_raw_total_voc-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.airgradient_raw_total_voc',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Raw total VOC',
-    'platform': 'airgradient',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': 'raw_total_volatile_organic_component',
-    'unique_id': '84fce612f5b8-tvoc_raw',
-    'unit_of_measurement': 'ticks',
-  })
-# ---
-# name: test_all_entities[sensor.airgradient_raw_total_voc-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Airgradient Raw total VOC',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'ticks',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.airgradient_raw_total_voc',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '31792',
   })
 # ---
 # name: test_all_entities[sensor.airgradient_raw_voc-entry]
@@ -702,55 +553,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '27.96',
-  })
-# ---
-# name: test_all_entities[sensor.airgradient_total_voc_index-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.airgradient_total_voc_index',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Total VOC index',
-    'platform': 'airgradient',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': 'total_volatile_organic_component_index',
-    'unique_id': '84fce612f5b8-tvoc',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_entities[sensor.airgradient_total_voc_index-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Airgradient Total VOC index',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.airgradient_total_voc_index',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '99',
   })
 # ---
 # name: test_all_entities[sensor.airgradient_voc_index-entry]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
Update display name of sensors to match what manufacturer calls the values as mentioned
https://github.com/home-assistant/core/issues/119111



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #119111
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
