### PR TITLE
Improve type hints in blackbird tests

### DIFF
--- a/tests/components/blackbird/test_media_player.py
+++ b/tests/components/blackbird/test_media_player.py
@@ -12,7 +12,10 @@ from homeassistant.components.blackbird.media_player import (
     PLATFORM_SCHEMA,
     setup_platform,
 )
-from homeassistant.components.media_player import MediaPlayerEntityFeature
+from homeassistant.components.media_player import (
+    MediaPlayerEntity,
+    MediaPlayerEntityFeature,
+)
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
@@ -166,13 +169,13 @@ def test_invalid_schemas() -> None:
 
 
 @pytest.fixture
-def mock_blackbird():
+def mock_blackbird() -> MockBlackbird:
     """Return a mock blackbird instance."""
     return MockBlackbird()
 
 
 @pytest.fixture
-async def setup_blackbird(hass, mock_blackbird):
+async def setup_blackbird(hass: HomeAssistant, mock_blackbird: MockBlackbird) -> None:
     """Set up blackbird."""
     with mock.patch(
         "homeassistant.components.blackbird.media_player.get_blackbird",
@@ -198,7 +201,9 @@ async def setup_blackbird(hass, mock_blackbird):
 
 
 @pytest.fixture
-def media_player_entity(hass, setup_blackbird):
+def media_player_entity(
+    hass: HomeAssistant, setup_blackbird: None
+) -> MediaPlayerEntity:
     """Return the media player entity."""
     media_player = hass.data[DATA_BLACKBIRD]["/dev/ttyUSB0-3"]
     media_player.hass = hass
@@ -206,7 +211,8 @@ def media_player_entity(hass, setup_blackbird):
     return media_player
 
 
-async def test_setup_platform(hass: HomeAssistant, setup_blackbird) -> None:
+@pytest.mark.usefixtures("setup_blackbird")
+async def test_setup_platform(hass: HomeAssistant) -> None:
     """Test setting up platform."""
     # One service must be registered
     assert hass.services.has_service(DOMAIN, SERVICE_SETALLZONES)
@@ -215,7 +221,9 @@ async def test_setup_platform(hass: HomeAssistant, setup_blackbird) -> None:
 
 
 async def test_setallzones_service_call_with_entity_id(
-    hass: HomeAssistant, media_player_entity, mock_blackbird
+    hass: HomeAssistant,
+    media_player_entity: MediaPlayerEntity,
+    mock_blackbird: MockBlackbird,
 ) -> None:
     """Test set all zone source service call with entity id."""
     await hass.async_add_executor_job(media_player_entity.update)
@@ -238,7 +246,9 @@ async def test_setallzones_service_call_with_entity_id(
 
 
 async def test_setallzones_service_call_without_entity_id(
-    mock_blackbird, hass: HomeAssistant, media_player_entity
+    mock_blackbird: MockBlackbird,
+    hass: HomeAssistant,
+    media_player_entity: MediaPlayerEntity,
 ) -> None:
     """Test set all zone source service call without entity id."""
     await hass.async_add_executor_job(media_player_entity.update)
@@ -257,7 +267,9 @@ async def test_setallzones_service_call_without_entity_id(
     assert media_player_entity.source == "three"
 
 
-async def test_update(hass: HomeAssistant, media_player_entity) -> None:
+async def test_update(
+    hass: HomeAssistant, media_player_entity: MediaPlayerEntity
+) -> None:
     """Test updating values from blackbird."""
     assert media_player_entity.state is None
     assert media_player_entity.source is None
@@ -268,12 +280,16 @@ async def test_update(hass: HomeAssistant, media_player_entity) -> None:
     assert media_player_entity.source == "one"
 
 
-async def test_name(media_player_entity) -> None:
+async def test_name(media_player_entity: MediaPlayerEntity) -> None:
     """Test name property."""
     assert media_player_entity.name == "Zone name"
 
 
-async def test_state(hass: HomeAssistant, media_player_entity, mock_blackbird) -> None:
+async def test_state(
+    hass: HomeAssistant,
+    media_player_entity: MediaPlayerEntity,
+    mock_blackbird: MockBlackbird,
+) -> None:
     """Test state property."""
     assert media_player_entity.state is None
 
@@ -285,7 +301,7 @@ async def test_state(hass: HomeAssistant, media_player_entity, mock_blackbird) -
     assert media_player_entity.state == STATE_OFF
 
 
-async def test_supported_features(media_player_entity) -> None:
+async def test_supported_features(media_player_entity: MediaPlayerEntity) -> None:
     """Test supported features property."""
     assert (
         media_player_entity.supported_features
@@ -295,28 +311,34 @@ async def test_supported_features(media_player_entity) -> None:
     )
 
 
-async def test_source(hass: HomeAssistant, media_player_entity) -> None:
+async def test_source(
+    hass: HomeAssistant, media_player_entity: MediaPlayerEntity
+) -> None:
     """Test source property."""
     assert media_player_entity.source is None
     await hass.async_add_executor_job(media_player_entity.update)
     assert media_player_entity.source == "one"
 
 
-async def test_media_title(hass: HomeAssistant, media_player_entity) -> None:
+async def test_media_title(
+    hass: HomeAssistant, media_player_entity: MediaPlayerEntity
+) -> None:
     """Test media title property."""
     assert media_player_entity.media_title is None
     await hass.async_add_executor_job(media_player_entity.update)
     assert media_player_entity.media_title == "one"
 
 
-async def test_source_list(media_player_entity) -> None:
+async def test_source_list(media_player_entity: MediaPlayerEntity) -> None:
     """Test source list property."""
     # Note, the list is sorted!
     assert media_player_entity.source_list == ["one", "two", "three"]
 
 
 async def test_select_source(
-    hass: HomeAssistant, media_player_entity, mock_blackbird
+    hass: HomeAssistant,
+    media_player_entity: MediaPlayerEntity,
+    mock_blackbird: MockBlackbird,
 ) -> None:
     """Test source selection methods."""
     await hass.async_add_executor_job(media_player_entity.update)
@@ -336,7 +358,9 @@ async def test_select_source(
 
 
 async def test_turn_on(
-    hass: HomeAssistant, media_player_entity, mock_blackbird
+    hass: HomeAssistant,
+    media_player_entity: MediaPlayerEntity,
+    mock_blackbird: MockBlackbird,
 ) -> None:
     """Testing turning on the zone."""
     mock_blackbird.zones[3].power = False
@@ -350,7 +374,9 @@ async def test_turn_on(
 
 
 async def test_turn_off(
-    hass: HomeAssistant, media_player_entity, mock_blackbird
+    hass: HomeAssistant,
+    media_player_entity: MediaPlayerEntity,
+    mock_blackbird: MockBlackbird,
 ) -> None:
     """Testing turning off the zone."""
     mock_blackbird.zones[3].power = True


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
