### PR TITLE
Improve type hints in camera tests

### DIFF
--- a/tests/components/camera/conftest.py
+++ b/tests/components/camera/conftest.py
@@ -3,6 +3,7 @@
 from unittest.mock import PropertyMock, patch
 
 import pytest
+from typing_extensions import AsyncGenerator, Generator
 
 from homeassistant.components import camera
 from homeassistant.components.camera.const import StreamType
@@ -15,13 +16,13 @@ from .common import WEBRTC_ANSWER
 
 
 @pytest.fixture(autouse=True)
-async def setup_homeassistant(hass: HomeAssistant):
+async def setup_homeassistant(hass: HomeAssistant) -> None:
     """Set up the homeassistant integration."""
     await async_setup_component(hass, "homeassistant", {})
 
 
 @pytest.fixture(autouse=True)
-async def camera_only() -> None:
+def camera_only() -> Generator[None]:
     """Enable only the camera platform."""
     with patch(
         "homeassistant.components.demo.COMPONENTS_WITH_CONFIG_ENTRY_DEMO_PLATFORM",
@@ -31,7 +32,7 @@ async def camera_only() -> None:
 
 
 @pytest.fixture(name="mock_camera")
-async def mock_camera_fixture(hass):
+async def mock_camera_fixture(hass: HomeAssistant) -> AsyncGenerator[None]:
     """Initialize a demo camera platform."""
     assert await async_setup_component(
         hass, "camera", {camera.DOMAIN: {"platform": "demo"}}
@@ -46,7 +47,7 @@ async def mock_camera_fixture(hass):
 
 
 @pytest.fixture(name="mock_camera_hls")
-async def mock_camera_hls_fixture(mock_camera):
+def mock_camera_hls_fixture(mock_camera: None) -> Generator[None]:
     """Initialize a demo camera platform with HLS."""
     with patch(
         "homeassistant.components.camera.Camera.frontend_stream_type",
@@ -56,7 +57,7 @@ async def mock_camera_hls_fixture(mock_camera):
 
 
 @pytest.fixture(name="mock_camera_web_rtc")
-async def mock_camera_web_rtc_fixture(hass):
+async def mock_camera_web_rtc_fixture(hass: HomeAssistant) -> AsyncGenerator[None]:
     """Initialize a demo camera platform with WebRTC."""
     assert await async_setup_component(
         hass, "camera", {camera.DOMAIN: {"platform": "demo"}}
@@ -77,7 +78,7 @@ async def mock_camera_web_rtc_fixture(hass):
 
 
 @pytest.fixture(name="mock_camera_with_device")
-async def mock_camera_with_device_fixture():
+def mock_camera_with_device_fixture() -> Generator[None]:
     """Initialize a demo camera platform with a device."""
     dev_info = DeviceInfo(
         identifiers={("camera", "test_unique_id")},
@@ -103,7 +104,7 @@ async def mock_camera_with_device_fixture():
 
 
 @pytest.fixture(name="mock_camera_with_no_name")
-async def mock_camera_with_no_name_fixture(mock_camera_with_device):
+def mock_camera_with_no_name_fixture(mock_camera_with_device: None) -> Generator[None]:
     """Initialize a demo camera platform with a device and no name."""
     with patch(
         "homeassistant.components.camera.Camera._attr_name",

--- a/tests/components/camera/test_init.py
+++ b/tests/components/camera/test_init.py
@@ -6,6 +6,7 @@ from types import ModuleType
 from unittest.mock import AsyncMock, Mock, PropertyMock, mock_open, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components import camera
 from homeassistant.components.camera.const import (
@@ -41,7 +42,7 @@ WEBRTC_OFFER = "v=0\r\n"
 
 
 @pytest.fixture(name="mock_stream")
-def mock_stream_fixture(hass):
+def mock_stream_fixture(hass: HomeAssistant) -> None:
     """Initialize a demo camera platform with streaming."""
     assert hass.loop.run_until_complete(
         async_setup_component(hass, "stream", {"stream": {}})
@@ -49,7 +50,7 @@ def mock_stream_fixture(hass):
 
 
 @pytest.fixture(name="image_mock_url")
-async def image_mock_url_fixture(hass):
+async def image_mock_url_fixture(hass: HomeAssistant) -> None:
     """Fixture for get_image tests."""
     await async_setup_component(
         hass, camera.DOMAIN, {camera.DOMAIN: {"platform": "demo"}}
@@ -58,7 +59,7 @@ async def image_mock_url_fixture(hass):
 
 
 @pytest.fixture(name="mock_stream_source")
-async def mock_stream_source_fixture():
+def mock_stream_source_fixture() -> Generator[AsyncMock]:
     """Fixture to create an RTSP stream source."""
     with patch(
         "homeassistant.components.camera.Camera.stream_source",
@@ -68,7 +69,7 @@ async def mock_stream_source_fixture():
 
 
 @pytest.fixture(name="mock_hls_stream_source")
-async def mock_hls_stream_source_fixture():
+async def mock_hls_stream_source_fixture() -> Generator[AsyncMock]:
     """Fixture to create an HLS stream source."""
     with patch(
         "homeassistant.components.camera.Camera.stream_source",
@@ -85,7 +86,7 @@ async def provide_web_rtc_answer(stream_source: str, offer: str, stream_id: str)
 
 
 @pytest.fixture(name="mock_rtsp_to_web_rtc")
-async def mock_rtsp_to_web_rtc_fixture(hass):
+def mock_rtsp_to_web_rtc_fixture(hass: HomeAssistant) -> Generator[Mock]:
     """Fixture that registers a mock rtsp to web_rtc provider."""
     mock_provider = Mock(side_effect=provide_web_rtc_answer)
     unsub = camera.async_register_rtsp_to_web_rtc_provider(
@@ -95,7 +96,8 @@ async def mock_rtsp_to_web_rtc_fixture(hass):
     unsub()
 
 
-async def test_get_image_from_camera(hass: HomeAssistant, image_mock_url) -> None:
+@pytest.mark.usefixtures("image_mock_url")
+async def test_get_image_from_camera(hass: HomeAssistant) -> None:
     """Grab an image from camera entity."""
 
     with patch(
@@ -109,9 +111,8 @@ async def test_get_image_from_camera(hass: HomeAssistant, image_mock_url) -> Non
     assert image.content == b"Test"
 
 
-async def test_get_image_from_camera_with_width_height(
-    hass: HomeAssistant, image_mock_url
-) -> None:
+@pytest.mark.usefixtures("image_mock_url")
+async def test_get_image_from_camera_with_width_height(hass: HomeAssistant) -> None:
     """Grab an image from camera entity with width and height."""
 
     turbo_jpeg = mock_turbo_jpeg(
@@ -136,8 +137,9 @@ async def test_get_image_from_camera_with_width_height(
     assert image.content == b"Test"
 
 
+@pytest.mark.usefixtures("image_mock_url")
 async def test_get_image_from_camera_with_width_height_scaled(
-    hass: HomeAssistant, image_mock_url
+    hass: HomeAssistant,
 ) -> None:
     """Grab an image from camera entity with width and height and scale it."""
 
@@ -164,9 +166,8 @@ async def test_get_image_from_camera_with_width_height_scaled(
     assert image.content == EMPTY_8_6_JPEG
 
 
-async def test_get_image_from_camera_not_jpeg(
-    hass: HomeAssistant, image_mock_url
-) -> None:
+@pytest.mark.usefixtures("image_mock_url")
+async def test_get_image_from_camera_not_jpeg(hass: HomeAssistant) -> None:
     """Grab an image from camera entity that we cannot scale."""
 
     turbo_jpeg = mock_turbo_jpeg(
@@ -192,8 +193,9 @@ async def test_get_image_from_camera_not_jpeg(
     assert image.content == b"png"
 
 
+@pytest.mark.usefixtures("mock_camera")
 async def test_get_stream_source_from_camera(
-    hass: HomeAssistant, mock_camera, mock_stream_source
+    hass: HomeAssistant, mock_stream_source: AsyncMock
 ) -> None:
     """Fetch stream source from camera entity."""
 
@@ -203,9 +205,8 @@ async def test_get_stream_source_from_camera(
     assert stream_source == STREAM_SOURCE
 
 
-async def test_get_image_without_exists_camera(
-    hass: HomeAssistant, image_mock_url
-) -> None:
+@pytest.mark.usefixtures("image_mock_url")
+async def test_get_image_without_exists_camera(hass: HomeAssistant) -> None:
     """Try to get image without exists camera."""
     with (
         patch(
@@ -217,7 +218,8 @@ async def test_get_image_without_exists_camera(
         await camera.async_get_image(hass, "camera.demo_camera")
 
 
-async def test_get_image_with_timeout(hass: HomeAssistant, image_mock_url) -> None:
+@pytest.mark.usefixtures("image_mock_url")
+async def test_get_image_with_timeout(hass: HomeAssistant) -> None:
     """Try to get image with timeout."""
     with (
         patch(
@@ -229,7 +231,8 @@ async def test_get_image_with_timeout(hass: HomeAssistant, image_mock_url) -> No
         await camera.async_get_image(hass, "camera.demo_camera")
 
 
-async def test_get_image_fails(hass: HomeAssistant, image_mock_url) -> None:
+@pytest.mark.usefixtures("image_mock_url")
+async def test_get_image_fails(hass: HomeAssistant) -> None:
     """Try to get image with timeout."""
     with (
         patch(
@@ -241,7 +244,8 @@ async def test_get_image_fails(hass: HomeAssistant, image_mock_url) -> None:
         await camera.async_get_image(hass, "camera.demo_camera")
 
 
-async def test_snapshot_service(hass: HomeAssistant, mock_camera) -> None:
+@pytest.mark.usefixtures("mock_camera")
+async def test_snapshot_service(hass: HomeAssistant) -> None:
     """Test snapshot service."""
     mopen = mock_open()
 
@@ -268,9 +272,8 @@ async def test_snapshot_service(hass: HomeAssistant, mock_camera) -> None:
         assert mock_write.mock_calls[0][1][0] == b"Test"
 
 
-async def test_snapshot_service_not_allowed_path(
-    hass: HomeAssistant, mock_camera
-) -> None:
+@pytest.mark.usefixtures("mock_camera")
+async def test_snapshot_service_not_allowed_path(hass: HomeAssistant) -> None:
     """Test snapshot service with a not allowed path."""
     mopen = mock_open()
 
@@ -292,8 +295,9 @@ async def test_snapshot_service_not_allowed_path(
         )
 
 
+@pytest.mark.usefixtures("mock_camera", "mock_stream")
 async def test_websocket_stream_no_source(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, mock_camera, mock_stream
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test camera/stream websocket command with camera with no source."""
     await async_setup_component(hass, "camera", {})
@@ -311,8 +315,9 @@ async def test_websocket_stream_no_source(
     assert not msg["success"]
 
 
+@pytest.mark.usefixtures("mock_camera", "mock_stream")
 async def test_websocket_camera_stream(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, mock_camera, mock_stream
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test camera/stream websocket command."""
     await async_setup_component(hass, "camera", {})
@@ -342,8 +347,9 @@ async def test_websocket_camera_stream(
         assert msg["result"]["url"][-13:] == "playlist.m3u8"
 
 
+@pytest.mark.usefixtures("mock_camera")
 async def test_websocket_get_prefs(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, mock_camera
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test get camera preferences websocket command."""
     await async_setup_component(hass, "camera", {})
@@ -359,8 +365,9 @@ async def test_websocket_get_prefs(
     assert msg["success"]
 
 
+@pytest.mark.usefixtures("mock_camera")
 async def test_websocket_update_preload_prefs(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, mock_camera
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test updating camera preferences."""
 
@@ -396,11 +403,11 @@ async def test_websocket_update_preload_prefs(
     assert msg["result"][PREF_PRELOAD_STREAM] is True
 
 
+@pytest.mark.usefixtures("mock_camera")
 async def test_websocket_update_orientation_prefs(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     entity_registry: er.EntityRegistry,
-    mock_camera,
 ) -> None:
     """Test updating camera preferences."""
     await async_setup_component(hass, "homeassistant", {})
@@ -454,9 +461,8 @@ async def test_websocket_update_orientation_prefs(
     assert msg["result"]["orientation"] == camera.Orientation.ROTATE_180
 
 
-async def test_play_stream_service_no_source(
-    hass: HomeAssistant, mock_camera, mock_stream
-) -> None:
+@pytest.mark.usefixtures("mock_camera", "mock_stream")
+async def test_play_stream_service_no_source(hass: HomeAssistant) -> None:
     """Test camera play_stream service."""
     data = {
         ATTR_ENTITY_ID: "camera.demo_camera",
@@ -469,9 +475,8 @@ async def test_play_stream_service_no_source(
         )
 
 
-async def test_handle_play_stream_service(
-    hass: HomeAssistant, mock_camera, mock_stream
-) -> None:
+@pytest.mark.usefixtures("mock_camera", "mock_stream")
+async def test_handle_play_stream_service(hass: HomeAssistant) -> None:
     """Test camera play_stream service."""
     await async_process_ha_core_config(
         hass,
@@ -502,7 +507,8 @@ async def test_handle_play_stream_service(
         assert mock_request_stream.called
 
 
-async def test_no_preload_stream(hass: HomeAssistant, mock_stream) -> None:
+@pytest.mark.usefixtures("mock_stream")
+async def test_no_preload_stream(hass: HomeAssistant) -> None:
     """Test camera preload preference."""
     demo_settings = camera.DynamicStreamSettings()
     with (
@@ -525,7 +531,8 @@ async def test_no_preload_stream(hass: HomeAssistant, mock_stream) -> None:
         assert not mock_request_stream.called
 
 
-async def test_preload_stream(hass: HomeAssistant, mock_stream) -> None:
+@pytest.mark.usefixtures("mock_stream")
+async def test_preload_stream(hass: HomeAssistant) -> None:
     """Test camera preload preference."""
     demo_settings = camera.DynamicStreamSettings(preload_stream=True)
     with (
@@ -549,7 +556,8 @@ async def test_preload_stream(hass: HomeAssistant, mock_stream) -> None:
         assert mock_create_stream.called
 
 
-async def test_record_service_invalid_path(hass: HomeAssistant, mock_camera) -> None:
+@pytest.mark.usefixtures("mock_camera")
+async def test_record_service_invalid_path(hass: HomeAssistant) -> None:
     """Test record service with invalid path."""
     with (
         patch.object(hass.config, "is_allowed_path", return_value=False),
@@ -567,7 +575,8 @@ async def test_record_service_invalid_path(hass: HomeAssistant, mock_camera) -> 
         )
 
 
-async def test_record_service(hass: HomeAssistant, mock_camera, mock_stream) -> None:
+@pytest.mark.usefixtures("mock_camera", "mock_stream")
+async def test_record_service(hass: HomeAssistant) -> None:
     """Test record service."""
     with (
         patch(
@@ -591,9 +600,8 @@ async def test_record_service(hass: HomeAssistant, mock_camera, mock_stream) -> 
         assert mock_record.called
 
 
-async def test_camera_proxy_stream(
-    hass: HomeAssistant, mock_camera, hass_client: ClientSessionGenerator
-) -> None:
+@pytest.mark.usefixtures("mock_camera")
+async def test_camera_proxy_stream(hass_client: ClientSessionGenerator) -> None:
     """Test record service."""
 
     client = await hass_client()
@@ -611,10 +619,9 @@ async def test_camera_proxy_stream(
             assert response.status == HTTPStatus.BAD_GATEWAY
 
 
+@pytest.mark.usefixtures("mock_camera_web_rtc")
 async def test_websocket_web_rtc_offer(
-    hass: HomeAssistant,
-    hass_ws_client: WebSocketGenerator,
-    mock_camera_web_rtc,
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test initiating a WebRTC stream with offer and answer."""
     client = await hass_ws_client(hass)
@@ -634,10 +641,9 @@ async def test_websocket_web_rtc_offer(
     assert response["result"]["answer"] == WEBRTC_ANSWER
 
 
+@pytest.mark.usefixtures("mock_camera_web_rtc")
 async def test_websocket_web_rtc_offer_invalid_entity(
-    hass: HomeAssistant,
-    hass_ws_client: WebSocketGenerator,
-    mock_camera_web_rtc,
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test WebRTC with a camera entity that does not exist."""
     client = await hass_ws_client(hass)
@@ -656,10 +662,9 @@ async def test_websocket_web_rtc_offer_invalid_entity(
     assert not response["success"]
 
 
+@pytest.mark.usefixtures("mock_camera_web_rtc")
 async def test_websocket_web_rtc_offer_missing_offer(
-    hass: HomeAssistant,
-    hass_ws_client: WebSocketGenerator,
-    mock_camera_web_rtc,
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test WebRTC stream with missing required fields."""
     client = await hass_ws_client(hass)
@@ -678,10 +683,9 @@ async def test_websocket_web_rtc_offer_missing_offer(
     assert response["error"]["code"] == "invalid_format"
 
 
+@pytest.mark.usefixtures("mock_camera_web_rtc")
 async def test_websocket_web_rtc_offer_failure(
-    hass: HomeAssistant,
-    hass_ws_client: WebSocketGenerator,
-    mock_camera_web_rtc,
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test WebRTC stream that fails handling the offer."""
     client = await hass_ws_client(hass)
@@ -707,10 +711,9 @@ async def test_websocket_web_rtc_offer_failure(
     assert response["error"]["message"] == "offer failed"
 
 
+@pytest.mark.usefixtures("mock_camera_web_rtc")
 async def test_websocket_web_rtc_offer_timeout(
-    hass: HomeAssistant,
-    hass_ws_client: WebSocketGenerator,
-    mock_camera_web_rtc,
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test WebRTC stream with timeout handling the offer."""
     client = await hass_ws_client(hass)
@@ -736,10 +739,9 @@ async def test_websocket_web_rtc_offer_timeout(
     assert response["error"]["message"] == "Timeout handling WebRTC offer"
 
 
+@pytest.mark.usefixtures("mock_camera")
 async def test_websocket_web_rtc_offer_invalid_stream_type(
-    hass: HomeAssistant,
-    hass_ws_client: WebSocketGenerator,
-    mock_camera,
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test WebRTC initiating for a camera with a different stream_type."""
     client = await hass_ws_client(hass)
@@ -759,17 +761,17 @@ async def test_websocket_web_rtc_offer_invalid_stream_type(
     assert response["error"]["code"] == "web_rtc_offer_failed"
 
 
-async def test_state_streaming(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, mock_camera
-) -> None:
+@pytest.mark.usefixtures("mock_camera")
+async def test_state_streaming(hass: HomeAssistant) -> None:
     """Camera state."""
     demo_camera = hass.states.get("camera.demo_camera")
     assert demo_camera is not None
     assert demo_camera.state == camera.STATE_STREAMING
 
 
+@pytest.mark.usefixtures("mock_camera", "mock_stream")
 async def test_stream_unavailable(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, mock_camera, mock_stream
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Camera state."""
     await async_setup_component(hass, "camera", {})
@@ -820,12 +822,11 @@ async def test_stream_unavailable(
     assert demo_camera.state == camera.STATE_STREAMING
 
 
+@pytest.mark.usefixtures("mock_camera", "mock_stream_source")
 async def test_rtsp_to_web_rtc_offer(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
-    mock_camera,
-    mock_stream_source,
-    mock_rtsp_to_web_rtc,
+    mock_rtsp_to_web_rtc: Mock,
 ) -> None:
     """Test creating a web_rtc offer from an rstp provider."""
     client = await hass_ws_client(hass)
@@ -848,12 +849,13 @@ async def test_rtsp_to_web_rtc_offer(
     assert mock_rtsp_to_web_rtc.called
 
 
+@pytest.mark.usefixtures(
+    "mock_camera",
+    "mock_hls_stream_source",  # Not an RTSP stream source
+    "mock_rtsp_to_web_rtc",
+)
 async def test_unsupported_rtsp_to_web_rtc_stream_type(
-    hass: HomeAssistant,
-    hass_ws_client: WebSocketGenerator,
-    mock_camera,
-    mock_hls_stream_source,  # Not an RTSP stream source
-    mock_rtsp_to_web_rtc,
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test rtsp-to-webrtc is not registered for non-RTSP streams."""
     client = await hass_ws_client(hass)
@@ -873,11 +875,9 @@ async def test_unsupported_rtsp_to_web_rtc_stream_type(
     assert not response["success"]
 
 
+@pytest.mark.usefixtures("mock_camera", "mock_stream_source")
 async def test_rtsp_to_web_rtc_provider_unregistered(
-    hass: HomeAssistant,
-    hass_ws_client: WebSocketGenerator,
-    mock_camera,
-    mock_stream_source,
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test creating a web_rtc offer from an rstp provider."""
     mock_provider = Mock(side_effect=provide_web_rtc_answer)
@@ -924,11 +924,9 @@ async def test_rtsp_to_web_rtc_provider_unregistered(
     assert not mock_provider.called
 
 
+@pytest.mark.usefixtures("mock_camera", "mock_stream_source")
 async def test_rtsp_to_web_rtc_offer_not_accepted(
-    hass: HomeAssistant,
-    hass_ws_client: WebSocketGenerator,
-    mock_camera,
-    mock_stream_source,
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test a provider that can't satisfy the rtsp to webrtc offer."""
 
@@ -962,10 +960,9 @@ async def test_rtsp_to_web_rtc_offer_not_accepted(
     unsub()
 
 
+@pytest.mark.usefixtures("mock_camera")
 async def test_use_stream_for_stills(
-    hass: HomeAssistant,
-    hass_client: ClientSessionGenerator,
-    mock_camera,
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> None:
     """Test that the component can grab images from stream."""
 
@@ -1080,9 +1077,8 @@ def test_deprecated_supported_features_ints(caplog: pytest.LogCaptureFixture) ->
     assert "is using deprecated supported features values" not in caplog.text
 
 
-async def test_entity_picture_url_changes_on_token_update(
-    hass: HomeAssistant, mock_camera
-) -> None:
+@pytest.mark.usefixtures("mock_camera")
+async def test_entity_picture_url_changes_on_token_update(hass: HomeAssistant) -> None:
     """Test the token is rotated and entity entity picture cache is cleared."""
     await async_setup_component(hass, "camera", {})
     await hass.async_block_till_done()

--- a/tests/components/camera/test_media_source.py
+++ b/tests/components/camera/test_media_source.py
@@ -12,14 +12,13 @@ from homeassistant.setup import async_setup_component
 
 
 @pytest.fixture(autouse=True)
-async def setup_media_source(hass):
+async def setup_media_source(hass: HomeAssistant) -> None:
     """Set up media source."""
     assert await async_setup_component(hass, "media_source", {})
 
 
-async def test_device_with_device(
-    hass: HomeAssistant, mock_camera_with_device, mock_camera
-) -> None:
+@pytest.mark.usefixtures("mock_camera_with_device", "mock_camera")
+async def test_device_with_device(hass: HomeAssistant) -> None:
     """Test browsing when camera has a device and a name."""
     item = await media_source.async_browse_media(hass, "media-source://camera")
     assert item.not_shown == 2
@@ -27,9 +26,8 @@ async def test_device_with_device(
     assert item.children[0].title == "Test Camera Device Demo camera without stream"
 
 
-async def test_device_with_no_name(
-    hass: HomeAssistant, mock_camera_with_no_name, mock_camera
-) -> None:
+@pytest.mark.usefixtures("mock_camera_with_no_name", "mock_camera")
+async def test_device_with_no_name(hass: HomeAssistant) -> None:
     """Test browsing when camera has device and name == None."""
     item = await media_source.async_browse_media(hass, "media-source://camera")
     assert item.not_shown == 2
@@ -37,7 +35,8 @@ async def test_device_with_no_name(
     assert item.children[0].title == "Test Camera Device Demo camera without stream"
 
 
-async def test_browsing_hls(hass: HomeAssistant, mock_camera_hls) -> None:
+@pytest.mark.usefixtures("mock_camera_hls")
+async def test_browsing_hls(hass: HomeAssistant) -> None:
     """Test browsing HLS camera media source."""
     item = await media_source.async_browse_media(hass, "media-source://camera")
     assert item is not None
@@ -54,7 +53,8 @@ async def test_browsing_hls(hass: HomeAssistant, mock_camera_hls) -> None:
     assert item.children[0].media_content_type == FORMAT_CONTENT_TYPE["hls"]
 
 
-async def test_browsing_mjpeg(hass: HomeAssistant, mock_camera) -> None:
+@pytest.mark.usefixtures("mock_camera")
+async def test_browsing_mjpeg(hass: HomeAssistant) -> None:
     """Test browsing MJPEG camera media source."""
     item = await media_source.async_browse_media(hass, "media-source://camera")
     assert item is not None
@@ -65,7 +65,8 @@ async def test_browsing_mjpeg(hass: HomeAssistant, mock_camera) -> None:
     assert item.children[0].title == "Demo camera without stream"
 
 
-async def test_browsing_web_rtc(hass: HomeAssistant, mock_camera_web_rtc) -> None:
+@pytest.mark.usefixtures("mock_camera_web_rtc")
+async def test_browsing_web_rtc(hass: HomeAssistant) -> None:
     """Test browsing WebRTC camera media source."""
     # 3 cameras:
     # one only supports WebRTC (no stream source)
@@ -90,7 +91,8 @@ async def test_browsing_web_rtc(hass: HomeAssistant, mock_camera_web_rtc) -> Non
         assert item.children[0].media_content_type == FORMAT_CONTENT_TYPE["hls"]
 
 
-async def test_resolving(hass: HomeAssistant, mock_camera_hls) -> None:
+@pytest.mark.usefixtures("mock_camera_hls")
+async def test_resolving(hass: HomeAssistant) -> None:
     """Test resolving."""
     # Adding stream enables HLS camera
     hass.config.components.add("stream")
@@ -107,7 +109,8 @@ async def test_resolving(hass: HomeAssistant, mock_camera_hls) -> None:
     assert item.mime_type == FORMAT_CONTENT_TYPE["hls"]
 
 
-async def test_resolving_errors(hass: HomeAssistant, mock_camera_hls) -> None:
+@pytest.mark.usefixtures("mock_camera_hls")
+async def test_resolving_errors(hass: HomeAssistant) -> None:
     """Test resolving."""
 
     with pytest.raises(media_source.Unresolvable) as exc_info:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
