### PR TITLE
Fix pylint warnings in testing config custom components

### DIFF
--- a/tests/testing_config/custom_components/test/image_processing.py
+++ b/tests/testing_config/custom_components/test/image_processing.py
@@ -1,11 +1,17 @@
 """Provide a mock image processing."""
 
 from homeassistant.components.image_processing import ImageProcessingEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 
 async def async_setup_platform(
-    hass, config, async_add_entities_callback, discovery_info=None
-):
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities_callback: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
     """Set up the test image_processing platform."""
     async_add_entities_callback([TestImageProcessing("camera.demo_camera", "Test")])
 
@@ -13,7 +19,7 @@ async def async_setup_platform(
 class TestImageProcessing(ImageProcessingEntity):
     """Test image processing entity."""
 
-    def __init__(self, camera_entity, name):
+    def __init__(self, camera_entity, name) -> None:
         """Initialize test image processing."""
         self._name = name
         self._camera = camera_entity

--- a/tests/testing_config/custom_components/test/light.py
+++ b/tests/testing_config/custom_components/test/light.py
@@ -5,6 +5,9 @@ Call init before using it in your tests to ensure clean test data.
 
 from homeassistant.components.light import ColorMode, LightEntity
 from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from tests.common import MockToggleEntity
 
@@ -13,6 +16,7 @@ ENTITIES = []
 
 def init(empty=False):
     """Initialize the platform with entities."""
+    # pylint: disable-next=global-statement
     global ENTITIES  # noqa: PLW0603
 
     ENTITIES = (
@@ -27,8 +31,11 @@ def init(empty=False):
 
 
 async def async_setup_platform(
-    hass, config, async_add_entities_callback, discovery_info=None
-):
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities_callback: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
     """Return mock entities."""
     async_add_entities_callback(ENTITIES)
 
@@ -64,7 +71,7 @@ class MockLight(MockToggleEntity, LightEntity):
         state,
         unique_id=None,
         supported_color_modes: set[ColorMode] | None = None,
-    ):
+    ) -> None:
         """Initialize the mock light."""
         super().__init__(name, state, unique_id)
         if supported_color_modes is None:

--- a/tests/testing_config/custom_components/test/lock.py
+++ b/tests/testing_config/custom_components/test/lock.py
@@ -4,6 +4,9 @@ Call init before using it in your tests to ensure clean test data.
 """
 
 from homeassistant.components.lock import LockEntity, LockEntityFeature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from tests.common import MockEntity
 
@@ -12,6 +15,7 @@ ENTITIES = {}
 
 def init(empty=False):
     """Initialize the platform with entities."""
+    # pylint: disable-next=global-statement
     global ENTITIES  # noqa: PLW0603
 
     ENTITIES = (
@@ -35,8 +39,11 @@ def init(empty=False):
 
 
 async def async_setup_platform(
-    hass, config, async_add_entities_callback, discovery_info=None
-):
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities_callback: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
     """Return mock entities."""
     async_add_entities_callback(list(ENTITIES.values()))
 

--- a/tests/testing_config/custom_components/test/remote.py
+++ b/tests/testing_config/custom_components/test/remote.py
@@ -5,6 +5,9 @@ Call init before using it in your tests to ensure clean test data.
 
 from homeassistant.components.remote import RemoteEntity
 from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from tests.common import MockToggleEntity
 
@@ -13,6 +16,7 @@ ENTITIES = []
 
 def init(empty=False):
     """Initialize the platform with entities."""
+    # pylint: disable-next=global-statement
     global ENTITIES  # noqa: PLW0603
 
     ENTITIES = (
@@ -27,8 +31,11 @@ def init(empty=False):
 
 
 async def async_setup_platform(
-    hass, config, async_add_entities_callback, discovery_info=None
-):
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities_callback: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
     """Return mock entities."""
     async_add_entities_callback(ENTITIES)
 

--- a/tests/testing_config/custom_components/test/switch.py
+++ b/tests/testing_config/custom_components/test/switch.py
@@ -1,8 +1,15 @@
 """Stub switch platform for translation tests."""
 
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
 
 async def async_setup_platform(
-    hass, config, async_add_entities_callback, discovery_info=None
-):
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities_callback: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
     """Stub setup for translation tests."""
     async_add_entities_callback([])

--- a/tests/testing_config/custom_components/test/weather.py
+++ b/tests/testing_config/custom_components/test/weather.py
@@ -33,6 +33,7 @@ ENTITIES = []
 
 def init(empty=False):
     """Initialize the platform with entities."""
+    # pylint: disable-next=global-statement
     global ENTITIES  # noqa: PLW0603
     ENTITIES = [] if empty else [MockWeather()]
 

--- a/tests/testing_config/custom_components/test_embedded/__init__.py
+++ b/tests/testing_config/custom_components/test_embedded/__init__.py
@@ -1,8 +1,11 @@
 """Component with embedded platforms."""
 
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
 DOMAIN = "test_embedded"
 
 
-async def async_setup(hass, config):
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Mock config."""
     return True

--- a/tests/testing_config/custom_components/test_embedded/switch.py
+++ b/tests/testing_config/custom_components/test_embedded/switch.py
@@ -1,7 +1,14 @@
 """Switch platform for the embedded component."""
 
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
 
 async def async_setup_platform(
-    hass, config, async_add_entities_callback, discovery_info=None
-):
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities_callback: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
     """Find and return test switches."""

--- a/tests/testing_config/custom_components/test_integration_platform/__init__.py
+++ b/tests/testing_config/custom_components/test_integration_platform/__init__.py
@@ -1,10 +1,13 @@
 """Provide a mock package component."""
 
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
 from .const import TEST  # noqa: F401
 
 DOMAIN = "test_integration_platform"
 
 
-async def async_setup(hass, config):
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Mock a successful setup."""
     return True

--- a/tests/testing_config/custom_components/test_package/__init__.py
+++ b/tests/testing_config/custom_components/test_package/__init__.py
@@ -1,10 +1,13 @@
 """Provide a mock package component."""
 
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
 from .const import TEST  # noqa: F401
 
 DOMAIN = "test_package"
 
 
-async def async_setup(hass, config):
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Mock a successful setup."""
     return True

--- a/tests/testing_config/custom_components/test_package_loaded_executor/__init__.py
+++ b/tests/testing_config/custom_components/test_package_loaded_executor/__init__.py
@@ -1,10 +1,13 @@
 """Provide a mock package component."""
 
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
 from .const import TEST  # noqa: F401
 
 DOMAIN = "test_package"
 
 
-async def async_setup(hass, config):
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Mock a successful setup."""
     return True

--- a/tests/testing_config/custom_components/test_package_loaded_loop/__init__.py
+++ b/tests/testing_config/custom_components/test_package_loaded_loop/__init__.py
@@ -1,8 +1,11 @@
 """Provide a mock package component."""
 
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
 from .const import TEST  # noqa: F401
 
 
-async def async_setup(hass, config):
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Mock a successful setup."""
     return True

--- a/tests/testing_config/custom_components/test_package_raises_cancelled_error/__init__.py
+++ b/tests/testing_config/custom_components/test_package_raises_cancelled_error/__init__.py
@@ -2,8 +2,11 @@
 
 import asyncio
 
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
 
-async def async_setup(hass, config):
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Mock a successful setup."""
     asyncio.current_task().cancel()
     await asyncio.sleep(0)

--- a/tests/testing_config/custom_components/test_package_raises_cancelled_error_config_entry/__init__.py
+++ b/tests/testing_config/custom_components/test_package_raises_cancelled_error_config_entry/__init__.py
@@ -2,13 +2,17 @@
 
 import asyncio
 
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
 
-async def async_setup(hass, config):
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Mock a successful setup."""
     return True
 
 
-async def async_setup_entry(hass, entry):
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Mock an unsuccessful entry setup."""
     asyncio.current_task().cancel()
     await asyncio.sleep(0)

--- a/tests/testing_config/custom_components/test_standalone.py
+++ b/tests/testing_config/custom_components/test_standalone.py
@@ -1,8 +1,11 @@
 """Provide a mock standalone component."""
 
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
 DOMAIN = "test_standalone"
 
 
-async def async_setup(hass, config):
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Mock a successful setup."""
     return True


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #119279
https://github.com/home-assistant/core/actions/runs/9462633125/job/26066072851?pr=119279

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
