### PR TITLE
Refactor BMW send_message and add tests

### DIFF
--- a/homeassistant/components/bmw_connected_drive/notify.py
+++ b/homeassistant/components/bmw_connected_drive/notify.py
@@ -89,7 +89,13 @@ class BMWNotificationService(BaseNotificationService):
             )
 
         except (vol.Invalid, TypeError, ValueError) as ex:
-            raise ServiceValidationError(f"Invalid POI data: {ex}") from ex
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_poi",
+                translation_placeholders={
+                    "poi_exception": str(ex),
+                },
+            ) from ex
 
         for vehicle in kwargs[ATTR_TARGET]:
             vehicle = cast(MyBMWVehicle, vehicle)

--- a/homeassistant/components/bmw_connected_drive/notify.py
+++ b/homeassistant/components/bmw_connected_drive/notify.py
@@ -20,7 +20,7 @@ from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import BMWConfigEntry
+from . import DOMAIN, BMWConfigEntry
 
 ATTR_LOCATION_ATTRIBUTES = ["street", "city", "postal_code", "country"]
 

--- a/homeassistant/components/bmw_connected_drive/notify.py
+++ b/homeassistant/components/bmw_connected_drive/notify.py
@@ -5,32 +5,35 @@ from __future__ import annotations
 import logging
 from typing import Any, cast
 
-from bimmer_connected.models import MyBMWAPIError
+from bimmer_connected.models import MyBMWAPIError, PointOfInterest
 from bimmer_connected.vehicle import MyBMWVehicle
+import voluptuous as vol
 
 from homeassistant.components.notify import (
     ATTR_DATA,
     ATTR_TARGET,
     BaseNotificationService,
 )
-from homeassistant.const import (
-    ATTR_LATITUDE,
-    ATTR_LOCATION,
-    ATTR_LONGITUDE,
-    ATTR_NAME,
-    CONF_ENTITY_ID,
-)
+from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE, CONF_ENTITY_ID
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import BMWConfigEntry
 
-ATTR_LAT = "lat"
 ATTR_LOCATION_ATTRIBUTES = ["street", "city", "postal_code", "country"]
-ATTR_LON = "lon"
-ATTR_SUBJECT = "subject"
-ATTR_TEXT = "text"
+
+POI_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_LATITUDE): cv.latitude,
+        vol.Required(ATTR_LONGITUDE): cv.longitude,
+        vol.Optional("street"): cv.string,
+        vol.Optional("city"): cv.string,
+        vol.Optional("postal_code"): cv.string,
+        vol.Optional("country"): cv.string,
+    }
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -71,33 +74,28 @@ class BMWNotificationService(BaseNotificationService):
 
     async def async_send_message(self, message: str = "", **kwargs: Any) -> None:
         """Send a message or POI to the car."""
+
+        try:
+            # Verify data schema
+            poi_data = kwargs.get(ATTR_DATA) or {}
+            POI_SCHEMA(poi_data)
+
+            # Create the POI object
+            poi = PointOfInterest(
+                lat=poi_data.pop(ATTR_LATITUDE),
+                lon=poi_data.pop(ATTR_LONGITUDE),
+                name=(message or None),
+                **poi_data,
+            )
+
+        except (vol.Invalid, TypeError, ValueError) as ex:
+            raise ServiceValidationError(f"Invalid POI data: {ex}") from ex
+
         for vehicle in kwargs[ATTR_TARGET]:
             vehicle = cast(MyBMWVehicle, vehicle)
             _LOGGER.debug("Sending message to %s", vehicle.name)
 
-            # Extract params from data dict
-            data = kwargs.get(ATTR_DATA)
-
-            # Check if message is a POI
-            if data is not None and ATTR_LOCATION in data:
-                location_dict = {
-                    ATTR_LAT: data[ATTR_LOCATION][ATTR_LATITUDE],
-                    ATTR_LON: data[ATTR_LOCATION][ATTR_LONGITUDE],
-                    ATTR_NAME: message,
-                }
-                # Update dictionary with additional attributes if available
-                location_dict.update(
-                    {
-                        k: v
-                        for k, v in data[ATTR_LOCATION].items()
-                        if k in ATTR_LOCATION_ATTRIBUTES
-                    }
-                )
-                try:
-                    await vehicle.remote_services.trigger_send_poi(location_dict)
-                except TypeError as ex:
-                    raise ValueError(str(ex)) from ex
-                except MyBMWAPIError as ex:
-                    raise HomeAssistantError(ex) from ex
-            else:
-                raise ValueError(f"'data.{ATTR_LOCATION}' is required.")
+            try:
+                await vehicle.remote_services.trigger_send_poi(poi)
+            except MyBMWAPIError as ex:
+                raise HomeAssistantError(ex) from ex

--- a/homeassistant/components/bmw_connected_drive/strings.json
+++ b/homeassistant/components/bmw_connected_drive/strings.json
@@ -168,5 +168,10 @@
         "rest_of_world": "Rest of world"
       }
     }
+  },
+  "exceptions": {
+    "invalid_poi": {
+      "message": "Invalid data for point of interest: {poi_exception}"
+    }
   }
 }

--- a/tests/components/bmw_connected_drive/__init__.py
+++ b/tests/components/bmw_connected_drive/__init__.py
@@ -1,6 +1,10 @@
 """Tests for the for the BMW Connected Drive integration."""
 
-from bimmer_connected.const import REMOTE_SERVICE_BASE_URL, VEHICLE_CHARGING_BASE_URL
+from bimmer_connected.const import (
+    REMOTE_SERVICE_BASE_URL,
+    VEHICLE_CHARGING_BASE_URL,
+    VEHICLE_POI_URL,
+)
 import respx
 
 from homeassistant import config_entries
@@ -71,6 +75,7 @@ def check_remote_service_call(
             or c.request.url.path.startswith(
                 VEHICLE_CHARGING_BASE_URL.replace("/{vin}", "")
             )
+            or c.request.url.path == VEHICLE_POI_URL
         )
         assert (
             first_remote_service_call.request.url.path.endswith(remote_service) is True
@@ -86,6 +91,10 @@ def check_remote_service_call(
                 dict(first_remote_service_call.request.url.params.items())
                 == remote_service_params
             )
+
+    # Send POI doesn't return a status response, so we can't check it
+    if remote_service == "send-to-car":
+        return
 
     # Now check final result
     last_event_status_call = next(

--- a/tests/components/bmw_connected_drive/test_notify.py
+++ b/tests/components/bmw_connected_drive/test_notify.py
@@ -1,0 +1,153 @@
+"""Test BMW numbers."""
+
+from unittest.mock import AsyncMock
+
+from bimmer_connected.models import MyBMWAPIError, MyBMWRemoteServiceError
+from bimmer_connected.tests.common import POI_DATA
+from bimmer_connected.vehicle.remote_services import RemoteServices
+import pytest
+import respx
+
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+
+from . import check_remote_service_call, setup_mocked_integration
+
+
+async def test_legacy_notify_service_simple(
+    hass: HomeAssistant,
+    bmw_fixture: respx.Router,
+) -> None:
+    """Test successful sending of POIs."""
+
+    # Setup component
+    assert await setup_mocked_integration(hass)
+
+    # Minimal required data
+    await hass.services.async_call(
+        "notify",
+        "bmw_connected_drive_ix_xdrive50",
+        {
+            "message": POI_DATA.get("name"),
+            "data": {
+                "latitude": POI_DATA.get("lat"),
+                "longitude": POI_DATA.get("lon"),
+            },
+        },
+        blocking=True,
+    )
+    check_remote_service_call(bmw_fixture, "send-to-car")
+
+    bmw_fixture.reset()
+
+    # Full data
+    await hass.services.async_call(
+        "notify",
+        "bmw_connected_drive_ix_xdrive50",
+        {
+            "message": POI_DATA.get("name"),
+            "data": {
+                "latitude": POI_DATA.get("lat"),
+                "longitude": POI_DATA.get("lon"),
+                "street": POI_DATA.get("street"),
+                "city": POI_DATA.get("city"),
+                "postal_code": POI_DATA.get("postal_code"),
+                "country": POI_DATA.get("country"),
+            },
+        },
+        blocking=True,
+    )
+    check_remote_service_call(bmw_fixture, "send-to-car")
+
+
+@pytest.mark.usefixtures("bmw_fixture")
+async def test_service_call_invalid_input(
+    hass: HomeAssistant,
+) -> None:
+    """Test invalid inputs."""
+
+    # Setup component
+    assert await setup_mocked_integration(hass)
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            "notify",
+            "bmw_connected_drive_ix_xdrive50",
+            {
+                "message": POI_DATA.get("name"),
+                "data": {
+                    "latitude": POI_DATA.get("lat"),
+                },
+            },
+            blocking=True,
+        )
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            "notify",
+            "bmw_connected_drive_ix_xdrive50",
+            {
+                "message": POI_DATA.get("name"),
+                "data": {
+                    "latitude": POI_DATA.get("lat"),
+                    "longitude": "text",
+                },
+            },
+            blocking=True,
+        )
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            "notify",
+            "bmw_connected_drive_ix_xdrive50",
+            {
+                "message": POI_DATA.get("name"),
+                "data": {
+                    "latitude": POI_DATA.get("lat"),
+                    "longitude": 9999,
+                },
+            },
+            blocking=True,
+        )
+
+
+@pytest.mark.usefixtures("bmw_fixture")
+@pytest.mark.parametrize(
+    ("raised", "expected"),
+    [
+        (MyBMWRemoteServiceError, HomeAssistantError),
+        (MyBMWAPIError, HomeAssistantError),
+    ],
+)
+async def test_service_call_fail(
+    hass: HomeAssistant,
+    raised: Exception,
+    expected: Exception,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test exception handling."""
+
+    # Setup component
+    assert await setup_mocked_integration(hass)
+
+    # Setup exception
+    monkeypatch.setattr(
+        RemoteServices,
+        "trigger_remote_service",
+        AsyncMock(side_effect=raised),
+    )
+
+    # Test
+    with pytest.raises(expected):
+        await hass.services.async_call(
+            "notify",
+            "bmw_connected_drive_ix_xdrive50",
+            {
+                "message": POI_DATA.get("name"),
+                "data": {
+                    "latitude": POI_DATA.get("lat"),
+                    "longitude": POI_DATA.get("lon"),
+                },
+            },
+            blocking=True,
+        )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds tests to BMW's legacy `notify` platform. Also the actual send_message code got refactored.
Hope this makes future discussions and migration to the new notify entities easier.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
