### PR TITLE
Fix pointless-string-statement pylint warning in emulated_hue tests

### DIFF
--- a/tests/components/emulated_hue/test_upnp.py
+++ b/tests/components/emulated_hue/test_upnp.py
@@ -27,7 +27,7 @@ BRIDGE_SERVER_PORT = get_test_instance_port()
 class MockTransport:
     """Mock asyncio transport."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Create a place to store the sends."""
         self.sends = []
 
@@ -63,7 +63,7 @@ def hue_client(
         yield client
 
 
-async def setup_hue(hass):
+async def setup_hue(hass: HomeAssistant) -> None:
     """Set up the emulated_hue integration."""
     with patch(
         "homeassistant.components.emulated_hue.async_create_upnp_datagram_endpoint"
@@ -82,7 +82,7 @@ def test_upnp_discovery_basic() -> None:
     mock_transport = MockTransport()
     upnp_responder_protocol.transport = mock_transport
 
-    """Original request emitted by the Hue Bridge v1 app."""
+    # Original request emitted by the Hue Bridge v1 app.
     request = """M-SEARCH * HTTP/1.1
 HOST:239.255.255.250:1900
 ST:ssdp:all
@@ -114,7 +114,7 @@ def test_upnp_discovery_rootdevice() -> None:
     mock_transport = MockTransport()
     upnp_responder_protocol.transport = mock_transport
 
-    """Original request emitted by Busch-Jaeger free@home SysAP."""
+    # Original request emitted by Busch-Jaeger free@home SysAP.
     request = """M-SEARCH * HTTP/1.1
 HOST: 239.255.255.250:1900
 MAN: "ssdp:discover"
@@ -146,7 +146,7 @@ def test_upnp_no_response() -> None:
     mock_transport = MockTransport()
     upnp_responder_protocol.transport = mock_transport
 
-    """Original request emitted by the Hue Bridge v1 app."""
+    # Original request emitted by the Hue Bridge v1 app.
     request = """INVALID * HTTP/1.1
 HOST:239.255.255.250:1900
 ST:ssdp:all
@@ -158,7 +158,7 @@ MX:3
 
     upnp_responder_protocol.datagram_received(encoded_request, 1234)
 
-    assert mock_transport.sends == []
+    assert not mock_transport.sends
 
 
 async def test_description_xml(hass: HomeAssistant, hue_client) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #119279
https://github.com/home-assistant/core/actions/runs/9461757208/job/26063248693?pr=119279

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
