### PR TITLE
Add primary child entities to parent device

### DIFF
--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -107,7 +107,6 @@ class CoordinatedTPLinkEntity(CoordinatorEntity[TPLinkDataUpdateCoordinator], AB
         feature: Feature | None = None,
         parent: Device | None = None,
         unique_id: str | None = None,
-        add_to_parent: bool = False,
     ) -> None:
         """Initialize the entity."""
         super().__init__(coordinator)
@@ -117,9 +116,9 @@ class CoordinatedTPLinkEntity(CoordinatorEntity[TPLinkDataUpdateCoordinator], AB
         registry_device = device
         name = device.alias
         if parent and parent.device_type != Device.Type.Hub:
-            if add_to_parent:
-                # Entity can be added to parent if add_to_parent parameter and not a hub
-                # Useful to assign primary controls to the parent for user experience.
+            if not feature or feature.category == Feature.Category.Primary:
+                # Entity will be added to parent if not a hub and no feature parameter
+                # (i.e. core platform like Light, Fan) or feature is primary like state
                 registry_device = parent
                 name = registry_device.alias
                 self._attr_name = device.alias
@@ -234,7 +233,6 @@ def _entities_for_device[_E: CoordinatedTPLinkEntity](
             coordinator,
             feature=feat,
             parent=parent,
-            add_to_parent=feat.category == Feature.Category.Primary,
         )
         for feat in device.features.values()
         if feat.type == feature_type

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -55,7 +55,6 @@ class TPLinkSwitch(CoordinatedTPLinkEntity, SwitchEntity):
         *,
         feature: Feature,
         parent: Device | None = None,
-        add_to_parent: bool = False,
     ) -> None:
         """Initialize the switch."""
         super().__init__(
@@ -63,16 +62,11 @@ class TPLinkSwitch(CoordinatedTPLinkEntity, SwitchEntity):
             coordinator,
             feature=feature,
             parent=parent,
-            add_to_parent=add_to_parent,
         )
         self._feature: Feature
 
         # Use the device name for the primary switch control
-        if (
-            feature.category is Feature.Category.Primary
-            and not parent
-            and add_to_parent
-        ):
+        if feature.category is Feature.Category.Primary and not parent:
             self._attr_name = None
 
         self.entity_description = _description_for_feature(

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -55,13 +55,24 @@ class TPLinkSwitch(CoordinatedTPLinkEntity, SwitchEntity):
         *,
         feature: Feature,
         parent: Device | None = None,
+        add_to_parent: bool = False,
     ) -> None:
         """Initialize the switch."""
-        super().__init__(device, coordinator, feature=feature, parent=parent)
+        super().__init__(
+            device,
+            coordinator,
+            feature=feature,
+            parent=parent,
+            add_to_parent=add_to_parent,
+        )
         self._feature: Feature
 
         # Use the device name for the primary switch control
-        if feature.category is Feature.Category.Primary:
+        if (
+            feature.category is Feature.Category.Primary
+            and not parent
+            and add_to_parent
+        ):
             self._attr_name = None
 
         self.entity_description = _description_for_feature(

--- a/tests/components/tplink/test_switch.py
+++ b/tests/components/tplink/test_switch.py
@@ -170,7 +170,7 @@ async def test_strip(hass: HomeAssistant) -> None:
         await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
         await hass.async_block_till_done()
 
-    entity_id = "switch.plug0"
+    entity_id = "switch.my_strip_plug0"
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON
 
@@ -187,7 +187,7 @@ async def test_strip(hass: HomeAssistant) -> None:
     feat.set_value.assert_called_once()
     feat.set_value.reset_mock()
 
-    entity_id = "switch.plug1"
+    entity_id = "switch.my_strip_plug1"
     state = hass.states.get(entity_id)
     assert state.state == STATE_OFF
 
@@ -223,7 +223,7 @@ async def test_strip_unique_ids(
         await hass.async_block_till_done()
 
     for plug_id in range(2):
-        entity_id = f"switch.plug{plug_id}"
+        entity_id = f"switch.my_strip_plug{plug_id}"
         assert (
             entity_registry.async_get(entity_id).unique_id == f"PLUG{plug_id}DEVICEID"
         )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds primary entities to the parent device for devices such as power strips and wall switches.

See https://github.com/home-assistant/core/pull/117785 for an explanation of the approach for merging into the tplink_rewrite branch.

Parent:

![image](https://github.com/home-assistant/core/assets/51370195/f1c492d1-dbe7-454e-9b9a-e125fa6ffbf5)

Child:

![image](https://github.com/home-assistant/core/assets/51370195/bf8cda0a-4b2e-4218-827a-53a0c9010053)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
