### PR TITLE
Fix root-import pylint warning in dlna_dmr tests

### DIFF
--- a/tests/components/dlna_dmr/test_media_player.py
+++ b/tests/components/dlna_dmr/test_media_player.py
@@ -20,7 +20,7 @@ from didl_lite import didl_lite
 import pytest
 
 from homeassistant import const as ha_const
-from homeassistant.components import ssdp
+from homeassistant.components import media_player as mp, ssdp
 from homeassistant.components.dlna_dmr.const import (
     CONF_BROWSE_UNFILTERED,
     CONF_CALLBACK_URL_OVERRIDE,
@@ -31,13 +31,10 @@ from homeassistant.components.dlna_dmr.const import (
 from homeassistant.components.dlna_dmr.data import EventListenAddr
 from homeassistant.components.dlna_dmr.media_player import DlnaDmrEntity
 from homeassistant.components.media_player import (
-    ATTR_TO_PROPERTY,
-    DOMAIN as MP_DOMAIN,
     MediaPlayerEntityFeature,
     MediaPlayerState,
     MediaType,
     RepeatMode,
-    const as mp_const,
 )
 from homeassistant.components.media_source import DOMAIN as MS_DOMAIN, PlayMedia
 from homeassistant.const import (
@@ -551,56 +548,56 @@ async def test_attributes(
     """Test attributes of a connected DlnaDmrEntity."""
     # Check attributes come directly from the device
     attrs = await get_attrs(hass, mock_entity_id)
-    assert attrs[mp_const.ATTR_MEDIA_VOLUME_LEVEL] is dmr_device_mock.volume_level
-    assert attrs[mp_const.ATTR_MEDIA_VOLUME_MUTED] is dmr_device_mock.is_volume_muted
-    assert attrs[mp_const.ATTR_MEDIA_DURATION] is dmr_device_mock.media_duration
-    assert attrs[mp_const.ATTR_MEDIA_POSITION] is dmr_device_mock.media_position
+    assert attrs[mp.ATTR_MEDIA_VOLUME_LEVEL] is dmr_device_mock.volume_level
+    assert attrs[mp.ATTR_MEDIA_VOLUME_MUTED] is dmr_device_mock.is_volume_muted
+    assert attrs[mp.ATTR_MEDIA_DURATION] is dmr_device_mock.media_duration
+    assert attrs[mp.ATTR_MEDIA_POSITION] is dmr_device_mock.media_position
     assert (
-        attrs[mp_const.ATTR_MEDIA_POSITION_UPDATED_AT]
+        attrs[mp.ATTR_MEDIA_POSITION_UPDATED_AT]
         is dmr_device_mock.media_position_updated_at
     )
-    assert attrs[mp_const.ATTR_MEDIA_CONTENT_ID] is dmr_device_mock.current_track_uri
-    assert attrs[mp_const.ATTR_MEDIA_ARTIST] is dmr_device_mock.media_artist
-    assert attrs[mp_const.ATTR_MEDIA_ALBUM_NAME] is dmr_device_mock.media_album_name
-    assert attrs[mp_const.ATTR_MEDIA_ALBUM_ARTIST] is dmr_device_mock.media_album_artist
-    assert attrs[mp_const.ATTR_MEDIA_TRACK] is dmr_device_mock.media_track_number
-    assert attrs[mp_const.ATTR_MEDIA_SERIES_TITLE] is dmr_device_mock.media_series_title
-    assert attrs[mp_const.ATTR_MEDIA_SEASON] is dmr_device_mock.media_season_number
-    assert attrs[mp_const.ATTR_MEDIA_EPISODE] is dmr_device_mock.media_episode_number
-    assert attrs[mp_const.ATTR_MEDIA_CHANNEL] is dmr_device_mock.media_channel_name
-    assert attrs[mp_const.ATTR_SOUND_MODE_LIST] is dmr_device_mock.preset_names
+    assert attrs[mp.ATTR_MEDIA_CONTENT_ID] is dmr_device_mock.current_track_uri
+    assert attrs[mp.ATTR_MEDIA_ARTIST] is dmr_device_mock.media_artist
+    assert attrs[mp.ATTR_MEDIA_ALBUM_NAME] is dmr_device_mock.media_album_name
+    assert attrs[mp.ATTR_MEDIA_ALBUM_ARTIST] is dmr_device_mock.media_album_artist
+    assert attrs[mp.ATTR_MEDIA_TRACK] is dmr_device_mock.media_track_number
+    assert attrs[mp.ATTR_MEDIA_SERIES_TITLE] is dmr_device_mock.media_series_title
+    assert attrs[mp.ATTR_MEDIA_SEASON] is dmr_device_mock.media_season_number
+    assert attrs[mp.ATTR_MEDIA_EPISODE] is dmr_device_mock.media_episode_number
+    assert attrs[mp.ATTR_MEDIA_CHANNEL] is dmr_device_mock.media_channel_name
+    assert attrs[mp.ATTR_SOUND_MODE_LIST] is dmr_device_mock.preset_names
 
     # Entity picture is cached, won't correspond to remote image
     assert isinstance(attrs[ha_const.ATTR_ENTITY_PICTURE], str)
 
     # media_title depends on what is available
-    assert attrs[mp_const.ATTR_MEDIA_TITLE] is dmr_device_mock.media_program_title
+    assert attrs[mp.ATTR_MEDIA_TITLE] is dmr_device_mock.media_program_title
     dmr_device_mock.media_program_title = None
     attrs = await get_attrs(hass, mock_entity_id)
-    assert attrs[mp_const.ATTR_MEDIA_TITLE] is dmr_device_mock.media_title
+    assert attrs[mp.ATTR_MEDIA_TITLE] is dmr_device_mock.media_title
 
     # media_content_type is mapped from UPnP class to MediaPlayer type
     dmr_device_mock.media_class = "object.item.audioItem.musicTrack"
     attrs = await get_attrs(hass, mock_entity_id)
-    assert attrs[mp_const.ATTR_MEDIA_CONTENT_TYPE] == MediaType.MUSIC
+    assert attrs[mp.ATTR_MEDIA_CONTENT_TYPE] == MediaType.MUSIC
     dmr_device_mock.media_class = "object.item.videoItem.movie"
     attrs = await get_attrs(hass, mock_entity_id)
-    assert attrs[mp_const.ATTR_MEDIA_CONTENT_TYPE] == MediaType.MOVIE
+    assert attrs[mp.ATTR_MEDIA_CONTENT_TYPE] == MediaType.MOVIE
     dmr_device_mock.media_class = "object.item.videoItem.videoBroadcast"
     attrs = await get_attrs(hass, mock_entity_id)
-    assert attrs[mp_const.ATTR_MEDIA_CONTENT_TYPE] == MediaType.TVSHOW
+    assert attrs[mp.ATTR_MEDIA_CONTENT_TYPE] == MediaType.TVSHOW
 
     # media_season & media_episode have a special case
     dmr_device_mock.media_season_number = "0"
     dmr_device_mock.media_episode_number = "123"
     attrs = await get_attrs(hass, mock_entity_id)
-    assert attrs[mp_const.ATTR_MEDIA_SEASON] == "1"
-    assert attrs[mp_const.ATTR_MEDIA_EPISODE] == "23"
+    assert attrs[mp.ATTR_MEDIA_SEASON] == "1"
+    assert attrs[mp.ATTR_MEDIA_EPISODE] == "23"
     dmr_device_mock.media_season_number = "0"
     dmr_device_mock.media_episode_number = "S1E23"  # Unexpected and not parsed
     attrs = await get_attrs(hass, mock_entity_id)
-    assert attrs[mp_const.ATTR_MEDIA_SEASON] == "0"
-    assert attrs[mp_const.ATTR_MEDIA_EPISODE] == "S1E23"
+    assert attrs[mp.ATTR_MEDIA_SEASON] == "0"
+    assert attrs[mp.ATTR_MEDIA_EPISODE] == "S1E23"
 
     # shuffle and repeat is based on device's play mode
     for play_mode, shuffle, repeat in [
@@ -614,13 +611,13 @@ async def test_attributes(
     ]:
         dmr_device_mock.play_mode = play_mode
         attrs = await get_attrs(hass, mock_entity_id)
-        assert attrs[mp_const.ATTR_MEDIA_SHUFFLE] is shuffle
-        assert attrs[mp_const.ATTR_MEDIA_REPEAT] == repeat
+        assert attrs[mp.ATTR_MEDIA_SHUFFLE] is shuffle
+        assert attrs[mp.ATTR_MEDIA_REPEAT] == repeat
     for bad_play_mode in [None, PlayMode.VENDOR_DEFINED]:
         dmr_device_mock.play_mode = bad_play_mode
         attrs = await get_attrs(hass, mock_entity_id)
-        assert mp_const.ATTR_MEDIA_SHUFFLE not in attrs
-        assert mp_const.ATTR_MEDIA_REPEAT not in attrs
+        assert mp.ATTR_MEDIA_SHUFFLE not in attrs
+        assert mp.ATTR_MEDIA_REPEAT not in attrs
 
 
 async def test_services(
@@ -629,65 +626,65 @@ async def test_services(
     """Test service calls of a connected DlnaDmrEntity."""
     # Check interface methods interact directly with the device
     await hass.services.async_call(
-        MP_DOMAIN,
+        mp.DOMAIN,
         ha_const.SERVICE_VOLUME_SET,
-        {ATTR_ENTITY_ID: mock_entity_id, mp_const.ATTR_MEDIA_VOLUME_LEVEL: 0.80},
+        {ATTR_ENTITY_ID: mock_entity_id, mp.ATTR_MEDIA_VOLUME_LEVEL: 0.80},
         blocking=True,
     )
     dmr_device_mock.async_set_volume_level.assert_awaited_once_with(0.80)
     await hass.services.async_call(
-        MP_DOMAIN,
+        mp.DOMAIN,
         ha_const.SERVICE_VOLUME_MUTE,
-        {ATTR_ENTITY_ID: mock_entity_id, mp_const.ATTR_MEDIA_VOLUME_MUTED: True},
+        {ATTR_ENTITY_ID: mock_entity_id, mp.ATTR_MEDIA_VOLUME_MUTED: True},
         blocking=True,
     )
     dmr_device_mock.async_mute_volume.assert_awaited_once_with(True)
     await hass.services.async_call(
-        MP_DOMAIN,
+        mp.DOMAIN,
         ha_const.SERVICE_MEDIA_PAUSE,
         {ATTR_ENTITY_ID: mock_entity_id},
         blocking=True,
     )
     dmr_device_mock.async_pause.assert_awaited_once_with()
     await hass.services.async_call(
-        MP_DOMAIN,
+        mp.DOMAIN,
         ha_const.SERVICE_MEDIA_PLAY,
         {ATTR_ENTITY_ID: mock_entity_id},
         blocking=True,
     )
     dmr_device_mock.async_pause.assert_awaited_once_with()
     await hass.services.async_call(
-        MP_DOMAIN,
+        mp.DOMAIN,
         ha_const.SERVICE_MEDIA_STOP,
         {ATTR_ENTITY_ID: mock_entity_id},
         blocking=True,
     )
     dmr_device_mock.async_stop.assert_awaited_once_with()
     await hass.services.async_call(
-        MP_DOMAIN,
+        mp.DOMAIN,
         ha_const.SERVICE_MEDIA_NEXT_TRACK,
         {ATTR_ENTITY_ID: mock_entity_id},
         blocking=True,
     )
     dmr_device_mock.async_next.assert_awaited_once_with()
     await hass.services.async_call(
-        MP_DOMAIN,
+        mp.DOMAIN,
         ha_const.SERVICE_MEDIA_PREVIOUS_TRACK,
         {ATTR_ENTITY_ID: mock_entity_id},
         blocking=True,
     )
     dmr_device_mock.async_previous.assert_awaited_once_with()
     await hass.services.async_call(
-        MP_DOMAIN,
+        mp.DOMAIN,
         ha_const.SERVICE_MEDIA_SEEK,
-        {ATTR_ENTITY_ID: mock_entity_id, mp_const.ATTR_MEDIA_SEEK_POSITION: 33},
+        {ATTR_ENTITY_ID: mock_entity_id, mp.ATTR_MEDIA_SEEK_POSITION: 33},
         blocking=True,
     )
     dmr_device_mock.async_seek_rel_time.assert_awaited_once_with(timedelta(seconds=33))
     await hass.services.async_call(
-        MP_DOMAIN,
-        mp_const.SERVICE_SELECT_SOUND_MODE,
-        {ATTR_ENTITY_ID: mock_entity_id, mp_const.ATTR_SOUND_MODE: "Default"},
+        mp.DOMAIN,
+        mp.SERVICE_SELECT_SOUND_MODE,
+        {ATTR_ENTITY_ID: mock_entity_id, mp.ATTR_SOUND_MODE: "Default"},
         blocking=True,
     )
     dmr_device_mock.async_select_preset.assert_awaited_once_with("Default")
@@ -701,15 +698,15 @@ async def test_play_media_stopped(
     dmr_device_mock.can_stop = True
     dmr_device_mock.transport_state = TransportState.STOPPED
     await hass.services.async_call(
-        MP_DOMAIN,
-        mp_const.SERVICE_PLAY_MEDIA,
+        mp.DOMAIN,
+        mp.SERVICE_PLAY_MEDIA,
         {
             ATTR_ENTITY_ID: mock_entity_id,
-            mp_const.ATTR_MEDIA_CONTENT_TYPE: MediaType.MUSIC,
-            mp_const.ATTR_MEDIA_CONTENT_ID: (
+            mp.ATTR_MEDIA_CONTENT_TYPE: MediaType.MUSIC,
+            mp.ATTR_MEDIA_CONTENT_ID: (
                 "http://198.51.100.20:8200/MediaItems/17621.mp3"
             ),
-            mp_const.ATTR_MEDIA_ENQUEUE: False,
+            mp.ATTR_MEDIA_ENQUEUE: False,
         },
         blocking=True,
     )
@@ -735,15 +732,15 @@ async def test_play_media_playing(
     dmr_device_mock.can_stop = False
     dmr_device_mock.transport_state = TransportState.PLAYING
     await hass.services.async_call(
-        MP_DOMAIN,
-        mp_const.SERVICE_PLAY_MEDIA,
+        mp.DOMAIN,
+        mp.SERVICE_PLAY_MEDIA,
         {
             ATTR_ENTITY_ID: mock_entity_id,
-            mp_const.ATTR_MEDIA_CONTENT_TYPE: MediaType.MUSIC,
-            mp_const.ATTR_MEDIA_CONTENT_ID: (
+            mp.ATTR_MEDIA_CONTENT_TYPE: MediaType.MUSIC,
+            mp.ATTR_MEDIA_CONTENT_ID: (
                 "http://198.51.100.20:8200/MediaItems/17621.mp3"
             ),
-            mp_const.ATTR_MEDIA_ENQUEUE: False,
+            mp.ATTR_MEDIA_ENQUEUE: False,
         },
         blocking=True,
     )
@@ -770,16 +767,16 @@ async def test_play_media_no_autoplay(
     dmr_device_mock.can_stop = True
     dmr_device_mock.transport_state = TransportState.STOPPED
     await hass.services.async_call(
-        MP_DOMAIN,
-        mp_const.SERVICE_PLAY_MEDIA,
+        mp.DOMAIN,
+        mp.SERVICE_PLAY_MEDIA,
         {
             ATTR_ENTITY_ID: mock_entity_id,
-            mp_const.ATTR_MEDIA_CONTENT_TYPE: MediaType.MUSIC,
-            mp_const.ATTR_MEDIA_CONTENT_ID: (
+            mp.ATTR_MEDIA_CONTENT_TYPE: MediaType.MUSIC,
+            mp.ATTR_MEDIA_CONTENT_ID: (
                 "http://198.51.100.20:8200/MediaItems/17621.mp3"
             ),
-            mp_const.ATTR_MEDIA_ENQUEUE: False,
-            mp_const.ATTR_MEDIA_EXTRA: {"autoplay": False},
+            mp.ATTR_MEDIA_ENQUEUE: False,
+            mp.ATTR_MEDIA_EXTRA: {"autoplay": False},
         },
         blocking=True,
     )
@@ -803,16 +800,16 @@ async def test_play_media_metadata(
 ) -> None:
     """Test play_media constructs useful metadata from user params."""
     await hass.services.async_call(
-        MP_DOMAIN,
-        mp_const.SERVICE_PLAY_MEDIA,
+        mp.DOMAIN,
+        mp.SERVICE_PLAY_MEDIA,
         {
             ATTR_ENTITY_ID: mock_entity_id,
-            mp_const.ATTR_MEDIA_CONTENT_TYPE: MediaType.MUSIC,
-            mp_const.ATTR_MEDIA_CONTENT_ID: (
+            mp.ATTR_MEDIA_CONTENT_TYPE: MediaType.MUSIC,
+            mp.ATTR_MEDIA_CONTENT_ID: (
                 "http://198.51.100.20:8200/MediaItems/17621.mp3"
             ),
-            mp_const.ATTR_MEDIA_ENQUEUE: False,
-            mp_const.ATTR_MEDIA_EXTRA: {
+            mp.ATTR_MEDIA_ENQUEUE: False,
+            mp.ATTR_MEDIA_EXTRA: {
                 "title": "Mock song",
                 "thumb": "http://198.51.100.20:8200/MediaItems/17621.jpg",
                 "metadata": {"artist": "Mock artist", "album": "Mock album"},
@@ -835,16 +832,14 @@ async def test_play_media_metadata(
     # Check again for a different media type
     dmr_device_mock.construct_play_media_metadata.reset_mock()
     await hass.services.async_call(
-        MP_DOMAIN,
-        mp_const.SERVICE_PLAY_MEDIA,
+        mp.DOMAIN,
+        mp.SERVICE_PLAY_MEDIA,
         {
             ATTR_ENTITY_ID: mock_entity_id,
-            mp_const.ATTR_MEDIA_CONTENT_TYPE: MediaType.TVSHOW,
-            mp_const.ATTR_MEDIA_CONTENT_ID: (
-                "http://198.51.100.20:8200/MediaItems/123.mkv"
-            ),
-            mp_const.ATTR_MEDIA_ENQUEUE: False,
-            mp_const.ATTR_MEDIA_EXTRA: {
+            mp.ATTR_MEDIA_CONTENT_TYPE: MediaType.TVSHOW,
+            mp.ATTR_MEDIA_CONTENT_ID: ("http://198.51.100.20:8200/MediaItems/123.mkv"),
+            mp.ATTR_MEDIA_ENQUEUE: False,
+            mp.ATTR_MEDIA_EXTRA: {
                 "title": "Mock show",
                 "metadata": {"season": 1, "episode": 12},
             },
@@ -870,12 +865,12 @@ async def test_play_media_local_source(
     await hass.async_block_till_done()
 
     await hass.services.async_call(
-        MP_DOMAIN,
-        mp_const.SERVICE_PLAY_MEDIA,
+        mp.DOMAIN,
+        mp.SERVICE_PLAY_MEDIA,
         {
             ATTR_ENTITY_ID: mock_entity_id,
-            mp_const.ATTR_MEDIA_CONTENT_TYPE: "video/mp4",
-            mp_const.ATTR_MEDIA_CONTENT_ID: (
+            mp.ATTR_MEDIA_CONTENT_TYPE: "video/mp4",
+            mp.ATTR_MEDIA_CONTENT_ID: (
                 "media-source://media_source/local/Epic Sax Guy 10 Hours.mp4"
             ),
         },
@@ -927,12 +922,12 @@ async def test_play_media_didl_metadata(
         return_value=play_media,
     ):
         await hass.services.async_call(
-            MP_DOMAIN,
-            mp_const.SERVICE_PLAY_MEDIA,
+            mp.DOMAIN,
+            mp.SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: mock_entity_id,
-                mp_const.ATTR_MEDIA_CONTENT_TYPE: "video/mp4",
-                mp_const.ATTR_MEDIA_CONTENT_ID: (
+                mp.ATTR_MEDIA_CONTENT_TYPE: "video/mp4",
+                mp.ATTR_MEDIA_CONTENT_ID: (
                     "media-source://media_source/local/Epic Sax Guy 10 Hours.mp4"
                 ),
             },
@@ -968,9 +963,9 @@ async def test_shuffle_repeat_modes(
     ]:
         dmr_device_mock.play_mode = init_mode
         await hass.services.async_call(
-            MP_DOMAIN,
+            mp.DOMAIN,
             ha_const.SERVICE_SHUFFLE_SET,
-            {ATTR_ENTITY_ID: mock_entity_id, mp_const.ATTR_MEDIA_SHUFFLE: shuffle_set},
+            {ATTR_ENTITY_ID: mock_entity_id, mp.ATTR_MEDIA_SHUFFLE: shuffle_set},
             blocking=True,
         )
         dmr_device_mock.async_set_play_mode.assert_awaited_with(expect_mode)
@@ -995,9 +990,9 @@ async def test_shuffle_repeat_modes(
     ]:
         dmr_device_mock.play_mode = init_mode
         await hass.services.async_call(
-            MP_DOMAIN,
+            mp.DOMAIN,
             ha_const.SERVICE_REPEAT_SET,
-            {ATTR_ENTITY_ID: mock_entity_id, mp_const.ATTR_MEDIA_REPEAT: repeat_set},
+            {ATTR_ENTITY_ID: mock_entity_id, mp.ATTR_MEDIA_REPEAT: repeat_set},
             blocking=True,
         )
         dmr_device_mock.async_set_play_mode.assert_awaited_with(expect_mode)
@@ -1009,9 +1004,9 @@ async def test_shuffle_repeat_modes(
     dmr_device_mock.valid_play_modes = {PlayMode.SHUFFLE, PlayMode.RANDOM}
     await get_attrs(hass, mock_entity_id)
     await hass.services.async_call(
-        MP_DOMAIN,
+        mp.DOMAIN,
         ha_const.SERVICE_SHUFFLE_SET,
-        {ATTR_ENTITY_ID: mock_entity_id, mp_const.ATTR_MEDIA_SHUFFLE: False},
+        {ATTR_ENTITY_ID: mock_entity_id, mp.ATTR_MEDIA_SHUFFLE: False},
         blocking=True,
     )
     dmr_device_mock.async_set_play_mode.assert_not_awaited()
@@ -1023,11 +1018,11 @@ async def test_shuffle_repeat_modes(
     dmr_device_mock.valid_play_modes = {PlayMode.REPEAT_ONE, PlayMode.REPEAT_ALL}
     await get_attrs(hass, mock_entity_id)
     await hass.services.async_call(
-        MP_DOMAIN,
+        mp.DOMAIN,
         ha_const.SERVICE_REPEAT_SET,
         {
             ATTR_ENTITY_ID: mock_entity_id,
-            mp_const.ATTR_MEDIA_REPEAT: RepeatMode.OFF,
+            mp.ATTR_MEDIA_REPEAT: RepeatMode.OFF,
         },
         blocking=True,
     )
@@ -1322,40 +1317,40 @@ async def test_unavailable_device(
 
     # Check attributes are unavailable
     attrs = mock_state.attributes
-    for attr in ATTR_TO_PROPERTY:
+    for attr in mp.ATTR_TO_PROPERTY:
         assert attr not in attrs
 
     assert attrs[ha_const.ATTR_FRIENDLY_NAME] == MOCK_DEVICE_NAME
     assert attrs[ha_const.ATTR_SUPPORTED_FEATURES] == 0
-    assert mp_const.ATTR_SOUND_MODE_LIST not in attrs
+    assert mp.ATTR_SOUND_MODE_LIST not in attrs
 
     # Check service calls do nothing
     SERVICES: list[tuple[str, dict]] = [
-        (ha_const.SERVICE_VOLUME_SET, {mp_const.ATTR_MEDIA_VOLUME_LEVEL: 0.80}),
-        (ha_const.SERVICE_VOLUME_MUTE, {mp_const.ATTR_MEDIA_VOLUME_MUTED: True}),
+        (ha_const.SERVICE_VOLUME_SET, {mp.ATTR_MEDIA_VOLUME_LEVEL: 0.80}),
+        (ha_const.SERVICE_VOLUME_MUTE, {mp.ATTR_MEDIA_VOLUME_MUTED: True}),
         (ha_const.SERVICE_MEDIA_PAUSE, {}),
         (ha_const.SERVICE_MEDIA_PLAY, {}),
         (ha_const.SERVICE_MEDIA_STOP, {}),
         (ha_const.SERVICE_MEDIA_NEXT_TRACK, {}),
         (ha_const.SERVICE_MEDIA_PREVIOUS_TRACK, {}),
-        (ha_const.SERVICE_MEDIA_SEEK, {mp_const.ATTR_MEDIA_SEEK_POSITION: 33}),
+        (ha_const.SERVICE_MEDIA_SEEK, {mp.ATTR_MEDIA_SEEK_POSITION: 33}),
         (
-            mp_const.SERVICE_PLAY_MEDIA,
+            mp.SERVICE_PLAY_MEDIA,
             {
-                mp_const.ATTR_MEDIA_CONTENT_TYPE: MediaType.MUSIC,
-                mp_const.ATTR_MEDIA_CONTENT_ID: (
+                mp.ATTR_MEDIA_CONTENT_TYPE: MediaType.MUSIC,
+                mp.ATTR_MEDIA_CONTENT_ID: (
                     "http://198.51.100.20:8200/MediaItems/17621.mp3"
                 ),
-                mp_const.ATTR_MEDIA_ENQUEUE: False,
+                mp.ATTR_MEDIA_ENQUEUE: False,
             },
         ),
-        (mp_const.SERVICE_SELECT_SOUND_MODE, {mp_const.ATTR_SOUND_MODE: "Default"}),
-        (ha_const.SERVICE_SHUFFLE_SET, {mp_const.ATTR_MEDIA_SHUFFLE: True}),
-        (ha_const.SERVICE_REPEAT_SET, {mp_const.ATTR_MEDIA_REPEAT: "all"}),
+        (mp.SERVICE_SELECT_SOUND_MODE, {mp.ATTR_SOUND_MODE: "Default"}),
+        (ha_const.SERVICE_SHUFFLE_SET, {mp.ATTR_MEDIA_SHUFFLE: True}),
+        (ha_const.SERVICE_REPEAT_SET, {mp.ATTR_MEDIA_REPEAT: "all"}),
     ]
     for service, data in SERVICES:
         await hass.services.async_call(
-            MP_DOMAIN,
+            mp.DOMAIN,
             service,
             {ATTR_ENTITY_ID: mock_entity_id, **data},
             blocking=True,
@@ -1980,9 +1975,9 @@ async def test_become_unavailable(
     # Interface service calls should flag that the device is unavailable, but
     # not disconnect it immediately
     await hass.services.async_call(
-        MP_DOMAIN,
+        mp.DOMAIN,
         ha_const.SERVICE_VOLUME_SET,
-        {ATTR_ENTITY_ID: mock_entity_id, mp_const.ATTR_MEDIA_VOLUME_LEVEL: 0.80},
+        {ATTR_ENTITY_ID: mock_entity_id, mp.ATTR_MEDIA_VOLUME_LEVEL: 0.80},
         blocking=True,
     )
 
@@ -2003,9 +1998,9 @@ async def test_become_unavailable(
     dmr_device_mock.async_update.side_effect = UpnpConnectionError
 
     await hass.services.async_call(
-        MP_DOMAIN,
+        mp.DOMAIN,
         ha_const.SERVICE_VOLUME_SET,
-        {ATTR_ENTITY_ID: mock_entity_id, mp_const.ATTR_MEDIA_VOLUME_LEVEL: 0.80},
+        {ATTR_ENTITY_ID: mock_entity_id, mp.ATTR_MEDIA_VOLUME_LEVEL: 0.80},
         blocking=True,
     )
     await async_update_entity(hass, mock_entity_id)
@@ -2083,10 +2078,10 @@ async def test_disappearing_device(
     directly to skip the availability check.
     """
     # Retrieve entity directly.
-    entity: DlnaDmrEntity = hass.data[MP_DOMAIN].get_entity(mock_disconnected_entity_id)
+    entity: DlnaDmrEntity = hass.data[mp.DOMAIN].get_entity(mock_disconnected_entity_id)
 
     # Test attribute access
-    for attr in ATTR_TO_PROPERTY:
+    for attr in mp.ATTR_TO_PROPERTY:
         value = getattr(entity, attr)
         assert value is None
 
@@ -2456,7 +2451,7 @@ async def test_udn_upnp_connection_added_if_missing(
     # Cause connection attempts to fail before adding entity
     ent_reg = async_get_er(hass)
     entry = ent_reg.async_get_or_create(
-        MP_DOMAIN,
+        mp.DOMAIN,
         DOMAIN,
         MOCK_DEVICE_UDN,
         config_entry=config_entry_mock,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, spotted in #119279

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
