### PR TITLE
Revert SamsungTV migration

### DIFF
--- a/homeassistant/components/samsungtv/__init__.py
+++ b/homeassistant/components/samsungtv/__init__.py
@@ -304,9 +304,24 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
                 new_connections = device.connections.copy()
                 new_connections.discard((dr.CONNECTION_NETWORK_MAC, "none"))
                 if new_connections != device.connections:
-                    dev_reg.async_update_device(
-                        device.id, new_connections=new_connections
+                    LOGGER.info(
+                        "Clearing invalid `none` mac connection "
+                        "from device %s for config entry %s",
+                        device.id,
+                        config_entry.entry_id,
                     )
+                    try:
+                        dev_reg.async_update_device(
+                            device.id, new_connections=new_connections
+                        )
+                    except KeyError:
+                        LOGGER.error(
+                            "Failed to remove `none` mac connection "
+                            "from device %s for config entry %s. Aborting migration",
+                            device.id,
+                            config_entry.entry_id,
+                        )
+                        return False
 
             minor_version = 2
             hass.config_entries.async_update_entry(config_entry, minor_version=2)

--- a/homeassistant/components/samsungtv/__init__.py
+++ b/homeassistant/components/samsungtv/__init__.py
@@ -297,33 +297,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     if version == 2:
         if minor_version < 2:
             # Cleanup invalid MAC addresses - see #103512
-            dev_reg = dr.async_get(hass)
-            for device in dr.async_entries_for_config_entry(
-                dev_reg, config_entry.entry_id
-            ):
-                new_connections = device.connections.copy()
-                new_connections.discard((dr.CONNECTION_NETWORK_MAC, "none"))
-                if new_connections != device.connections:
-                    # The migration is failing for some users, so we log the error
-                    # see #119082 for sample errors
-                    LOGGER.info(
-                        "Clearing invalid `none` mac connection "
-                        "from device %s for config entry %s",
-                        device.id,
-                        config_entry.entry_id,
-                    )
-                    try:
-                        dev_reg.async_update_device(
-                            device.id, new_connections=new_connections
-                        )
-                    except KeyError:
-                        LOGGER.error(
-                            "Failed to remove `none` mac connection "
-                            "from device %s for config entry %s. Aborting migration",
-                            device.id,
-                            config_entry.entry_id,
-                        )
-                        return False
+            # Reverted due to device registry collisions - see #119082 / #119249
 
             minor_version = 2
             hass.config_entries.async_update_entry(config_entry, minor_version=2)

--- a/homeassistant/components/samsungtv/__init__.py
+++ b/homeassistant/components/samsungtv/__init__.py
@@ -304,6 +304,8 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
                 new_connections = device.connections.copy()
                 new_connections.discard((dr.CONNECTION_NETWORK_MAC, "none"))
                 if new_connections != device.connections:
+                    # The migration is failing for some users, so we log the error
+                    # see #119082 for sample errors
                     LOGGER.info(
                         "Clearing invalid `none` mac connection "
                         "from device %s for config entry %s",

--- a/tests/components/samsungtv/test_init.py
+++ b/tests/components/samsungtv/test_init.py
@@ -220,10 +220,14 @@ async def test_incorrectly_formatted_mac_fixed(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("remotews", "rest_api")
+@pytest.mark.xfail
 async def test_cleanup_mac(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry, snapshot: SnapshotAssertion
 ) -> None:
-    """Test for `none` mac cleanup #103512."""
+    """Test for `none` mac cleanup #103512.
+
+    Reverted due to device registry collisions in #119249 / #119082
+    """
     entry = MockConfigEntry(
         domain=SAMSUNGTV_DOMAIN,
         data=MOCK_ENTRY_WS_WITH_MAC,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I am unable to reproduce the issue in #119082
As a temporary measure, I think we should skip the migration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
