### PR TITLE
Improve type hints in amberelectric tests

### DIFF
--- a/tests/components/amberelectric/test_binary_sensor.py
+++ b/tests/components/amberelectric/test_binary_sensor.py
@@ -28,7 +28,7 @@ MOCK_API_TOKEN = "psk_0000000000000000"
 
 
 @pytest.fixture
-async def setup_no_spike(hass) -> AsyncGenerator:
+async def setup_no_spike(hass: HomeAssistant) -> AsyncGenerator[Mock]:
     """Set up general channel."""
     MockConfigEntry(
         domain="amberelectric",
@@ -51,7 +51,7 @@ async def setup_no_spike(hass) -> AsyncGenerator:
 
 
 @pytest.fixture
-async def setup_potential_spike(hass) -> AsyncGenerator:
+async def setup_potential_spike(hass: HomeAssistant) -> AsyncGenerator[Mock]:
     """Set up general channel."""
     MockConfigEntry(
         domain="amberelectric",
@@ -80,7 +80,7 @@ async def setup_potential_spike(hass) -> AsyncGenerator:
 
 
 @pytest.fixture
-async def setup_spike(hass) -> AsyncGenerator:
+async def setup_spike(hass: HomeAssistant) -> AsyncGenerator[Mock]:
     """Set up general channel."""
     MockConfigEntry(
         domain="amberelectric",
@@ -108,7 +108,8 @@ async def setup_spike(hass) -> AsyncGenerator:
         yield mock_update.return_value
 
 
-def test_no_spike_sensor(hass: HomeAssistant, setup_no_spike) -> None:
+@pytest.mark.usefixtures("setup_no_spike")
+def test_no_spike_sensor(hass: HomeAssistant) -> None:
     """Testing the creation of the Amber renewables sensor."""
     assert len(hass.states.async_all()) == 5
     sensor = hass.states.get("binary_sensor.mock_title_price_spike")
@@ -118,7 +119,8 @@ def test_no_spike_sensor(hass: HomeAssistant, setup_no_spike) -> None:
     assert sensor.attributes["spike_status"] == "none"
 
 
-def test_potential_spike_sensor(hass: HomeAssistant, setup_potential_spike) -> None:
+@pytest.mark.usefixtures("setup_potential_spike")
+def test_potential_spike_sensor(hass: HomeAssistant) -> None:
     """Testing the creation of the Amber renewables sensor."""
     assert len(hass.states.async_all()) == 5
     sensor = hass.states.get("binary_sensor.mock_title_price_spike")
@@ -128,7 +130,8 @@ def test_potential_spike_sensor(hass: HomeAssistant, setup_potential_spike) -> N
     assert sensor.attributes["spike_status"] == "potential"
 
 
-def test_spike_sensor(hass: HomeAssistant, setup_spike) -> None:
+@pytest.mark.usefixtures("setup_spike")
+def test_spike_sensor(hass: HomeAssistant) -> None:
     """Testing the creation of the Amber renewables sensor."""
     assert len(hass.states.async_all()) == 5
     sensor = hass.states.get("binary_sensor.mock_title_price_spike")

--- a/tests/components/amberelectric/test_sensor.py
+++ b/tests/components/amberelectric/test_sensor.py
@@ -31,7 +31,7 @@ MOCK_API_TOKEN = "psk_0000000000000000"
 
 
 @pytest.fixture
-async def setup_general(hass) -> AsyncGenerator:
+async def setup_general(hass: HomeAssistant) -> AsyncGenerator[Mock]:
     """Set up general channel."""
     MockConfigEntry(
         domain="amberelectric",
@@ -54,7 +54,9 @@ async def setup_general(hass) -> AsyncGenerator:
 
 
 @pytest.fixture
-async def setup_general_and_controlled_load(hass) -> AsyncGenerator:
+async def setup_general_and_controlled_load(
+    hass: HomeAssistant,
+) -> AsyncGenerator[Mock]:
     """Set up general channel and controller load channel."""
     MockConfigEntry(
         domain="amberelectric",
@@ -78,7 +80,7 @@ async def setup_general_and_controlled_load(hass) -> AsyncGenerator:
 
 
 @pytest.fixture
-async def setup_general_and_feed_in(hass) -> AsyncGenerator:
+async def setup_general_and_feed_in(hass: HomeAssistant) -> AsyncGenerator[Mock]:
     """Set up general channel and feed in channel."""
     MockConfigEntry(
         domain="amberelectric",
@@ -138,9 +140,8 @@ async def test_general_price_sensor(hass: HomeAssistant, setup_general: Mock) ->
     assert attributes.get("range_max") == 0.12
 
 
-async def test_general_and_controlled_load_price_sensor(
-    hass: HomeAssistant, setup_general_and_controlled_load: Mock
-) -> None:
+@pytest.mark.usefixtures("setup_general_and_controlled_load")
+async def test_general_and_controlled_load_price_sensor(hass: HomeAssistant) -> None:
     """Test the Controlled Price sensor."""
     assert len(hass.states.async_all()) == 8
     price = hass.states.get("sensor.mock_title_controlled_load_price")
@@ -161,9 +162,8 @@ async def test_general_and_controlled_load_price_sensor(
     assert attributes["attribution"] == "Data provided by Amber Electric"
 
 
-async def test_general_and_feed_in_price_sensor(
-    hass: HomeAssistant, setup_general_and_feed_in: Mock
-) -> None:
+@pytest.mark.usefixtures("setup_general_and_feed_in")
+async def test_general_and_feed_in_price_sensor(hass: HomeAssistant) -> None:
     """Test the Feed In sensor."""
     assert len(hass.states.async_all()) == 8
     price = hass.states.get("sensor.mock_title_feed_in_price")
@@ -227,9 +227,8 @@ async def test_general_forecast_sensor(
     assert first_forecast.get("range_max") == 0.12
 
 
-async def test_controlled_load_forecast_sensor(
-    hass: HomeAssistant, setup_general_and_controlled_load: Mock
-) -> None:
+@pytest.mark.usefixtures("setup_general_and_controlled_load")
+async def test_controlled_load_forecast_sensor(hass: HomeAssistant) -> None:
     """Test the Controlled Load Forecast sensor."""
     assert len(hass.states.async_all()) == 8
     price = hass.states.get("sensor.mock_title_controlled_load_forecast")
@@ -252,9 +251,8 @@ async def test_controlled_load_forecast_sensor(
     assert first_forecast["descriptor"] == "very_low"
 
 
-async def test_feed_in_forecast_sensor(
-    hass: HomeAssistant, setup_general_and_feed_in: Mock
-) -> None:
+@pytest.mark.usefixtures("setup_general_and_feed_in")
+async def test_feed_in_forecast_sensor(hass: HomeAssistant) -> None:
     """Test the Feed In Forecast sensor."""
     assert len(hass.states.async_all()) == 8
     price = hass.states.get("sensor.mock_title_feed_in_forecast")
@@ -277,7 +275,8 @@ async def test_feed_in_forecast_sensor(
     assert first_forecast["descriptor"] == "very_low"
 
 
-def test_renewable_sensor(hass: HomeAssistant, setup_general) -> None:
+@pytest.mark.usefixtures("setup_general")
+def test_renewable_sensor(hass: HomeAssistant) -> None:
     """Testing the creation of the Amber renewables sensor."""
     assert len(hass.states.async_all()) == 5
     sensor = hass.states.get("sensor.mock_title_renewables")
@@ -285,9 +284,8 @@ def test_renewable_sensor(hass: HomeAssistant, setup_general) -> None:
     assert sensor.state == "51"
 
 
-def test_general_price_descriptor_descriptor_sensor(
-    hass: HomeAssistant, setup_general: Mock
-) -> None:
+@pytest.mark.usefixtures("setup_general")
+def test_general_price_descriptor_descriptor_sensor(hass: HomeAssistant) -> None:
     """Test the General Price Descriptor sensor."""
     assert len(hass.states.async_all()) == 5
     price = hass.states.get("sensor.mock_title_general_price_descriptor")
@@ -295,8 +293,9 @@ def test_general_price_descriptor_descriptor_sensor(
     assert price.state == "extremely_low"
 
 
+@pytest.mark.usefixtures("setup_general_and_controlled_load")
 def test_general_and_controlled_load_price_descriptor_sensor(
-    hass: HomeAssistant, setup_general_and_controlled_load: Mock
+    hass: HomeAssistant,
 ) -> None:
     """Test the Controlled Price Descriptor sensor."""
     assert len(hass.states.async_all()) == 8
@@ -305,9 +304,8 @@ def test_general_and_controlled_load_price_descriptor_sensor(
     assert price.state == "extremely_low"
 
 
-def test_general_and_feed_in_price_descriptor_sensor(
-    hass: HomeAssistant, setup_general_and_feed_in: Mock
-) -> None:
+@pytest.mark.usefixtures("setup_general_and_feed_in")
+def test_general_and_feed_in_price_descriptor_sensor(hass: HomeAssistant) -> None:
     """Test the Feed In Price Descriptor sensor."""
     assert len(hass.states.async_all()) == 8
     price = hass.states.get("sensor.mock_title_feed_in_price_descriptor")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
