### PR TITLE
Fix statistic_during_period after core restart

### DIFF
--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -1505,7 +1505,7 @@ def statistic_during_period(
         if end_time is None:
             tail_start_time = _last_statistic(session, Statistics, metadata_id)
             if tail_start_time:
-                tail_start_time -= timedelta(hours=1)
+                tail_start_time += timedelta(hours=1)
             else:
                 tail_start_time = now.replace(minute=0, second=0, microsecond=0)
         elif tail_only:

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -1244,11 +1244,28 @@ def _first_statistic(
     table: type[StatisticsBase],
     metadata_id: int,
 ) -> datetime | None:
-    """Return the data of the oldest statistic row for a given metadata id."""
+    """Return the date of the oldest statistic row for a given metadata id."""
     stmt = lambda_stmt(
         lambda: select(table.start_ts)
         .filter(table.metadata_id == metadata_id)
         .order_by(table.start_ts.asc())
+        .limit(1)
+    )
+    if stats := cast(Sequence[Row], execute_stmt_lambda_element(session, stmt)):
+        return dt_util.utc_from_timestamp(stats[0].start_ts)
+    return None
+
+
+def _last_statistic(
+    session: Session,
+    table: type[StatisticsBase],
+    metadata_id: int,
+) -> datetime | None:
+    """Return the date of the newest statistic row for a given metadata id."""
+    stmt = lambda_stmt(
+        lambda: select(table.start_ts)
+        .filter(table.metadata_id == metadata_id)
+        .order_by(table.start_ts.desc())
         .limit(1)
     )
     if stats := cast(Sequence[Row], execute_stmt_lambda_element(session, stmt)):
@@ -1486,7 +1503,11 @@ def statistic_during_period(
         tail_start_time: datetime | None = None
         tail_end_time: datetime | None = None
         if end_time is None:
-            tail_start_time = now.replace(minute=0, second=0, microsecond=0)
+            tail_start_time = _last_statistic(session, Statistics, metadata_id)
+            if tail_start_time:
+                tail_start_time -= timedelta(hours=1)
+            else:
+                tail_start_time = now.replace(minute=0, second=0, microsecond=0)
         elif tail_only:
             tail_start_time = start_time
             tail_end_time = end_time

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -1505,7 +1505,7 @@ def statistic_during_period(
         if end_time is None:
             tail_start_time = _last_statistic(session, Statistics, metadata_id)
             if tail_start_time:
-                tail_start_time += timedelta(hours=1)
+                tail_start_time += Statistics.duration
             else:
                 tail_start_time = now.replace(minute=0, second=0, microsecond=0)
         elif tail_only:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix statistic_during_period after core restart, before recorder has compiled statistics for the period during which core was down

Fixes an issue seen when debugging tests for https://github.com/home-assistant/core/pull/115291

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
