### PR TITLE
Rework UniFi tests to not use runtime data

### DIFF
--- a/homeassistant/components/unifi/config_flow.py
+++ b/homeassistant/components/unifi/config_flow.py
@@ -21,6 +21,7 @@ import voluptuous as vol
 from homeassistant.components import ssdp
 from homeassistant.config_entries import (
     ConfigEntry,
+    ConfigEntryState,
     ConfigFlow,
     ConfigFlowResult,
     OptionsFlow,
@@ -163,7 +164,10 @@ class UnifiFlowHandler(ConfigFlow, domain=UNIFI_DOMAIN):
                 config_entry = self.reauth_config_entry
                 abort_reason = "reauth_successful"
 
-            if config_entry:
+            if (
+                config_entry is not None
+                and config_entry.state is not ConfigEntryState.NOT_LOADED
+            ):
                 hub = config_entry.runtime_data
 
                 if hub and hub.available:

--- a/tests/common.py
+++ b/tests/common.py
@@ -39,7 +39,7 @@ from homeassistant.components.device_automation import (  # noqa: F401
     _async_get_device_automation_capabilities as async_get_device_automation_capabilities,
 )
 from homeassistant.config import async_process_component_config
-from homeassistant.config_entries import ConfigEntry, ConfigFlow, _DataT
+from homeassistant.config_entries import ConfigEntry, ConfigFlow
 from homeassistant.const import (
     DEVICE_DEFAULT_NAME,
     EVENT_HOMEASSISTANT_CLOSE,
@@ -972,10 +972,8 @@ class MockToggleEntity(entity.ToggleEntity):
             return None
 
 
-class MockConfigEntry(config_entries.ConfigEntry[_DataT]):
+class MockConfigEntry(config_entries.ConfigEntry):
     """Helper for creating config entries that adds some defaults."""
-
-    runtime_data: _DataT
 
     def __init__(
         self,

--- a/tests/components/unifi/test_button.py
+++ b/tests/components/unifi/test_button.py
@@ -123,7 +123,7 @@ async def _test_button_entity(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     aioclient_mock: AiohttpClientMocker,
-    websocket_mock,
+    mock_websocket_state,
     config_entry: ConfigEntry,
     entity_count: int,
     entity_id: str,
@@ -164,11 +164,11 @@ async def _test_button_entity(
     # Availability signalling
 
     # Controller disconnects
-    await websocket_mock.disconnect()
+    await mock_websocket_state.disconnect()
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
     # Controller reconnects
-    await websocket_mock.reconnect()
+    await mock_websocket_state.reconnect()
     assert hass.states.get(entity_id).state != STATE_UNAVAILABLE
 
 
@@ -218,8 +218,8 @@ async def test_device_button_entities(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     aioclient_mock: AiohttpClientMocker,
-    config_entry_setup,
-    websocket_mock,
+    config_entry_setup: ConfigEntry,
+    mock_websocket_state,
     entity_count: int,
     entity_id: str,
     unique_id: str,
@@ -233,7 +233,7 @@ async def test_device_button_entities(
         hass,
         entity_registry,
         aioclient_mock,
-        websocket_mock,
+        mock_websocket_state,
         config_entry_setup,
         entity_count,
         entity_id,
@@ -279,8 +279,8 @@ async def test_wlan_button_entities(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     aioclient_mock: AiohttpClientMocker,
-    config_entry_setup,
-    websocket_mock,
+    config_entry_setup: ConfigEntry,
+    mock_websocket_state,
     entity_count: int,
     entity_id: str,
     unique_id: str,
@@ -308,7 +308,7 @@ async def test_wlan_button_entities(
         hass,
         entity_registry,
         aioclient_mock,
-        websocket_mock,
+        mock_websocket_state,
         config_entry_setup,
         entity_count,
         entity_id,

--- a/tests/components/unifi/test_config_flow.py
+++ b/tests/components/unifi/test_config_flow.py
@@ -564,11 +564,11 @@ async def test_form_ssdp_gets_form_with_ignored_entry(hass: HomeAssistant) -> No
         data=ssdp.SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
-            ssdp_location="http://1.2.3.4:1234/rootDesc.xml",
+            ssdp_location="http://2.3.4.5:1234/rootDesc.xml",
             upnp={
                 "friendlyName": "UniFi Dream Machine New",
                 "modelDescription": "UniFi Dream Machine Pro",
-                "serialNumber": "1",
+                "serialNumber": "2",
             },
         ),
     )
@@ -581,7 +581,7 @@ async def test_form_ssdp_gets_form_with_ignored_entry(hass: HomeAssistant) -> No
         if flow["flow_id"] == result["flow_id"]
     )
     assert context["title_placeholders"] == {
-        "host": "1.2.3.4",
+        "host": "2.3.4.5",
         "site": "default",
     }
 

--- a/tests/components/unifi/test_config_flow.py
+++ b/tests/components/unifi/test_config_flow.py
@@ -564,11 +564,11 @@ async def test_form_ssdp_gets_form_with_ignored_entry(hass: HomeAssistant) -> No
         data=ssdp.SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
-            ssdp_location="http://2.3.4.5:1234/rootDesc.xml",
+            ssdp_location="http://1.2.3.4:1234/rootDesc.xml",
             upnp={
                 "friendlyName": "UniFi Dream Machine New",
                 "modelDescription": "UniFi Dream Machine Pro",
-                "serialNumber": "2",
+                "serialNumber": "1",
             },
         ),
     )
@@ -581,7 +581,7 @@ async def test_form_ssdp_gets_form_with_ignored_entry(hass: HomeAssistant) -> No
         if flow["flow_id"] == result["flow_id"]
     )
     assert context["title_placeholders"] == {
-        "host": "2.3.4.5",
+        "host": "1.2.3.4",
         "site": "default",
     }
 

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -49,7 +49,7 @@ from tests.common import async_fire_time_changed
 @pytest.mark.usefixtures("mock_device_registry")
 async def test_tracked_wireless_clients(
     hass: HomeAssistant,
-    mock_unifi_websocket,
+    mock_websocket_message,
     config_entry_setup: ConfigEntry,
     client_payload: list[dict[str, Any]],
 ) -> None:
@@ -60,7 +60,7 @@ async def test_tracked_wireless_clients(
     # Updated timestamp marks client as home
     client = client_payload[0]
     client["last_seen"] = dt_util.as_timestamp(dt_util.utcnow())
-    mock_unifi_websocket(message=MessageKey.CLIENT, data=client)
+    mock_websocket_message(message=MessageKey.CLIENT, data=client)
     await hass.async_block_till_done()
 
     assert hass.states.get("device_tracker.client").state == STATE_HOME
@@ -78,7 +78,7 @@ async def test_tracked_wireless_clients(
     assert hass.states.get("device_tracker.client").state == STATE_NOT_HOME
 
     # Same timestamp doesn't explicitly mark client as away
-    mock_unifi_websocket(message=MessageKey.CLIENT, data=client)
+    mock_websocket_message(message=MessageKey.CLIENT, data=client)
     await hass.async_block_till_done()
 
     assert hass.states.get("device_tracker.client").state == STATE_HOME
@@ -146,7 +146,7 @@ async def test_tracked_wireless_clients(
 @pytest.mark.usefixtures("config_entry_setup")
 @pytest.mark.usefixtures("mock_device_registry")
 async def test_tracked_clients(
-    hass: HomeAssistant, mock_unifi_websocket, client_payload: list[dict[str, Any]]
+    hass: HomeAssistant, mock_websocket_message, client_payload: list[dict[str, Any]]
 ) -> None:
     """Test the update_items function with some clients."""
     assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 5
@@ -170,7 +170,7 @@ async def test_tracked_clients(
 
     client_1 = client_payload[0]
     client_1["last_seen"] = dt_util.as_timestamp(dt_util.utcnow())
-    mock_unifi_websocket(message=MessageKey.CLIENT, data=client_1)
+    mock_websocket_message(message=MessageKey.CLIENT, data=client_1)
     await hass.async_block_till_done()
 
     assert hass.states.get("device_tracker.client_1").state == STATE_HOME
@@ -196,7 +196,7 @@ async def test_tracked_clients(
 async def test_tracked_wireless_clients_event_source(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
-    mock_unifi_websocket,
+    mock_websocket_message,
     config_entry_setup: ConfigEntry,
     client_payload: list[dict[str, Any]],
 ) -> None:
@@ -226,7 +226,7 @@ async def test_tracked_wireless_clients_event_source(
         ),
         "_id": "5ea331fa30c49e00f90ddc1a",
     }
-    mock_unifi_websocket(message=MessageKey.EVENT, data=event)
+    mock_websocket_message(message=MessageKey.EVENT, data=event)
     await hass.async_block_till_done()
     assert hass.states.get("device_tracker.client").state == STATE_HOME
 
@@ -249,7 +249,7 @@ async def test_tracked_wireless_clients_event_source(
         ),
         "_id": "5ea32ff730c49e00f90dca1a",
     }
-    mock_unifi_websocket(message=MessageKey.EVENT, data=event)
+    mock_websocket_message(message=MessageKey.EVENT, data=event)
     await hass.async_block_till_done()
     assert hass.states.get("device_tracker.client").state == STATE_HOME
 
@@ -275,7 +275,7 @@ async def test_tracked_wireless_clients_event_source(
 
     # New data
     client["last_seen"] = dt_util.as_timestamp(dt_util.utcnow())
-    mock_unifi_websocket(message=MessageKey.CLIENT, data=client)
+    mock_websocket_message(message=MessageKey.CLIENT, data=client)
     await hass.async_block_till_done()
     assert hass.states.get("device_tracker.client").state == STATE_HOME
 
@@ -298,7 +298,7 @@ async def test_tracked_wireless_clients_event_source(
         ),
         "_id": "5ea32ff730c49e00f90dca1a",
     }
-    mock_unifi_websocket(message=MessageKey.EVENT, data=event)
+    mock_websocket_message(message=MessageKey.EVENT, data=event)
     await hass.async_block_till_done()
     assert hass.states.get("device_tracker.client").state == STATE_HOME
 
@@ -361,7 +361,7 @@ async def test_tracked_wireless_clients_event_source(
 async def test_tracked_devices(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
-    mock_unifi_websocket,
+    mock_websocket_message,
     device_payload: list[dict[str, Any]],
 ) -> None:
     """Test the update_items function with some devices."""
@@ -375,7 +375,7 @@ async def test_tracked_devices(
     device_2 = device_payload[1]
     device_2["state"] = 1
     device_2["next_interval"] = 50
-    mock_unifi_websocket(message=MessageKey.DEVICE, data=[device_1, device_2])
+    mock_websocket_message(message=MessageKey.DEVICE, data=[device_1, device_2])
     await hass.async_block_till_done()
 
     assert hass.states.get("device_tracker.device_1").state == STATE_HOME
@@ -392,7 +392,7 @@ async def test_tracked_devices(
 
     # Disabled device is unavailable
     device_1["disabled"] = True
-    mock_unifi_websocket(message=MessageKey.DEVICE, data=device_1)
+    mock_websocket_message(message=MessageKey.DEVICE, data=device_1)
     await hass.async_block_till_done()
 
     assert hass.states.get("device_tracker.device_1").state == STATE_UNAVAILABLE
@@ -422,7 +422,7 @@ async def test_tracked_devices(
 @pytest.mark.usefixtures("config_entry_setup")
 @pytest.mark.usefixtures("mock_device_registry")
 async def test_remove_clients(
-    hass: HomeAssistant, mock_unifi_websocket, client_payload: list[dict[str, Any]]
+    hass: HomeAssistant, mock_websocket_message, client_payload: list[dict[str, Any]]
 ) -> None:
     """Test the remove_items function with some clients."""
     assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 2
@@ -430,7 +430,7 @@ async def test_remove_clients(
     assert hass.states.get("device_tracker.client_2")
 
     # Remove client
-    mock_unifi_websocket(message=MessageKey.CLIENT_REMOVED, data=client_payload[0])
+    mock_websocket_message(message=MessageKey.CLIENT_REMOVED, data=client_payload[0])
     await hass.async_block_till_done()
     await hass.async_block_till_done()
 
@@ -479,19 +479,19 @@ async def test_remove_clients(
 )
 @pytest.mark.usefixtures("config_entry_setup")
 @pytest.mark.usefixtures("mock_device_registry")
-async def test_hub_state_change(hass: HomeAssistant, websocket_mock) -> None:
+async def test_hub_state_change(hass: HomeAssistant, mock_websocket_state) -> None:
     """Verify entities state reflect on hub connection becoming unavailable."""
     assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 2
     assert hass.states.get("device_tracker.client").state == STATE_NOT_HOME
     assert hass.states.get("device_tracker.device").state == STATE_HOME
 
     # Controller unavailable
-    await websocket_mock.disconnect()
+    await mock_websocket_state.disconnect()
     assert hass.states.get("device_tracker.client").state == STATE_UNAVAILABLE
     assert hass.states.get("device_tracker.device").state == STATE_UNAVAILABLE
 
     # Controller available
-    await websocket_mock.reconnect()
+    await mock_websocket_state.reconnect()
     assert hass.states.get("device_tracker.client").state == STATE_NOT_HOME
     assert hass.states.get("device_tracker.device").state == STATE_HOME
 
@@ -707,7 +707,7 @@ async def test_option_track_devices(
 @pytest.mark.usefixtures("mock_device_registry")
 async def test_option_ssid_filter(
     hass: HomeAssistant,
-    mock_unifi_websocket,
+    mock_websocket_message,
     config_entry_factory: Callable[[], ConfigEntry],
     client_payload: list[dict[str, Any]],
 ) -> None:
@@ -753,12 +753,12 @@ async def test_option_ssid_filter(
     # Roams to SSID outside of filter
     client = client_payload[0]
     client["essid"] = "other_ssid"
-    mock_unifi_websocket(message=MessageKey.CLIENT, data=client)
+    mock_websocket_message(message=MessageKey.CLIENT, data=client)
 
     # Data update while SSID filter is in effect shouldn't create the client
     client_on_ssid2 = client_payload[1]
     client_on_ssid2["last_seen"] = dt_util.as_timestamp(dt_util.utcnow())
-    mock_unifi_websocket(message=MessageKey.CLIENT, data=client_on_ssid2)
+    mock_websocket_message(message=MessageKey.CLIENT, data=client_on_ssid2)
     await hass.async_block_till_done()
 
     new_time = dt_util.utcnow() + timedelta(
@@ -782,7 +782,7 @@ async def test_option_ssid_filter(
 
     client["last_seen"] += 1
     client_on_ssid2["last_seen"] += 1
-    mock_unifi_websocket(message=MessageKey.CLIENT, data=[client, client_on_ssid2])
+    mock_websocket_message(message=MessageKey.CLIENT, data=[client, client_on_ssid2])
     await hass.async_block_till_done()
 
     assert hass.states.get("device_tracker.client").state == STATE_HOME
@@ -801,7 +801,7 @@ async def test_option_ssid_filter(
     assert hass.states.get("device_tracker.client").state == STATE_NOT_HOME
 
     client_on_ssid2["last_seen"] += 1
-    mock_unifi_websocket(message=MessageKey.CLIENT, data=client_on_ssid2)
+    mock_websocket_message(message=MessageKey.CLIENT, data=client_on_ssid2)
     await hass.async_block_till_done()
 
     # Client won't go away until after next update
@@ -809,7 +809,7 @@ async def test_option_ssid_filter(
 
     # Trigger update to get client marked as away
     client_on_ssid2["last_seen"] += 1
-    mock_unifi_websocket(message=MessageKey.CLIENT, data=client_on_ssid2)
+    mock_websocket_message(message=MessageKey.CLIENT, data=client_on_ssid2)
     await hass.async_block_till_done()
 
     new_time += timedelta(
@@ -825,7 +825,7 @@ async def test_option_ssid_filter(
 @pytest.mark.usefixtures("mock_device_registry")
 async def test_wireless_client_go_wired_issue(
     hass: HomeAssistant,
-    mock_unifi_websocket,
+    mock_websocket_message,
     config_entry_factory: Callable[[], ConfigEntry],
     client_payload: list[dict[str, Any]],
 ) -> None:
@@ -855,7 +855,7 @@ async def test_wireless_client_go_wired_issue(
     client = client_payload[0]
     client["last_seen"] = dt_util.as_timestamp(dt_util.utcnow())
     client["is_wired"] = True
-    mock_unifi_websocket(message=MessageKey.CLIENT, data=client)
+    mock_websocket_message(message=MessageKey.CLIENT, data=client)
     await hass.async_block_till_done()
 
     # Wired bug fix keeps client marked as wireless
@@ -876,7 +876,7 @@ async def test_wireless_client_go_wired_issue(
 
     # Try to mark client as connected
     client["last_seen"] += 1
-    mock_unifi_websocket(message=MessageKey.CLIENT, data=client)
+    mock_websocket_message(message=MessageKey.CLIENT, data=client)
     await hass.async_block_till_done()
 
     # Make sure it don't go online again until wired bug disappears
@@ -886,7 +886,7 @@ async def test_wireless_client_go_wired_issue(
     # Make client wireless
     client["last_seen"] += 1
     client["is_wired"] = False
-    mock_unifi_websocket(message=MessageKey.CLIENT, data=client)
+    mock_websocket_message(message=MessageKey.CLIENT, data=client)
     await hass.async_block_till_done()
 
     # Client is no longer affected by wired bug and can be marked online
@@ -898,7 +898,7 @@ async def test_wireless_client_go_wired_issue(
 @pytest.mark.usefixtures("mock_device_registry")
 async def test_option_ignore_wired_bug(
     hass: HomeAssistant,
-    mock_unifi_websocket,
+    mock_websocket_message,
     config_entry_factory: Callable[[], ConfigEntry],
     client_payload: list[dict[str, Any]],
 ) -> None:
@@ -925,7 +925,7 @@ async def test_option_ignore_wired_bug(
     # Trigger wired bug
     client = client_payload[0]
     client["is_wired"] = True
-    mock_unifi_websocket(message=MessageKey.CLIENT, data=client)
+    mock_websocket_message(message=MessageKey.CLIENT, data=client)
     await hass.async_block_till_done()
 
     # Wired bug in effect
@@ -946,7 +946,7 @@ async def test_option_ignore_wired_bug(
 
     # Mark client as connected again
     client["last_seen"] += 1
-    mock_unifi_websocket(message=MessageKey.CLIENT, data=client)
+    mock_websocket_message(message=MessageKey.CLIENT, data=client)
     await hass.async_block_till_done()
 
     # Ignoring wired bug allows client to go home again even while affected
@@ -956,7 +956,7 @@ async def test_option_ignore_wired_bug(
     # Make client wireless
     client["last_seen"] += 1
     client["is_wired"] = False
-    mock_unifi_websocket(message=MessageKey.CLIENT, data=client)
+    mock_websocket_message(message=MessageKey.CLIENT, data=client)
     await hass.async_block_till_done()
 
     # Client is wireless and still connected

--- a/tests/components/unifi/test_hub.py
+++ b/tests/components/unifi/test_hub.py
@@ -80,7 +80,7 @@ async def test_reset_fails(
 async def test_connection_state_signalling(
     hass: HomeAssistant,
     mock_device_registry,
-    websocket_mock,
+    mock_websocket_state,
     config_entry_factory: Callable[[], ConfigEntry],
     client_payload: list[dict[str, Any]],
 ) -> None:
@@ -99,17 +99,19 @@ async def test_connection_state_signalling(
     # Controller is connected
     assert hass.states.get("device_tracker.client").state == "home"
 
-    await websocket_mock.disconnect()
+    await mock_websocket_state.disconnect()
     # Controller is disconnected
     assert hass.states.get("device_tracker.client").state == "unavailable"
 
-    await websocket_mock.reconnect()
+    await mock_websocket_state.reconnect()
     # Controller is once again connected
     assert hass.states.get("device_tracker.client").state == "home"
 
 
 async def test_reconnect_mechanism(
-    aioclient_mock: AiohttpClientMocker, websocket_mock, config_entry_setup: ConfigEntry
+    aioclient_mock: AiohttpClientMocker,
+    mock_websocket_state,
+    config_entry_setup: ConfigEntry,
 ) -> None:
     """Verify reconnect prints only on first reconnection try."""
     aioclient_mock.clear_requests()
@@ -118,13 +120,13 @@ async def test_reconnect_mechanism(
         status=HTTPStatus.BAD_GATEWAY,
     )
 
-    await websocket_mock.disconnect()
+    await mock_websocket_state.disconnect()
     assert aioclient_mock.call_count == 0
 
-    await websocket_mock.reconnect(fail=True)
+    await mock_websocket_state.reconnect(fail=True)
     assert aioclient_mock.call_count == 1
 
-    await websocket_mock.reconnect(fail=True)
+    await mock_websocket_state.reconnect(fail=True)
     assert aioclient_mock.call_count == 2
 
 
@@ -138,7 +140,7 @@ async def test_reconnect_mechanism(
     ],
 )
 @pytest.mark.usefixtures("config_entry_setup")
-async def test_reconnect_mechanism_exceptions(websocket_mock, exception) -> None:
+async def test_reconnect_mechanism_exceptions(mock_websocket_state, exception) -> None:
     """Verify async_reconnect calls expected methods."""
     with (
         patch("aiounifi.Controller.login", side_effect=exception),
@@ -146,9 +148,9 @@ async def test_reconnect_mechanism_exceptions(websocket_mock, exception) -> None
             "homeassistant.components.unifi.hub.hub.UnifiWebsocket.reconnect"
         ) as mock_reconnect,
     ):
-        await websocket_mock.disconnect()
+        await mock_websocket_state.disconnect()
 
-        await websocket_mock.reconnect()
+        await mock_websocket_state.reconnect()
         mock_reconnect.assert_called_once()
 
 

--- a/tests/components/unifi/test_init.py
+++ b/tests/components/unifi/test_init.py
@@ -176,7 +176,7 @@ async def test_remove_config_entry_device(
     config_entry_factory: Callable[[], ConfigEntry],
     client_payload: list[dict[str, Any]],
     device_payload: list[dict[str, Any]],
-    mock_unifi_websocket,
+    mock_websocket_message,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Verify removing a device manually."""
@@ -206,7 +206,7 @@ async def test_remove_config_entry_device(
     )
 
     # Remove a client from Unifi API
-    mock_unifi_websocket(message=MessageKey.CLIENT_REMOVED, data=[client_payload[1]])
+    mock_websocket_message(message=MessageKey.CLIENT_REMOVED, data=[client_payload[1]])
     await hass.async_block_till_done()
 
     # Try to remove an inactive client from UI: allowed

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -355,7 +355,7 @@ async def test_no_clients(hass: HomeAssistant) -> None:
 )
 async def test_bandwidth_sensors(
     hass: HomeAssistant,
-    mock_unifi_websocket,
+    mock_websocket_message,
     config_entry_options: MappingProxyType[str, Any],
     config_entry_setup: ConfigEntry,
     client_payload: list[dict[str, Any]],
@@ -391,7 +391,7 @@ async def test_bandwidth_sensors(
     wireless_client["rx_bytes-r"] = 3456000000
     wireless_client["tx_bytes-r"] = 7891000000
 
-    mock_unifi_websocket(message=MessageKey.CLIENT, data=wireless_client)
+    mock_websocket_message(message=MessageKey.CLIENT, data=wireless_client)
     await hass.async_block_till_done()
 
     assert hass.states.get("sensor.wireless_client_rx").state == "3456.0"
@@ -402,7 +402,7 @@ async def test_bandwidth_sensors(
     new_time = dt_util.utcnow()
     wireless_client["last_seen"] = dt_util.as_timestamp(new_time)
 
-    mock_unifi_websocket(message=MessageKey.CLIENT, data=wireless_client)
+    mock_websocket_message(message=MessageKey.CLIENT, data=wireless_client)
     await hass.async_block_till_done()
 
     with freeze_time(new_time):
@@ -490,7 +490,7 @@ async def test_uptime_sensors(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     freezer: FrozenDateTimeFactory,
-    mock_unifi_websocket,
+    mock_websocket_message,
     config_entry_options: MappingProxyType[str, Any],
     config_entry_factory: Callable[[], ConfigEntry],
     client_payload: list[dict[str, Any]],
@@ -516,7 +516,7 @@ async def test_uptime_sensors(
     uptime_client["uptime"] = event_uptime
     now = datetime(2021, 1, 1, 1, 1, 4, tzinfo=dt_util.UTC)
     with patch("homeassistant.util.dt.now", return_value=now):
-        mock_unifi_websocket(message=MessageKey.CLIENT, data=uptime_client)
+        mock_websocket_message(message=MessageKey.CLIENT, data=uptime_client)
         await hass.async_block_till_done()
 
     assert hass.states.get("sensor.client1_uptime").state == "2021-01-01T01:00:00+00:00"
@@ -526,7 +526,7 @@ async def test_uptime_sensors(
     uptime_client["uptime"] = new_uptime
     now = datetime(2021, 2, 1, 1, 1, 0, tzinfo=dt_util.UTC)
     with patch("homeassistant.util.dt.now", return_value=now):
-        mock_unifi_websocket(message=MessageKey.CLIENT, data=uptime_client)
+        mock_websocket_message(message=MessageKey.CLIENT, data=uptime_client)
         await hass.async_block_till_done()
 
     assert hass.states.get("sensor.client1_uptime").state == "2021-02-01T01:00:00+00:00"
@@ -583,7 +583,7 @@ async def test_uptime_sensors(
 @pytest.mark.usefixtures("config_entry_setup")
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_remove_sensors(
-    hass: HomeAssistant, mock_unifi_websocket, client_payload: list[dict[str, Any]]
+    hass: HomeAssistant, mock_websocket_message, client_payload: list[dict[str, Any]]
 ) -> None:
     """Verify removing of clients work as expected."""
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 6
@@ -595,7 +595,7 @@ async def test_remove_sensors(
     assert hass.states.get("sensor.wireless_client_uptime")
 
     # Remove wired client
-    mock_unifi_websocket(message=MessageKey.CLIENT_REMOVED, data=client_payload[0])
+    mock_websocket_message(message=MessageKey.CLIENT_REMOVED, data=client_payload[0])
     await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 3
@@ -612,8 +612,8 @@ async def test_remove_sensors(
 async def test_poe_port_switches(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    mock_unifi_websocket,
-    websocket_mock,
+    mock_websocket_message,
+    mock_websocket_state,
 ) -> None:
     """Test the update_items function with some clients."""
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 2
@@ -642,34 +642,34 @@ async def test_poe_port_switches(
     # Update state object
     device_1 = deepcopy(DEVICE_1)
     device_1["port_table"][0]["poe_power"] = "5.12"
-    mock_unifi_websocket(message=MessageKey.DEVICE, data=device_1)
+    mock_websocket_message(message=MessageKey.DEVICE, data=device_1)
     await hass.async_block_till_done()
     assert hass.states.get("sensor.mock_name_port_1_poe_power").state == "5.12"
 
     # PoE is disabled
     device_1 = deepcopy(DEVICE_1)
     device_1["port_table"][0]["poe_mode"] = "off"
-    mock_unifi_websocket(message=MessageKey.DEVICE, data=device_1)
+    mock_websocket_message(message=MessageKey.DEVICE, data=device_1)
     await hass.async_block_till_done()
     assert hass.states.get("sensor.mock_name_port_1_poe_power").state == "0"
 
     # Availability signalling
 
     # Controller disconnects
-    await websocket_mock.disconnect()
+    await mock_websocket_state.disconnect()
     assert (
         hass.states.get("sensor.mock_name_port_1_poe_power").state == STATE_UNAVAILABLE
     )
 
     # Controller reconnects
-    await websocket_mock.reconnect()
+    await mock_websocket_state.reconnect()
     assert (
         hass.states.get("sensor.mock_name_port_1_poe_power").state != STATE_UNAVAILABLE
     )
 
     # Device gets disabled
     device_1["disabled"] = True
-    mock_unifi_websocket(message=MessageKey.DEVICE, data=device_1)
+    mock_websocket_message(message=MessageKey.DEVICE, data=device_1)
     await hass.async_block_till_done()
     assert (
         hass.states.get("sensor.mock_name_port_1_poe_power").state == STATE_UNAVAILABLE
@@ -677,7 +677,7 @@ async def test_poe_port_switches(
 
     # Device gets re-enabled
     device_1["disabled"] = False
-    mock_unifi_websocket(message=MessageKey.DEVICE, data=device_1)
+    mock_websocket_message(message=MessageKey.DEVICE, data=device_1)
     await hass.async_block_till_done()
     assert hass.states.get("sensor.mock_name_port_1_poe_power")
 
@@ -686,8 +686,8 @@ async def test_poe_port_switches(
 async def test_wlan_client_sensors(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    mock_unifi_websocket,
-    websocket_mock,
+    mock_websocket_message,
+    mock_websocket_state,
     config_entry_factory: Callable[[], ConfigEntry],
     client_payload: list[dict[str, Any]],
 ) -> None:
@@ -730,10 +730,10 @@ async def test_wlan_client_sensors(
     # Verify state update - increasing number
     wireless_client_1 = client_payload[0]
     wireless_client_1["essid"] = "SSID 1"
-    mock_unifi_websocket(message=MessageKey.CLIENT, data=wireless_client_1)
+    mock_websocket_message(message=MessageKey.CLIENT, data=wireless_client_1)
     wireless_client_2 = client_payload[1]
     wireless_client_2["essid"] = "SSID 1"
-    mock_unifi_websocket(message=MessageKey.CLIENT, data=wireless_client_2)
+    mock_websocket_message(message=MessageKey.CLIENT, data=wireless_client_2)
     await hass.async_block_till_done()
 
     ssid_1 = hass.states.get("sensor.ssid_1")
@@ -748,7 +748,7 @@ async def test_wlan_client_sensors(
     # Verify state update - decreasing number
 
     wireless_client_1["essid"] = "SSID"
-    mock_unifi_websocket(message=MessageKey.CLIENT, data=wireless_client_1)
+    mock_websocket_message(message=MessageKey.CLIENT, data=wireless_client_1)
 
     async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL)
     await hass.async_block_till_done()
@@ -759,7 +759,7 @@ async def test_wlan_client_sensors(
     # Verify state update - decreasing number
 
     wireless_client_2["last_seen"] = 0
-    mock_unifi_websocket(message=MessageKey.CLIENT, data=wireless_client_2)
+    mock_websocket_message(message=MessageKey.CLIENT, data=wireless_client_2)
 
     async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL)
     await hass.async_block_till_done()
@@ -770,23 +770,23 @@ async def test_wlan_client_sensors(
     # Availability signalling
 
     # Controller disconnects
-    await websocket_mock.disconnect()
+    await mock_websocket_state.disconnect()
     assert hass.states.get("sensor.ssid_1").state == STATE_UNAVAILABLE
 
     # Controller reconnects
-    await websocket_mock.reconnect()
+    await mock_websocket_state.reconnect()
     assert hass.states.get("sensor.ssid_1").state == "0"
 
     # WLAN gets disabled
     wlan_1 = deepcopy(WLAN)
     wlan_1["enabled"] = False
-    mock_unifi_websocket(message=MessageKey.WLAN_CONF_UPDATED, data=wlan_1)
+    mock_websocket_message(message=MessageKey.WLAN_CONF_UPDATED, data=wlan_1)
     await hass.async_block_till_done()
     assert hass.states.get("sensor.ssid_1").state == STATE_UNAVAILABLE
 
     # WLAN gets re-enabled
     wlan_1["enabled"] = True
-    mock_unifi_websocket(message=MessageKey.WLAN_CONF_UPDATED, data=wlan_1)
+    mock_websocket_message(message=MessageKey.WLAN_CONF_UPDATED, data=wlan_1)
     await hass.async_block_till_done()
     assert hass.states.get("sensor.ssid_1").state == "0"
 
@@ -828,7 +828,7 @@ async def test_wlan_client_sensors(
 async def test_outlet_power_readings(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    mock_unifi_websocket,
+    mock_websocket_message,
     device_payload: list[dict[str, Any]],
     entity_id: str,
     expected_unique_id: str,
@@ -852,7 +852,7 @@ async def test_outlet_power_readings(
         updated_device_data = deepcopy(device_payload[0])
         updated_device_data.update(changed_data)
 
-        mock_unifi_websocket(message=MessageKey.DEVICE, data=updated_device_data)
+        mock_websocket_message(message=MessageKey.DEVICE, data=updated_device_data)
         await hass.async_block_till_done()
 
         sensor_data = hass.states.get(f"sensor.{entity_id}")
@@ -887,7 +887,7 @@ async def test_outlet_power_readings(
 async def test_device_uptime(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    mock_unifi_websocket,
+    mock_websocket_message,
     config_entry_factory: Callable[[], ConfigEntry],
     device_payload: list[dict[str, Any]],
 ) -> None:
@@ -909,7 +909,7 @@ async def test_device_uptime(
     device["uptime"] = 64
     now = datetime(2021, 1, 1, 1, 1, 4, tzinfo=dt_util.UTC)
     with patch("homeassistant.util.dt.now", return_value=now):
-        mock_unifi_websocket(message=MessageKey.DEVICE, data=device)
+        mock_websocket_message(message=MessageKey.DEVICE, data=device)
 
     assert hass.states.get("sensor.device_uptime").state == "2021-01-01T01:00:00+00:00"
 
@@ -919,7 +919,7 @@ async def test_device_uptime(
     device["uptime"] = 60
     now = datetime(2021, 2, 1, 1, 1, 0, tzinfo=dt_util.UTC)
     with patch("homeassistant.util.dt.now", return_value=now):
-        mock_unifi_websocket(message=MessageKey.DEVICE, data=device)
+        mock_websocket_message(message=MessageKey.DEVICE, data=device)
 
     assert hass.states.get("sensor.device_uptime").state == "2021-02-01T01:00:00+00:00"
 
@@ -955,7 +955,7 @@ async def test_device_uptime(
 async def test_device_temperature(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    mock_unifi_websocket,
+    mock_websocket_message,
     device_payload: list[dict[str, Any]],
 ) -> None:
     """Verify that temperature sensors are working as expected."""
@@ -969,7 +969,7 @@ async def test_device_temperature(
     # Verify new event change temperature
     device = device_payload[0]
     device["general_temperature"] = 60
-    mock_unifi_websocket(message=MessageKey.DEVICE, data=device)
+    mock_websocket_message(message=MessageKey.DEVICE, data=device)
     assert hass.states.get("sensor.device_temperature").state == "60"
 
 
@@ -1004,7 +1004,7 @@ async def test_device_temperature(
 async def test_device_state(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    mock_unifi_websocket,
+    mock_websocket_message,
     device_payload: list[dict[str, Any]],
 ) -> None:
     """Verify that state sensors are working as expected."""
@@ -1017,7 +1017,7 @@ async def test_device_state(
     device = device_payload[0]
     for i in list(map(int, DeviceState)):
         device["state"] = i
-        mock_unifi_websocket(message=MessageKey.DEVICE, data=device)
+        mock_websocket_message(message=MessageKey.DEVICE, data=device)
         assert hass.states.get("sensor.device_state").state == DEVICE_STATES[i]
 
 
@@ -1041,7 +1041,7 @@ async def test_device_state(
 async def test_device_system_stats(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    mock_unifi_websocket,
+    mock_websocket_message,
     device_payload: list[dict[str, Any]],
 ) -> None:
     """Verify that device stats sensors are working as expected."""
@@ -1065,7 +1065,7 @@ async def test_device_system_stats(
     # Verify new event change system-stats
     device = device_payload[0]
     device["system-stats"] = {"cpu": 7.7, "mem": 33.3, "uptime": 7316}
-    mock_unifi_websocket(message=MessageKey.DEVICE, data=device)
+    mock_websocket_message(message=MessageKey.DEVICE, data=device)
 
     assert hass.states.get("sensor.device_cpu_utilization").state == "7.7"
     assert hass.states.get("sensor.device_memory_utilization").state == "33.3"
@@ -1138,7 +1138,7 @@ async def test_device_system_stats(
 async def test_bandwidth_port_sensors(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    mock_unifi_websocket,
+    mock_websocket_message,
     config_entry_setup: ConfigEntry,
     config_entry_options: MappingProxyType[str, Any],
     device_payload,
@@ -1206,7 +1206,7 @@ async def test_bandwidth_port_sensors(
     device_1["port_table"][0]["rx_bytes-r"] = 3456000000
     device_1["port_table"][0]["tx_bytes-r"] = 7891000000
 
-    mock_unifi_websocket(message=MessageKey.DEVICE, data=device_1)
+    mock_websocket_message(message=MessageKey.DEVICE, data=device_1)
     await hass.async_block_till_done()
 
     assert hass.states.get("sensor.mock_name_port_1_rx").state == "27648.00000"

--- a/tests/components/unifi/test_update.py
+++ b/tests/components/unifi/test_update.py
@@ -61,7 +61,7 @@ DEVICE_2 = {
 
 @pytest.mark.parametrize("device_payload", [[DEVICE_1, DEVICE_2]])
 @pytest.mark.usefixtures("config_entry_setup")
-async def test_device_updates(hass: HomeAssistant, mock_unifi_websocket) -> None:
+async def test_device_updates(hass: HomeAssistant, mock_websocket_message) -> None:
     """Test the update_items function with some devices."""
     assert len(hass.states.async_entity_ids(UPDATE_DOMAIN)) == 2
 
@@ -95,7 +95,7 @@ async def test_device_updates(hass: HomeAssistant, mock_unifi_websocket) -> None
 
     device_1 = deepcopy(DEVICE_1)
     device_1["state"] = 4
-    mock_unifi_websocket(message=MessageKey.DEVICE, data=device_1)
+    mock_websocket_message(message=MessageKey.DEVICE, data=device_1)
     await hass.async_block_till_done()
 
     device_1_state = hass.states.get("update.device_1")
@@ -110,7 +110,7 @@ async def test_device_updates(hass: HomeAssistant, mock_unifi_websocket) -> None
     device_1["version"] = "4.3.17.11279"
     device_1["upgradable"] = False
     del device_1["upgrade_to_firmware"]
-    mock_unifi_websocket(message=MessageKey.DEVICE, data=device_1)
+    mock_websocket_message(message=MessageKey.DEVICE, data=device_1)
     await hass.async_block_till_done()
 
     device_1_state = hass.states.get("update.device_1")
@@ -173,15 +173,15 @@ async def test_install(
 
 @pytest.mark.parametrize("device_payload", [[DEVICE_1]])
 @pytest.mark.usefixtures("config_entry_setup")
-async def test_hub_state_change(hass: HomeAssistant, websocket_mock) -> None:
+async def test_hub_state_change(hass: HomeAssistant, mock_websocket_state) -> None:
     """Verify entities state reflect on hub becoming unavailable."""
     assert len(hass.states.async_entity_ids(UPDATE_DOMAIN)) == 1
     assert hass.states.get("update.device_1").state == STATE_ON
 
     # Controller unavailable
-    await websocket_mock.disconnect()
+    await mock_websocket_state.disconnect()
     assert hass.states.get("update.device_1").state == STATE_UNAVAILABLE
 
     # Controller available
-    await websocket_mock.reconnect()
+    await mock_websocket_state.reconnect()
     assert hass.states.get("update.device_1").state == STATE_ON


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rework websocket fixtures to not use hub directly
Changes are to remedy review comment https://github.com/home-assistant/core/pull/117457/files#r1606145050

Other changes are cosmetic.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
