### PR TITLE
Add esphome native device update entities

### DIFF
--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -38,6 +38,7 @@ from aioesphomeapi import (
     TextInfo,
     TextSensorInfo,
     TimeInfo,
+    UpdateInfo,
     UserService,
     ValveInfo,
     build_unique_id,
@@ -82,6 +83,7 @@ INFO_TYPE_TO_PLATFORM: dict[type[EntityInfo], Platform] = {
     TextInfo: Platform.TEXT,
     TextSensorInfo: Platform.SENSOR,
     TimeInfo: Platform.TIME,
+    UpdateInfo: Platform.UPDATE,
     ValveInfo: Platform.VALVE,
 }
 

--- a/homeassistant/components/esphome/update.py
+++ b/homeassistant/components/esphome/update.py
@@ -205,7 +205,7 @@ class ESPHomeDashboardUpdateEntity(
 
 
 class ESPHomeUpdateEntity(EsphomeEntity[UpdateInfo, UpdateState], UpdateEntity):
-    "A update implementation for esphome."
+    """A update implementation for esphome."""
 
     _attr_supported_features = (
         UpdateEntityFeature.INSTALL | UpdateEntityFeature.PROGRESS

--- a/homeassistant/components/esphome/update.py
+++ b/homeassistant/components/esphome/update.py
@@ -230,6 +230,8 @@ class ESPHomeUpdateEntity(EsphomeEntity[UpdateInfo, UpdateState], UpdateEntity):
     @esphome_state_property
     def in_progress(self) -> bool | int | None:
         """Return if the update is in progress."""
+        if self._state.has_progress:
+            return int(self._state.progress)
         return self._state.in_progress
 
     @property

--- a/homeassistant/components/esphome/update.py
+++ b/homeassistant/components/esphome/update.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-from aioesphomeapi import DeviceInfo as ESPHomeDeviceInfo, EntityInfo
+from aioesphomeapi import (
+    DeviceInfo as ESPHomeDeviceInfo,
+    EntityInfo,
+    UpdateInfo,
+    UpdateState,
+)
 
 from homeassistant.components.update import (
     UpdateDeviceClass,
@@ -19,10 +24,17 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util.enum import try_parse_enum
 
 from .coordinator import ESPHomeDashboardCoordinator
 from .dashboard import async_get_dashboard
 from .domain_data import DomainData
+from .entity import (
+    EsphomeEntity,
+    convert_api_error_ha_error,
+    esphome_state_property,
+    platform_async_setup_entry,
+)
 from .entry_data import RuntimeEntryData
 
 KEY_UPDATE_LOCK = "esphome_update_lock"
@@ -36,6 +48,15 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up ESPHome update based on a config entry."""
+    await platform_async_setup_entry(
+        hass,
+        entry,
+        async_add_entities,
+        info_type=UpdateInfo,
+        entity_type=ESPHomeUpdateEntity,
+        state_type=UpdateState,
+    )
+
     if (dashboard := async_get_dashboard(hass)) is None:
         return
     entry_data = DomainData.get(hass).get_entry_data(entry)
@@ -54,7 +75,7 @@ async def async_setup_entry(
             unsub()
         unsubs.clear()
 
-        async_add_entities([ESPHomeUpdateEntity(entry_data, dashboard)])
+        async_add_entities([ESPHomeDashboardUpdateEntity(entry_data, dashboard)])
 
     if entry_data.available and dashboard.last_update_success:
         _async_setup_update_entity()
@@ -66,7 +87,9 @@ async def async_setup_entry(
     ]
 
 
-class ESPHomeUpdateEntity(CoordinatorEntity[ESPHomeDashboardCoordinator], UpdateEntity):
+class ESPHomeDashboardUpdateEntity(
+    CoordinatorEntity[ESPHomeDashboardCoordinator], UpdateEntity
+):
     """Defines an ESPHome update entity."""
 
     _attr_has_entity_name = True
@@ -179,3 +202,63 @@ class ESPHomeUpdateEntity(CoordinatorEntity[ESPHomeDashboardCoordinator], Update
                     )
             finally:
                 await self.coordinator.async_request_refresh()
+
+
+class ESPHomeUpdateEntity(EsphomeEntity[UpdateInfo, UpdateState], UpdateEntity):
+    "A update implementation for esphome."
+
+    _attr_supported_features = (
+        UpdateEntityFeature.INSTALL | UpdateEntityFeature.PROGRESS
+    )
+
+    @callback
+    def _on_static_info_update(self, static_info: EntityInfo) -> None:
+        """Set attrs from static info."""
+        super()._on_static_info_update(static_info)
+        static_info = self._static_info
+        self._attr_device_class = try_parse_enum(
+            UpdateDeviceClass, static_info.device_class
+        )
+
+    @property
+    @esphome_state_property
+    def installed_version(self) -> str | None:
+        """Return the installed version."""
+        return self._state.current_version
+
+    @property
+    @esphome_state_property
+    def in_progress(self) -> bool | int | None:
+        """Return if the update is in progress."""
+        return self._state.in_progress
+
+    @property
+    @esphome_state_property
+    def latest_version(self) -> str | None:
+        """Return the latest version."""
+        return self._state.latest_version
+
+    @property
+    @esphome_state_property
+    def release_summary(self) -> str | None:
+        """Return the release summary."""
+        return self._state.release_summary
+
+    @property
+    @esphome_state_property
+    def release_url(self) -> str | None:
+        """Return the release URL."""
+        return self._state.release_url
+
+    @property
+    @esphome_state_property
+    def title(self) -> str | None:
+        """Return the title of the update."""
+        return self._state.title
+
+    @convert_api_error_ha_error
+    async def async_install(
+        self, version: str | None, backup: bool, **kwargs: Any
+    ) -> None:
+        """Update the current value."""
+        self._client.update_command(key=self._key, install=True)

--- a/tests/components/esphome/test_update.py
+++ b/tests/components/esphome/test_update.py
@@ -14,8 +14,10 @@ from aioesphomeapi import (
 import pytest
 
 from homeassistant.components.esphome.dashboard import async_get_dashboard
-from homeassistant.components.update import UpdateEntityFeature
+from homeassistant.components.update import DOMAIN as UPDATE_DOMAIN, UpdateEntityFeature
+from homeassistant.components.update.const import SERVICE_INSTALL
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
     ATTR_SUPPORTED_FEATURES,
     STATE_OFF,
     STATE_ON,
@@ -491,7 +493,12 @@ async def test_generic_device_update_entity_has_update(
     assert state is not None
     assert state.state == STATE_ON
 
-    mock_client.update_command(key=1, install=True)
+    await hass.services.async_call(
+        UPDATE_DOMAIN,
+        SERVICE_INSTALL,
+        {ATTR_ENTITY_ID: "update.test_myupdate"},
+        blocking=True,
+    )
 
     mock_device.set_state(
         UpdateState(

--- a/tests/components/esphome/test_update.py
+++ b/tests/components/esphome/test_update.py
@@ -83,7 +83,7 @@ async def test_update_entity(
 
     with patch(
         "homeassistant.components.esphome.update.DomainData.get_entry_data",
-        return_value=Mock(available=True, device_info=mock_device_info),
+        return_value=Mock(available=True, device_info=mock_device_info, info={}),
     ):
         assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
@@ -266,7 +266,7 @@ async def test_update_entity_dashboard_not_available_startup(
     with (
         patch(
             "homeassistant.components.esphome.update.DomainData.get_entry_data",
-            return_value=Mock(available=True, device_info=mock_device_info),
+            return_value=Mock(available=True, device_info=mock_device_info, info={}),
         ),
         patch(
             "esphome_dashboard_api.ESPHomeDashboardAPI.get_devices",
@@ -358,7 +358,7 @@ async def test_update_entity_not_present_without_dashboard(
     """Test ESPHome update entity does not get created if there is no dashboard."""
     with patch(
         "homeassistant.components.esphome.update.DomainData.get_entry_data",
-        return_value=Mock(available=True, device_info=mock_device_info),
+        return_value=Mock(available=True, device_info=mock_device_info, info={}),
     ):
         assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support for native device provided update entities. This will allow purchased/pre-installed devices to manage their own updates provided from the manufacturer/creator/company without the need for the ESPHome dashboard to be installed.

Related PRs:
- https://github.com/esphome/esphome/pull/6885
- https://github.com/esphome/aioesphomeapi/pull/882
- https://github.com/home-assistant/core/pull/119348

TODO:
- [x] Tests
- [x] Bump dependency in separate PR

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
