### PR TITLE
Add configurable keep_alive to Ollama integration

### DIFF
--- a/homeassistant/components/ollama/__init__.py
+++ b/homeassistant/components/ollama/__init__.py
@@ -14,7 +14,14 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 
-from .const import CONF_MAX_HISTORY, CONF_MODEL, CONF_PROMPT, DEFAULT_TIMEOUT, DOMAIN
+from .const import (
+    CONF_KEEP_ALIVE,
+    CONF_MAX_HISTORY,
+    CONF_MODEL,
+    CONF_PROMPT,
+    DEFAULT_TIMEOUT,
+    DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,6 +30,7 @@ __all__ = [
     "CONF_PROMPT",
     "CONF_MODEL",
     "CONF_MAX_HISTORY",
+    "CONF_KEEP_ALIVE",
     "DOMAIN",
 ]
 

--- a/homeassistant/components/ollama/config_flow.py
+++ b/homeassistant/components/ollama/config_flow.py
@@ -33,9 +33,11 @@ from homeassistant.helpers.selector import (
 )
 
 from .const import (
+    CONF_KEEP_ALIVE,
     CONF_MAX_HISTORY,
     CONF_MODEL,
     CONF_PROMPT,
+    DEFAULT_KEEP_ALIVE,
     DEFAULT_MAX_HISTORY,
     DEFAULT_MODEL,
     DEFAULT_PROMPT,
@@ -233,6 +235,16 @@ def ollama_config_option_schema(options: MappingProxyType[str, Any]) -> dict:
         ): NumberSelector(
             NumberSelectorConfig(
                 min=0, max=sys.maxsize, step=1, mode=NumberSelectorMode.BOX
+            )
+        ),
+        vol.Optional(
+            CONF_KEEP_ALIVE,
+            description={
+                "suggested_value": options.get(CONF_KEEP_ALIVE, DEFAULT_KEEP_ALIVE)
+            },
+        ): NumberSelector(
+            NumberSelectorConfig(
+                min=-1, max=sys.maxsize, step=1, mode=NumberSelectorMode.BOX
             )
         ),
     }

--- a/homeassistant/components/ollama/const.py
+++ b/homeassistant/components/ollama/const.py
@@ -72,6 +72,9 @@ An overview of the areas and the devices in this smart home:
 Answer the user's questions using the information about this smart home.
 Keep your answers brief and do not apologize."""
 
+CONF_KEEP_ALIVE = "keep_alive"
+DEFAULT_KEEP_ALIVE = 5 * 60  # seconds. Default is 5m, following ollama default
+
 KEEP_ALIVE_FOREVER = -1
 DEFAULT_TIMEOUT = 5.0  # seconds
 

--- a/homeassistant/components/ollama/const.py
+++ b/homeassistant/components/ollama/const.py
@@ -73,7 +73,7 @@ Answer the user's questions using the information about this smart home.
 Keep your answers brief and do not apologize."""
 
 CONF_KEEP_ALIVE = "keep_alive"
-DEFAULT_KEEP_ALIVE = 5 * 60  # seconds. Default is 5m, following ollama default
+DEFAULT_KEEP_ALIVE = -1  # seconds. -1 = indefinite, 0 = never
 
 KEEP_ALIVE_FOREVER = -1
 DEFAULT_TIMEOUT = 5.0  # seconds

--- a/homeassistant/components/ollama/conversation.py
+++ b/homeassistant/components/ollama/conversation.py
@@ -26,13 +26,14 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import ulid
 
 from .const import (
+    CONF_KEEP_ALIVE,
     CONF_MAX_HISTORY,
     CONF_MODEL,
     CONF_PROMPT,
+    DEFAULT_KEEP_ALIVE,
     DEFAULT_MAX_HISTORY,
     DEFAULT_PROMPT,
     DOMAIN,
-    KEEP_ALIVE_FOREVER,
     MAX_HISTORY_SECONDS,
 )
 from .models import ExposedEntity, MessageHistory, MessageRole
@@ -151,7 +152,8 @@ class OllamaConversationEntity(
                 # Make a copy of the messages because we mutate the list later
                 messages=list(message_history.messages),
                 stream=False,
-                keep_alive=KEEP_ALIVE_FOREVER,
+                # keep_alive requires specifying unit. In this case, seconds
+                keep_alive=f"{settings.get(CONF_KEEP_ALIVE, DEFAULT_KEEP_ALIVE)}s",
             )
         except (ollama.RequestError, ollama.ResponseError) as err:
             _LOGGER.error("Unexpected error talking to Ollama server: %s", err)

--- a/homeassistant/components/ollama/strings.json
+++ b/homeassistant/components/ollama/strings.json
@@ -26,7 +26,7 @@
         "data": {
           "prompt": "Prompt template",
           "max_history": "Max history messages",
-          "keep_alive": "Duration in seconds for Ollama to keep model in memory"
+          "keep_alive": "Duration in seconds for Ollama to keep model in memory. -1 = indefinite, 0 = never."
         }
       }
     }

--- a/homeassistant/components/ollama/strings.json
+++ b/homeassistant/components/ollama/strings.json
@@ -25,7 +25,8 @@
       "init": {
         "data": {
           "prompt": "Prompt template",
-          "max_history": "Max history messages"
+          "max_history": "Max history messages",
+          "keep_alive": "Duration in seconds for Ollama to keep model in memory"
         }
       }
     }

--- a/homeassistant/components/ollama/strings.json
+++ b/homeassistant/components/ollama/strings.json
@@ -26,6 +26,9 @@
         "data": {
           "prompt": "Prompt template",
           "max_history": "Max history messages",
+          "keep_alive": "Keep alive"
+        },
+        "data_description": {
           "keep_alive": "Duration in seconds for Ollama to keep model in memory. -1 = indefinite, 0 = never."
         }
       }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This makes the `keep_alive` value for the Ollama integration user configurable (value in seconds). Currently, this value is set at a fixed "-1". This means the Ollama model of choice is permanently kept in memory on the host running Ollama, which can be a substantial resource draw when not in constant use. This change also switches the default value from "-1" to 5 minutes, which is the [default used by Ollama](https://github.com/ollama/ollama/blob/cddc63381cffcde5ab50877e831b7595cc6a6d6e/docs/faq.md?plain=1#L235).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A. 
- This PR is related to issue: N/A. New PR following maintainer request in https://github.com/home-assistant/core/pull/119176#issuecomment-2156225541
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33191

See screenshot of implementation. Acceptable values are -1 (indefinite), 0 (immediately free memory), and 1 onward. I have tested -1, 0, the default of 300, and a few random values.
![image](https://github.com/home-assistant/core/assets/3392952/e1ed391f-da89-4531-a6cb-ac1e344c24f4)


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io

[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr