### PR TITLE
Allow source sensor to be changed in threshold helper

### DIFF
--- a/homeassistant/components/threshold/__init__.py
+++ b/homeassistant/components/threshold/__init__.py
@@ -3,6 +3,7 @@
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -18,6 +19,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def config_entry_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Update listener, called when the config entry options are changed."""
+
+    # Remove device link for entry, the source device may have changed.
+    # The link will be recreated after load.
+    device_registry = dr.async_get(hass)
+    devices = device_registry.devices.get_devices_for_config_entry_id(entry.entry_id)
+
+    for device in devices:
+        device_registry.async_update_device(
+            device.id, remove_config_entry_id=entry.entry_id
+        )
+
     await hass.config_entries.async_reload(entry.entry_id)
 
 

--- a/homeassistant/components/threshold/config_flow.py
+++ b/homeassistant/components/threshold/config_flow.py
@@ -48,15 +48,15 @@ OPTIONS_SCHEMA = vol.Schema(
                 mode=selector.NumberSelectorMode.BOX, step="any"
             ),
         ),
+        vol.Required(CONF_ENTITY_ID): selector.EntitySelector(
+            selector.EntitySelectorConfig(domain=SENSOR_DOMAIN)
+        ),
     }
 )
 
 CONFIG_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_NAME): selector.TextSelector(),
-        vol.Required(CONF_ENTITY_ID): selector.EntitySelector(
-            selector.EntitySelectorConfig(domain=SENSOR_DOMAIN)
-        ),
     }
 ).extend(OPTIONS_SCHEMA.schema)
 

--- a/tests/components/threshold/test_config_flow.py
+++ b/tests/components/threshold/test_config_flow.py
@@ -129,6 +129,7 @@ async def test_options(hass: HomeAssistant) -> None:
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
+            "entity_id": input_sensor,
             "hysteresis": 0.0,
             "upper": 20.0,
         },

--- a/tests/components/threshold/test_init.py
+++ b/tests/components/threshold/test_init.py
@@ -4,7 +4,7 @@ import pytest
 
 from homeassistant.components.threshold.const import DOMAIN
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.common import MockConfigEntry
 
@@ -44,6 +44,7 @@ async def test_setup_and_remove_config_entry(
 
     # Check the platform is setup correctly
     state = hass.states.get(threshold_entity_id)
+    assert state
     assert state.state == "on"
     assert state.attributes["entity_id"] == input_sensor
     assert state.attributes["hysteresis"] == 0.0
@@ -60,3 +61,64 @@ async def test_setup_and_remove_config_entry(
     # Check the state and entity registry entry are removed
     assert hass.states.get(threshold_entity_id) is None
     assert entity_registry.async_get(threshold_entity_id) is None
+
+
+@pytest.mark.parametrize("platform", ["sensor"])
+async def test_entry_changed(hass: HomeAssistant, platform) -> None:
+    """Test reconfiguring."""
+
+    device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
+
+    def _create_mock_entity(domain: str, name: str) -> er.RegistryEntry:
+        config_entry = MockConfigEntry(
+            data={},
+            domain="test",
+            title=f"{name}",
+        )
+        config_entry.add_to_hass(hass)
+        device_entry = device_registry.async_get_or_create(
+            identifiers={("test", name)}, config_entry_id=config_entry.entry_id
+        )
+        return entity_registry.async_get_or_create(
+            domain, "test", name, suggested_object_id=name, device_id=device_entry.id
+        )
+
+    def _get_device_config_entries(entry: er.RegistryEntry) -> set[str]:
+        assert entry.device_id
+        device = device_registry.async_get(entry.device_id)
+        assert device
+        return device.config_entries
+
+    # Set up entities, with backing devices and config entries
+    run1_entry = _create_mock_entity("sensor", "initial")
+    run2_entry = _create_mock_entity("sensor", "changed")
+
+    # Setup the config entry
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            "entity_id": "sensor.initial",
+            "hysteresis": 0.0,
+            "lower": -2.0,
+            "name": "My threshold",
+            "upper": None,
+        },
+        title="My integration",
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.entry_id in _get_device_config_entries(run1_entry)
+    assert config_entry.entry_id not in _get_device_config_entries(run2_entry)
+
+    hass.config_entries.async_update_entry(
+        config_entry, options={**config_entry.options, "entity_id": "sensor.changed"}
+    )
+    await hass.async_block_till_done()
+
+    # Check that the config entry association has updated
+    assert config_entry.entry_id not in _get_device_config_entries(run1_entry)
+    assert config_entry.entry_id in _get_device_config_entries(run2_entry)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow changing the source sensor the the threshold helper.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- WTH: https://community.home-assistant.io/t/wth-why-cant-i-change-the-input-sensor-of-a-threshold-sensor-helper-when-it-was-created-via-user-interface/472812

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
