### PR TITLE
Add model to Teslemetry Wall Connectors

### DIFF
--- a/homeassistant/components/teslemetry/entity.py
+++ b/homeassistant/components/teslemetry/entity.py
@@ -211,6 +211,14 @@ class TeslemetryWallConnectorEntity(
         """Initialize common aspects of a Teslemetry entity."""
         self.din = din
         self._attr_unique_id = f"{data.id}-{din}-{key}"
+
+        # Find the model from the info coordinator
+        model: str | None = None
+        for wc in data.info_coordinator.data.get("components_wall_connectors", []):
+            if wc["din"] == din:
+                model = wc.get("part_name")
+                break
+
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, din)},
             manufacturer="Tesla",
@@ -218,6 +226,7 @@ class TeslemetryWallConnectorEntity(
             name="Wall Connector",
             via_device=(DOMAIN, str(data.id)),
             serial_number=din.split("-")[-1],
+            model=model,
         )
 
         super().__init__(data.live_coordinator, data.api, key)

--- a/tests/components/teslemetry/fixtures/site_info.json
+++ b/tests/components/teslemetry/fixtures/site_info.json
@@ -82,12 +82,14 @@
       "wall_connectors": [
         {
           "device_id": "123abc",
-          "din": "abc123",
+          "din": "abc-123",
+          "part_name": "Gen 3 Wall Connector",
           "is_active": true
         },
         {
           "device_id": "234bcd",
-          "din": "bcd234",
+          "din": "bcd-234",
+          "part_name": "Gen 3 Wall Connector",
           "is_active": true
         }
       ],

--- a/tests/components/teslemetry/fixtures/site_info.json
+++ b/tests/components/teslemetry/fixtures/site_info.json
@@ -82,7 +82,7 @@
       "wall_connectors": [
         {
           "device_id": "123abc",
-          "din": "abc-123",
+          "din": "abd-123",
           "part_name": "Gen 3 Wall Connector",
           "is_active": true
         },

--- a/tests/components/teslemetry/snapshots/test_diagnostics.ambr
+++ b/tests/components/teslemetry/snapshots/test_diagnostics.ambr
@@ -76,7 +76,7 @@
           'components_wall_connectors': list([
             dict({
               'device_id': '123abc',
-              'din': 'abc-123',
+              'din': 'abd-123',
               'is_active': True,
               'part_name': 'Gen 3 Wall Connector',
             }),

--- a/tests/components/teslemetry/snapshots/test_diagnostics.ambr
+++ b/tests/components/teslemetry/snapshots/test_diagnostics.ambr
@@ -76,13 +76,15 @@
           'components_wall_connectors': list([
             dict({
               'device_id': '123abc',
-              'din': 'abc123',
+              'din': 'abc-123',
               'is_active': True,
+              'part_name': 'Gen 3 Wall Connector',
             }),
             dict({
               'device_id': '234bcd',
-              'din': 'bcd234',
+              'din': 'bcd-234',
               'is_active': True,
+              'part_name': 'Gen 3 Wall Connector',
             }),
           ]),
           'components_wifi_commissioning_enabled': True,

--- a/tests/components/teslemetry/snapshots/test_init.ambr
+++ b/tests/components/teslemetry/snapshots/test_init.ambr
@@ -110,7 +110,7 @@
     'labels': set({
     }),
     'manufacturer': 'Tesla',
-    'model': None,
+    'model': 'Gen 3 Wall Connector',
     'name': 'Wall Connector',
     'name_by_user': None,
     'serial_number': '234',

--- a/tests/components/teslemetry/snapshots/test_init.ambr
+++ b/tests/components/teslemetry/snapshots/test_init.ambr
@@ -80,7 +80,7 @@
     'labels': set({
     }),
     'manufacturer': 'Tesla',
-    'model': None,
+    'model': 'Gen 3 Wall Connector',
     'name': 'Wall Connector',
     'name_by_user': None,
     'serial_number': '123',


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add model name to Teslemetry Wall Connector device entries

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
