### PR TITLE
Improve incomfort binary sensors

### DIFF
--- a/homeassistant/components/incomfort/binary_sensor.py
+++ b/homeassistant/components/incomfort/binary_sensor.py
@@ -36,7 +36,7 @@ SENSOR_TYPES: tuple[IncomfortBinarySensorEntityDescription, ...] = (
         device_class=BinarySensorDeviceClass.PROBLEM,
         value_key="is_failed",
         extra_state_attributes_fn=lambda status: {
-            "fault_code": status["fault_code"] or "-",
+            "fault_code": status["fault_code"] or "none",
         },
     ),
     IncomfortBinarySensorEntityDescription(

--- a/homeassistant/components/incomfort/binary_sensor.py
+++ b/homeassistant/components/incomfort/binary_sensor.py
@@ -26,7 +26,7 @@ class IncomfortBinarySensorEntityDescription(BinarySensorEntityDescription):
     """Describes Incomfort binary sensor entity."""
 
     value_key: str
-    extra_state_attributes_fn: Callable[[dict[str, Any]], dict[str, Any]]
+    extra_state_attributes_fn: Callable[[dict[str, Any]], dict[str, Any]] | None = None
 
 
 SENSOR_TYPES: tuple[IncomfortBinarySensorEntityDescription, ...] = (
@@ -35,7 +35,28 @@ SENSOR_TYPES: tuple[IncomfortBinarySensorEntityDescription, ...] = (
         translation_key="fault",
         device_class=BinarySensorDeviceClass.PROBLEM,
         value_key="is_failed",
-        extra_state_attributes_fn=lambda status: {"fault_code": status["fault_code"]},
+        extra_state_attributes_fn=lambda status: {
+            "fault_code": status["fault_code"] or "-",
+            "fault": status["fault_code"].name if status["fault_code"] else "-",
+        },
+    ),
+    IncomfortBinarySensorEntityDescription(
+        key="is_pumping",
+        translation_key="is_pumping",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        value_key="is_pumping",
+    ),
+    IncomfortBinarySensorEntityDescription(
+        key="is_burning",
+        translation_key="is_burning",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        value_key="is_burning",
+    ),
+    IncomfortBinarySensorEntityDescription(
+        key="is_tapping",
+        translation_key="is_tapping",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        value_key="is_tapping",
     ),
 )
 
@@ -77,6 +98,8 @@ class IncomfortBinarySensor(IncomfortBoilerEntity, BinarySensorEntity):
         return self._heater.status[self.entity_description.value_key]
 
     @property
-    def extra_state_attributes(self) -> dict[str, Any]:
+    def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the device state attributes."""
-        return self.entity_description.extra_state_attributes_fn(self._heater.status)
+        if (attributes_fn := self.entity_description.extra_state_attributes_fn) is None:
+            return None
+        return attributes_fn(self._heater.status)

--- a/homeassistant/components/incomfort/binary_sensor.py
+++ b/homeassistant/components/incomfort/binary_sensor.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
-from incomfortclient import FaultCode, Heater as InComfortHeater
+from incomfortclient import Heater as InComfortHeater
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -29,13 +29,6 @@ class IncomfortBinarySensorEntityDescription(BinarySensorEntityDescription):
     extra_state_attributes_fn: Callable[[dict[str, Any]], dict[str, Any]] | None = None
 
 
-def get_fault_code_label_name(value: FaultCode | None) -> str:
-    """Get label from fault code IntEnum."""
-    if value is None:
-        return "-"
-    return value.name
-
-
 SENSOR_TYPES: tuple[IncomfortBinarySensorEntityDescription, ...] = (
     IncomfortBinarySensorEntityDescription(
         key="failed",
@@ -44,7 +37,6 @@ SENSOR_TYPES: tuple[IncomfortBinarySensorEntityDescription, ...] = (
         value_key="is_failed",
         extra_state_attributes_fn=lambda status: {
             "fault_code": status["fault_code"] or "-",
-            "fault": get_fault_code_label_name(status["fault_code"]),
         },
     ),
     IncomfortBinarySensorEntityDescription(

--- a/homeassistant/components/incomfort/binary_sensor.py
+++ b/homeassistant/components/incomfort/binary_sensor.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
-from incomfortclient import Heater as InComfortHeater
+from incomfortclient import FaultCode, Heater as InComfortHeater
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -29,6 +29,13 @@ class IncomfortBinarySensorEntityDescription(BinarySensorEntityDescription):
     extra_state_attributes_fn: Callable[[dict[str, Any]], dict[str, Any]] | None = None
 
 
+def get_fault_code_label_name(value: FaultCode | None) -> str:
+    """Get label from fault code IntEnum."""
+    if value is None:
+        return "-"
+    return value.name
+
+
 SENSOR_TYPES: tuple[IncomfortBinarySensorEntityDescription, ...] = (
     IncomfortBinarySensorEntityDescription(
         key="failed",
@@ -37,7 +44,7 @@ SENSOR_TYPES: tuple[IncomfortBinarySensorEntityDescription, ...] = (
         value_key="is_failed",
         extra_state_attributes_fn=lambda status: {
             "fault_code": status["fault_code"] or "-",
-            "fault": status["fault_code"].name if status["fault_code"] else "-",
+            "fault": get_fault_code_label_name(status["fault_code"]),
         },
     ),
     IncomfortBinarySensorEntityDescription(

--- a/homeassistant/components/incomfort/strings.json
+++ b/homeassistant/components/incomfort/strings.json
@@ -56,33 +56,7 @@
   "entity": {
     "binary_sensor": {
       "fault": {
-        "name": "Fault",
-        "state_attributes": {
-          "fault": {
-            "state": {
-              "sensor_fault_after_self_check_e0": "[%key:component::incomfort::entity::water_heater::boiler::state::sensor_fault_after_self_check_e0%]",
-              "cv_temperature_too_high_e1": "[%key:component::incomfort::entity::water_heater::boiler::state::cv_temperature_too_high_e1%]",
-              "s1_and_s2_interchanged_e2": "[%key:component::incomfort::entity::water_heater::boiler::state::s1_and_s2_interchanged_e2%]",
-              "no_flame_signal_e4": "[%key:component::incomfort::entity::water_heater::boiler::state::no_flame_signal_e4%]",
-              "poor_flame_signal_e5": "[%key:component::incomfort::entity::water_heater::boiler::state::poor_flame_signal_e5%]",
-              "flame_detection_fault_e6": "[%key:component::incomfort::entity::water_heater::boiler::state::flame_detection_fault_e6%]",
-              "incorrect_fan_speed_e8": "[%key:component::incomfort::entity::water_heater::boiler::state::incorrect_fan_speed_e8%]",
-              "sensor_fault_s1_e10": "[%key:component::incomfort::entity::water_heater::boiler::state::sensor_fault_s1_e10%]",
-              "sensor_fault_s1_e11": "[%key:component::incomfort::entity::water_heater::boiler::state::sensor_fault_s1_e10%]",
-              "sensor_fault_s1_e12": "[%key:component::incomfort::entity::water_heater::boiler::state::sensor_fault_s1_e10%]",
-              "sensor_fault_s1_e13": "[%key:component::incomfort::entity::water_heater::boiler::state::sensor_fault_s1_e10%]",
-              "sensor_fault_s1_e14": "[%key:component::incomfort::entity::water_heater::boiler::state::sensor_fault_s1_e10%]",
-              "sensor_fault_s2_e20": "[%key:component::incomfort::entity::water_heater::boiler::state::sensor_fault_s2_e20%]",
-              "sensor_fault_s2_e21": "[%key:component::incomfort::entity::water_heater::boiler::state::sensor_fault_s2_e20%]",
-              "sensor_fault_s2_e22": "[%key:component::incomfort::entity::water_heater::boiler::state::sensor_fault_s2_e20%]",
-              "sensor_fault_s2_e23": "[%key:component::incomfort::entity::water_heater::boiler::state::sensor_fault_s2_e20%]",
-              "sensor_fault_s2_e24": "[%key:component::incomfort::entity::water_heater::boiler::state::sensor_fault_s2_e20%]",
-              "shortcut_outside_sensor_temperature_e27": "[%key:component::incomfort::entity::water_heater::boiler::state::shortcut_outside_sensor_temperature_e27%]",
-              "gas_valve_relay_faulty_e29": "[%key:component::incomfort::entity::water_heater::boiler::state::gas_valve_relay_faulty_e29%]",
-              "gas_valve_relay_faulty_e30": "[%key:component::incomfort::entity::water_heater::boiler::state::gas_valve_relay_faulty_e29%]"
-            }
-          }
-        }
+        "name": "Fault"
       },
       "is_burning": {
         "name": "Burner"

--- a/homeassistant/components/incomfort/strings.json
+++ b/homeassistant/components/incomfort/strings.json
@@ -56,7 +56,42 @@
   "entity": {
     "binary_sensor": {
       "fault": {
-        "name": "Fault"
+        "name": "Fault",
+        "state_attributes": {
+          "fault": {
+            "state": {
+              "sensor_fault_after_self_check_e0": "[%key:component::incomfort::entity::water_heater::boiler::state::sensor_fault_after_self_check_e0%]",
+              "cv_temperature_too_high_e1": "[%key:component::incomfort::entity::water_heater::boiler::state::cv_temperature_too_high_e1%]",
+              "s1_and_s2_interchanged_e2": "[%key:component::incomfort::entity::water_heater::boiler::state::s1_and_s2_interchanged_e2%]",
+              "no_flame_signal_e4": "[%key:component::incomfort::entity::water_heater::boiler::state::no_flame_signal_e4%]",
+              "poor_flame_signal_e5": "[%key:component::incomfort::entity::water_heater::boiler::state::poor_flame_signal_e5%]",
+              "flame_detection_fault_e6": "[%key:component::incomfort::entity::water_heater::boiler::state::flame_detection_fault_e6%]",
+              "incorrect_fan_speed_e8": "[%key:component::incomfort::entity::water_heater::boiler::state::incorrect_fan_speed_e8%]",
+              "sensor_fault_s1_e10": "[%key:component::incomfort::entity::water_heater::boiler::state::sensor_fault_s1_e10%]",
+              "sensor_fault_s1_e11": "[%key:component::incomfort::entity::water_heater::boiler::state::sensor_fault_s1_e10%]",
+              "sensor_fault_s1_e12": "[%key:component::incomfort::entity::water_heater::boiler::state::sensor_fault_s1_e10%]",
+              "sensor_fault_s1_e13": "[%key:component::incomfort::entity::water_heater::boiler::state::sensor_fault_s1_e10%]",
+              "sensor_fault_s1_e14": "[%key:component::incomfort::entity::water_heater::boiler::state::sensor_fault_s1_e10%]",
+              "sensor_fault_s2_e20": "[%key:component::incomfort::entity::water_heater::boiler::state::sensor_fault_s2_e20%]",
+              "sensor_fault_s2_e21": "[%key:component::incomfort::entity::water_heater::boiler::state::sensor_fault_s2_e20%]",
+              "sensor_fault_s2_e22": "[%key:component::incomfort::entity::water_heater::boiler::state::sensor_fault_s2_e20%]",
+              "sensor_fault_s2_e23": "[%key:component::incomfort::entity::water_heater::boiler::state::sensor_fault_s2_e20%]",
+              "sensor_fault_s2_e24": "[%key:component::incomfort::entity::water_heater::boiler::state::sensor_fault_s2_e20%]",
+              "shortcut_outside_sensor_temperature_e27": "[%key:component::incomfort::entity::water_heater::boiler::state::shortcut_outside_sensor_temperature_e27%]",
+              "gas_valve_relay_faulty_e29": "[%key:component::incomfort::entity::water_heater::boiler::state::gas_valve_relay_faulty_e29%]",
+              "gas_valve_relay_faulty_e30": "[%key:component::incomfort::entity::water_heater::boiler::state::gas_valve_relay_faulty_e29%]"
+            }
+          }
+        }
+      },
+      "is_burning": {
+        "name": "Burner"
+      },
+      "is_pumping": {
+        "name": "Pump"
+      },
+      "is_tapping": {
+        "name": "Hot water tap"
       }
     },
     "sensor": {

--- a/homeassistant/components/incomfort/strings.json
+++ b/homeassistant/components/incomfort/strings.json
@@ -56,7 +56,14 @@
   "entity": {
     "binary_sensor": {
       "fault": {
-        "name": "Fault"
+        "name": "Fault",
+        "state_attributes": {
+          "fault_code": {
+            "state": {
+              "none": "None"
+            }
+          }
+        }
       },
       "is_burning": {
         "name": "Burner"

--- a/tests/components/incomfort/conftest.py
+++ b/tests/components/incomfort/conftest.py
@@ -3,6 +3,7 @@
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from incomfortclient import DisplayCode
 import pytest
 from typing_extensions import Generator
 
@@ -16,6 +17,23 @@ MOCK_CONFIG = {
     "host": "192.168.1.12",
     "username": "admin",
     "password": "verysecret",
+}
+
+MOCK_HEATER_STATUS = {
+    "display_code": DisplayCode(126),
+    "display_text": "standby",
+    "fault_code": None,
+    "is_burning": False,
+    "is_failed": False,
+    "is_pumping": False,
+    "is_tapping": False,
+    "heater_temp": 35.34,
+    "tap_temp": 30.21,
+    "pressure": 1.86,
+    "serial_no": "c0ffeec0ffee",
+    "nodenr": 249,
+    "rf_message_rssi": 30,
+    "rfstatus_cntr": 0,
 }
 
 
@@ -48,22 +66,7 @@ def mock_config_entry(
 @pytest.fixture
 def mock_heater_status() -> dict[str, Any]:
     """Mock heater status."""
-    return {
-        "display_code": 126,
-        "display_text": "standby",
-        "fault_code": None,
-        "is_burning": False,
-        "is_failed": False,
-        "is_pumping": False,
-        "is_tapping": False,
-        "heater_temp": 35.34,
-        "tap_temp": 30.21,
-        "pressure": 1.86,
-        "serial_no": "c0ffeec0ffee",
-        "nodenr": 249,
-        "rf_message_rssi": 30,
-        "rfstatus_cntr": 0,
-    }
+    return dict(MOCK_HEATER_STATUS)
 
 
 @pytest.fixture

--- a/tests/components/incomfort/snapshots/test_binary_sensor.ambr
+++ b/tests/components/incomfort/snapshots/test_binary_sensor.ambr
@@ -1,4 +1,51 @@
 # serializer version: 1
+# name: test_setup_platform[binary_sensor.boiler_burner-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_burner',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Burner',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_burning',
+    'unique_id': 'c0ffeec0ffee_is_burning',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_platform[binary_sensor.boiler_burner-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Burner',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_burner',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_setup_platform[binary_sensor.boiler_fault-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -36,11 +83,106 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'fault_code': None,
+      'fault': '-',
+      'fault_code': '-',
       'friendly_name': 'Boiler Fault',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.boiler_fault',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_setup_platform[binary_sensor.boiler_hot_water_tap-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_hot_water_tap',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Hot water tap',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_tapping',
+    'unique_id': 'c0ffeec0ffee_is_tapping',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_platform[binary_sensor.boiler_hot_water_tap-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Hot water tap',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_hot_water_tap',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_setup_platform[binary_sensor.boiler_pump-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_pump',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Pump',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_pumping',
+    'unique_id': 'c0ffeec0ffee_is_pumping',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_platform[binary_sensor.boiler_pump-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Pump',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_pump',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/incomfort/snapshots/test_binary_sensor.ambr
+++ b/tests/components/incomfort/snapshots/test_binary_sensor.ambr
@@ -1,4 +1,764 @@
 # serializer version: 1
+# name: test_setup_binary_sensors_alt[is_burning][binary_sensor.boiler_burner-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_burner',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Burner',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_burning',
+    'unique_id': 'c0ffeec0ffee_is_burning',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_burning][binary_sensor.boiler_burner-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Burner',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_burner',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_burning][binary_sensor.boiler_fault-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_fault',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Fault',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'fault',
+    'unique_id': 'c0ffeec0ffee_failed',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_burning][binary_sensor.boiler_fault-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'fault': '-',
+      'fault_code': '-',
+      'friendly_name': 'Boiler Fault',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_fault',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_burning][binary_sensor.boiler_hot_water_tap-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_hot_water_tap',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Hot water tap',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_tapping',
+    'unique_id': 'c0ffeec0ffee_is_tapping',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_burning][binary_sensor.boiler_hot_water_tap-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Hot water tap',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_hot_water_tap',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_burning][binary_sensor.boiler_pump-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_pump',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Pump',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_pumping',
+    'unique_id': 'c0ffeec0ffee_is_pumping',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_burning][binary_sensor.boiler_pump-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Pump',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_pump',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_failed][binary_sensor.boiler_burner-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_burner',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Burner',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_burning',
+    'unique_id': 'c0ffeec0ffee_is_burning',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_failed][binary_sensor.boiler_burner-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Burner',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_burner',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_failed][binary_sensor.boiler_fault-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_fault',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Fault',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'fault',
+    'unique_id': 'c0ffeec0ffee_failed',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_failed][binary_sensor.boiler_fault-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'fault': 'CV_TEMPERATURE_TOO_HIGH_E1',
+      'fault_code': <FaultCode.CV_TEMPERATURE_TOO_HIGH_E1: 1>,
+      'friendly_name': 'Boiler Fault',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_fault',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_failed][binary_sensor.boiler_hot_water_tap-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_hot_water_tap',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Hot water tap',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_tapping',
+    'unique_id': 'c0ffeec0ffee_is_tapping',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_failed][binary_sensor.boiler_hot_water_tap-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Hot water tap',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_hot_water_tap',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_failed][binary_sensor.boiler_pump-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_pump',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Pump',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_pumping',
+    'unique_id': 'c0ffeec0ffee_is_pumping',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_failed][binary_sensor.boiler_pump-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Pump',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_pump',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_pumping][binary_sensor.boiler_burner-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_burner',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Burner',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_burning',
+    'unique_id': 'c0ffeec0ffee_is_burning',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_pumping][binary_sensor.boiler_burner-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Burner',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_burner',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_pumping][binary_sensor.boiler_fault-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_fault',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Fault',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'fault',
+    'unique_id': 'c0ffeec0ffee_failed',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_pumping][binary_sensor.boiler_fault-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'fault': '-',
+      'fault_code': '-',
+      'friendly_name': 'Boiler Fault',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_fault',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_pumping][binary_sensor.boiler_hot_water_tap-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_hot_water_tap',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Hot water tap',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_tapping',
+    'unique_id': 'c0ffeec0ffee_is_tapping',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_pumping][binary_sensor.boiler_hot_water_tap-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Hot water tap',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_hot_water_tap',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_pumping][binary_sensor.boiler_pump-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_pump',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Pump',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_pumping',
+    'unique_id': 'c0ffeec0ffee_is_pumping',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_pumping][binary_sensor.boiler_pump-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Pump',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_pump',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_tapping][binary_sensor.boiler_burner-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_burner',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Burner',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_burning',
+    'unique_id': 'c0ffeec0ffee_is_burning',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_tapping][binary_sensor.boiler_burner-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Burner',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_burner',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_tapping][binary_sensor.boiler_fault-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_fault',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Fault',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'fault',
+    'unique_id': 'c0ffeec0ffee_failed',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_tapping][binary_sensor.boiler_fault-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'fault': '-',
+      'fault_code': '-',
+      'friendly_name': 'Boiler Fault',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_fault',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_tapping][binary_sensor.boiler_hot_water_tap-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_hot_water_tap',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Hot water tap',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_tapping',
+    'unique_id': 'c0ffeec0ffee_is_tapping',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_tapping][binary_sensor.boiler_hot_water_tap-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Hot water tap',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_hot_water_tap',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_tapping][binary_sensor.boiler_pump-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_pump',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Pump',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_pumping',
+    'unique_id': 'c0ffeec0ffee_is_pumping',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_tapping][binary_sensor.boiler_pump-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Pump',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_pump',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_setup_platform[binary_sensor.boiler_burner-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/incomfort/snapshots/test_binary_sensor.ambr
+++ b/tests/components/incomfort/snapshots/test_binary_sensor.ambr
@@ -83,7 +83,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'fault_code': '-',
+      'fault_code': 'none',
       'friendly_name': 'Boiler Fault',
     }),
     'context': <ANY>,
@@ -743,7 +743,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'fault_code': '-',
+      'fault_code': 'none',
       'friendly_name': 'Boiler Fault',
     }),
     'context': <ANY>,
@@ -1073,7 +1073,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'fault_code': '-',
+      'fault_code': 'none',
       'friendly_name': 'Boiler Fault',
     }),
     'context': <ANY>,
@@ -1403,7 +1403,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'fault_code': '-',
+      'fault_code': 'none',
       'friendly_name': 'Boiler Fault',
     }),
     'context': <ANY>,

--- a/tests/components/incomfort/snapshots/test_binary_sensor.ambr
+++ b/tests/components/incomfort/snapshots/test_binary_sensor.ambr
@@ -83,7 +83,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'fault': '-',
       'fault_code': '-',
       'friendly_name': 'Boiler Fault',
     }),
@@ -189,6 +188,147 @@
     'state': 'off',
   })
 # ---
+# name: test_setup_binary_sensors_alt[is_burning][binary_sensor.boiler_running-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_running',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Running',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_pumping',
+    'unique_id': 'c0ffeec0ffee_is_pumping',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_burning][binary_sensor.boiler_running-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Running',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_running',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_burning][binary_sensor.boiler_running_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_running_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Running',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_burning',
+    'unique_id': 'c0ffeec0ffee_is_burning',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_burning][binary_sensor.boiler_running_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Running',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_running_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_burning][binary_sensor.boiler_running_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_running_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Running',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_tapping',
+    'unique_id': 'c0ffeec0ffee_is_tapping',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_burning][binary_sensor.boiler_running_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Running',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_running_3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_setup_binary_sensors_alt[is_failed][binary_sensor.boiler_burner-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -273,7 +413,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'fault': 'CV_TEMPERATURE_TOO_HIGH_E1',
       'fault_code': <FaultCode.CV_TEMPERATURE_TOO_HIGH_E1: 1>,
       'friendly_name': 'Boiler Fault',
     }),
@@ -379,6 +518,147 @@
     'state': 'off',
   })
 # ---
+# name: test_setup_binary_sensors_alt[is_failed][binary_sensor.boiler_running-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_running',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Running',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_pumping',
+    'unique_id': 'c0ffeec0ffee_is_pumping',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_failed][binary_sensor.boiler_running-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Running',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_running',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_failed][binary_sensor.boiler_running_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_running_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Running',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_burning',
+    'unique_id': 'c0ffeec0ffee_is_burning',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_failed][binary_sensor.boiler_running_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Running',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_running_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_failed][binary_sensor.boiler_running_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_running_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Running',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_tapping',
+    'unique_id': 'c0ffeec0ffee_is_tapping',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_failed][binary_sensor.boiler_running_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Running',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_running_3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_setup_binary_sensors_alt[is_pumping][binary_sensor.boiler_burner-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -463,7 +743,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'fault': '-',
       'fault_code': '-',
       'friendly_name': 'Boiler Fault',
     }),
@@ -569,6 +848,147 @@
     'state': 'on',
   })
 # ---
+# name: test_setup_binary_sensors_alt[is_pumping][binary_sensor.boiler_running-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_running',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Running',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_pumping',
+    'unique_id': 'c0ffeec0ffee_is_pumping',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_pumping][binary_sensor.boiler_running-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Running',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_running',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_pumping][binary_sensor.boiler_running_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_running_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Running',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_burning',
+    'unique_id': 'c0ffeec0ffee_is_burning',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_pumping][binary_sensor.boiler_running_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Running',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_running_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_pumping][binary_sensor.boiler_running_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_running_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Running',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_tapping',
+    'unique_id': 'c0ffeec0ffee_is_tapping',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_pumping][binary_sensor.boiler_running_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Running',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_running_3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_setup_binary_sensors_alt[is_tapping][binary_sensor.boiler_burner-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -653,7 +1073,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'fault': '-',
       'fault_code': '-',
       'friendly_name': 'Boiler Fault',
     }),
@@ -759,6 +1178,147 @@
     'state': 'off',
   })
 # ---
+# name: test_setup_binary_sensors_alt[is_tapping][binary_sensor.boiler_running-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_running',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Running',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_pumping',
+    'unique_id': 'c0ffeec0ffee_is_pumping',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_tapping][binary_sensor.boiler_running-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Running',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_running',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_tapping][binary_sensor.boiler_running_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_running_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Running',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_burning',
+    'unique_id': 'c0ffeec0ffee_is_burning',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_tapping][binary_sensor.boiler_running_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Running',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_running_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_tapping][binary_sensor.boiler_running_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_running_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Running',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_tapping',
+    'unique_id': 'c0ffeec0ffee_is_tapping',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_binary_sensors_alt[is_tapping][binary_sensor.boiler_running_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Running',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_running_3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_setup_platform[binary_sensor.boiler_burner-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -843,7 +1403,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'problem',
-      'fault': '-',
       'fault_code': '-',
       'friendly_name': 'Boiler Fault',
     }),
@@ -943,6 +1502,147 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.boiler_pump',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_setup_platform[binary_sensor.boiler_running-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_running',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Running',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_pumping',
+    'unique_id': 'c0ffeec0ffee_is_pumping',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_platform[binary_sensor.boiler_running-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Running',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_running',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_setup_platform[binary_sensor.boiler_running_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_running_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Running',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_burning',
+    'unique_id': 'c0ffeec0ffee_is_burning',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_platform[binary_sensor.boiler_running_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Running',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_running_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_setup_platform[binary_sensor.boiler_running_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.boiler_running_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Running',
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_tapping',
+    'unique_id': 'c0ffeec0ffee_is_tapping',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_platform[binary_sensor.boiler_running_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Boiler Running',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.boiler_running_3',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/incomfort/snapshots/test_water_heater.ambr
+++ b/tests/components/incomfort/snapshots/test_water_heater.ambr
@@ -39,7 +39,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 35.3,
-      'display_code': 126,
+      'display_code': <DisplayCode.STANDBY: 126>,
       'display_text': 'standby',
       'friendly_name': 'Boiler',
       'icon': 'mdi:thermometer-lines',

--- a/tests/components/incomfort/test_binary_sensor.py
+++ b/tests/components/incomfort/test_binary_sensor.py
@@ -2,12 +2,16 @@
 
 from unittest.mock import MagicMock, patch
 
+from incomfortclient import FaultCode
+import pytest
 from syrupy import SnapshotAssertion
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+
+from .conftest import MOCK_HEATER_STATUS
 
 from tests.common import snapshot_platform
 
@@ -21,5 +25,33 @@ async def test_setup_platform(
     mock_config_entry: ConfigEntry,
 ) -> None:
     """Test the incomfort entities are set up correctly."""
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    "mock_heater_status",
+    [
+        MOCK_HEATER_STATUS
+        | {
+            "is_failed": True,
+            "display_code": None,
+            "fault_code": FaultCode.CV_TEMPERATURE_TOO_HIGH_E1,
+        },
+        MOCK_HEATER_STATUS | {"is_pumping": True},
+        MOCK_HEATER_STATUS | {"is_burning": True},
+        MOCK_HEATER_STATUS | {"is_tapping": True},
+    ],
+    ids=["is_failed", "is_pumping", "is_burning", "is_tapping"],
+)
+@patch("homeassistant.components.incomfort.PLATFORMS", [Platform.BINARY_SENSOR])
+async def test_setup_binary_sensors_alt(
+    hass: HomeAssistant,
+    mock_incomfort: MagicMock,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    mock_config_entry: ConfigEntry,
+) -> None:
+    """Test the incomfort heater ."""
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add extra sensors to indicate the running state of the burner, pump and hot water tap.

![afbeelding](https://github.com/home-assistant/core/assets/7188918/6413f2fb-76df-4074-b382-d9e0a7c86937)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
