### PR TITLE
Improve type hints in blueprint tests

### DIFF
--- a/tests/components/blueprint/test_models.py
+++ b/tests/components/blueprint/test_models.py
@@ -11,7 +11,7 @@ from homeassistant.util.yaml import Input
 
 
 @pytest.fixture
-def blueprint_1():
+def blueprint_1() -> models.Blueprint:
     """Blueprint fixture."""
     return models.Blueprint(
         {
@@ -61,7 +61,7 @@ def blueprint_2(request: pytest.FixtureRequest) -> models.Blueprint:
 
 
 @pytest.fixture
-def domain_bps(hass):
+def domain_bps(hass: HomeAssistant) -> models.DomainBlueprints:
     """Domain blueprints fixture."""
     return models.DomainBlueprints(
         hass, "automation", logging.getLogger(__name__), None, AsyncMock()
@@ -92,7 +92,7 @@ def test_blueprint_model_init() -> None:
         )
 
 
-def test_blueprint_properties(blueprint_1) -> None:
+def test_blueprint_properties(blueprint_1: models.Blueprint) -> None:
     """Test properties."""
     assert blueprint_1.metadata == {
         "name": "Hello",
@@ -147,7 +147,7 @@ def test_blueprint_validate() -> None:
     ).validate() == ["Requires at least Home Assistant 100000.0.0"]
 
 
-def test_blueprint_inputs(blueprint_2) -> None:
+def test_blueprint_inputs(blueprint_2: models.Blueprint) -> None:
     """Test blueprint inputs."""
     inputs = models.BlueprintInputs(
         blueprint_2,
@@ -167,7 +167,7 @@ def test_blueprint_inputs(blueprint_2) -> None:
     }
 
 
-def test_blueprint_inputs_validation(blueprint_1) -> None:
+def test_blueprint_inputs_validation(blueprint_1: models.Blueprint) -> None:
     """Test blueprint input validation."""
     inputs = models.BlueprintInputs(
         blueprint_1,
@@ -177,7 +177,7 @@ def test_blueprint_inputs_validation(blueprint_1) -> None:
         inputs.validate()
 
 
-def test_blueprint_inputs_default(blueprint_2) -> None:
+def test_blueprint_inputs_default(blueprint_2: models.Blueprint) -> None:
     """Test blueprint inputs."""
     inputs = models.BlueprintInputs(
         blueprint_2,
@@ -192,7 +192,7 @@ def test_blueprint_inputs_default(blueprint_2) -> None:
     assert inputs.async_substitute() == {"example": 1, "example-default": "test"}
 
 
-def test_blueprint_inputs_override_default(blueprint_2) -> None:
+def test_blueprint_inputs_override_default(blueprint_2: models.Blueprint) -> None:
     """Test blueprint inputs."""
     inputs = models.BlueprintInputs(
         blueprint_2,
@@ -216,7 +216,7 @@ def test_blueprint_inputs_override_default(blueprint_2) -> None:
 
 
 async def test_domain_blueprints_get_blueprint_errors(
-    hass: HomeAssistant, domain_bps
+    hass: HomeAssistant, domain_bps: models.DomainBlueprints
 ) -> None:
     """Test domain blueprints."""
     assert hass.data["blueprint"]["automation"] is domain_bps
@@ -236,7 +236,7 @@ async def test_domain_blueprints_get_blueprint_errors(
         await domain_bps.async_get_blueprint("non-existing-path")
 
 
-async def test_domain_blueprints_caching(domain_bps) -> None:
+async def test_domain_blueprints_caching(domain_bps: models.DomainBlueprints) -> None:
     """Test domain blueprints cache blueprints."""
     obj = object()
     with patch.object(domain_bps, "_load_blueprint", return_value=obj):
@@ -253,7 +253,9 @@ async def test_domain_blueprints_caching(domain_bps) -> None:
         assert await domain_bps.async_get_blueprint("something") is obj_2
 
 
-async def test_domain_blueprints_inputs_from_config(domain_bps, blueprint_1) -> None:
+async def test_domain_blueprints_inputs_from_config(
+    domain_bps: models.DomainBlueprints, blueprint_1: models.Blueprint
+) -> None:
     """Test DomainBlueprints.async_inputs_from_config."""
     with pytest.raises(errors.InvalidBlueprintInputs):
         await domain_bps.async_inputs_from_config({"not-referencing": "use_blueprint"})
@@ -274,7 +276,9 @@ async def test_domain_blueprints_inputs_from_config(domain_bps, blueprint_1) -> 
     assert inputs.inputs == {"test-input": None}
 
 
-async def test_domain_blueprints_add_blueprint(domain_bps, blueprint_1) -> None:
+async def test_domain_blueprints_add_blueprint(
+    domain_bps: models.DomainBlueprints, blueprint_1: models.Blueprint
+) -> None:
     """Test DomainBlueprints.async_add_blueprint."""
     with patch.object(domain_bps, "_create_file") as create_file_mock:
         await domain_bps.async_add_blueprint(blueprint_1, "something.yaml")
@@ -286,7 +290,9 @@ async def test_domain_blueprints_add_blueprint(domain_bps, blueprint_1) -> None:
         assert not mock_load.mock_calls
 
 
-async def test_inputs_from_config_nonexisting_blueprint(domain_bps) -> None:
+async def test_inputs_from_config_nonexisting_blueprint(
+    domain_bps: models.DomainBlueprints,
+) -> None:
     """Test referring non-existing blueprint."""
     with pytest.raises(errors.FailedToLoad):
         await domain_bps.async_inputs_from_config(

--- a/tests/components/blueprint/test_websocket_api.py
+++ b/tests/components/blueprint/test_websocket_api.py
@@ -1,6 +1,7 @@
 """Test websocket API."""
 
 from pathlib import Path
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -15,19 +16,23 @@ from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture
-def automation_config():
+def automation_config() -> dict[str, Any]:
     """Automation config."""
     return {}
 
 
 @pytest.fixture
-def script_config():
+def script_config() -> dict[str, Any]:
     """Script config."""
     return {}
 
 
 @pytest.fixture(autouse=True)
-async def setup_bp(hass, automation_config, script_config):
+async def setup_bp(
+    hass: HomeAssistant,
+    automation_config: dict[str, Any],
+    script_config: dict[str, Any],
+) -> None:
     """Fixture to set up the blueprint component."""
     assert await async_setup_component(hass, "blueprint", {})
 
@@ -135,11 +140,11 @@ async def test_import_blueprint(
     }
 
 
+@pytest.mark.usefixtures("setup_bp")
 async def test_import_blueprint_update(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     hass_ws_client: WebSocketGenerator,
-    setup_bp,
 ) -> None:
     """Test importing blueprints."""
     raw_data = Path(
@@ -182,7 +187,6 @@ async def test_import_blueprint_update(
 
 async def test_save_blueprint(
     hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test saving blueprints."""
@@ -236,7 +240,6 @@ async def test_save_blueprint(
 
 async def test_save_existing_file(
     hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test saving blueprints."""
@@ -262,7 +265,6 @@ async def test_save_existing_file(
 
 async def test_save_existing_file_override(
     hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test saving blueprints."""
@@ -298,7 +300,6 @@ async def test_save_existing_file_override(
 
 async def test_save_file_error(
     hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test saving blueprints with OS error."""
@@ -323,7 +324,6 @@ async def test_save_file_error(
 
 async def test_save_invalid_blueprint(
     hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test saving invalid blueprints."""
@@ -352,7 +352,6 @@ async def test_save_invalid_blueprint(
 
 async def test_delete_blueprint(
     hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test deleting blueprints."""
@@ -377,7 +376,6 @@ async def test_delete_blueprint(
 
 async def test_delete_non_exist_file_blueprint(
     hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test deleting non existing blueprints."""
@@ -417,7 +415,6 @@ async def test_delete_non_exist_file_blueprint(
 )
 async def test_delete_blueprint_in_use_by_automation(
     hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test deleting a blueprint which is in use."""
@@ -463,7 +460,6 @@ async def test_delete_blueprint_in_use_by_automation(
 )
 async def test_delete_blueprint_in_use_by_script(
     hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test deleting a blueprint which is in use."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
