### PR TITLE
beginning of tplink deco integration

### DIFF
--- a/homeassistant/components/tplink_deco/__init__.py
+++ b/homeassistant/components/tplink_deco/__init__.py
@@ -1,0 +1,67 @@
+"""Support for TP-Link Deco routers."""
+
+from datetime import timedelta
+import logging
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PORT, CONF_SSL
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import DOMAIN, PLATFORMS, KEY_ROUTER, KEY_COORDINATOR_STATUS
+from .errors import CannotLoginException
+from .router import TPLinkDecoRouter
+
+_LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = timedelta(seconds=30)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up TP-Link Deco component."""
+    router = TPLinkDecoRouter(hass, entry)
+    try:
+        if not await router.async_setup():
+            raise ConfigEntryNotReady
+    except CannotLoginException as ex:
+        raise ConfigEntryNotReady from ex
+
+    hass.data.setdefault(DOMAIN, {})
+
+    async def async_update_status() -> dict[str, Any] | None:
+        """Fetch status from the router."""
+        return await router.async_get_status()
+
+    coordinator_status = DataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        name=f"{router.device_name} Status",
+        update_method=async_update_status,
+        update_interval=SCAN_INTERVAL,
+    )
+
+    await coordinator_status.async_config_entry_first_refresh()
+
+    hass.data[DOMAIN][entry.entry_id] = {
+        KEY_ROUTER: router,
+        KEY_COORDINATOR_STATUS: coordinator_status,
+    }
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+        if not hass.data[DOMAIN]:
+            hass.data.pop(DOMAIN)
+
+    return unload_ok

--- a/homeassistant/components/tplink_deco/const.py
+++ b/homeassistant/components/tplink_deco/const.py
@@ -1,0 +1,6 @@
+"""Constants for tplink-deco integration."""
+
+DOMAIN = "tplink_deco"
+PLATFORMS = ["sensor"] 
+KEY_ROUTER = "router"
+KEY_COORDINATOR_STATUS = "coordinator_status"

--- a/homeassistant/components/tplink_deco/errors.py
+++ b/homeassistant/components/tplink_deco/errors.py
@@ -1,0 +1,4 @@
+"""Error handling for custom exception."""
+
+class CannotLoginException(Exception):
+    """Exception to show auth error."""

--- a/homeassistant/components/tplink_deco/manifest.json
+++ b/homeassistant/components/tplink_deco/manifest.json
@@ -1,0 +1,11 @@
+{
+    "domain": "tplink_deco",
+    "name": "TP-Link Deco",
+    "codeowners": ["@anisar17"],
+    "config_flow": true,
+    "documentation": "https://www.home-assistant.io/integrations/tplink_deco",
+    "iot_class": "local_polling",
+    "requirements": [],
+    "dependencies": []
+  }
+  

--- a/homeassistant/components/tplink_deco/router.py
+++ b/homeassistant/components/tplink_deco/router.py
@@ -1,0 +1,24 @@
+"""Router support for Tplink deco."""
+
+import logging
+
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+from .errors import CannotLoginException
+
+_LOGGER = logging.getLogger(__name__)
+
+class tplinkDeco:
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry):
+        self.hass = hass
+        self.entry = entry
+        self.device_name = "tplink-deco"
+        self.track_devices = True
+
+    async def async_setup(self) -> bool:
+        """Set up the tplink deco."""
+        return True
+
+    async def async_get_status(self) -> dict:
+        """Fetch the current status of the router."""
+        return {"status": "ok"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Trying to add tplink deco to track the router. Previous tplink integrations only track other smart devices such as lights and power strips but this will eventually be able to track the routers to return the status. Ideally will be able to also display wifi speed and software version/updates.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # N/A
- This PR is related to issue:  N/A
- Link to documentation pull request: N/A 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
