### PR TITLE
Fix tplink attribute update handling, test coverage and other review comments

### DIFF
--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -189,7 +189,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     parent_coordinator = TPLinkDataUpdateCoordinator(hass, device, timedelta(seconds=5))
     child_coordinators: list[TPLinkDataUpdateCoordinator] = []
 
-    if device.is_strip:
+    if device.children:
         child_coordinators = [
             # The child coordinators only update energy data so we can
             # set a longer update interval to avoid flooding the device

--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -17,6 +17,7 @@ from kasa import (
     KasaException,
 )
 from kasa.httpclient import get_cookie_jar
+from kasa.iot import IotStrip
 
 from homeassistant import config_entries
 from homeassistant.components import network
@@ -189,7 +190,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     parent_coordinator = TPLinkDataUpdateCoordinator(hass, device, timedelta(seconds=5))
     child_coordinators: list[TPLinkDataUpdateCoordinator] = []
 
-    if device.children:
+    # The iot HS300 allows a limited number of concurrent requests and fetching the
+    # emeter information requires separate ones so create child coordinators here.
+    if isinstance(device, IotStrip):
         child_coordinators = [
             # The child coordinators only update energy data so we can
             # set a longer update interval to avoid flooding the device

--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -17,6 +17,7 @@ from kasa import (
 )
 
 from homeassistant.components.light import LightEntity
+from homeassistant.components.sensor import SensorEntity
 from homeassistant.const import EntityCategory
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
@@ -117,7 +118,10 @@ class CoordinatedTPLinkEntity(CoordinatorEntity[TPLinkDataUpdateCoordinator], AB
         registry_device = device
         name = device.alias
         if parent and parent.device_type != Device.Type.Hub:
-            if not feature or feature.category == Feature.Category.Primary:
+            # Check for SensorEntity can be removed when sensor features are implemented
+            if not isinstance(self, SensorEntity) and (
+                not feature or feature.category == Feature.Category.Primary
+            ):
                 # Entity will be added to parent if not a hub and no feature parameter
                 # (i.e. core platform like Light, Fan) or feature is primary like state
                 registry_device = parent
@@ -165,7 +169,7 @@ class CoordinatedTPLinkEntity(CoordinatorEntity[TPLinkDataUpdateCoordinator], AB
         if isinstance(self, LightEntity):
             unique_id = device.mac.replace(":", "").upper()
             # For backwards compat with pyHS100
-            if device.device_type == DeviceType.Dimmer:
+            if device.device_type is DeviceType.Dimmer:
                 # Dimmers used to use the switch format since
                 # pyHS100 treated them as SmartPlug but the old code
                 # created them as lights
@@ -200,8 +204,12 @@ class CoordinatedTPLinkEntity(CoordinatorEntity[TPLinkDataUpdateCoordinator], AB
         raise NotImplementedError
 
     @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
+    def _async_call_update_attrs(self) -> None:
+        """Call update_attrs and make entity unavailable on error.
+
+        update_attrs can sometimes fail if a device firmware update breaks the
+        downstream library.
+        """
         try:
             self._async_update_attrs()
         except Exception as ex:  # noqa: BLE001
@@ -209,13 +217,23 @@ class CoordinatedTPLinkEntity(CoordinatorEntity[TPLinkDataUpdateCoordinator], AB
                 _LOGGER.warning(
                     "Unable to read data for %s %s: %s",
                     self._device,
-                    self.entity_description,
+                    self.entity_id,
                     ex,
                 )
             self._attr_available = False
+        else:
+            self._attr_available = True
 
-        self._attr_available = True
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._async_call_update_attrs()
         super()._handle_coordinator_update()
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self.coordinator.last_update_success and self._attr_available
 
 
 def _entities_for_device[_E: CoordinatedTPLinkEntity](

--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -15,6 +15,7 @@ from kasa import (
     KasaException,
     TimeoutError,
 )
+from kasa.iot import IotDevice
 
 from homeassistant.components.light import LightEntity
 from homeassistant.components.sensor import SensorEntity
@@ -169,7 +170,9 @@ class CoordinatedTPLinkEntity(CoordinatorEntity[TPLinkDataUpdateCoordinator], AB
         if isinstance(self, LightEntity):
             unique_id = device.mac.replace(":", "").upper()
             # For backwards compat with pyHS100
-            if device.device_type is DeviceType.Dimmer:
+            if device.device_type is DeviceType.Dimmer and isinstance(
+                device, IotDevice
+            ):
                 # Dimmers used to use the switch format since
                 # pyHS100 treated them as SmartPlug but the old code
                 # created them as lights

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -199,7 +199,7 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
         if len(self._attr_supported_color_modes) == 1:
             # If the light supports only a single color mode, set it now
             self._fixed_color_mode = next(iter(self._attr_supported_color_modes))
-        self._async_update_attrs()
+        self._async_call_update_attrs()
 
     @callback
     def _async_extract_brightness_transition(
@@ -306,12 +306,6 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
         elif color_mode is ColorMode.HS:
             hue, saturation, _ = light_module.hsv
             self._attr_hs_color = hue, saturation
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        self._async_update_attrs()
-        super()._handle_coordinator_update()
 
 
 class TPLinkSmartLightStrip(TPLinkSmartBulb):

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -169,7 +169,7 @@ class SmartPlugSensor(CoordinatedTPLinkEntity, SensorEntity):
             else:
                 assert description.device_class
                 self._attr_translation_key = f"{description.device_class.value}_child"
-        self._async_update_attrs()
+        self._async_call_update_attrs()
 
     @callback
     def _async_update_attrs(self) -> None:
@@ -177,9 +177,3 @@ class SmartPlugSensor(CoordinatedTPLinkEntity, SensorEntity):
         self._attr_native_value = async_emeter_from_device(
             self._device, self.entity_description
         )
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        self._async_update_attrs()
-        super()._handle_coordinator_update()

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -137,9 +137,12 @@ async def async_setup_entry(
     if parent.children:
         # Historically we only add the children if the device is a strip
         for idx, child in enumerate(parent.children):
-            entities.extend(
-                _async_sensors_for_device(child, children_coordinators[idx], parent)
-            )
+            # Only iot strips have child coordinators
+            if children_coordinators:
+                coordinator = children_coordinators[idx]
+            else:
+                coordinator = parent_coordinator
+            entities.extend(_async_sensors_for_device(child, coordinator, parent))
     else:
         entities.extend(_async_sensors_for_device(parent, parent_coordinator))
 

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -72,7 +72,7 @@ class TPLinkSwitch(CoordinatedTPLinkEntity, SwitchEntity):
         self.entity_description = _description_for_feature(
             SwitchEntityDescription, feature
         )
-        self._async_update_attrs()
+        self._async_call_update_attrs()
 
     @async_refresh_after
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/tests/components/tplink/__init__.py
+++ b/tests/components/tplink/__init__.py
@@ -39,6 +39,7 @@ IP_ADDRESS2 = "127.0.0.2"
 ALIAS = "My Bulb"
 MODEL = "HS100"
 MAC_ADDRESS = "aa:bb:cc:dd:ee:ff"
+DEVICE_ID = "123456789ABCDEFGH"
 DHCP_FORMATTED_MAC_ADDRESS = MAC_ADDRESS.replace(":", "")
 MAC_ADDRESS2 = "11:22:33:44:55:66"
 DEFAULT_ENTRY_TITLE = f"{ALIAS} {MODEL}"
@@ -94,7 +95,7 @@ CREATE_ENTRY_DATA_AUTH2 = {
 
 
 def _mock_protocol() -> BaseProtocol:
-    protocol = MagicMock(auto_spec=BaseProtocol)
+    protocol = MagicMock(spec=BaseProtocol)
     protocol.close = AsyncMock()
     return protocol
 
@@ -103,14 +104,15 @@ def _mocked_device(
     device_config=DEVICE_CONFIG_LEGACY,
     credentials_hash=CREDENTIALS_HASH_LEGACY,
     mac=MAC_ADDRESS,
-    device_id=MAC_ADDRESS,
+    device_id=DEVICE_ID,
     alias=ALIAS,
     modules: list[str] | None = None,
     children: list[Device] | None = None,
     features: list[str] | None = None,
     device_type=DeviceType.Unknown,
+    spec: type = Device,
 ) -> Device:
-    device = MagicMock(auto_spec=Device, name="Mocked device")
+    device = MagicMock(spec=spec, name="Mocked device")
     device.update = AsyncMock()
     device.turn_off = AsyncMock()
     device.turn_on = AsyncMock()
@@ -150,7 +152,7 @@ def _mocked_device(
 def _mocked_feature(
     value: Any, id: str, type_=Feature.Type.Sensor, category=Feature.Category.Debug
 ) -> Feature:
-    feature = MagicMock(auto_spec=Feature, name="Mocked feature")
+    feature = MagicMock(spec=Feature, name="Mocked feature")
     feature.id = id
     feature.name = id
     feature.value = value
@@ -161,7 +163,7 @@ def _mocked_feature(
 
 
 def _mocked_light_module() -> Light:
-    light = MagicMock(auto_spec=Light, name="Mocked light module")
+    light = MagicMock(spec=Light, name="Mocked light module")
     light.update = AsyncMock()
     light.brightness = 50
     light.color_temp = 4000
@@ -182,7 +184,7 @@ def _mocked_light_module() -> Light:
 
 
 def _mocked_light_effect_module() -> LightEffect:
-    effect = MagicMock(auto_spec=LightEffect, name="Mocked light effect")
+    effect = MagicMock(spec=LightEffect, name="Mocked light effect")
     effect.has_effects = True
     effect.has_custom_effects = True
     effect.effect = "Effect1"

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import copy
 from datetime import timedelta
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
-from kasa import AuthenticationError, Module
+from kasa import AuthenticationError, Feature, KasaException, Module
 import pytest
 
 from homeassistant import setup
@@ -21,6 +21,7 @@ from homeassistant.const import (
     CONF_USERNAME,
     STATE_ON,
     STATE_UNAVAILABLE,
+    EntityCategory,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import EntityRegistry
@@ -297,3 +298,101 @@ async def test_plug_auth_fails(hass: HomeAssistant) -> None:
         )
         == 1
     )
+
+
+async def test_update_attrs_fails_in_init(
+    hass: HomeAssistant,
+    entity_registry: EntityRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a smart plug auth failure."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
+    )
+    config_entry.add_to_hass(hass)
+    light = _mocked_device(modules=[Module.Light], alias="my_light")
+    light_module = light.modules[Module.Light]
+    p = PropertyMock(side_effect=KasaException)
+    type(light_module).color_temp = p
+    light.__str__ = lambda _: "MockLight"
+    with _patch_discovery(device=light), _patch_connect(device=light):
+        await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "light.my_light"
+    entity = entity_registry.async_get(entity_id)
+    assert entity
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_UNAVAILABLE
+    assert "Unable to read data for MockLight None:" in caplog.text
+
+
+async def test_update_attrs_fails_on_update(
+    hass: HomeAssistant,
+    entity_registry: EntityRegistry,
+    freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a smart plug auth failure."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
+    )
+    config_entry.add_to_hass(hass)
+    light = _mocked_device(modules=[Module.Light], alias="my_light")
+    light_module = light.modules[Module.Light]
+
+    with _patch_discovery(device=light), _patch_connect(device=light):
+        await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "light.my_light"
+    entity = entity_registry.async_get(entity_id)
+    assert entity
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+
+    p = PropertyMock(side_effect=KasaException)
+    type(light_module).color_temp = p
+    light.__str__ = lambda _: "MockLight"
+    freezer.tick(5)
+    async_fire_time_changed(hass)
+    entity = entity_registry.async_get(entity_id)
+    assert entity
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_UNAVAILABLE
+    assert f"Unable to read data for MockLight {entity_id}:" in caplog.text
+    # Check only logs once
+    caplog.clear()
+    freezer.tick(5)
+    async_fire_time_changed(hass)
+    entity = entity_registry.async_get(entity_id)
+    assert entity
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_UNAVAILABLE
+    assert f"Unable to read data for MockLight {entity_id}:" not in caplog.text
+
+
+async def test_feature_no_category(
+    hass: HomeAssistant,
+    entity_registry: EntityRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a strip unique id."""
+    already_migrated_config_entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
+    )
+    already_migrated_config_entry.add_to_hass(hass)
+    dev = _mocked_device(
+        alias="my_plug",
+        features=["led"],
+    )
+    dev.features["led"].category = Feature.Category.Unset
+    with _patch_discovery(device=dev), _patch_connect(device=dev):
+        await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "switch.my_plug_led"
+    entity = entity_registry.async_get(entity_id)
+    assert entity
+    assert entity.entity_category == EntityCategory.DIAGNOSTIC
+    assert "Unhandled category Category.Unset, fallback to DIAGNOSTIC" in caplog.text

--- a/tests/components/tplink/test_light.py
+++ b/tests/components/tplink/test_light.py
@@ -91,7 +91,7 @@ async def test_dimmer_unique_id(hass: HomeAssistant) -> None:
     ("device", "transition"),
     [
         (_mocked_device(modules=[Module.Light]), 2.0),
-        (_mocked_device(modules=[Module.Light]), None),
+        (_mocked_device(modules=[Module.Light, Module.LightEffect]), None),
     ],
 )
 async def test_color_light(

--- a/tests/components/tplink/test_light.py
+++ b/tests/components/tplink/test_light.py
@@ -14,6 +14,7 @@ from kasa import (
     TimeoutError,
 )
 from kasa.interfaces import LightEffect
+from kasa.iot import IotDevice
 import pytest
 
 from homeassistant.components import tplink
@@ -53,8 +54,17 @@ from . import (
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
+@pytest.mark.parametrize(
+    ("device_type"),
+    [
+        pytest.param(DeviceType.Dimmer, id="Dimmer"),
+        pytest.param(DeviceType.Bulb, id="Bulb"),
+        pytest.param(DeviceType.LightStrip, id="LightStrip"),
+        pytest.param(DeviceType.WallSwitch, id="WallSwitch"),
+    ],
+)
 async def test_light_unique_id(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, device_type
 ) -> None:
     """Test a light unique id."""
     already_migrated_config_entry = MockConfigEntry(
@@ -62,12 +72,16 @@ async def test_light_unique_id(
     )
     already_migrated_config_entry.add_to_hass(hass)
     light = _mocked_device(modules=[Module.Light], alias="my_light")
+    light.device_type = device_type
     with _patch_discovery(device=light), _patch_connect(device=light):
         await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
         await hass.async_block_till_done()
 
     entity_id = "light.my_light"
-    assert entity_registry.async_get(entity_id).unique_id == "AABBCCDDEEFF"
+    assert (
+        entity_registry.async_get(entity_id).unique_id
+        == MAC_ADDRESS.replace(":", "").upper()
+    )
 
 
 async def test_dimmer_unique_id(hass: HomeAssistant) -> None:
@@ -76,7 +90,12 @@ async def test_dimmer_unique_id(hass: HomeAssistant) -> None:
         domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
     )
     already_migrated_config_entry.add_to_hass(hass)
-    light = _mocked_device(modules=[Module.Light], alias="my_light")
+    light = _mocked_device(
+        modules=[Module.Light],
+        alias="my_light",
+        spec=IotDevice,
+        device_id="aa:bb:cc:dd:ee:ff",
+    )
     light.device_type = DeviceType.Dimmer
     with _patch_discovery(device=light), _patch_connect(device=light):
         await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})

--- a/tests/components/tplink/test_sensor.py
+++ b/tests/components/tplink/test_sensor.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
-from . import MAC_ADDRESS, _mocked_device, _patch_connect, _patch_discovery
+from . import DEVICE_ID, MAC_ADDRESS, _mocked_device, _patch_connect, _patch_discovery
 
 from tests.common import MockConfigEntry
 
@@ -139,11 +139,11 @@ async def test_sensor_unique_id(
         await hass.async_block_till_done()
 
     expected = {
-        "sensor.my_plug_current_consumption": "aa:bb:cc:dd:ee:ff_current_power_w",
-        "sensor.my_plug_total_consumption": "aa:bb:cc:dd:ee:ff_total_energy_kwh",
-        "sensor.my_plug_today_s_consumption": "aa:bb:cc:dd:ee:ff_today_energy_kwh",
-        "sensor.my_plug_voltage": "aa:bb:cc:dd:ee:ff_voltage",
-        "sensor.my_plug_current": "aa:bb:cc:dd:ee:ff_current_a",
+        "sensor.my_plug_current_consumption": f"{DEVICE_ID}_current_power_w",
+        "sensor.my_plug_total_consumption": f"{DEVICE_ID}_total_energy_kwh",
+        "sensor.my_plug_today_s_consumption": f"{DEVICE_ID}_today_energy_kwh",
+        "sensor.my_plug_voltage": f"{DEVICE_ID}_voltage",
+        "sensor.my_plug_current": f"{DEVICE_ID}_current_a",
     }
     for sensor_entity_id, value in expected.items():
         assert entity_registry.async_get(sensor_entity_id).unique_id == value

--- a/tests/components/tplink/test_switch.py
+++ b/tests/components/tplink/test_switch.py
@@ -24,6 +24,7 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util, slugify
 
 from . import (
+    DEVICE_ID,
     MAC_ADDRESS,
     _mocked_device,
     _mocked_strip_children,
@@ -128,7 +129,7 @@ async def test_plug_unique_id(
         await hass.async_block_till_done()
 
     entity_id = "switch.my_plug"
-    assert entity_registry.async_get(entity_id).unique_id == "aa:bb:cc:dd:ee:ff"
+    assert entity_registry.async_get(entity_id).unique_id == DEVICE_ID
 
 
 async def test_plug_update_fails(hass: HomeAssistant) -> None:

--- a/tests/components/tplink/test_switch.py
+++ b/tests/components/tplink/test_switch.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from unittest.mock import AsyncMock
 
 from kasa import AuthenticationError, Device, KasaException, Module, TimeoutError
+from kasa.iot import IotStrip
 import pytest
 
 from homeassistant.components import tplink
@@ -164,6 +165,7 @@ async def test_strip(hass: HomeAssistant) -> None:
         alias="my_strip",
         children=_mocked_strip_children(features=["state"]),
         features=["state", "led"],
+        spec=IotStrip,
     )
     strip.children[0].features["state"].value = True
     strip.children[1].features["state"].value = False


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

PR to update https://github.com/home-assistant/core/pull/117758:
- Implement update_attrs so that the error check and setting to unavailable happens in `__init__` as well as on coordinator update.
- Fix missing test coverage (coverage report below)
- Address review comments on 117758

See https://github.com/home-assistant/core/pull/117785 for an explanation of the approach for merging into the tplink_rewrite branch

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->


File	statements	missing	excluded	coverage
homeassistant/components/tplink/__init__.py	112	0	0	100%
homeassistant/components/tplink/config_flow.py	222	0	0	100%
homeassistant/components/tplink/const.py	13	0	0	100%
homeassistant/components/tplink/coordinator.py	23	0	0	100%
homeassistant/components/tplink/diagnostics.py	14	0	0	100%
homeassistant/components/tplink/entity.py	111	0	1	100%
homeassistant/components/tplink/light.py	165	0	0	100%
homeassistant/components/tplink/models.py	7	0	0	100%
homeassistant/components/tplink/sensor.py	57	0	0	100%
homeassistant/components/tplink/switch.py	36	0	0	100%
Total	760	0	1	100%

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
