### PR TITLE
Get suggested_unit_of_measurement via unit converter's UNIT_CLASS

### DIFF
--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -404,7 +404,7 @@ class SensorEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         suggested_unit_of_measurement = self.suggested_unit_of_measurement
 
         if suggested_unit_of_measurement is None:
-            # Fallback to suggested by the unit conversion rules from device class
+            # Fallback to unit suggested by the unit conversion rules from device class
             suggested_unit_of_measurement = self.hass.config.units.get_converted_unit(
                 self.device_class, self.native_unit_of_measurement
             )
@@ -412,8 +412,8 @@ class SensorEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         if suggested_unit_of_measurement is None and (
             unit_converter := UNIT_CONVERTERS.get(self.device_class)
         ):
-            # Fallback to suggested by the unit conversion rules from unit converter
-            # if no specific conversion rule is set for the device class
+            # If the device class is not known by the unit system but has a unit converter,
+            # fall back to the unit suggested by the unit converter's unit class.
             suggested_unit_of_measurement = self.hass.config.units.get_converted_unit(
                 unit_converter.UNIT_CLASS, self.native_unit_of_measurement
             )

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -403,10 +403,17 @@ class SensorEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         # Unit suggested by the integration
         suggested_unit_of_measurement = self.suggested_unit_of_measurement
 
+        if suggested_unit_of_measurement is None:
+            # Fallback to suggested by the unit conversion rules from device class
+            suggested_unit_of_measurement = self.hass.config.units.get_converted_unit(
+                self.device_class, self.native_unit_of_measurement
+            )
+
         if suggested_unit_of_measurement is None and (
             unit_converter := UNIT_CONVERTERS.get(self.device_class)
         ):
-            # Fallback to suggested by the unit conversion rules
+            # Fallback to suggested by the unit conversion rules from unit converter
+            # if no specific conversion rule is set for the device class
             suggested_unit_of_measurement = self.hass.config.units.get_converted_unit(
                 unit_converter.UNIT_CLASS, self.native_unit_of_measurement
             )

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -403,10 +403,12 @@ class SensorEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         # Unit suggested by the integration
         suggested_unit_of_measurement = self.suggested_unit_of_measurement
 
-        if suggested_unit_of_measurement is None:
+        if suggested_unit_of_measurement is None and (
+            unit_converter := UNIT_CONVERTERS.get(self.device_class)
+        ):
             # Fallback to suggested by the unit conversion rules
             suggested_unit_of_measurement = self.hass.config.units.get_converted_unit(
-                self.device_class, self.native_unit_of_measurement
+                unit_converter.UNIT_CLASS, self.native_unit_of_measurement
             )
 
         if suggested_unit_of_measurement is None:

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -942,7 +942,21 @@ async def test_custom_unit_change(
             "1000000",
             "1093613",
             SensorDeviceClass.DISTANCE,
-        )
+        ),
+        # Volume Storage (subclass of Volume)
+        (
+            US_CUSTOMARY_SYSTEM,
+            UnitOfVolume.LITERS,
+            UnitOfVolume.GALLONS,
+            UnitOfVolume.GALLONS,
+            UnitOfVolume.FLUID_OUNCES,
+            1000,
+            "1000",
+            "264",
+            "264",
+            "33814",
+            SensorDeviceClass.VOLUME_STORAGE,
+        ),
     ],
 )
 async def test_unit_conversion_priority(
@@ -1475,7 +1489,7 @@ async def test_unit_conversion_priority_suggested_unit_change_2(
             1,
             1000,
             SensorDeviceClass.ATMOSPHERIC_PRESSURE,
-            {"sensor.private": {"suggested_unit_of_measurement": "inHg"}},
+            {"sensor.private": {"suggested_unit_of_measurement": "psi"}},
         ),
     ],
 )

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -1489,7 +1489,7 @@ async def test_unit_conversion_priority_suggested_unit_change_2(
             1,
             1000,
             SensorDeviceClass.ATMOSPHERIC_PRESSURE,
-            {"sensor.private": {"suggested_unit_of_measurement": "psi"}},
+            {"sensor.private": {"suggested_unit_of_measurement": "inHg"}},
         ),
     ],
 )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adjusts the way `sensor` components get a suggested unit. It now also takes into account the `UNIT_CLASS` of a unit converter in addition to the device class itself to allow for "sub-classes" such as `VOLUME_STORAGE`.

I have tested against `tests/components/*/test_sensor.py` and `tests/components/sensor/` locally. ~~and did only find a minor issue (see changed tests) except where tests generally fail.~~
~~However I'm not sure if this could still be a breaking change.~~

**Background**
I changed the `device_class` from `SensorDeviceClass.VOLUME` to `SensorDeviceClass.VOLUME_STORAGE` and it broke unit conversion, i.e. no conversion from native liters to gallons was taking place anymore (cf. #119172).

This is due to [`UnitSystem.get_converted_unit()`](https://github.com/home-assistant/core/blob/9e7a6408c25a4156f3e03d9a1943a138cd46b8fd/homeassistant/util/unit_system.py#L196) trying to look up allowed unit conversions via `str(device_class)`. 
Using `SensorDeviceClass.VOLUME` this was working, but not using `SensorDeviceClass.VOLUME_STORAGE` as conversions are done on [`volume` only](https://github.com/home-assistant/core/blob/9e7a6408c25a4156f3e03d9a1943a138cd46b8fd/homeassistant/util/unit_system.py#L344-L347).

As both device classes define the same [`UnitConverter`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/sensor/const.py#L505-L506) and all unit converters require a `UNIT_CLASS` (which is `volume` in this case) this seems to be a valid replacement.

It cannot be replaced as device class `atmospheric_pressure` is [forced to inHg](https://github.com/home-assistant/core/blob/9e7a6408c25a4156f3e03d9a1943a138cd46b8fd/homeassistant/util/unit_system.py#L300-L305) and the `UnitSystem`'s conversion (`pressure`) would ignore that.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #119172
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
