### PR TITLE
Allow openweathermap integration to use locations from a zone

### DIFF
--- a/homeassistant/components/openweathermap/__init__.py
+++ b/homeassistant/components/openweathermap/__init__.py
@@ -15,8 +15,10 @@ from homeassistant.const import (
     CONF_LONGITUDE,
     CONF_MODE,
     CONF_NAME,
+    CONF_ZONE,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.helpers.event import async_track_state_change_event
 
 from .const import CONFIG_FLOW_VERSION, OWM_MODE_V25, PLATFORMS
 from .coordinator import WeatherUpdateCoordinator
@@ -34,6 +36,7 @@ class OpenweathermapData:
 
     name: str
     coordinator: WeatherUpdateCoordinator
+    event_unsubscribe: CALLBACK_TYPE | None = None
 
 
 async def async_setup_entry(
@@ -42,8 +45,15 @@ async def async_setup_entry(
     """Set up OpenWeatherMap as config entry."""
     name = entry.data[CONF_NAME]
     api_key = entry.data[CONF_API_KEY]
-    latitude = entry.data.get(CONF_LATITUDE, hass.config.latitude)
-    longitude = entry.data.get(CONF_LONGITUDE, hass.config.longitude)
+    zone = entry.data.get(CONF_ZONE)
+    if zone:
+        zone_state = hass.states.get(zone)
+        if zone_state:
+            latitude = zone_state.attributes.get("latitude")
+            longitude = zone_state.attributes.get("longitude")
+    else:
+        latitude = entry.data.get(CONF_LATITUDE, hass.config.latitude)
+        longitude = entry.data.get(CONF_LONGITUDE, hass.config.longitude)
     language = entry.options[CONF_LANGUAGE]
     mode = entry.options[CONF_MODE]
 
@@ -57,11 +67,19 @@ async def async_setup_entry(
         owm_client, latitude, longitude, hass
     )
 
+    event_unsubscribe = None
+    if zone:
+        event_unsubscribe = async_track_state_change_event(
+            hass, zone, weather_coordinator.zone_update
+        )
+
     await weather_coordinator.async_config_entry_first_refresh()
 
     entry.async_on_unload(entry.add_update_listener(async_update_options))
 
-    entry.runtime_data = OpenweathermapData(name, weather_coordinator)
+    entry.runtime_data = OpenweathermapData(
+        name, weather_coordinator, event_unsubscribe
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -101,4 +119,6 @@ async def async_unload_entry(
     hass: HomeAssistant, entry: OpenweathermapConfigEntry
 ) -> bool:
     """Unload a config entry."""
+    if entry.runtime_data.event_unsubscribe is not None:
+        entry.runtime_data.event_unsubscribe()
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/openweathermap/coordinator.py
+++ b/homeassistant/components/openweathermap/coordinator.py
@@ -17,7 +17,7 @@ from homeassistant.components.weather import (
     ATTR_CONDITION_SUNNY,
     Forecast,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, EventStateChangedData, HomeAssistant
 from homeassistant.helpers import sun
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
@@ -201,3 +201,11 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
             return ATTR_CONDITION_CLEAR_NIGHT
 
         return CONDITION_MAP.get(weather_code)
+
+    async def zone_update(self, event: Event[EventStateChangedData]) -> None:
+        """Update latitude and longitude from event."""
+        if (to_state := event.data["new_state"]) is None:
+            return
+        self._latitude = to_state.attributes["latitude"]
+        self._longitude = to_state.attributes["longitude"]
+        await self.async_refresh()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Allows the openweathermap integration to use the location of a zone, instead of a statically set latitude and longitude .
This makes it much more useful for use on a boat, or in an RV, or for people who frequently move :)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
