### PR TITLE
Cleanup Reolink firmware update entity

### DIFF
--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -93,7 +93,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         """Check for firmware updates."""
         async with asyncio.timeout(host.api.timeout * (RETRY_ATTEMPTS + 2)):
             try:
-                await host.api.check_new_firmware(host.firmware_ch_list)
+                await host.api.check_new_firmware()
             except ReolinkError as err:
                 if starting:
                     _LOGGER.debug(

--- a/homeassistant/components/reolink/update.py
+++ b/homeassistant/components/reolink/update.py
@@ -40,7 +40,7 @@ HOST_UPDATE_ENTITIES = (
     ReolinkHostUpdateEntityDescription(
         key="firmware",
         supported=lambda api: api.supported(None, "firmware"),
-        device_class=UpdateDeviceClass.FIRMWARE
+        device_class=UpdateDeviceClass.FIRMWARE,
     ),
 )
 

--- a/homeassistant/components/reolink/update.py
+++ b/homeassistant/components/reolink/update.py
@@ -40,6 +40,7 @@ HOST_UPDATE_ENTITIES = (
     ReolinkHostUpdateEntityDescription(
         key="firmware",
         supported=lambda api: api.supported(None, "firmware"),
+        device_class=UpdateDeviceClass.FIRMWARE
     ),
 )
 
@@ -67,7 +68,6 @@ class ReolinkHostUpdateEntity(
     """Update entity class for Reolink Host."""
 
     entity_description: ReolinkHostUpdateEntityDescription
-    _attr_device_class = UpdateDeviceClass.FIRMWARE
     _attr_release_url = "https://reolink.com/download-center/"
 
     def __init__(

--- a/homeassistant/components/reolink/update.py
+++ b/homeassistant/components/reolink/update.py
@@ -23,10 +23,7 @@ from homeassistant.helpers.event import async_call_later
 
 from . import ReolinkData
 from .const import DOMAIN
-from .entity import (
-    ReolinkHostCoordinatorEntity,
-    ReolinkHostEntityDescription,
-)
+from .entity import ReolinkHostCoordinatorEntity, ReolinkHostEntityDescription
 
 POLL_AFTER_INSTALL = 120
 

--- a/homeassistant/components/reolink/update.py
+++ b/homeassistant/components/reolink/update.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime
-import logging
-from typing import Any, Literal
+from typing import Any
 
 from reolink_aio.exceptions import ReolinkError
 from reolink_aio.software_version import NewSoftwareVersion
@@ -12,6 +12,7 @@ from reolink_aio.software_version import NewSoftwareVersion
 from homeassistant.components.update import (
     UpdateDeviceClass,
     UpdateEntity,
+    UpdateEntityDescription,
     UpdateEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -22,11 +23,28 @@ from homeassistant.helpers.event import async_call_later
 
 from . import ReolinkData
 from .const import DOMAIN
-from .entity import ReolinkBaseCoordinatorEntity
-
-LOGGER = logging.getLogger(__name__)
+from .entity import (
+    ReolinkHostCoordinatorEntity,
+    ReolinkHostEntityDescription,
+)
 
 POLL_AFTER_INSTALL = 120
+
+
+@dataclass(frozen=True, kw_only=True)
+class ReolinkHostUpdateEntityDescription(
+    UpdateEntityDescription,
+    ReolinkHostEntityDescription,
+):
+    """A class that describes host update entities."""
+
+
+HOST_UPDATE_ENTITIES = (
+    ReolinkHostUpdateEntityDescription(
+        key="firmware",
+        supported=lambda api: api.supported(None, "firmware"),
+    ),
+)
 
 
 async def async_setup_entry(
@@ -36,26 +54,33 @@ async def async_setup_entry(
 ) -> None:
     """Set up update entities for Reolink component."""
     reolink_data: ReolinkData = hass.data[DOMAIN][config_entry.entry_id]
-    async_add_entities([ReolinkUpdateEntity(reolink_data)])
+
+    entities: list[ReolinkHostUpdateEntity] = [
+        ReolinkHostUpdateEntity(reolink_data, entity_description)
+        for entity_description in HOST_UPDATE_ENTITIES
+        if entity_description.supported(reolink_data.host.api)
+    ]
+    async_add_entities(entities)
 
 
-class ReolinkUpdateEntity(
-    ReolinkBaseCoordinatorEntity[str | Literal[False] | NewSoftwareVersion],
+class ReolinkHostUpdateEntity(
+    ReolinkHostCoordinatorEntity,
     UpdateEntity,
 ):
-    """Update entity for a Netgear device."""
+    """Update entity class for Reolink Host."""
 
+    entity_description: ReolinkHostUpdateEntityDescription
     _attr_device_class = UpdateDeviceClass.FIRMWARE
     _attr_release_url = "https://reolink.com/download-center/"
 
     def __init__(
         self,
         reolink_data: ReolinkData,
+        entity_description: ReolinkHostUpdateEntityDescription,
     ) -> None:
-        """Initialize a Netgear device."""
+        """Initialize Reolink update entity."""
+        self.entity_description = entity_description
         super().__init__(reolink_data, reolink_data.firmware_coordinator)
-
-        self._attr_unique_id = f"{self._host.unique_id}"
         self._cancel_update: CALLBACK_TYPE | None = None
 
     @property
@@ -66,32 +91,35 @@ class ReolinkUpdateEntity(
     @property
     def latest_version(self) -> str | None:
         """Latest version available for install."""
-        if not self.coordinator.data:
+        new_firmware = self._host.api.firmware_update_available()
+        if not new_firmware:
             return self.installed_version
 
-        if isinstance(self.coordinator.data, str):
-            return self.coordinator.data
+        if isinstance(new_firmware, str):
+            return new_firmware
 
-        return self.coordinator.data.version_string
+        return new_firmware.version_string
 
     @property
     def supported_features(self) -> UpdateEntityFeature:
         """Flag supported features."""
         supported_features = UpdateEntityFeature.INSTALL
-        if isinstance(self.coordinator.data, NewSoftwareVersion):
+        new_firmware = self._host.api.firmware_update_available()
+        if isinstance(new_firmware, NewSoftwareVersion):
             supported_features |= UpdateEntityFeature.RELEASE_NOTES
         return supported_features
 
     async def async_release_notes(self) -> str | None:
         """Return the release notes."""
-        if not isinstance(self.coordinator.data, NewSoftwareVersion):
+        new_firmware = self._host.api.firmware_update_available()
+        if not isinstance(new_firmware, NewSoftwareVersion):
             return None
 
         return (
             "If the install button fails, download this"
-            f" [firmware zip file]({self.coordinator.data.download_url})."
+            f" [firmware zip file]({new_firmware.download_url})."
             " Then, follow the installation guide (PDF in the zip file).\n\n"
-            f"## Release notes\n\n{self.coordinator.data.release_notes}"
+            f"## Release notes\n\n{new_firmware.release_notes}"
         )
 
     async def async_install(

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -86,6 +86,7 @@ def reolink_connect_class() -> Generator[MagicMock]:
         host_mock.camera_name.return_value = TEST_NVR_NAME
         host_mock.camera_sw_version.return_value = "v1.1.0.0.0.0000"
         host_mock.camera_uid.return_value = TEST_UID
+        host_mock.firmware_update_available.return_value = False
         host_mock.session_active = True
         host_mock.timeout = 60
         host_mock.renewtimer.return_value = 600

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -200,10 +200,7 @@ async def test_migrate_entity_ids(
     )
 
     assert entity_registry.async_get_entity_id(domain, const.DOMAIN, original_id)
-    assert (
-        entity_registry.async_get_entity_id(domain, const.DOMAIN, new_id)
-        is None
-    )
+    assert entity_registry.async_get_entity_id(domain, const.DOMAIN, new_id) is None
 
     # setup CH 0 and host entities/device
     with patch("homeassistant.components.reolink.PLATFORMS", [domain]):

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -178,40 +178,42 @@ async def test_cleanup_disconnected_cams(
     assert sorted(device_models) == sorted(expected_models)
 
 
-async def test_cleanup_deprecated_entities(
+async def test_migrate_entity_ids(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     reolink_connect: MagicMock,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test deprecated ir_lights light entity is cleaned."""
+    """Test entity ids that need to be migrated."""
     reolink_connect.channels = [0]
-    ir_id = f"{TEST_MAC}_0_ir_lights"
+    original_id = f"{TEST_MAC}"
+    new_id = f"{TEST_MAC}_firmware"
+    domain = Platform.UPDATE
 
     entity_registry.async_get_or_create(
-        domain=Platform.LIGHT,
+        domain=domain,
         platform=const.DOMAIN,
-        unique_id=ir_id,
+        unique_id=original_id,
         config_entry=config_entry,
-        suggested_object_id=ir_id,
+        suggested_object_id=original_id,
         disabled_by=None,
     )
 
-    assert entity_registry.async_get_entity_id(Platform.LIGHT, const.DOMAIN, ir_id)
+    assert entity_registry.async_get_entity_id(domain, const.DOMAIN, original_id)
     assert (
-        entity_registry.async_get_entity_id(Platform.SWITCH, const.DOMAIN, ir_id)
+        entity_registry.async_get_entity_id(domain, const.DOMAIN, new_id)
         is None
     )
 
-    # setup CH 0 and NVR switch entities/device
-    with patch("homeassistant.components.reolink.PLATFORMS", [Platform.SWITCH]):
+    # setup CH 0 and host entities/device
+    with patch("homeassistant.components.reolink.PLATFORMS", [domain]):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
     assert (
-        entity_registry.async_get_entity_id(Platform.LIGHT, const.DOMAIN, ir_id) is None
+        entity_registry.async_get_entity_id(domain, const.DOMAIN, original_id) is None
     )
-    assert entity_registry.async_get_entity_id(Platform.SWITCH, const.DOMAIN, ir_id)
+    assert entity_registry.async_get_entity_id(domain, const.DOMAIN, new_id)
 
 
 async def test_no_repair_issue(
@@ -331,4 +333,4 @@ async def test_firmware_repair_issue(
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert (const.DOMAIN, "firmware_update") in issue_registry.issues
+    assert (const.DOMAIN, "firmware_update_host") in issue_registry.issues

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -333,4 +333,4 @@ async def test_firmware_repair_issue(
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert (const.DOMAIN, "firmware_update_host") in issue_registry.issues
+    assert (const.DOMAIN, "firmware_update") in issue_registry.issues


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `ReolinkHostCoordinatorEntity` for the firmware update entity, making the `ReolinkBaseCoordinatorEntity` obsolete.
Also use the new `firmware_update_available` function (which will also be used for the IPC channel camera's).

This does mean the unique_id of the firmware entity changes from "{mac}" to "{mac}_firmware".
Migration code has been added (and tests, and tested myself) to allow for smooth migration.

This makes the firmware update entity follow the same structure as all other reolink platforms.
(using a entity_description etc).

Once this is merged, I have a follow up PR that will implement the firmware update entities for IPC cameras connected to the channels of a Reolink Home Hub/NVR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
