### PR TITLE
Switch unifiprotect lib to use uiprotect

### DIFF
--- a/homeassistant/components/unifiprotect/__init__.py
+++ b/homeassistant/components/unifiprotect/__init__.py
@@ -6,14 +6,14 @@ from datetime import timedelta
 import logging
 
 from aiohttp.client_exceptions import ServerDisconnectedError
-from pyunifiprotect.data import Bootstrap
-from pyunifiprotect.data.types import FirmwareReleaseChannel
-from pyunifiprotect.exceptions import ClientError, NotAuthorized
+from uiprotect.data import Bootstrap
+from uiprotect.data.types import FirmwareReleaseChannel
+from uiprotect.exceptions import ClientError, NotAuthorized
 
-# Import the test_util.anonymize module from the pyunifiprotect package
+# Import the test_util.anonymize module from the uiprotect package
 # in __init__ to ensure it gets imported in the executor since the
 # diagnostics module will not be imported in the executor.
-from pyunifiprotect.test_util.anonymize import anonymize_data  # noqa: F401
+from uiprotect.test_util.anonymize import anonymize_data  # noqa: F401
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP

--- a/homeassistant/components/unifiprotect/binary_sensor.py
+++ b/homeassistant/components/unifiprotect/binary_sensor.py
@@ -6,7 +6,7 @@ import dataclasses
 import logging
 from typing import Any
 
-from pyunifiprotect.data import (
+from uiprotect.data import (
     NVR,
     Camera,
     Light,
@@ -16,7 +16,7 @@ from pyunifiprotect.data import (
     ProtectModelWithId,
     Sensor,
 )
-from pyunifiprotect.data.nvr import UOSDisk
+from uiprotect.data.nvr import UOSDisk
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,

--- a/homeassistant/components/unifiprotect/button.py
+++ b/homeassistant/components/unifiprotect/button.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 import logging
 from typing import Final
 
-from pyunifiprotect.data import ProtectAdoptableDeviceModel, ProtectModelWithId
+from uiprotect.data import ProtectAdoptableDeviceModel, ProtectModelWithId
 
 from homeassistant.components.button import (
     ButtonDeviceClass,

--- a/homeassistant/components/unifiprotect/camera.py
+++ b/homeassistant/components/unifiprotect/camera.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any, cast
 
-from pyunifiprotect.data import (
+from typing_extensions import Generator
+from uiprotect.data import (
     Camera as UFPCamera,
     CameraChannel,
     ModelType,
@@ -13,7 +14,6 @@ from pyunifiprotect.data import (
     ProtectModelWithId,
     StateType,
 )
-from typing_extensions import Generator
 
 from homeassistant.components.camera import Camera, CameraEntityFeature
 from homeassistant.config_entries import ConfigEntry

--- a/homeassistant/components/unifiprotect/config_flow.py
+++ b/homeassistant/components/unifiprotect/config_flow.py
@@ -8,9 +8,9 @@ from pathlib import Path
 from typing import Any
 
 from aiohttp import CookieJar
-from pyunifiprotect import ProtectApiClient
-from pyunifiprotect.data import NVR
-from pyunifiprotect.exceptions import ClientError, NotAuthorized
+from uiprotect import ProtectApiClient
+from uiprotect.data import NVR
+from uiprotect.exceptions import ClientError, NotAuthorized
 from unifi_discovery import async_console_is_alive
 import voluptuous as vol
 

--- a/homeassistant/components/unifiprotect/const.py
+++ b/homeassistant/components/unifiprotect/const.py
@@ -1,6 +1,6 @@
 """Constant definitions for UniFi Protect Integration."""
 
-from pyunifiprotect.data import ModelType, Version
+from uiprotect.data import ModelType, Version
 
 from homeassistant.const import Platform
 

--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -8,8 +8,9 @@ from functools import partial
 import logging
 from typing import Any, cast
 
-from pyunifiprotect import ProtectApiClient
-from pyunifiprotect.data import (
+from typing_extensions import Generator
+from uiprotect import ProtectApiClient
+from uiprotect.data import (
     NVR,
     Bootstrap,
     Camera,
@@ -20,9 +21,8 @@ from pyunifiprotect.data import (
     ProtectAdoptableDeviceModel,
     WSSubscriptionMessage,
 )
-from pyunifiprotect.exceptions import ClientError, NotAuthorized
-from pyunifiprotect.utils import log_event
-from typing_extensions import Generator
+from uiprotect.exceptions import ClientError, NotAuthorized
+from uiprotect.utils import log_event
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback

--- a/homeassistant/components/unifiprotect/diagnostics.py
+++ b/homeassistant/components/unifiprotect/diagnostics.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from pyunifiprotect.test_util.anonymize import anonymize_data
+from uiprotect.test_util.anonymize import anonymize_data
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant

--- a/homeassistant/components/unifiprotect/entity.py
+++ b/homeassistant/components/unifiprotect/entity.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Sequence
 import logging
 from typing import TYPE_CHECKING, Any
 
-from pyunifiprotect.data import (
+from uiprotect.data import (
     NVR,
     Camera,
     Chime,

--- a/homeassistant/components/unifiprotect/light.py
+++ b/homeassistant/components/unifiprotect/light.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pyunifiprotect.data import (
+from uiprotect.data import (
     Light,
     ModelType,
     ProtectAdoptableDeviceModel,

--- a/homeassistant/components/unifiprotect/lock.py
+++ b/homeassistant/components/unifiprotect/lock.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any, cast
 
-from pyunifiprotect.data import (
+from uiprotect.data import (
     Doorlock,
     LockStatusType,
     ModelType,

--- a/homeassistant/components/unifiprotect/manifest.json
+++ b/homeassistant/components/unifiprotect/manifest.json
@@ -40,7 +40,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["uiprotect", "unifi_discovery"],
-  "requirements": ["uiprotect==0.3.7", "unifi-discovery==1.1.8"],
+  "requirements": ["uiprotect==0.3.9", "unifi-discovery==1.1.8"],
   "ssdp": [
     {
       "manufacturer": "Ubiquiti Networks",

--- a/homeassistant/components/unifiprotect/manifest.json
+++ b/homeassistant/components/unifiprotect/manifest.json
@@ -39,8 +39,8 @@
   "documentation": "https://www.home-assistant.io/integrations/unifiprotect",
   "integration_type": "hub",
   "iot_class": "local_push",
-  "loggers": ["pyunifiprotect", "unifi_discovery"],
-  "requirements": ["pyunifiprotect==5.1.2", "unifi-discovery==1.1.8"],
+  "loggers": ["uiprotect", "unifi_discovery"],
+  "requirements": ["uiprotect==0.3.7", "unifi-discovery==1.1.8"],
   "ssdp": [
     {
       "manufacturer": "Ubiquiti Networks",

--- a/homeassistant/components/unifiprotect/media_player.py
+++ b/homeassistant/components/unifiprotect/media_player.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 import logging
 from typing import Any, cast
 
-from pyunifiprotect.data import (
+from uiprotect.data import (
     Camera,
     ModelType,
     ProtectAdoptableDeviceModel,
     ProtectModelWithId,
     StateType,
 )
-from pyunifiprotect.exceptions import StreamError
+from uiprotect.exceptions import StreamError
 
 from homeassistant.components import media_source
 from homeassistant.components.media_player import (

--- a/homeassistant/components/unifiprotect/media_source.py
+++ b/homeassistant/components/unifiprotect/media_source.py
@@ -7,15 +7,9 @@ from datetime import date, datetime, timedelta
 from enum import Enum
 from typing import Any, NoReturn, cast
 
-from pyunifiprotect.data import (
-    Camera,
-    Event,
-    EventType,
-    ModelType,
-    SmartDetectObjectType,
-)
-from pyunifiprotect.exceptions import NvrError
-from pyunifiprotect.utils import from_js_time
+from uiprotect.data import Camera, Event, EventType, ModelType, SmartDetectObjectType
+from uiprotect.exceptions import NvrError
+from uiprotect.utils import from_js_time
 from yarl import URL
 
 from homeassistant.components.camera import CameraImageView

--- a/homeassistant/components/unifiprotect/migrate.py
+++ b/homeassistant/components/unifiprotect/migrate.py
@@ -6,8 +6,8 @@ from itertools import chain
 import logging
 from typing import TypedDict
 
-from pyunifiprotect import ProtectApiClient
-from pyunifiprotect.data import Bootstrap
+from uiprotect import ProtectApiClient
+from uiprotect.data import Bootstrap
 
 from homeassistant.components.automation import automations_with_entity
 from homeassistant.components.script import scripts_with_entity

--- a/homeassistant/components/unifiprotect/models.py
+++ b/homeassistant/components/unifiprotect/models.py
@@ -8,7 +8,7 @@ from enum import Enum
 import logging
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
-from pyunifiprotect.data import NVR, Event, ProtectAdoptableDeviceModel
+from uiprotect.data import NVR, Event, ProtectAdoptableDeviceModel
 
 from homeassistant.helpers.entity import EntityDescription
 

--- a/homeassistant/components/unifiprotect/number.py
+++ b/homeassistant/components/unifiprotect/number.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 import logging
 from typing import Any
 
-from pyunifiprotect.data import (
+from uiprotect.data import (
     Camera,
     Doorlock,
     Light,

--- a/homeassistant/components/unifiprotect/repairs.py
+++ b/homeassistant/components/unifiprotect/repairs.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from typing import cast
 
-from pyunifiprotect import ProtectApiClient
-from pyunifiprotect.data import Bootstrap, Camera, ModelType
-from pyunifiprotect.data.types import FirmwareReleaseChannel
+from uiprotect import ProtectApiClient
+from uiprotect.data import Bootstrap, Camera, ModelType
+from uiprotect.data.types import FirmwareReleaseChannel
 import voluptuous as vol
 
 from homeassistant import data_entry_flow

--- a/homeassistant/components/unifiprotect/select.py
+++ b/homeassistant/components/unifiprotect/select.py
@@ -8,8 +8,8 @@ from enum import Enum
 import logging
 from typing import Any, Final
 
-from pyunifiprotect.api import ProtectApiClient
-from pyunifiprotect.data import (
+from uiprotect.api import ProtectApiClient
+from uiprotect.data import (
     Camera,
     ChimeType,
     DoorbellMessageType,

--- a/homeassistant/components/unifiprotect/sensor.py
+++ b/homeassistant/components/unifiprotect/sensor.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import logging
 from typing import Any, cast
 
-from pyunifiprotect.data import (
+from uiprotect.data import (
     NVR,
     Camera,
     Light,

--- a/homeassistant/components/unifiprotect/services.py
+++ b/homeassistant/components/unifiprotect/services.py
@@ -7,9 +7,9 @@ import functools
 from typing import Any, cast
 
 from pydantic import ValidationError
-from pyunifiprotect.api import ProtectApiClient
-from pyunifiprotect.data import Camera, Chime
-from pyunifiprotect.exceptions import ClientError
+from uiprotect.api import ProtectApiClient
+from uiprotect.data import Camera, Chime
+from uiprotect.exceptions import ClientError
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass

--- a/homeassistant/components/unifiprotect/switch.py
+++ b/homeassistant/components/unifiprotect/switch.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 import logging
 from typing import Any
 
-from pyunifiprotect.data import (
+from uiprotect.data import (
     NVR,
     Camera,
     ProtectAdoptableDeviceModel,

--- a/homeassistant/components/unifiprotect/text.py
+++ b/homeassistant/components/unifiprotect/text.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from pyunifiprotect.data import (
+from uiprotect.data import (
     Camera,
     DoorbellMessageType,
     ProtectAdoptableDeviceModel,

--- a/homeassistant/components/unifiprotect/utils.py
+++ b/homeassistant/components/unifiprotect/utils.py
@@ -10,8 +10,9 @@ import socket
 from typing import Any
 
 from aiohttp import CookieJar
-from pyunifiprotect import ProtectApiClient
-from pyunifiprotect.data import (
+from typing_extensions import Generator
+from uiprotect import ProtectApiClient
+from uiprotect.data import (
     Bootstrap,
     CameraChannel,
     Light,
@@ -19,7 +20,6 @@ from pyunifiprotect.data import (
     LightModeType,
     ProtectAdoptableDeviceModel,
 )
-from typing_extensions import Generator
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (

--- a/homeassistant/components/unifiprotect/views.py
+++ b/homeassistant/components/unifiprotect/views.py
@@ -9,8 +9,8 @@ from typing import Any
 from urllib.parse import urlencode
 
 from aiohttp import web
-from pyunifiprotect.data import Camera, Event
-from pyunifiprotect.exceptions import ClientError
+from uiprotect.data import Camera, Event
+from uiprotect.exceptions import ClientError
 
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.core import HomeAssistant, callback

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2785,7 +2785,7 @@ twitchAPI==4.0.0
 uasiren==0.0.1
 
 # homeassistant.components.unifiprotect
-uiprotect==0.3.7
+uiprotect==0.3.9
 
 # homeassistant.components.landisgyr_heat_meter
 ultraheat-api==0.5.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2363,9 +2363,6 @@ pytrydan==0.7.0
 # homeassistant.components.usb
 pyudev==0.24.1
 
-# homeassistant.components.unifiprotect
-pyunifiprotect==5.1.2
-
 # homeassistant.components.uptimerobot
 pyuptimerobot==22.2.0
 
@@ -2786,6 +2783,9 @@ twitchAPI==4.0.0
 
 # homeassistant.components.ukraine_alarm
 uasiren==0.0.1
+
+# homeassistant.components.unifiprotect
+uiprotect==0.3.7
 
 # homeassistant.components.landisgyr_heat_meter
 ultraheat-api==0.5.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2165,7 +2165,7 @@ twitchAPI==4.0.0
 uasiren==0.0.1
 
 # homeassistant.components.unifiprotect
-uiprotect==0.3.7
+uiprotect==0.3.9
 
 # homeassistant.components.landisgyr_heat_meter
 ultraheat-api==0.5.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1848,9 +1848,6 @@ pytrydan==0.7.0
 # homeassistant.components.usb
 pyudev==0.24.1
 
-# homeassistant.components.unifiprotect
-pyunifiprotect==5.1.2
-
 # homeassistant.components.uptimerobot
 pyuptimerobot==22.2.0
 
@@ -2166,6 +2163,9 @@ twitchAPI==4.0.0
 
 # homeassistant.components.ukraine_alarm
 uasiren==0.0.1
+
+# homeassistant.components.unifiprotect
+uiprotect==0.3.7
 
 # homeassistant.components.landisgyr_heat_meter
 ultraheat-api==0.5.7

--- a/tests/components/unifiprotect/conftest.py
+++ b/tests/components/unifiprotect/conftest.py
@@ -13,8 +13,8 @@ from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from pyunifiprotect import ProtectApiClient
-from pyunifiprotect.data import (
+from uiprotect import ProtectApiClient
+from uiprotect.data import (
     NVR,
     Bootstrap,
     Camera,

--- a/tests/components/unifiprotect/test_binary_sensor.py
+++ b/tests/components/unifiprotect/test_binary_sensor.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from unittest.mock import Mock
 
-from pyunifiprotect.data import Camera, Event, EventType, Light, MountType, Sensor
-from pyunifiprotect.data.nvr import EventMetadata
+from uiprotect.data import Camera, Event, EventType, Light, MountType, Sensor
+from uiprotect.data.nvr import EventMetadata
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.unifiprotect.binary_sensor import (

--- a/tests/components/unifiprotect/test_button.py
+++ b/tests/components/unifiprotect/test_button.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, Mock
 
-from pyunifiprotect.data.devices import Camera, Chime, Doorlock
+from uiprotect.data.devices import Camera, Chime, Doorlock
 
 from homeassistant.components.unifiprotect.const import DEFAULT_ATTRIBUTION
 from homeassistant.const import ATTR_ATTRIBUTION, ATTR_ENTITY_ID, Platform

--- a/tests/components/unifiprotect/test_camera.py
+++ b/tests/components/unifiprotect/test_camera.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, Mock
 
-from pyunifiprotect.data import Camera as ProtectCamera, CameraChannel, StateType
-from pyunifiprotect.exceptions import NvrError
+from uiprotect.data import Camera as ProtectCamera, CameraChannel, StateType
+from uiprotect.exceptions import NvrError
 
 from homeassistant.components.camera import (
     CameraEntityFeature,

--- a/tests/components/unifiprotect/test_config_flow.py
+++ b/tests/components/unifiprotect/test_config_flow.py
@@ -7,8 +7,8 @@ import socket
 from unittest.mock import patch
 
 import pytest
-from pyunifiprotect import NotAuthorized, NvrError, ProtectApiClient
-from pyunifiprotect.data import NVR, Bootstrap, CloudAccount
+from uiprotect import NotAuthorized, NvrError, ProtectApiClient
+from uiprotect.data import NVR, Bootstrap, CloudAccount
 
 from homeassistant import config_entries
 from homeassistant.components import dhcp, ssdp

--- a/tests/components/unifiprotect/test_diagnostics.py
+++ b/tests/components/unifiprotect/test_diagnostics.py
@@ -1,6 +1,6 @@
 """Test UniFi Protect diagnostics."""
 
-from pyunifiprotect.data import NVR, Light
+from uiprotect.data import NVR, Light
 
 from homeassistant.components.unifiprotect.const import CONF_ALLOW_EA
 from homeassistant.core import HomeAssistant

--- a/tests/components/unifiprotect/test_init.py
+++ b/tests/components/unifiprotect/test_init.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
 
-from pyunifiprotect import NotAuthorized, NvrError, ProtectApiClient
-from pyunifiprotect.data import NVR, Bootstrap, CloudAccount, Light
+from uiprotect import NotAuthorized, NvrError, ProtectApiClient
+from uiprotect.data import NVR, Bootstrap, CloudAccount, Light
 
 from homeassistant.components.unifiprotect.const import (
     AUTH_RETRIES,

--- a/tests/components/unifiprotect/test_light.py
+++ b/tests/components/unifiprotect/test_light.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, Mock
 
-from pyunifiprotect.data import Light
-from pyunifiprotect.data.types import LEDLevel
+from uiprotect.data import Light
+from uiprotect.data.types import LEDLevel
 
 from homeassistant.components.light import ATTR_BRIGHTNESS
 from homeassistant.components.unifiprotect.const import DEFAULT_ATTRIBUTION

--- a/tests/components/unifiprotect/test_lock.py
+++ b/tests/components/unifiprotect/test_lock.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, Mock
 
-from pyunifiprotect.data import Doorlock, LockStatusType
+from uiprotect.data import Doorlock, LockStatusType
 
 from homeassistant.components.unifiprotect.const import DEFAULT_ATTRIBUTION
 from homeassistant.const import (

--- a/tests/components/unifiprotect/test_media_player.py
+++ b/tests/components/unifiprotect/test_media_player.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from pyunifiprotect.data import Camera
-from pyunifiprotect.exceptions import StreamError
+from uiprotect.data import Camera
+from uiprotect.exceptions import StreamError
 
 from homeassistant.components.media_player import (
     ATTR_MEDIA_CONTENT_TYPE,

--- a/tests/components/unifiprotect/test_media_source.py
+++ b/tests/components/unifiprotect/test_media_source.py
@@ -5,7 +5,7 @@ from ipaddress import IPv4Address
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from pyunifiprotect.data import (
+from uiprotect.data import (
     Bootstrap,
     Camera,
     Event,
@@ -13,7 +13,7 @@ from pyunifiprotect.data import (
     Permission,
     SmartDetectObjectType,
 )
-from pyunifiprotect.exceptions import NvrError
+from uiprotect.exceptions import NvrError
 
 from homeassistant.components.media_player import BrowseError, MediaClass
 from homeassistant.components.media_source import MediaSourceItem

--- a/tests/components/unifiprotect/test_migrate.py
+++ b/tests/components/unifiprotect/test_migrate.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from pyunifiprotect.data import Camera
+from uiprotect.data import Camera
 
 from homeassistant.components.automation import DOMAIN as AUTOMATION_DOMAIN
 from homeassistant.components.repairs.issue_handler import (

--- a/tests/components/unifiprotect/test_number.py
+++ b/tests/components/unifiprotect/test_number.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 from unittest.mock import AsyncMock, Mock
 
 import pytest
-from pyunifiprotect.data import Camera, Doorlock, IRLEDMode, Light
+from uiprotect.data import Camera, Doorlock, IRLEDMode, Light
 
 from homeassistant.components.unifiprotect.const import DEFAULT_ATTRIBUTION
 from homeassistant.components.unifiprotect.number import (

--- a/tests/components/unifiprotect/test_recorder.py
+++ b/tests/components/unifiprotect/test_recorder.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from unittest.mock import Mock
 
-from pyunifiprotect.data import Camera, Event, EventType
+from uiprotect.data import Camera, Event, EventType
 
 from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.history import get_significant_states

--- a/tests/components/unifiprotect/test_repairs.py
+++ b/tests/components/unifiprotect/test_repairs.py
@@ -6,7 +6,7 @@ from copy import copy, deepcopy
 from http import HTTPStatus
 from unittest.mock import AsyncMock, Mock
 
-from pyunifiprotect.data import Camera, CloudAccount, ModelType, Version
+from uiprotect.data import Camera, CloudAccount, ModelType, Version
 
 from homeassistant.components.repairs.issue_handler import (
     async_process_repairs_platforms,

--- a/tests/components/unifiprotect/test_select.py
+++ b/tests/components/unifiprotect/test_select.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from copy import copy
 from unittest.mock import AsyncMock, Mock
 
-from pyunifiprotect.data import (
+from uiprotect.data import (
     Camera,
     DoorbellMessageType,
     IRLEDMode,
@@ -17,7 +17,7 @@ from pyunifiprotect.data import (
     RecordingMode,
     Viewer,
 )
-from pyunifiprotect.data.nvr import DoorbellMessage
+from uiprotect.data.nvr import DoorbellMessage
 
 from homeassistant.components.select import ATTR_OPTIONS
 from homeassistant.components.unifiprotect.const import DEFAULT_ATTRIBUTION

--- a/tests/components/unifiprotect/test_sensor.py
+++ b/tests/components/unifiprotect/test_sensor.py
@@ -6,15 +6,8 @@ from datetime import datetime, timedelta
 from unittest.mock import Mock
 
 import pytest
-from pyunifiprotect.data import (
-    NVR,
-    Camera,
-    Event,
-    EventType,
-    Sensor,
-    SmartDetectObjectType,
-)
-from pyunifiprotect.data.nvr import EventMetadata, LicensePlateMetadata
+from uiprotect.data import NVR, Camera, Event, EventType, Sensor, SmartDetectObjectType
+from uiprotect.data.nvr import EventMetadata, LicensePlateMetadata
 
 from homeassistant.components.unifiprotect.const import DEFAULT_ATTRIBUTION
 from homeassistant.components.unifiprotect.sensor import (

--- a/tests/components/unifiprotect/test_services.py
+++ b/tests/components/unifiprotect/test_services.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, Mock
 
 import pytest
-from pyunifiprotect.data import Camera, Chime, Color, Light, ModelType
-from pyunifiprotect.data.devices import CameraZone
-from pyunifiprotect.exceptions import BadRequest
+from uiprotect.data import Camera, Chime, Color, Light, ModelType
+from uiprotect.data.devices import CameraZone
+from uiprotect.exceptions import BadRequest
 
 from homeassistant.components.unifiprotect.const import ATTR_MESSAGE, DOMAIN
 from homeassistant.components.unifiprotect.services import (

--- a/tests/components/unifiprotect/test_switch.py
+++ b/tests/components/unifiprotect/test_switch.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, Mock
 
 import pytest
-from pyunifiprotect.data import Camera, Light, Permission, RecordingMode, VideoMode
+from uiprotect.data import Camera, Light, Permission, RecordingMode, VideoMode
 
 from homeassistant.components.unifiprotect.const import DEFAULT_ATTRIBUTION
 from homeassistant.components.unifiprotect.switch import (

--- a/tests/components/unifiprotect/test_text.py
+++ b/tests/components/unifiprotect/test_text.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, Mock
 
-from pyunifiprotect.data import Camera, DoorbellMessageType, LCDMessage
+from uiprotect.data import Camera, DoorbellMessageType, LCDMessage
 
 from homeassistant.components.unifiprotect.const import DEFAULT_ATTRIBUTION
 from homeassistant.components.unifiprotect.text import CAMERA

--- a/tests/components/unifiprotect/test_views.py
+++ b/tests/components/unifiprotect/test_views.py
@@ -6,8 +6,8 @@ from unittest.mock import AsyncMock, Mock
 
 from aiohttp import ClientResponse
 import pytest
-from pyunifiprotect.data import Camera, Event, EventType
-from pyunifiprotect.exceptions import ClientError
+from uiprotect.data import Camera, Event, EventType
+from uiprotect.exceptions import ClientError
 
 from homeassistant.components.unifiprotect.views import (
     async_generate_event_video_url,

--- a/tests/components/unifiprotect/utils.py
+++ b/tests/components/unifiprotect/utils.py
@@ -8,8 +8,8 @@ from datetime import timedelta
 from typing import Any
 from unittest.mock import Mock
 
-from pyunifiprotect import ProtectApiClient
-from pyunifiprotect.data import (
+from uiprotect import ProtectApiClient
+from uiprotect.data import (
     Bootstrap,
     Camera,
     Event,
@@ -18,8 +18,8 @@ from pyunifiprotect.data import (
     ProtectAdoptableDeviceModel,
     WSSubscriptionMessage,
 )
-from pyunifiprotect.data.bootstrap import ProtectDeviceRef
-from pyunifiprotect.test_util.anonymize import random_hex
+from uiprotect.data.bootstrap import ProtectDeviceRef
+from uiprotect.test_util.anonymize import random_hex
 
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, split_entity_id


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The `pyunifiprotect` library is no longer licensed under an MIT license. It has changed to a [BUSL-1.1 license](https://github.com/AngellusMortis/pyunifiprotect/pull/385). In Home Assistant, it has been replaced with [`uiprotect`](https://github.com/uilibs/uiprotect), which was split off from `pyunifiprotect` before the license was changed.

I'm grateful for all the work that briis, and AngellusMortis have put into `pyunifiprotect`, and I'm sad to see this as the outcome. I had hoped things would have turned out differently.

The [`uiprotect`](https://github.com/uilibs/uiprotect) library is seeking maintainers https://github.com/uilibs/uiprotect#looking-for-maintainers

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
