### PR TITLE
2024.6.2

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -163,7 +163,6 @@ homeassistant.components.easyenergy.*
 homeassistant.components.ecovacs.*
 homeassistant.components.ecowitt.*
 homeassistant.components.efergy.*
-homeassistant.components.electrasmart.*
 homeassistant.components.electric_kiwi.*
 homeassistant.components.elgato.*
 homeassistant.components.elkm1.*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1486,8 +1486,6 @@ build.json @home-assistant/supervisor
 /tests/components/unifi/ @Kane610
 /homeassistant/components/unifi_direct/ @tofuSCHNITZEL
 /homeassistant/components/unifiled/ @florisvdk
-/homeassistant/components/unifiprotect/ @bdraco
-/tests/components/unifiprotect/ @bdraco
 /homeassistant/components/upb/ @gwww
 /tests/components/upb/ @gwww
 /homeassistant/components/upc_connect/ @pvizeli @fabaff

--- a/homeassistant/components/aladdin_connect/const.py
+++ b/homeassistant/components/aladdin_connect/const.py
@@ -2,5 +2,5 @@
 
 DOMAIN = "aladdin_connect"
 
-OAUTH2_AUTHORIZE = "https://app.aladdinconnect.com/login.html"
+OAUTH2_AUTHORIZE = "https://app.aladdinconnect.net/login.html"
 OAUTH2_TOKEN = "https://twdvzuefzh.execute-api.us-east-2.amazonaws.com/v1/oauth2/token"

--- a/homeassistant/components/azure_data_explorer/__init__.py
+++ b/homeassistant/components/azure_data_explorer/__init__.py
@@ -62,13 +62,12 @@ async def async_setup(hass: HomeAssistant, yaml_config: ConfigType) -> bool:
 
     Adds an empty filter to hass data.
     Tries to get a filter from yaml, if present set to hass data.
-    If config is empty after getting the filter, return, otherwise emit
-    deprecated warning and pass the rest to the config flow.
     """
 
-    hass.data.setdefault(DOMAIN, {DATA_FILTER: {}})
+    hass.data.setdefault(DOMAIN, {DATA_FILTER: FILTER_SCHEMA({})})
     if DOMAIN in yaml_config:
-        hass.data[DOMAIN][DATA_FILTER] = yaml_config[DOMAIN][CONF_FILTER]
+        hass.data[DOMAIN][DATA_FILTER] = yaml_config[DOMAIN].pop(CONF_FILTER)
+
     return True
 
 
@@ -207,6 +206,6 @@ class AzureDataExplorer:
         if "\n" in state.state:
             return None, dropped + 1
 
-        json_event = str(json.dumps(obj=state, cls=JSONEncoder).encode("utf-8"))
+        json_event = json.dumps(obj=state, cls=JSONEncoder)
 
         return (json_event, dropped)

--- a/homeassistant/components/azure_data_explorer/client.py
+++ b/homeassistant/components/azure_data_explorer/client.py
@@ -23,7 +23,7 @@ from .const import (
     CONF_APP_REG_ID,
     CONF_APP_REG_SECRET,
     CONF_AUTHORITY_ID,
-    CONF_USE_FREE,
+    CONF_USE_QUEUED_CLIENT,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -35,7 +35,6 @@ class AzureDataExplorerClient:
     def __init__(self, data: Mapping[str, Any]) -> None:
         """Create the right class."""
 
-        self._cluster_ingest_uri = data[CONF_ADX_CLUSTER_INGEST_URI]
         self._database = data[CONF_ADX_DATABASE_NAME]
         self._table = data[CONF_ADX_TABLE_NAME]
         self._ingestion_properties = IngestionProperties(
@@ -45,24 +44,36 @@ class AzureDataExplorerClient:
             ingestion_mapping_reference="ha_json_mapping",
         )
 
-        # Create cLient for ingesting and querying data
-        kcsb = KustoConnectionStringBuilder.with_aad_application_key_authentication(
-            self._cluster_ingest_uri,
-            data[CONF_APP_REG_ID],
-            data[CONF_APP_REG_SECRET],
-            data[CONF_AUTHORITY_ID],
+        # Create client for ingesting data
+        kcsb_ingest = (
+            KustoConnectionStringBuilder.with_aad_application_key_authentication(
+                data[CONF_ADX_CLUSTER_INGEST_URI],
+                data[CONF_APP_REG_ID],
+                data[CONF_APP_REG_SECRET],
+                data[CONF_AUTHORITY_ID],
+            )
         )
 
-        if data[CONF_USE_FREE] is True:
-            # Queded is the only option supported on free tear of ADX
-            self.write_client = QueuedIngestClient(kcsb)
-        else:
-            self.write_client = ManagedStreamingIngestClient.from_dm_kcsb(kcsb)
+        # Create client for querying data
+        kcsb_query = (
+            KustoConnectionStringBuilder.with_aad_application_key_authentication(
+                data[CONF_ADX_CLUSTER_INGEST_URI].replace("ingest-", ""),
+                data[CONF_APP_REG_ID],
+                data[CONF_APP_REG_SECRET],
+                data[CONF_AUTHORITY_ID],
+            )
+        )
 
-        self.query_client = KustoClient(kcsb)
+        if data[CONF_USE_QUEUED_CLIENT] is True:
+            # Queded is the only option supported on free tear of ADX
+            self.write_client = QueuedIngestClient(kcsb_ingest)
+        else:
+            self.write_client = ManagedStreamingIngestClient.from_dm_kcsb(kcsb_ingest)
+
+        self.query_client = KustoClient(kcsb_query)
 
     def test_connection(self) -> None:
-        """Test connection, will throw Exception when it cannot connect."""
+        """Test connection, will throw Exception if it cannot connect."""
 
         query = f"{self._table} | take 1"
 

--- a/homeassistant/components/azure_data_explorer/config_flow.py
+++ b/homeassistant/components/azure_data_explorer/config_flow.py
@@ -10,6 +10,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigFlowResult
+from homeassistant.helpers.selector import BooleanSelector
 
 from . import AzureDataExplorerClient
 from .const import (
@@ -19,7 +20,7 @@ from .const import (
     CONF_APP_REG_ID,
     CONF_APP_REG_SECRET,
     CONF_AUTHORITY_ID,
-    CONF_USE_FREE,
+    CONF_USE_QUEUED_CLIENT,
     DEFAULT_OPTIONS,
     DOMAIN,
 )
@@ -34,7 +35,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Required(CONF_APP_REG_ID): str,
         vol.Required(CONF_APP_REG_SECRET): str,
         vol.Required(CONF_AUTHORITY_ID): str,
-        vol.Optional(CONF_USE_FREE, default=False): bool,
+        vol.Required(CONF_USE_QUEUED_CLIENT, default=False): BooleanSelector(),
     }
 )
 

--- a/homeassistant/components/azure_data_explorer/const.py
+++ b/homeassistant/components/azure_data_explorer/const.py
@@ -17,7 +17,7 @@ CONF_AUTHORITY_ID = "authority_id"
 CONF_SEND_INTERVAL = "send_interval"
 CONF_MAX_DELAY = "max_delay"
 CONF_FILTER = DATA_FILTER = "filter"
-CONF_USE_FREE = "use_queued_ingestion"
+CONF_USE_QUEUED_CLIENT = "use_queued_ingestion"
 DATA_HUB = "hub"
 STEP_USER = "user"
 

--- a/homeassistant/components/azure_data_explorer/strings.json
+++ b/homeassistant/components/azure_data_explorer/strings.json
@@ -3,15 +3,19 @@
     "step": {
       "user": {
         "title": "Setup your Azure Data Explorer integration",
-        "description": "Enter connection details.",
+        "description": "Enter connection details",
         "data": {
-          "cluster_ingest_uri": "Cluster ingest URI",
-          "database": "Database name",
-          "table": "Table name",
+          "cluster_ingest_uri": "Cluster Ingest URI",
+          "authority_id": "Authority ID",
           "client_id": "Client ID",
           "client_secret": "Client secret",
-          "authority_id": "Authority ID",
+          "database": "Database name",
+          "table": "Table name",
           "use_queued_ingestion": "Use queued ingestion"
+        },
+        "data_description": {
+          "cluster_ingest_uri": "Ingest-URI of the cluster",
+          "use_queued_ingestion": "Must be enabled when using ADX free cluster"
         }
       }
     },

--- a/homeassistant/components/control4/__init__.py
+++ b/homeassistant/components/control4/__init__.py
@@ -120,7 +120,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     director_all_items = json.loads(director_all_items)
     entry_data[CONF_DIRECTOR_ALL_ITEMS] = director_all_items
 
-    entry_data[CONF_UI_CONFIGURATION] = json.loads(await director.getUiConfiguration())
+    # Check if OS version is 3 or higher to get UI configuration
+    entry_data[CONF_UI_CONFIGURATION] = None
+    if int(entry_data[CONF_DIRECTOR_SW_VERSION].split(".")[0]) >= 3:
+        entry_data[CONF_UI_CONFIGURATION] = json.loads(
+            await director.getUiConfiguration()
+        )
 
     # Load options from config entry
     entry_data[CONF_SCAN_INTERVAL] = entry.options.get(

--- a/homeassistant/components/control4/media_player.py
+++ b/homeassistant/components/control4/media_player.py
@@ -81,11 +81,18 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up Control4 rooms from a config entry."""
+    entry_data = hass.data[DOMAIN][entry.entry_id]
+    ui_config = entry_data[CONF_UI_CONFIGURATION]
+
+    # OS 2 will not have a ui_configuration
+    if not ui_config:
+        _LOGGER.debug("No UI Configuration found for Control4")
+        return
+
     all_rooms = await get_rooms(hass, entry)
     if not all_rooms:
         return
 
-    entry_data = hass.data[DOMAIN][entry.entry_id]
     scan_interval = entry_data[CONF_SCAN_INTERVAL]
     _LOGGER.debug("Scan interval = %s", scan_interval)
 
@@ -118,8 +125,6 @@ async def async_setup_entry(
         for k, item in items_by_id.items()
         if "parentId" in item and k > 1
     }
-
-    ui_config = entry_data[CONF_UI_CONFIGURATION]
 
     entity_list = []
     for room in all_rooms:

--- a/homeassistant/components/electrasmart/manifest.json
+++ b/homeassistant/components/electrasmart/manifest.json
@@ -5,5 +5,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/electrasmart",
   "iot_class": "cloud_polling",
-  "requirements": ["pyElectra==1.2.0"]
+  "requirements": ["pyElectra==1.2.1"]
 }

--- a/homeassistant/components/elgato/light.py
+++ b/homeassistant/components/elgato/light.py
@@ -59,7 +59,15 @@ class ElgatoLight(ElgatoEntity, LightEntity):
         self._attr_unique_id = coordinator.data.info.serial_number
 
         # Elgato Light supporting color, have a different temperature range
-        if self.coordinator.data.settings.power_on_hue is not None:
+        if (
+            self.coordinator.data.info.product_name
+            in (
+                "Elgato Light Strip",
+                "Elgato Light Strip Pro",
+            )
+            or self.coordinator.data.settings.power_on_hue
+            or self.coordinator.data.state.hue is not None
+        ):
             self._attr_supported_color_modes = {ColorMode.COLOR_TEMP, ColorMode.HS}
             self._attr_min_mireds = 153
             self._attr_max_mireds = 285

--- a/homeassistant/components/enigma2/media_player.py
+++ b/homeassistant/components/enigma2/media_player.py
@@ -141,10 +141,10 @@ class Enigma2Device(MediaPlayerEntity):
         self._device: OpenWebIfDevice = device
         self._entry = entry
 
-        self._attr_unique_id = device.mac_address
+        self._attr_unique_id = device.mac_address or entry.entry_id
 
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, device.mac_address)},
+            identifiers={(DOMAIN, self._attr_unique_id)},
             manufacturer=about["info"]["brand"],
             model=about["info"]["model"],
             configuration_url=device.base,

--- a/homeassistant/components/envisalink/alarm_control_panel.py
+++ b/homeassistant/components/envisalink/alarm_control_panel.py
@@ -116,8 +116,9 @@ class EnvisalinkAlarm(EnvisalinkDevice, AlarmControlPanelEntity):
     ):
         """Initialize the alarm panel."""
         self._partition_number = partition_number
-        self._code = code
         self._panic_type = panic_type
+        self._alarm_control_panel_option_default_code = code
+        self._attr_code_format = CodeFormat.NUMBER
 
         _LOGGER.debug("Setting up alarm: %s", alarm_name)
         super().__init__(alarm_name, info, controller)
@@ -142,13 +143,6 @@ class EnvisalinkAlarm(EnvisalinkDevice, AlarmControlPanelEntity):
             self.async_write_ha_state()
 
     @property
-    def code_format(self) -> CodeFormat | None:
-        """Regex for code format or None if no code is required."""
-        if self._code:
-            return None
-        return CodeFormat.NUMBER
-
-    @property
     def state(self) -> str:
         """Return the state of the device."""
         state = STATE_UNKNOWN
@@ -169,34 +163,15 @@ class EnvisalinkAlarm(EnvisalinkDevice, AlarmControlPanelEntity):
 
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
-        if code:
-            self.hass.data[DATA_EVL].disarm_partition(str(code), self._partition_number)
-        else:
-            self.hass.data[DATA_EVL].disarm_partition(
-                str(self._code), self._partition_number
-            )
+        self.hass.data[DATA_EVL].disarm_partition(code, self._partition_number)
 
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm home command."""
-        if code:
-            self.hass.data[DATA_EVL].arm_stay_partition(
-                str(code), self._partition_number
-            )
-        else:
-            self.hass.data[DATA_EVL].arm_stay_partition(
-                str(self._code), self._partition_number
-            )
+        self.hass.data[DATA_EVL].arm_stay_partition(code, self._partition_number)
 
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
-        if code:
-            self.hass.data[DATA_EVL].arm_away_partition(
-                str(code), self._partition_number
-            )
-        else:
-            self.hass.data[DATA_EVL].arm_away_partition(
-                str(self._code), self._partition_number
-            )
+        self.hass.data[DATA_EVL].arm_away_partition(code, self._partition_number)
 
     async def async_alarm_trigger(self, code: str | None = None) -> None:
         """Alarm trigger command. Will be used to trigger a panic alarm."""
@@ -204,9 +179,7 @@ class EnvisalinkAlarm(EnvisalinkDevice, AlarmControlPanelEntity):
 
     async def async_alarm_arm_night(self, code: str | None = None) -> None:
         """Send arm night command."""
-        self.hass.data[DATA_EVL].arm_night_partition(
-            str(code) if code else str(self._code), self._partition_number
-        )
+        self.hass.data[DATA_EVL].arm_night_partition(code, self._partition_number)
 
     @callback
     def async_alarm_keypress(self, keypress=None):

--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -20,5 +20,5 @@
   "documentation": "https://www.home-assistant.io/integrations/frontend",
   "integration_type": "system",
   "quality_scale": "internal",
-  "requirements": ["home-assistant-frontend==20240605.0"]
+  "requirements": ["home-assistant-frontend==20240610.0"]
 }

--- a/homeassistant/components/gardena_bluetooth/manifest.json
+++ b/homeassistant/components/gardena_bluetooth/manifest.json
@@ -13,5 +13,5 @@
   "dependencies": ["bluetooth_adapters"],
   "documentation": "https://www.home-assistant.io/integrations/gardena_bluetooth",
   "iot_class": "local_polling",
-  "requirements": ["gardena-bluetooth==1.4.1"]
+  "requirements": ["gardena-bluetooth==1.4.2"]
 }

--- a/homeassistant/components/glances/manifest.json
+++ b/homeassistant/components/glances/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/glances",
   "iot_class": "local_polling",
   "loggers": ["glances_api"],
-  "requirements": ["glances-api==0.7.0"]
+  "requirements": ["glances-api==0.8.0"]
 }

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -1586,6 +1586,17 @@ class ArmDisArmTrait(_Trait):
             if features & required_feature != 0
         ]
 
+    def _default_arm_state(self):
+        states = self._supported_states()
+
+        if STATE_ALARM_TRIGGERED in states:
+            states.remove(STATE_ALARM_TRIGGERED)
+
+        if len(states) != 1:
+            raise SmartHomeError(ERR_NOT_SUPPORTED, "ArmLevel missing")
+
+        return states[0]
+
     def sync_attributes(self):
         """Return ArmDisarm attributes for a sync request."""
         response = {}
@@ -1609,10 +1620,13 @@ class ArmDisArmTrait(_Trait):
     def query_attributes(self):
         """Return ArmDisarm query attributes."""
         armed_state = self.state.attributes.get("next_state", self.state.state)
-        response = {"isArmed": armed_state in self.state_to_service}
-        if response["isArmed"]:
-            response.update({"currentArmLevel": armed_state})
-        return response
+
+        if armed_state in self.state_to_service:
+            return {"isArmed": True, "currentArmLevel": armed_state}
+        return {
+            "isArmed": False,
+            "currentArmLevel": self._default_arm_state(),
+        }
 
     async def execute(self, command, data, params, challenge):
         """Execute an ArmDisarm command."""
@@ -1620,15 +1634,7 @@ class ArmDisArmTrait(_Trait):
             # If no arm level given, we can only arm it if there is
             # only one supported arm type. We never default to triggered.
             if not (arm_level := params.get("armLevel")):
-                states = self._supported_states()
-
-                if STATE_ALARM_TRIGGERED in states:
-                    states.remove(STATE_ALARM_TRIGGERED)
-
-                if len(states) != 1:
-                    raise SmartHomeError(ERR_NOT_SUPPORTED, "ArmLevel missing")
-
-                arm_level = states[0]
+                arm_level = self._default_arm_state()
 
             if self.state.state == arm_level:
                 raise SmartHomeError(ERR_ALREADY_ARMED, "System is already armed")

--- a/homeassistant/components/google_generative_ai_conversation/__init__.py
+++ b/homeassistant/components/google_generative_ai_conversation/__init__.py
@@ -71,7 +71,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         try:
             response = await model.generate_content_async(prompt_parts)
         except (
-            ClientError,
+            GoogleAPICallError,
             ValueError,
             genai_types.BlockedPromptException,
             genai_types.StopCandidateException,

--- a/homeassistant/components/google_generative_ai_conversation/conversation.py
+++ b/homeassistant/components/google_generative_ai_conversation/conversation.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-import google.ai.generativelanguage as glm
 from google.api_core.exceptions import GoogleAPICallError
 import google.generativeai as genai
+from google.generativeai import protos
 import google.generativeai.types as genai_types
 from google.protobuf.json_format import MessageToDict
 import voluptuous as vol
@@ -93,7 +93,7 @@ def _format_tool(tool: llm.Tool) -> dict[str, Any]:
 
     parameters = _format_schema(convert(tool.parameters))
 
-    return glm.Tool(
+    return protos.Tool(
         {
             "function_declarations": [
                 {
@@ -349,13 +349,13 @@ class GoogleGenerativeAIConversationEntity(
 
                 LOGGER.debug("Tool response: %s", function_response)
                 tool_responses.append(
-                    glm.Part(
-                        function_response=glm.FunctionResponse(
+                    protos.Part(
+                        function_response=protos.FunctionResponse(
                             name=tool_name, response=function_response
                         )
                     )
                 )
-            chat_request = glm.Content(parts=tool_responses)
+            chat_request = protos.Content(parts=tool_responses)
 
         intent_response.async_set_speech(
             " ".join([part.text.strip() for part in chat_response.parts if part.text])

--- a/homeassistant/components/google_generative_ai_conversation/manifest.json
+++ b/homeassistant/components/google_generative_ai_conversation/manifest.json
@@ -9,5 +9,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "quality_scale": "platinum",
-  "requirements": ["google-generativeai==0.5.4", "voluptuous-openapi==0.0.4"]
+  "requirements": ["google-generativeai==0.6.0", "voluptuous-openapi==0.0.4"]
 }

--- a/homeassistant/components/group/sensor.py
+++ b/homeassistant/components/group/sensor.py
@@ -36,7 +36,14 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
-from homeassistant.core import HomeAssistant, State, callback
+from homeassistant.core import (
+    CALLBACK_TYPE,
+    Event,
+    EventStateChangedData,
+    HomeAssistant,
+    State,
+    callback,
+)
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.entity import (
@@ -45,6 +52,7 @@ from homeassistant.helpers.entity import (
     get_unit_of_measurement,
 )
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.issue_registry import (
     IssueSeverity,
     async_create_issue,
@@ -329,6 +337,7 @@ class SensorGroup(GroupEntity, SensorEntity):
         self._native_unit_of_measurement = unit_of_measurement
         self._valid_units: set[str | None] = set()
         self._can_convert: bool = False
+        self.calculate_attributes_later: CALLBACK_TYPE | None = None
         self._attr_name = name
         if name == DEFAULT_NAME:
             self._attr_name = f"{DEFAULT_NAME} {sensor_type}".capitalize()
@@ -345,13 +354,32 @@ class SensorGroup(GroupEntity, SensorEntity):
 
     async def async_added_to_hass(self) -> None:
         """When added to hass."""
+        for entity_id in self._entity_ids:
+            if self.hass.states.get(entity_id) is None:
+                self.calculate_attributes_later = async_track_state_change_event(
+                    self.hass, self._entity_ids, self.calculate_state_attributes
+                )
+                break
+        if not self.calculate_attributes_later:
+            await self.calculate_state_attributes()
+        await super().async_added_to_hass()
+
+    async def calculate_state_attributes(
+        self, event: Event[EventStateChangedData] | None = None
+    ) -> None:
+        """Calculate state attributes."""
+        for entity_id in self._entity_ids:
+            if self.hass.states.get(entity_id) is None:
+                return
+        if self.calculate_attributes_later:
+            self.calculate_attributes_later()
+            self.calculate_attributes_later = None
         self._attr_state_class = self._calculate_state_class(self._state_class)
         self._attr_device_class = self._calculate_device_class(self._device_class)
         self._attr_native_unit_of_measurement = self._calculate_unit_of_measurement(
             self._native_unit_of_measurement
         )
         self._valid_units = self._get_valid_units()
-        await super().async_added_to_hass()
 
     @callback
     def async_update_group_state(self) -> None:

--- a/homeassistant/components/idasen_desk/config_flow.py
+++ b/homeassistant/components/idasen_desk/config_flow.py
@@ -64,7 +64,7 @@ class IdasenDeskConfigFlow(ConfigFlow, domain=DOMAIN):
 
             desk = Desk(None, monitor_height=False)
             try:
-                await desk.connect(discovery_info.device, auto_reconnect=False)
+                await desk.connect(discovery_info.device, retry=False)
             except AuthFailedError:
                 errors["base"] = "auth_failed"
             except TimeoutError:

--- a/homeassistant/components/imgw_pib/manifest.json
+++ b/homeassistant/components/imgw_pib/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/imgw_pib",
   "iot_class": "cloud_polling",
   "quality_scale": "platinum",
-  "requirements": ["imgw_pib==1.0.4"]
+  "requirements": ["imgw_pib==1.0.5"]
 }

--- a/homeassistant/components/nest/manifest.json
+++ b/homeassistant/components/nest/manifest.json
@@ -20,5 +20,5 @@
   "iot_class": "cloud_push",
   "loggers": ["google_nest_sdm"],
   "quality_scale": "platinum",
-  "requirements": ["google-nest-sdm==4.0.4"]
+  "requirements": ["google-nest-sdm==4.0.5"]
 }

--- a/homeassistant/components/nexia/climate.py
+++ b/homeassistant/components/nexia/climate.py
@@ -388,12 +388,12 @@ class NexiaZone(NexiaThermostatZoneEntity, ClimateEntity):
 
     async def async_turn_off(self) -> None:
         """Turn off the zone."""
-        await self.async_set_hvac_mode(OPERATION_MODE_OFF)
+        await self.async_set_hvac_mode(HVACMode.OFF)
         self._signal_zone_update()
 
     async def async_turn_on(self) -> None:
         """Turn on the zone."""
-        await self.async_set_hvac_mode(OPERATION_MODE_AUTO)
+        await self.async_set_hvac_mode(HVACMode.AUTO)
         self._signal_zone_update()
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:

--- a/homeassistant/components/openweathermap/repairs.py
+++ b/homeassistant/components/openweathermap/repairs.py
@@ -73,7 +73,7 @@ def async_create_issue(hass: HomeAssistant, entry_id: str) -> None:
         domain=DOMAIN,
         issue_id=_get_issue_id(entry_id),
         is_fixable=True,
-        is_persistent=True,
+        is_persistent=False,
         severity=ir.IssueSeverity.WARNING,
         learn_more_url="https://www.home-assistant.io/integrations/openweathermap/",
         translation_key="deprecated_v25",

--- a/homeassistant/components/opower/manifest.json
+++ b/homeassistant/components/opower/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/opower",
   "iot_class": "cloud_polling",
   "loggers": ["opower"],
-  "requirements": ["opower==0.4.6"]
+  "requirements": ["opower==0.4.7"]
 }

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -1263,6 +1263,7 @@ def _get_oldest_sum_statistic(
     main_start_time: datetime | None,
     tail_start_time: datetime | None,
     oldest_stat: datetime | None,
+    oldest_5_min_stat: datetime | None,
     tail_only: bool,
     metadata_id: int,
 ) -> float | None:
@@ -1307,6 +1308,15 @@ def _get_oldest_sum_statistic(
 
     if (
         head_start_time is not None
+        and oldest_5_min_stat is not None
+        and (
+            # If we want stats older than the short term purge window, don't lookup
+            # the oldest sum in the short term table, as it would be prioritized
+            # over older LongTermStats.
+            (oldest_stat is None)
+            or (oldest_5_min_stat < oldest_stat)
+            or (oldest_5_min_stat <= head_start_time)
+        )
         and (
             oldest_sum := _get_oldest_sum_statistic_in_sub_period(
                 session, head_start_time, StatisticsShortTerm, metadata_id
@@ -1478,12 +1488,11 @@ def statistic_during_period(
         tail_end_time: datetime | None = None
         if end_time is None:
             tail_start_time = now.replace(minute=0, second=0, microsecond=0)
+        elif tail_only:
+            tail_start_time = start_time
+            tail_end_time = end_time
         elif end_time.minute:
-            tail_start_time = (
-                start_time
-                if tail_only
-                else end_time.replace(minute=0, second=0, microsecond=0)
-            )
+            tail_start_time = end_time.replace(minute=0, second=0, microsecond=0)
             tail_end_time = end_time
 
         # Calculate the main period
@@ -1518,6 +1527,7 @@ def statistic_during_period(
                     main_start_time,
                     tail_start_time,
                     oldest_stat,
+                    oldest_5_min_stat,
                     tail_only,
                     metadata_id,
                 )

--- a/homeassistant/components/roborock/manifest.json
+++ b/homeassistant/components/roborock/manifest.json
@@ -7,7 +7,7 @@
   "iot_class": "local_polling",
   "loggers": ["roborock"],
   "requirements": [
-    "python-roborock==2.2.3",
+    "python-roborock==2.3.0",
     "vacuum-map-parser-roborock==0.1.2"
   ]
 }

--- a/homeassistant/components/samsungtv/__init__.py
+++ b/homeassistant/components/samsungtv/__init__.py
@@ -297,16 +297,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     if version == 2:
         if minor_version < 2:
             # Cleanup invalid MAC addresses - see #103512
-            dev_reg = dr.async_get(hass)
-            for device in dr.async_entries_for_config_entry(
-                dev_reg, config_entry.entry_id
-            ):
-                new_connections = device.connections.copy()
-                new_connections.discard((dr.CONNECTION_NETWORK_MAC, "none"))
-                if new_connections != device.connections:
-                    dev_reg.async_update_device(
-                        device.id, new_connections=new_connections
-                    )
+            # Reverted due to device registry collisions - see #119082 / #119249
 
             minor_version = 2
             hass.config_entries.async_update_entry(config_entry, minor_version=2)

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import contextlib
 from typing import Final
 
 from aioshelly.block_device import BlockDevice
@@ -301,13 +300,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ShellyConfigEntry) -> b
             entry, platforms
         ):
             if shelly_entry_data.rpc:
-                with contextlib.suppress(DeviceConnectionError):
-                    # If the device is restarting or has gone offline before
-                    # the ping/pong timeout happens, the shutdown command
-                    # will fail, but we don't care since we are unloading
-                    # and if we setup again, we will fix anything that is
-                    # in an inconsistent state at that time.
-                    await shelly_entry_data.rpc.shutdown()
+                await shelly_entry_data.rpc.shutdown()
 
         return unload_ok
 

--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -625,7 +625,13 @@ class ShellyRpcCoordinator(ShellyCoordinatorBase[RpcDevice]):
             if self.connected:  # Already connected
                 return
             self.connected = True
-            await self._async_run_connected_events()
+            try:
+                await self._async_run_connected_events()
+            except DeviceConnectionError as err:
+                LOGGER.error(
+                    "Error running connected events for device %s: %s", self.name, err
+                )
+                self.last_update_success = False
 
     async def _async_run_connected_events(self) -> None:
         """Run connected events.
@@ -699,10 +705,18 @@ class ShellyRpcCoordinator(ShellyCoordinatorBase[RpcDevice]):
         if self.device.connected:
             try:
                 await async_stop_scanner(self.device)
+                await super().shutdown()
             except InvalidAuthError:
                 self.entry.async_start_reauth(self.hass)
                 return
-        await super().shutdown()
+            except DeviceConnectionError as err:
+                # If the device is restarting or has gone offline before
+                # the ping/pong timeout happens, the shutdown command
+                # will fail, but we don't care since we are unloading
+                # and if we setup again, we will fix anything that is
+                # in an inconsistent state at that time.
+                LOGGER.debug("Error during shutdown for device %s: %s", self.name, err)
+                return
         await self._async_disconnected(False)
 
 

--- a/homeassistant/components/shelly/manifest.json
+++ b/homeassistant/components/shelly/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_push",
   "loggers": ["aioshelly"],
   "quality_scale": "platinum",
-  "requirements": ["aioshelly==10.0.0"],
+  "requirements": ["aioshelly==10.0.1"],
   "zeroconf": [
     {
       "type": "_http._tcp.local.",

--- a/homeassistant/components/synology_dsm/const.py
+++ b/homeassistant/components/synology_dsm/const.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from aiohttp import ClientTimeout
 from synology_dsm.api.surveillance_station.const import SNAPSHOT_PROFILE_BALANCED
 from synology_dsm.exceptions import (
     SynologyDSMAPIErrorException,
@@ -40,7 +41,7 @@ DEFAULT_PORT = 5000
 DEFAULT_PORT_SSL = 5001
 # Options
 DEFAULT_SCAN_INTERVAL = 15  # min
-DEFAULT_TIMEOUT = 30  # sec
+DEFAULT_TIMEOUT = ClientTimeout(total=60, connect=15)
 DEFAULT_SNAPSHOT_QUALITY = SNAPSHOT_PROFILE_BALANCED
 
 ENTITY_UNIT_LOAD = "load"

--- a/homeassistant/components/synology_dsm/manifest.json
+++ b/homeassistant/components/synology_dsm/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://www.home-assistant.io/integrations/synology_dsm",
   "iot_class": "local_polling",
   "loggers": ["synology_dsm"],
-  "requirements": ["py-synologydsm-api==2.4.2"],
+  "requirements": ["py-synologydsm-api==2.4.4"],
   "ssdp": [
     {
       "manufacturer": "Synology",

--- a/homeassistant/components/thethingsnetwork/manifest.json
+++ b/homeassistant/components/thethingsnetwork/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/thethingsnetwork",
   "integration_type": "hub",
   "iot_class": "cloud_polling",
-  "requirements": ["ttn_client==0.0.4"]
+  "requirements": ["ttn_client==1.0.0"]
 }

--- a/homeassistant/components/unifiprotect/__init__.py
+++ b/homeassistant/components/unifiprotect/__init__.py
@@ -6,14 +6,14 @@ from datetime import timedelta
 import logging
 
 from aiohttp.client_exceptions import ServerDisconnectedError
-from pyunifiprotect.data import Bootstrap
-from pyunifiprotect.data.types import FirmwareReleaseChannel
-from pyunifiprotect.exceptions import ClientError, NotAuthorized
+from uiprotect.data import Bootstrap
+from uiprotect.data.types import FirmwareReleaseChannel
+from uiprotect.exceptions import ClientError, NotAuthorized
 
-# Import the test_util.anonymize module from the pyunifiprotect package
+# Import the test_util.anonymize module from the uiprotect package
 # in __init__ to ensure it gets imported in the executor since the
 # diagnostics module will not be imported in the executor.
-from pyunifiprotect.test_util.anonymize import anonymize_data  # noqa: F401
+from uiprotect.test_util.anonymize import anonymize_data  # noqa: F401
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP

--- a/homeassistant/components/unifiprotect/binary_sensor.py
+++ b/homeassistant/components/unifiprotect/binary_sensor.py
@@ -6,7 +6,7 @@ import dataclasses
 import logging
 from typing import Any
 
-from pyunifiprotect.data import (
+from uiprotect.data import (
     NVR,
     Camera,
     Light,
@@ -16,7 +16,7 @@ from pyunifiprotect.data import (
     ProtectModelWithId,
     Sensor,
 )
-from pyunifiprotect.data.nvr import UOSDisk
+from uiprotect.data.nvr import UOSDisk
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,

--- a/homeassistant/components/unifiprotect/button.py
+++ b/homeassistant/components/unifiprotect/button.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 import logging
 from typing import Final
 
-from pyunifiprotect.data import ProtectAdoptableDeviceModel, ProtectModelWithId
+from uiprotect.data import ProtectAdoptableDeviceModel, ProtectModelWithId
 
 from homeassistant.components.button import (
     ButtonDeviceClass,

--- a/homeassistant/components/unifiprotect/camera.py
+++ b/homeassistant/components/unifiprotect/camera.py
@@ -6,7 +6,7 @@ from collections.abc import Generator
 import logging
 from typing import Any, cast
 
-from pyunifiprotect.data import (
+from uiprotect.data import (
     Camera as UFPCamera,
     CameraChannel,
     ModelType,

--- a/homeassistant/components/unifiprotect/config_flow.py
+++ b/homeassistant/components/unifiprotect/config_flow.py
@@ -8,9 +8,9 @@ from pathlib import Path
 from typing import Any
 
 from aiohttp import CookieJar
-from pyunifiprotect import ProtectApiClient
-from pyunifiprotect.data import NVR
-from pyunifiprotect.exceptions import ClientError, NotAuthorized
+from uiprotect import ProtectApiClient
+from uiprotect.data import NVR
+from uiprotect.exceptions import ClientError, NotAuthorized
 from unifi_discovery import async_console_is_alive
 import voluptuous as vol
 

--- a/homeassistant/components/unifiprotect/const.py
+++ b/homeassistant/components/unifiprotect/const.py
@@ -1,6 +1,6 @@
 """Constant definitions for UniFi Protect Integration."""
 
-from pyunifiprotect.data import ModelType, Version
+from uiprotect.data import ModelType, Version
 
 from homeassistant.const import Platform
 

--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -8,8 +8,8 @@ from functools import partial
 import logging
 from typing import Any, cast
 
-from pyunifiprotect import ProtectApiClient
-from pyunifiprotect.data import (
+from uiprotect import ProtectApiClient
+from uiprotect.data import (
     NVR,
     Bootstrap,
     Camera,
@@ -20,8 +20,8 @@ from pyunifiprotect.data import (
     ProtectAdoptableDeviceModel,
     WSSubscriptionMessage,
 )
-from pyunifiprotect.exceptions import ClientError, NotAuthorized
-from pyunifiprotect.utils import log_event
+from uiprotect.exceptions import ClientError, NotAuthorized
+from uiprotect.utils import log_event
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback

--- a/homeassistant/components/unifiprotect/diagnostics.py
+++ b/homeassistant/components/unifiprotect/diagnostics.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from pyunifiprotect.test_util.anonymize import anonymize_data
+from uiprotect.test_util.anonymize import anonymize_data
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant

--- a/homeassistant/components/unifiprotect/entity.py
+++ b/homeassistant/components/unifiprotect/entity.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Sequence
 import logging
 from typing import TYPE_CHECKING, Any
 
-from pyunifiprotect.data import (
+from uiprotect.data import (
     NVR,
     Camera,
     Chime,

--- a/homeassistant/components/unifiprotect/light.py
+++ b/homeassistant/components/unifiprotect/light.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pyunifiprotect.data import (
+from uiprotect.data import (
     Light,
     ModelType,
     ProtectAdoptableDeviceModel,

--- a/homeassistant/components/unifiprotect/lock.py
+++ b/homeassistant/components/unifiprotect/lock.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any, cast
 
-from pyunifiprotect.data import (
+from uiprotect.data import (
     Doorlock,
     LockStatusType,
     ModelType,

--- a/homeassistant/components/unifiprotect/manifest.json
+++ b/homeassistant/components/unifiprotect/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "unifiprotect",
   "name": "UniFi Protect",
-  "codeowners": ["@bdraco"],
+  "codeowners": [],
   "config_flow": true,
   "dependencies": ["http", "repairs"],
   "dhcp": [
@@ -40,7 +40,6 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["pyunifiprotect", "unifi_discovery"],
-  "quality_scale": "platinum",
   "requirements": ["pyunifiprotect==5.1.2", "unifi-discovery==1.1.8"],
   "ssdp": [
     {

--- a/homeassistant/components/unifiprotect/manifest.json
+++ b/homeassistant/components/unifiprotect/manifest.json
@@ -40,7 +40,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["uiprotect", "unifi_discovery"],
-  "requirements": ["uiprotect==0.4.0", "unifi-discovery==1.1.8"],
+  "requirements": ["uiprotect==0.4.1", "unifi-discovery==1.1.8"],
   "ssdp": [
     {
       "manufacturer": "Ubiquiti Networks",

--- a/homeassistant/components/unifiprotect/manifest.json
+++ b/homeassistant/components/unifiprotect/manifest.json
@@ -40,7 +40,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["uiprotect", "unifi_discovery"],
-  "requirements": ["uiprotect==0.3.9", "unifi-discovery==1.1.8"],
+  "requirements": ["uiprotect==0.4.0", "unifi-discovery==1.1.8"],
   "ssdp": [
     {
       "manufacturer": "Ubiquiti Networks",

--- a/homeassistant/components/unifiprotect/manifest.json
+++ b/homeassistant/components/unifiprotect/manifest.json
@@ -39,8 +39,8 @@
   "documentation": "https://www.home-assistant.io/integrations/unifiprotect",
   "integration_type": "hub",
   "iot_class": "local_push",
-  "loggers": ["pyunifiprotect", "unifi_discovery"],
-  "requirements": ["pyunifiprotect==5.1.2", "unifi-discovery==1.1.8"],
+  "loggers": ["uiprotect", "unifi_discovery"],
+  "requirements": ["uiprotect==0.3.9", "unifi-discovery==1.1.8"],
   "ssdp": [
     {
       "manufacturer": "Ubiquiti Networks",

--- a/homeassistant/components/unifiprotect/media_player.py
+++ b/homeassistant/components/unifiprotect/media_player.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 import logging
 from typing import Any, cast
 
-from pyunifiprotect.data import (
+from uiprotect.data import (
     Camera,
     ModelType,
     ProtectAdoptableDeviceModel,
     ProtectModelWithId,
     StateType,
 )
-from pyunifiprotect.exceptions import StreamError
+from uiprotect.exceptions import StreamError
 
 from homeassistant.components import media_source
 from homeassistant.components.media_player import (

--- a/homeassistant/components/unifiprotect/media_source.py
+++ b/homeassistant/components/unifiprotect/media_source.py
@@ -7,15 +7,9 @@ from datetime import date, datetime, timedelta
 from enum import Enum
 from typing import Any, NoReturn, cast
 
-from pyunifiprotect.data import (
-    Camera,
-    Event,
-    EventType,
-    ModelType,
-    SmartDetectObjectType,
-)
-from pyunifiprotect.exceptions import NvrError
-from pyunifiprotect.utils import from_js_time
+from uiprotect.data import Camera, Event, EventType, ModelType, SmartDetectObjectType
+from uiprotect.exceptions import NvrError
+from uiprotect.utils import from_js_time
 from yarl import URL
 
 from homeassistant.components.camera import CameraImageView

--- a/homeassistant/components/unifiprotect/migrate.py
+++ b/homeassistant/components/unifiprotect/migrate.py
@@ -6,8 +6,8 @@ from itertools import chain
 import logging
 from typing import TypedDict
 
-from pyunifiprotect import ProtectApiClient
-from pyunifiprotect.data import Bootstrap
+from uiprotect import ProtectApiClient
+from uiprotect.data import Bootstrap
 
 from homeassistant.components.automation import automations_with_entity
 from homeassistant.components.script import scripts_with_entity

--- a/homeassistant/components/unifiprotect/models.py
+++ b/homeassistant/components/unifiprotect/models.py
@@ -8,7 +8,7 @@ from enum import Enum
 import logging
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
-from pyunifiprotect.data import NVR, Event, ProtectAdoptableDeviceModel
+from uiprotect.data import NVR, Event, ProtectAdoptableDeviceModel
 
 from homeassistant.helpers.entity import EntityDescription
 

--- a/homeassistant/components/unifiprotect/number.py
+++ b/homeassistant/components/unifiprotect/number.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 import logging
 from typing import Any
 
-from pyunifiprotect.data import (
+from uiprotect.data import (
     Camera,
     Doorlock,
     Light,

--- a/homeassistant/components/unifiprotect/repairs.py
+++ b/homeassistant/components/unifiprotect/repairs.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from typing import cast
 
-from pyunifiprotect import ProtectApiClient
-from pyunifiprotect.data import Bootstrap, Camera, ModelType
-from pyunifiprotect.data.types import FirmwareReleaseChannel
+from uiprotect import ProtectApiClient
+from uiprotect.data import Bootstrap, Camera, ModelType
+from uiprotect.data.types import FirmwareReleaseChannel
 import voluptuous as vol
 
 from homeassistant import data_entry_flow

--- a/homeassistant/components/unifiprotect/select.py
+++ b/homeassistant/components/unifiprotect/select.py
@@ -8,8 +8,8 @@ from enum import Enum
 import logging
 from typing import Any, Final
 
-from pyunifiprotect.api import ProtectApiClient
-from pyunifiprotect.data import (
+from uiprotect.api import ProtectApiClient
+from uiprotect.data import (
     Camera,
     ChimeType,
     DoorbellMessageType,

--- a/homeassistant/components/unifiprotect/sensor.py
+++ b/homeassistant/components/unifiprotect/sensor.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import logging
 from typing import Any, cast
 
-from pyunifiprotect.data import (
+from uiprotect.data import (
     NVR,
     Camera,
     Light,

--- a/homeassistant/components/unifiprotect/services.py
+++ b/homeassistant/components/unifiprotect/services.py
@@ -7,9 +7,9 @@ import functools
 from typing import Any, cast
 
 from pydantic import ValidationError
-from pyunifiprotect.api import ProtectApiClient
-from pyunifiprotect.data import Camera, Chime
-from pyunifiprotect.exceptions import ClientError
+from uiprotect.api import ProtectApiClient
+from uiprotect.data import Camera, Chime
+from uiprotect.exceptions import ClientError
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass

--- a/homeassistant/components/unifiprotect/switch.py
+++ b/homeassistant/components/unifiprotect/switch.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 import logging
 from typing import Any
 
-from pyunifiprotect.data import (
+from uiprotect.data import (
     NVR,
     Camera,
     ProtectAdoptableDeviceModel,

--- a/homeassistant/components/unifiprotect/text.py
+++ b/homeassistant/components/unifiprotect/text.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from pyunifiprotect.data import (
+from uiprotect.data import (
     Camera,
     DoorbellMessageType,
     ProtectAdoptableDeviceModel,

--- a/homeassistant/components/unifiprotect/utils.py
+++ b/homeassistant/components/unifiprotect/utils.py
@@ -10,8 +10,8 @@ import socket
 from typing import Any
 
 from aiohttp import CookieJar
-from pyunifiprotect import ProtectApiClient
-from pyunifiprotect.data import (
+from uiprotect import ProtectApiClient
+from uiprotect.data import (
     Bootstrap,
     CameraChannel,
     Light,

--- a/homeassistant/components/unifiprotect/views.py
+++ b/homeassistant/components/unifiprotect/views.py
@@ -9,8 +9,8 @@ from typing import Any
 from urllib.parse import urlencode
 
 from aiohttp import web
-from pyunifiprotect.data import Camera, Event
-from pyunifiprotect.exceptions import ClientError
+from uiprotect.data import Camera, Event
+from uiprotect.exceptions import ClientError
 
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.core import HomeAssistant, callback

--- a/homeassistant/components/waqi/manifest.json
+++ b/homeassistant/components/waqi/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/waqi",
   "iot_class": "cloud_polling",
   "loggers": ["aiowaqi"],
-  "requirements": ["aiowaqi==3.0.1"]
+  "requirements": ["aiowaqi==3.1.0"]
 }

--- a/homeassistant/components/workday/binary_sensor.py
+++ b/homeassistant/components/workday/binary_sensor.py
@@ -269,7 +269,7 @@ class IsWorkdaySensor(BinarySensorEntity):
 
     def _update_state_and_setup_listener(self) -> None:
         """Update state and setup listener for next interval."""
-        now = dt_util.utcnow()
+        now = dt_util.now()
         self.update_data(now)
         self.unsub = async_track_point_in_utc_time(
             self.hass, self.point_in_time_listener, self.get_next_interval(now)

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2024
 MINOR_VERSION: Final = 6
-PATCH_VERSION: Final = "1"
+PATCH_VERSION: Final = "2"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 12, 0)

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
+from functools import cache, partial
 from typing import Any
 
+import slugify as unicode_slug
 import voluptuous as vol
 
 from homeassistant.components.climate.intent import INTENT_GET_TEMPERATURE
@@ -175,10 +177,11 @@ class IntentTool(Tool):
 
     def __init__(
         self,
+        name: str,
         intent_handler: intent.IntentHandler,
     ) -> None:
         """Init the class."""
-        self.name = intent_handler.intent_type
+        self.name = name
         self.description = (
             intent_handler.description or f"Execute Home Assistant {self.name} intent"
         )
@@ -260,6 +263,9 @@ class AssistAPI(API):
             hass=hass,
             id=LLM_API_ASSIST,
             name="Assist",
+        )
+        self.cached_slugify = cache(
+            partial(unicode_slug.slugify, separator="_", lowercase=False)
         )
 
     async def async_get_api_instance(self, llm_context: LLMContext) -> APIInstance:
@@ -373,7 +379,10 @@ class AssistAPI(API):
                 or intent_handler.platforms & exposed_domains
             ]
 
-        return [IntentTool(intent_handler) for intent_handler in intent_handlers]
+        return [
+            IntentTool(self.cached_slugify(intent_handler.intent_type), intent_handler)
+            for intent_handler in intent_handlers
+        ]
 
 
 def _get_exposed_entities(

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -1758,10 +1758,6 @@ class Script:
             # runs before sleeping as otherwise if two runs are started at the exact
             # same time they will cancel each other out.
             self._log("Restarting")
-            # Important: yield to the event loop to allow the script to start in case
-            # the script is restarting itself so it ends up in the script stack and
-            # the recursion check above will prevent the script from running.
-            await asyncio.sleep(0)
             await self.async_stop(update_state=False, spare=run)
 
         if started_action:

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -32,7 +32,7 @@ habluetooth==3.1.1
 hass-nabucasa==0.81.1
 hassil==1.7.1
 home-assistant-bluetooth==1.12.0
-home-assistant-frontend==20240605.0
+home-assistant-frontend==20240610.0
 home-assistant-intents==2024.6.5
 httpx==0.27.0
 ifaddr==0.2.0

--- a/mypy.ini
+++ b/mypy.ini
@@ -1393,16 +1393,6 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
-[mypy-homeassistant.components.electrasmart.*]
-check_untyped_defs = true
-disallow_incomplete_defs = true
-disallow_subclassing_any = true
-disallow_untyped_calls = true
-disallow_untyped_decorators = true
-disallow_untyped_defs = true
-warn_return_any = true
-warn_unreachable = true
-
 [mypy-homeassistant.components.electric_kiwi.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "homeassistant"
-version     = "2024.6.1"
+version     = "2024.6.2"
 license     = {text = "Apache-2.0"}
 description = "Open-source home automation platform running on Python 3."
 readme      = "README.rst"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1670,7 +1670,7 @@ pyControl4==1.1.0
 pyDuotecno==2024.5.1
 
 # homeassistant.components.electrasmart
-pyElectra==1.2.0
+pyElectra==1.2.1
 
 # homeassistant.components.emby
 pyEmby==1.9

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2306,7 +2306,7 @@ python-rabbitair==0.0.8
 python-ripple-api==0.0.3
 
 # homeassistant.components.roborock
-python-roborock==2.2.3
+python-roborock==2.3.0
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.36

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -974,7 +974,7 @@ google-cloud-pubsub==2.13.11
 google-cloud-texttospeech==2.12.3
 
 # homeassistant.components.google_generative_ai_conversation
-google-generativeai==0.5.4
+google-generativeai==0.6.0
 
 # homeassistant.components.nest
 google-nest-sdm==4.0.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -912,7 +912,7 @@ fyta_cli==0.4.1
 gTTS==2.2.4
 
 # homeassistant.components.gardena_bluetooth
-gardena-bluetooth==1.4.1
+gardena-bluetooth==1.4.2
 
 # homeassistant.components.google_assistant_sdk
 gassist-text==0.0.11

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2779,7 +2779,7 @@ twitchAPI==4.0.0
 uasiren==0.0.1
 
 # homeassistant.components.unifiprotect
-uiprotect==0.3.9
+uiprotect==0.4.0
 
 # homeassistant.components.landisgyr_heat_meter
 ultraheat-api==0.5.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -389,7 +389,7 @@ aiovlc==0.3.2
 aiovodafone==0.6.0
 
 # homeassistant.components.waqi
-aiowaqi==3.0.1
+aiowaqi==3.1.0
 
 # homeassistant.components.watttime
 aiowatttime==0.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -955,7 +955,7 @@ gios==4.0.0
 gitterpy==0.1.7
 
 # homeassistant.components.glances
-glances-api==0.7.0
+glances-api==0.8.0
 
 # homeassistant.components.goalzero
 goalzero==0.2.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2357,9 +2357,6 @@ pytrydan==0.6.1
 # homeassistant.components.usb
 pyudev==0.24.1
 
-# homeassistant.components.unifiprotect
-pyunifiprotect==5.1.2
-
 # homeassistant.components.uptimerobot
 pyuptimerobot==22.2.0
 
@@ -2780,6 +2777,9 @@ twitchAPI==4.0.0
 
 # homeassistant.components.ukraine_alarm
 uasiren==0.0.1
+
+# homeassistant.components.unifiprotect
+uiprotect==0.3.9
 
 # homeassistant.components.landisgyr_heat_meter
 ultraheat-api==0.5.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2779,7 +2779,7 @@ twitchAPI==4.0.0
 uasiren==0.0.1
 
 # homeassistant.components.unifiprotect
-uiprotect==0.4.0
+uiprotect==0.4.1
 
 # homeassistant.components.landisgyr_heat_meter
 ultraheat-api==0.5.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -353,7 +353,7 @@ aioruuvigateway==0.1.0
 aiosenz==1.0.0
 
 # homeassistant.components.shelly
-aioshelly==10.0.0
+aioshelly==10.0.1
 
 # homeassistant.components.skybell
 aioskybell==22.7.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1146,7 +1146,7 @@ iglo==1.2.7
 ihcsdk==2.8.5
 
 # homeassistant.components.imgw_pib
-imgw_pib==1.0.4
+imgw_pib==1.0.5
 
 # homeassistant.components.incomfort
 incomfort-client==0.5.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1649,7 +1649,7 @@ py-schluter==0.1.7
 py-sucks==0.9.10
 
 # homeassistant.components.synology_dsm
-py-synologydsm-api==2.4.2
+py-synologydsm-api==2.4.4
 
 # homeassistant.components.zabbix
 py-zabbix==1.1.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1087,7 +1087,7 @@ hole==0.8.0
 holidays==0.50
 
 # homeassistant.components.frontend
-home-assistant-frontend==20240605.0
+home-assistant-frontend==20240610.0
 
 # homeassistant.components.conversation
 home-assistant-intents==2024.6.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -977,7 +977,7 @@ google-cloud-texttospeech==2.12.3
 google-generativeai==0.6.0
 
 # homeassistant.components.nest
-google-nest-sdm==4.0.4
+google-nest-sdm==4.0.5
 
 # homeassistant.components.google_travel_time
 googlemaps==2.5.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1501,7 +1501,7 @@ openwrt-luci-rpc==1.1.17
 openwrt-ubus-rpc==0.0.2
 
 # homeassistant.components.opower
-opower==0.4.6
+opower==0.4.7
 
 # homeassistant.components.oralb
 oralb-ble==0.17.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2764,7 +2764,7 @@ transmission-rpc==7.0.3
 ttls==1.5.1
 
 # homeassistant.components.thethingsnetwork
-ttn_client==0.0.4
+ttn_client==1.0.0
 
 # homeassistant.components.tuya
 tuya-device-sharing-sdk==0.1.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -800,7 +800,7 @@ google-api-python-client==2.71.0
 google-cloud-pubsub==2.13.11
 
 # homeassistant.components.google_generative_ai_conversation
-google-generativeai==0.5.4
+google-generativeai==0.6.0
 
 # homeassistant.components.nest
 google-nest-sdm==4.0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -889,7 +889,7 @@ hole==0.8.0
 holidays==0.50
 
 # homeassistant.components.frontend
-home-assistant-frontend==20240605.0
+home-assistant-frontend==20240610.0
 
 # homeassistant.components.conversation
 home-assistant-intents==2024.6.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1311,7 +1311,7 @@ py-nightscout==1.2.2
 py-sucks==0.9.10
 
 # homeassistant.components.synology_dsm
-py-synologydsm-api==2.4.2
+py-synologydsm-api==2.4.4
 
 # homeassistant.components.seventeentrack
 py17track==2021.12.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1326,7 +1326,7 @@ pyControl4==1.1.0
 pyDuotecno==2024.5.1
 
 # homeassistant.components.electrasmart
-pyElectra==1.2.0
+pyElectra==1.2.1
 
 # homeassistant.components.rfxtrx
 pyRFXtrx==0.31.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -803,7 +803,7 @@ google-cloud-pubsub==2.13.11
 google-generativeai==0.6.0
 
 # homeassistant.components.nest
-google-nest-sdm==4.0.4
+google-nest-sdm==4.0.5
 
 # homeassistant.components.google_travel_time
 googlemaps==2.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2153,7 +2153,7 @@ twitchAPI==4.0.0
 uasiren==0.0.1
 
 # homeassistant.components.unifiprotect
-uiprotect==0.4.0
+uiprotect==0.4.1
 
 # homeassistant.components.landisgyr_heat_meter
 ultraheat-api==0.5.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1201,7 +1201,7 @@ openhomedevice==2.2.0
 openwebifpy==4.2.4
 
 # homeassistant.components.opower
-opower==0.4.6
+opower==0.4.7
 
 # homeassistant.components.oralb
 oralb-ble==0.17.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -747,7 +747,7 @@ fyta_cli==0.4.1
 gTTS==2.2.4
 
 # homeassistant.components.gardena_bluetooth
-gardena-bluetooth==1.4.1
+gardena-bluetooth==1.4.2
 
 # homeassistant.components.google_assistant_sdk
 gassist-text==0.0.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1836,9 +1836,6 @@ pytrydan==0.6.1
 # homeassistant.components.usb
 pyudev==0.24.1
 
-# homeassistant.components.unifiprotect
-pyunifiprotect==5.1.2
-
 # homeassistant.components.uptimerobot
 pyuptimerobot==22.2.0
 
@@ -2154,6 +2151,9 @@ twitchAPI==4.0.0
 
 # homeassistant.components.ukraine_alarm
 uasiren==0.0.1
+
+# homeassistant.components.unifiprotect
+uiprotect==0.3.9
 
 # homeassistant.components.landisgyr_heat_meter
 ultraheat-api==0.5.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -933,7 +933,7 @@ idasen-ha==2.5.3
 ifaddr==0.2.0
 
 # homeassistant.components.imgw_pib
-imgw_pib==1.0.4
+imgw_pib==1.0.5
 
 # homeassistant.components.influxdb
 influxdb-client==1.24.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1794,7 +1794,7 @@ python-qbittorrent==0.4.3
 python-rabbitair==0.0.8
 
 # homeassistant.components.roborock
-python-roborock==2.2.3
+python-roborock==2.3.0
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.36

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -326,7 +326,7 @@ aioruuvigateway==0.1.0
 aiosenz==1.0.0
 
 # homeassistant.components.shelly
-aioshelly==10.0.0
+aioshelly==10.0.1
 
 # homeassistant.components.skybell
 aioskybell==22.7.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2138,7 +2138,7 @@ transmission-rpc==7.0.3
 ttls==1.5.1
 
 # homeassistant.components.thethingsnetwork
-ttn_client==0.0.4
+ttn_client==1.0.0
 
 # homeassistant.components.tuya
 tuya-device-sharing-sdk==0.1.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -362,7 +362,7 @@ aiovlc==0.3.2
 aiovodafone==0.6.0
 
 # homeassistant.components.waqi
-aiowaqi==3.0.1
+aiowaqi==3.1.0
 
 # homeassistant.components.watttime
 aiowatttime==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2153,7 +2153,7 @@ twitchAPI==4.0.0
 uasiren==0.0.1
 
 # homeassistant.components.unifiprotect
-uiprotect==0.3.9
+uiprotect==0.4.0
 
 # homeassistant.components.landisgyr_heat_meter
 ultraheat-api==0.5.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -784,7 +784,7 @@ getmac==0.9.4
 gios==4.0.0
 
 # homeassistant.components.glances
-glances-api==0.7.0
+glances-api==0.8.0
 
 # homeassistant.components.goalzero
 goalzero==0.2.2

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -30,7 +30,6 @@ PIP_VERSION_RANGE_SEPARATOR = re.compile(r"^(==|>=|<=|~=|!=|<|>|===)?(.*)$")
 
 IGNORE_STANDARD_LIBRARY_VIOLATIONS = {
     # Integrations which have standard library requirements.
-    "electrasmart",
     "slide",
     "suez_water",
 }

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -2771,6 +2771,7 @@ async def test_recursive_automation_starting_script(
                     ],
                     "action": [
                         {"service": "test.automation_started"},
+                        {"delay": 0.001},
                         {"service": "script.script1"},
                     ],
                 }
@@ -2817,7 +2818,10 @@ async def test_recursive_automation_starting_script(
         assert script_warning_msg in caplog.text
 
 
-@pytest.mark.parametrize("automation_mode", SCRIPT_MODE_CHOICES)
+@pytest.mark.parametrize(
+    "automation_mode",
+    [mode for mode in SCRIPT_MODE_CHOICES if mode != SCRIPT_MODE_RESTART],
+)
 @pytest.mark.parametrize("wait_for_stop_scripts_after_shutdown", [True])
 async def test_recursive_automation(
     hass: HomeAssistant, automation_mode, caplog: pytest.LogCaptureFixture
@@ -2865,6 +2869,68 @@ async def test_recursive_automation(
 
         hass.bus.async_fire("trigger_automation")
         await asyncio.wait_for(service_called.wait(), 1)
+
+        # Trigger 1st stage script shutdown
+        hass.set_state(CoreState.stopping)
+        hass.bus.async_fire("homeassistant_stop")
+        await asyncio.wait_for(stop_scripts_at_shutdown_called.wait(), 1)
+
+        # Trigger 2nd stage script shutdown
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=90))
+        await hass.async_block_till_done()
+
+        assert "Disallowed recursion detected" not in caplog.text
+
+
+@pytest.mark.parametrize("wait_for_stop_scripts_after_shutdown", [True])
+async def test_recursive_automation_restart_mode(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test automation restarting itself.
+
+    The automation is an infinite loop since it keeps restarting itself
+
+    - Illegal recursion detection should not be triggered
+    - Home Assistant should not hang on shut down
+    """
+    stop_scripts_at_shutdown_called = asyncio.Event()
+    real_stop_scripts_at_shutdown = _async_stop_scripts_at_shutdown
+
+    async def stop_scripts_at_shutdown(*args):
+        await real_stop_scripts_at_shutdown(*args)
+        stop_scripts_at_shutdown_called.set()
+
+    with patch(
+        "homeassistant.helpers.script._async_stop_scripts_at_shutdown",
+        wraps=stop_scripts_at_shutdown,
+    ):
+        assert await async_setup_component(
+            hass,
+            automation.DOMAIN,
+            {
+                automation.DOMAIN: {
+                    "mode": SCRIPT_MODE_RESTART,
+                    "trigger": [
+                        {"platform": "event", "event_type": "trigger_automation"},
+                    ],
+                    "action": [
+                        {"event": "trigger_automation"},
+                        {"service": "test.automation_done"},
+                    ],
+                }
+            },
+        )
+
+        service_called = asyncio.Event()
+
+        async def async_service_handler(service):
+            if service.service == "automation_done":
+                service_called.set()
+
+        hass.services.async_register("test", "automation_done", async_service_handler)
+
+        hass.bus.async_fire("trigger_automation")
+        await asyncio.sleep(0)
 
         # Trigger 1st stage script shutdown
         hass.set_state(CoreState.stopping)
@@ -3097,3 +3163,72 @@ async def test_two_automations_call_restart_script_same_time(
     await hass.async_block_till_done()
     assert len(events) == 2
     cancel()
+
+
+async def test_two_automation_call_restart_script_right_after_each_other(
+    hass: HomeAssistant,
+) -> None:
+    """Test two automations call a restart script right after each other."""
+
+    events = async_capture_events(hass, "repeat_test_script_finished")
+
+    assert await async_setup_component(
+        hass,
+        input_boolean.DOMAIN,
+        {
+            input_boolean.DOMAIN: {
+                "test_1": None,
+                "test_2": None,
+            }
+        },
+    )
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "state",
+                        "entity_id": ["input_boolean.test_1", "input_boolean.test_1"],
+                        "from": "off",
+                        "to": "on",
+                    },
+                    "action": [
+                        {
+                            "repeat": {
+                                "count": 2,
+                                "sequence": [
+                                    {
+                                        "delay": {
+                                            "hours": 0,
+                                            "minutes": 0,
+                                            "seconds": 0,
+                                            "milliseconds": 100,
+                                        }
+                                    }
+                                ],
+                            }
+                        },
+                        {"event": "repeat_test_script_finished", "event_data": {}},
+                    ],
+                    "id": "automation_0",
+                    "mode": "restart",
+                },
+            ]
+        },
+    )
+    hass.states.async_set("input_boolean.test_1", "off")
+    hass.states.async_set("input_boolean.test_2", "off")
+    await hass.async_block_till_done()
+    hass.states.async_set("input_boolean.test_1", "on")
+    hass.states.async_set("input_boolean.test_2", "on")
+    await asyncio.sleep(0)
+    hass.states.async_set("input_boolean.test_1", "off")
+    hass.states.async_set("input_boolean.test_2", "off")
+    await asyncio.sleep(0)
+    hass.states.async_set("input_boolean.test_1", "on")
+    hass.states.async_set("input_boolean.test_2", "on")
+    await hass.async_block_till_done()
+    assert len(events) == 1

--- a/tests/components/azure_data_explorer/const.py
+++ b/tests/components/azure_data_explorer/const.py
@@ -8,7 +8,7 @@ from homeassistant.components.azure_data_explorer.const import (
     CONF_APP_REG_SECRET,
     CONF_AUTHORITY_ID,
     CONF_SEND_INTERVAL,
-    CONF_USE_FREE,
+    CONF_USE_QUEUED_CLIENT,
 )
 
 AZURE_DATA_EXPLORER_PATH = "homeassistant.components.azure_data_explorer"
@@ -29,7 +29,7 @@ BASE_CONFIG_URI = {
 }
 
 BASIC_OPTIONS = {
-    CONF_USE_FREE: False,
+    CONF_USE_QUEUED_CLIENT: False,
     CONF_SEND_INTERVAL: 5,
 }
 
@@ -39,10 +39,10 @@ BASE_CONFIG_FULL = BASE_CONFIG | BASIC_OPTIONS | BASE_CONFIG_URI
 
 BASE_CONFIG_IMPORT = {
     CONF_ADX_CLUSTER_INGEST_URI: "https://cluster.region.kusto.windows.net",
-    CONF_USE_FREE: False,
+    CONF_USE_QUEUED_CLIENT: False,
     CONF_SEND_INTERVAL: 5,
 }
 
-FREE_OPTIONS = {CONF_USE_FREE: True, CONF_SEND_INTERVAL: 5}
+FREE_OPTIONS = {CONF_USE_QUEUED_CLIENT: True, CONF_SEND_INTERVAL: 5}
 
 BASE_CONFIG_FREE = BASE_CONFIG | FREE_OPTIONS

--- a/tests/components/elgato/fixtures/light-strip/info.json
+++ b/tests/components/elgato/fixtures/light-strip/info.json
@@ -1,5 +1,5 @@
 {
-  "productName": "Elgato Key Light",
+  "productName": "Elgato Light Strip",
   "hardwareBoardType": 53,
   "firmwareBuildNumber": 192,
   "firmwareVersion": "1.0.3",

--- a/tests/components/elgato/snapshots/test_light.ambr
+++ b/tests/components/elgato/snapshots/test_light.ambr
@@ -218,7 +218,7 @@
     'labels': set({
     }),
     'manufacturer': 'Elgato',
-    'model': 'Elgato Key Light',
+    'model': 'Elgato Light Strip',
     'name': 'Frenck',
     'name_by_user': None,
     'serial_number': 'CN11A1A00001',
@@ -333,7 +333,7 @@
     'labels': set({
     }),
     'manufacturer': 'Elgato',
-    'model': 'Elgato Key Light',
+    'model': 'Elgato Light Strip',
     'name': 'Frenck',
     'name_by_user': None,
     'serial_number': 'CN11A1A00001',

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1931,7 +1931,10 @@ async def test_arm_disarm_disarm(hass: HomeAssistant) -> None:
         }
     }
 
-    assert trt.query_attributes() == {"isArmed": False}
+    assert trt.query_attributes() == {
+        "currentArmLevel": "armed_custom_bypass",
+        "isArmed": False,
+    }
 
     assert trt.can_execute(trait.COMMAND_ARMDISARM, {"arm": False})
 

--- a/tests/components/google_generative_ai_conversation/test_conversation.py
+++ b/tests/components/google_generative_ai_conversation/test_conversation.py
@@ -12,6 +12,9 @@ import voluptuous as vol
 
 from homeassistant.components import conversation
 from homeassistant.components.conversation import trace
+from homeassistant.components.google_generative_ai_conversation.conversation import (
+    _escape_decode,
+)
 from homeassistant.const import CONF_LLM_HASS_API
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -504,3 +507,18 @@ async def test_conversation_agent(
         mock_config_entry.entry_id
     )
     assert agent.supported_languages == "*"
+
+
+async def test_escape_decode() -> None:
+    """Test _escape_decode."""
+    assert _escape_decode(
+        {
+            "param1": ["test_value", "param1\\'s value"],
+            "param2": "param2\\'s value",
+            "param3": {"param31": "Cheminée", "param32": "Chemin\\303\\251e"},
+        }
+    ) == {
+        "param1": ["test_value", "param1's value"],
+        "param2": "param2's value",
+        "param3": {"param31": "Cheminée", "param32": "Cheminée"},
+    }

--- a/tests/components/group/test_sensor.py
+++ b/tests/components/group/test_sensor.py
@@ -763,3 +763,52 @@ async def test_last_sensor(hass: HomeAssistant) -> None:
         state = hass.states.get("sensor.test_last")
         assert str(float(value)) == state.state
         assert entity_id == state.attributes.get("last_entity_id")
+
+
+async def test_sensors_attributes_added_when_entity_info_available(
+    hass: HomeAssistant,
+) -> None:
+    """Test the sensor calculate attributes once all entities attributes are available."""
+    config = {
+        SENSOR_DOMAIN: {
+            "platform": GROUP_DOMAIN,
+            "name": DEFAULT_NAME,
+            "type": "sum",
+            "entities": ["sensor.test_1", "sensor.test_2", "sensor.test_3"],
+            "unique_id": "very_unique_id",
+        }
+    }
+
+    entity_ids = config["sensor"]["entities"]
+
+    assert await async_setup_component(hass, "sensor", config)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.sensor_group_sum")
+
+    assert state.state == STATE_UNAVAILABLE
+    assert state.attributes.get(ATTR_ENTITY_ID) is None
+    assert state.attributes.get(ATTR_DEVICE_CLASS) is None
+    assert state.attributes.get(ATTR_STATE_CLASS) is None
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) is None
+
+    for entity_id, value in dict(zip(entity_ids, VALUES, strict=False)).items():
+        hass.states.async_set(
+            entity_id,
+            value,
+            {
+                ATTR_DEVICE_CLASS: SensorDeviceClass.VOLUME,
+                ATTR_STATE_CLASS: SensorStateClass.TOTAL,
+                ATTR_UNIT_OF_MEASUREMENT: "L",
+            },
+        )
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.sensor_group_sum")
+
+    assert float(state.state) == pytest.approx(float(SUM_VALUE))
+    assert state.attributes.get(ATTR_ENTITY_ID) == entity_ids
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.VOLUME
+    assert state.attributes.get(ATTR_ICON) is None
+    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.TOTAL
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "L"

--- a/tests/components/idasen_desk/test_config_flow.py
+++ b/tests/components/idasen_desk/test_config_flow.py
@@ -305,4 +305,4 @@ async def test_bluetooth_step_success(hass: HomeAssistant) -> None:
     }
     assert result2["result"].unique_id == IDASEN_DISCOVERY_INFO.address
     assert len(mock_setup_entry.mock_calls) == 1
-    desk_connect.assert_called_with(ANY, auto_reconnect=False)
+    desk_connect.assert_called_with(ANY, retry=False)

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -794,6 +794,334 @@ async def test_statistic_during_period_hole(
     }
 
 
+@pytest.mark.freeze_time(datetime.datetime(2022, 10, 21, 6, 31, tzinfo=datetime.UTC))
+async def test_statistic_during_period_partial_overlap(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test statistic_during_period."""
+    now = dt_util.utcnow()
+
+    await async_recorder_block_till_done(hass)
+    client = await hass_ws_client()
+
+    zero = now
+    start = zero.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    # Sum shall be tracking a hypothetical sensor that is 0 at midnight, and grows by 1 per minute.
+    # The test will have 4 hours of LTS-only data (0:00-3:59:59), followed by 2 hours of overlapping STS/LTS (4:00-5:59:59), followed by 30 minutes of STS only (6:00-6:29:59)
+    # similar to how a real recorder might look after purging STS.
+
+    # The datapoint at i=0 (start = 0:00) will be 60 as that is the growth during the hour starting at the start period
+    imported_stats_hours = [
+        {
+            "start": (start + timedelta(hours=i)),
+            "min": i * 60,
+            "max": i * 60 + 60,
+            "mean": i * 60 + 30,
+            "sum": (i + 1) * 60,
+        }
+        for i in range(6)
+    ]
+
+    # The datapoint at i=0 (start = 4:00) would be the sensor's value at t=4:05, or 245
+    imported_stats_5min = [
+        {
+            "start": (start + timedelta(hours=4, minutes=5 * i)),
+            "min": 4 * 60 + i * 5,
+            "max": 4 * 60 + i * 5 + 5,
+            "mean": 4 * 60 + i * 5 + 2.5,
+            "sum": 4 * 60 + (i + 1) * 5,
+        }
+        for i in range(30)
+    ]
+
+    assert imported_stats_hours[-1]["sum"] == 360
+    assert imported_stats_hours[-1]["start"] == start.replace(
+        hour=5, minute=0, second=0, microsecond=0
+    )
+    assert imported_stats_5min[-1]["sum"] == 390
+    assert imported_stats_5min[-1]["start"] == start.replace(
+        hour=6, minute=25, second=0, microsecond=0
+    )
+
+    statId = "sensor.test_overlapping"
+    imported_metadata = {
+        "has_mean": False,
+        "has_sum": True,
+        "name": "Total imported energy overlapping",
+        "source": "recorder",
+        "statistic_id": statId,
+        "unit_of_measurement": "kWh",
+    }
+
+    recorder.get_instance(hass).async_import_statistics(
+        imported_metadata,
+        imported_stats_hours,
+        Statistics,
+    )
+    recorder.get_instance(hass).async_import_statistics(
+        imported_metadata,
+        imported_stats_5min,
+        StatisticsShortTerm,
+    )
+    await async_wait_recording_done(hass)
+
+    metadata = get_metadata(hass, statistic_ids={statId})
+    metadata_id = metadata[statId][0]
+    run_cache = get_short_term_statistics_run_cache(hass)
+    # Verify the import of the short term statistics
+    # also updates the run cache
+    assert run_cache.get_latest_ids({metadata_id}) is not None
+
+    # Get all the stats, should consider all hours and 5mins
+    await client.send_json_auto_id(
+        {
+            "type": "recorder/statistic_during_period",
+            "statistic_id": statId,
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    assert response["result"] == {
+        "change": 390,
+        "max": 390,
+        "min": 0,
+        "mean": 195,
+    }
+
+    async def assert_stat_during_fixed(client, start_time, end_time, expect):
+        json = {
+            "type": "recorder/statistic_during_period",
+            "types": list(expect.keys()),
+            "statistic_id": statId,
+            "fixed_period": {},
+        }
+        if start_time:
+            json["fixed_period"]["start_time"] = start_time.isoformat()
+        if end_time:
+            json["fixed_period"]["end_time"] = end_time.isoformat()
+
+        await client.send_json_auto_id(json)
+        response = await client.receive_json()
+        assert response["success"]
+        assert response["result"] == expect
+
+    # One hours worth of growth in LTS-only
+    start_time = start.replace(hour=1)
+    end_time = start.replace(hour=2)
+    await assert_stat_during_fixed(
+        client, start_time, end_time, {"change": 60, "min": 60, "max": 120, "mean": 90}
+    )
+
+    # Five minutes of growth in STS-only
+    start_time = start.replace(hour=6, minute=15)
+    end_time = start.replace(hour=6, minute=20)
+    await assert_stat_during_fixed(
+        client,
+        start_time,
+        end_time,
+        {
+            "change": 5,
+            "min": 6 * 60 + 15,
+            "max": 6 * 60 + 20,
+            "mean": 6 * 60 + (15 + 20) / 2,
+        },
+    )
+
+    # Six minutes of growth in STS-only
+    start_time = start.replace(hour=6, minute=14)
+    end_time = start.replace(hour=6, minute=20)
+    await assert_stat_during_fixed(
+        client,
+        start_time,
+        end_time,
+        {
+            "change": 5,
+            "min": 6 * 60 + 15,
+            "max": 6 * 60 + 20,
+            "mean": 6 * 60 + (15 + 20) / 2,
+        },
+    )
+
+    # Six minutes of growth in STS-only
+    # 5-minute Change includes start times exactly on or before a statistics start, but end times are not counted unless they are greater than start.
+    start_time = start.replace(hour=6, minute=15)
+    end_time = start.replace(hour=6, minute=21)
+    await assert_stat_during_fixed(
+        client,
+        start_time,
+        end_time,
+        {
+            "change": 10,
+            "min": 6 * 60 + 15,
+            "max": 6 * 60 + 25,
+            "mean": 6 * 60 + (15 + 25) / 2,
+        },
+    )
+
+    # Five minutes of growth in overlapping LTS+STS
+    start_time = start.replace(hour=5, minute=15)
+    end_time = start.replace(hour=5, minute=20)
+    await assert_stat_during_fixed(
+        client,
+        start_time,
+        end_time,
+        {
+            "change": 5,
+            "min": 5 * 60 + 15,
+            "max": 5 * 60 + 20,
+            "mean": 5 * 60 + (15 + 20) / 2,
+        },
+    )
+
+    # Five minutes of growth in overlapping LTS+STS (start of hour)
+    start_time = start.replace(hour=5, minute=0)
+    end_time = start.replace(hour=5, minute=5)
+    await assert_stat_during_fixed(
+        client,
+        start_time,
+        end_time,
+        {"change": 5, "min": 5 * 60, "max": 5 * 60 + 5, "mean": 5 * 60 + (5) / 2},
+    )
+
+    # Five minutes of growth in overlapping LTS+STS (end of hour)
+    start_time = start.replace(hour=4, minute=55)
+    end_time = start.replace(hour=5, minute=0)
+    await assert_stat_during_fixed(
+        client,
+        start_time,
+        end_time,
+        {
+            "change": 5,
+            "min": 4 * 60 + 55,
+            "max": 5 * 60,
+            "mean": 4 * 60 + (55 + 60) / 2,
+        },
+    )
+
+    # Five minutes of growth in STS-only, with a minute offset. Despite that this does not cover the full period, result is still 5
+    start_time = start.replace(hour=6, minute=16)
+    end_time = start.replace(hour=6, minute=21)
+    await assert_stat_during_fixed(
+        client,
+        start_time,
+        end_time,
+        {
+            "change": 5,
+            "min": 6 * 60 + 20,
+            "max": 6 * 60 + 25,
+            "mean": 6 * 60 + (20 + 25) / 2,
+        },
+    )
+
+    # 7 minutes of growth in STS-only, spanning two intervals
+    start_time = start.replace(hour=6, minute=14)
+    end_time = start.replace(hour=6, minute=21)
+    await assert_stat_during_fixed(
+        client,
+        start_time,
+        end_time,
+        {
+            "change": 10,
+            "min": 6 * 60 + 15,
+            "max": 6 * 60 + 25,
+            "mean": 6 * 60 + (15 + 25) / 2,
+        },
+    )
+
+    # One hours worth of growth in LTS-only, with arbitrary minute offsets
+    # Since this does not fully cover the hour, result is None?
+    start_time = start.replace(hour=1, minute=40)
+    end_time = start.replace(hour=2, minute=12)
+    await assert_stat_during_fixed(
+        client,
+        start_time,
+        end_time,
+        {"change": None, "min": None, "max": None, "mean": None},
+    )
+
+    # One hours worth of growth in LTS-only, with arbitrary minute offsets, covering a whole 1-hour period
+    start_time = start.replace(hour=1, minute=40)
+    end_time = start.replace(hour=3, minute=12)
+    await assert_stat_during_fixed(
+        client,
+        start_time,
+        end_time,
+        {"change": 60, "min": 120, "max": 180, "mean": 150},
+    )
+
+    # 90 minutes of growth in window overlapping LTS+STS/STS-only (4:41 - 6:11)
+    start_time = start.replace(hour=4, minute=41)
+    end_time = start_time + timedelta(minutes=90)
+    await assert_stat_during_fixed(
+        client,
+        start_time,
+        end_time,
+        {
+            "change": 90,
+            "min": 4 * 60 + 45,
+            "max": 4 * 60 + 45 + 90,
+            "mean": 4 * 60 + 45 + 45,
+        },
+    )
+
+    # 4 hours of growth in overlapping LTS-only/LTS+STS (2:01-6:01)
+    start_time = start.replace(hour=2, minute=1)
+    end_time = start_time + timedelta(minutes=240)
+    # 60 from LTS (3:00-3:59), 125 from STS (25 intervals) (4:00-6:01)
+    await assert_stat_during_fixed(
+        client,
+        start_time,
+        end_time,
+        {"change": 185, "min": 3 * 60, "max": 3 * 60 + 185, "mean": 3 * 60 + 185 / 2},
+    )
+
+    # 4 hours of growth in overlapping LTS-only/LTS+STS (1:31-5:31)
+    start_time = start.replace(hour=1, minute=31)
+    end_time = start_time + timedelta(minutes=240)
+    # 120 from LTS (2:00-3:59), 95 from STS (19 intervals) 4:00-5:31
+    await assert_stat_during_fixed(
+        client,
+        start_time,
+        end_time,
+        {"change": 215, "min": 2 * 60, "max": 2 * 60 + 215, "mean": 2 * 60 + 215 / 2},
+    )
+
+    # 5 hours of growth, start time only (1:31-end)
+    start_time = start.replace(hour=1, minute=31)
+    end_time = None
+    # will be actually 2:00 - end
+    await assert_stat_during_fixed(
+        client,
+        start_time,
+        end_time,
+        {"change": 4 * 60 + 30, "min": 120, "max": 390, "mean": (390 + 120) / 2},
+    )
+
+    # 5 hours of growth, end_time_only (0:00-5:00)
+    start_time = None
+    end_time = start.replace(hour=5)
+    await assert_stat_during_fixed(
+        client,
+        start_time,
+        end_time,
+        {"change": 5 * 60, "min": 0, "max": 5 * 60, "mean": (5 * 60) / 2},
+    )
+
+    # 5 hours 1 minute of growth, end_time_only (0:00-5:01)
+    start_time = None
+    end_time = start.replace(hour=5, minute=1)
+    # 4 hours LTS, 1 hour and 5 minutes STS (4:00-5:01)
+    await assert_stat_during_fixed(
+        client,
+        start_time,
+        end_time,
+        {"change": 5 * 60 + 5, "min": 0, "max": 5 * 60 + 5, "mean": (5 * 60 + 5) / 2},
+    )
+
+
 @pytest.mark.freeze_time(datetime.datetime(2022, 10, 21, 7, 25, tzinfo=datetime.UTC))
 @pytest.mark.parametrize(
     ("calendar_period", "start_time", "end_time"),

--- a/tests/components/samsungtv/test_init.py
+++ b/tests/components/samsungtv/test_init.py
@@ -220,10 +220,14 @@ async def test_incorrectly_formatted_mac_fixed(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("remotews", "rest_api")
+@pytest.mark.xfail
 async def test_cleanup_mac(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry, snapshot: SnapshotAssertion
 ) -> None:
-    """Test for `none` mac cleanup #103512."""
+    """Test for `none` mac cleanup #103512.
+
+    Reverted due to device registry collisions in #119249 / #119082
+    """
     entry = MockConfigEntry(
         domain=SAMSUNGTV_DOMAIN,
         data=MOCK_ENTRY_WS_WITH_MAC,

--- a/tests/components/unifiprotect/conftest.py
+++ b/tests/components/unifiprotect/conftest.py
@@ -13,8 +13,8 @@ from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from pyunifiprotect import ProtectApiClient
-from pyunifiprotect.data import (
+from uiprotect import ProtectApiClient
+from uiprotect.data import (
     NVR,
     Bootstrap,
     Camera,

--- a/tests/components/unifiprotect/test_binary_sensor.py
+++ b/tests/components/unifiprotect/test_binary_sensor.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from unittest.mock import Mock
 
-from pyunifiprotect.data import Camera, Event, EventType, Light, MountType, Sensor
-from pyunifiprotect.data.nvr import EventMetadata
+from uiprotect.data import Camera, Event, EventType, Light, MountType, Sensor
+from uiprotect.data.nvr import EventMetadata
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.unifiprotect.binary_sensor import (

--- a/tests/components/unifiprotect/test_button.py
+++ b/tests/components/unifiprotect/test_button.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, Mock
 
-from pyunifiprotect.data.devices import Camera, Chime, Doorlock
+from uiprotect.data.devices import Camera, Chime, Doorlock
 
 from homeassistant.components.unifiprotect.const import DEFAULT_ATTRIBUTION
 from homeassistant.const import ATTR_ATTRIBUTION, ATTR_ENTITY_ID, Platform

--- a/tests/components/unifiprotect/test_camera.py
+++ b/tests/components/unifiprotect/test_camera.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, Mock
 
-from pyunifiprotect.data import Camera as ProtectCamera, CameraChannel, StateType
-from pyunifiprotect.exceptions import NvrError
+from uiprotect.data import Camera as ProtectCamera, CameraChannel, StateType
+from uiprotect.exceptions import NvrError
 
 from homeassistant.components.camera import (
     CameraEntityFeature,

--- a/tests/components/unifiprotect/test_config_flow.py
+++ b/tests/components/unifiprotect/test_config_flow.py
@@ -7,8 +7,8 @@ import socket
 from unittest.mock import patch
 
 import pytest
-from pyunifiprotect import NotAuthorized, NvrError, ProtectApiClient
-from pyunifiprotect.data import NVR, Bootstrap, CloudAccount
+from uiprotect import NotAuthorized, NvrError, ProtectApiClient
+from uiprotect.data import NVR, Bootstrap, CloudAccount
 
 from homeassistant import config_entries
 from homeassistant.components import dhcp, ssdp

--- a/tests/components/unifiprotect/test_diagnostics.py
+++ b/tests/components/unifiprotect/test_diagnostics.py
@@ -1,6 +1,6 @@
 """Test UniFi Protect diagnostics."""
 
-from pyunifiprotect.data import NVR, Light
+from uiprotect.data import NVR, Light
 
 from homeassistant.components.unifiprotect.const import CONF_ALLOW_EA
 from homeassistant.core import HomeAssistant

--- a/tests/components/unifiprotect/test_init.py
+++ b/tests/components/unifiprotect/test_init.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
 
-from pyunifiprotect import NotAuthorized, NvrError, ProtectApiClient
-from pyunifiprotect.data import NVR, Bootstrap, CloudAccount, Light
+from uiprotect import NotAuthorized, NvrError, ProtectApiClient
+from uiprotect.data import NVR, Bootstrap, CloudAccount, Light
 
 from homeassistant.components.unifiprotect.const import (
     AUTH_RETRIES,

--- a/tests/components/unifiprotect/test_light.py
+++ b/tests/components/unifiprotect/test_light.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, Mock
 
-from pyunifiprotect.data import Light
-from pyunifiprotect.data.types import LEDLevel
+from uiprotect.data import Light
+from uiprotect.data.types import LEDLevel
 
 from homeassistant.components.light import ATTR_BRIGHTNESS
 from homeassistant.components.unifiprotect.const import DEFAULT_ATTRIBUTION

--- a/tests/components/unifiprotect/test_lock.py
+++ b/tests/components/unifiprotect/test_lock.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, Mock
 
-from pyunifiprotect.data import Doorlock, LockStatusType
+from uiprotect.data import Doorlock, LockStatusType
 
 from homeassistant.components.unifiprotect.const import DEFAULT_ATTRIBUTION
 from homeassistant.const import (

--- a/tests/components/unifiprotect/test_media_player.py
+++ b/tests/components/unifiprotect/test_media_player.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from pyunifiprotect.data import Camera
-from pyunifiprotect.exceptions import StreamError
+from uiprotect.data import Camera
+from uiprotect.exceptions import StreamError
 
 from homeassistant.components.media_player import (
     ATTR_MEDIA_CONTENT_TYPE,

--- a/tests/components/unifiprotect/test_media_source.py
+++ b/tests/components/unifiprotect/test_media_source.py
@@ -5,7 +5,7 @@ from ipaddress import IPv4Address
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from pyunifiprotect.data import (
+from uiprotect.data import (
     Bootstrap,
     Camera,
     Event,
@@ -13,7 +13,7 @@ from pyunifiprotect.data import (
     Permission,
     SmartDetectObjectType,
 )
-from pyunifiprotect.exceptions import NvrError
+from uiprotect.exceptions import NvrError
 
 from homeassistant.components.media_player import BrowseError, MediaClass
 from homeassistant.components.media_source import MediaSourceItem

--- a/tests/components/unifiprotect/test_migrate.py
+++ b/tests/components/unifiprotect/test_migrate.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from pyunifiprotect.data import Camera
+from uiprotect.data import Camera
 
 from homeassistant.components.automation import DOMAIN as AUTOMATION_DOMAIN
 from homeassistant.components.repairs.issue_handler import (

--- a/tests/components/unifiprotect/test_number.py
+++ b/tests/components/unifiprotect/test_number.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 from unittest.mock import AsyncMock, Mock
 
 import pytest
-from pyunifiprotect.data import Camera, Doorlock, IRLEDMode, Light
+from uiprotect.data import Camera, Doorlock, IRLEDMode, Light
 
 from homeassistant.components.unifiprotect.const import DEFAULT_ATTRIBUTION
 from homeassistant.components.unifiprotect.number import (

--- a/tests/components/unifiprotect/test_recorder.py
+++ b/tests/components/unifiprotect/test_recorder.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from unittest.mock import Mock
 
-from pyunifiprotect.data import Camera, Event, EventType
+from uiprotect.data import Camera, Event, EventType
 
 from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.history import get_significant_states

--- a/tests/components/unifiprotect/test_repairs.py
+++ b/tests/components/unifiprotect/test_repairs.py
@@ -6,7 +6,7 @@ from copy import copy, deepcopy
 from http import HTTPStatus
 from unittest.mock import AsyncMock, Mock
 
-from pyunifiprotect.data import Camera, CloudAccount, ModelType, Version
+from uiprotect.data import Camera, CloudAccount, ModelType, Version
 
 from homeassistant.components.repairs.issue_handler import (
     async_process_repairs_platforms,

--- a/tests/components/unifiprotect/test_select.py
+++ b/tests/components/unifiprotect/test_select.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from copy import copy
 from unittest.mock import AsyncMock, Mock
 
-from pyunifiprotect.data import (
+from uiprotect.data import (
     Camera,
     DoorbellMessageType,
     IRLEDMode,
@@ -17,7 +17,7 @@ from pyunifiprotect.data import (
     RecordingMode,
     Viewer,
 )
-from pyunifiprotect.data.nvr import DoorbellMessage
+from uiprotect.data.nvr import DoorbellMessage
 
 from homeassistant.components.select import ATTR_OPTIONS
 from homeassistant.components.unifiprotect.const import DEFAULT_ATTRIBUTION

--- a/tests/components/unifiprotect/test_sensor.py
+++ b/tests/components/unifiprotect/test_sensor.py
@@ -5,15 +5,8 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from unittest.mock import Mock
 
-from pyunifiprotect.data import (
-    NVR,
-    Camera,
-    Event,
-    EventType,
-    Sensor,
-    SmartDetectObjectType,
-)
-from pyunifiprotect.data.nvr import EventMetadata, LicensePlateMetadata
+from uiprotect.data import NVR, Camera, Event, EventType, Sensor, SmartDetectObjectType
+from uiprotect.data.nvr import EventMetadata, LicensePlateMetadata
 
 from homeassistant.components.unifiprotect.const import DEFAULT_ATTRIBUTION
 from homeassistant.components.unifiprotect.sensor import (

--- a/tests/components/unifiprotect/test_services.py
+++ b/tests/components/unifiprotect/test_services.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, Mock
 
 import pytest
-from pyunifiprotect.data import Camera, Chime, Color, Light, ModelType
-from pyunifiprotect.data.devices import CameraZone
-from pyunifiprotect.exceptions import BadRequest
+from uiprotect.data import Camera, Chime, Color, Light, ModelType
+from uiprotect.data.devices import CameraZone
+from uiprotect.exceptions import BadRequest
 
 from homeassistant.components.unifiprotect.const import ATTR_MESSAGE, DOMAIN
 from homeassistant.components.unifiprotect.services import (

--- a/tests/components/unifiprotect/test_switch.py
+++ b/tests/components/unifiprotect/test_switch.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, Mock
 
 import pytest
-from pyunifiprotect.data import Camera, Light, Permission, RecordingMode, VideoMode
+from uiprotect.data import Camera, Light, Permission, RecordingMode, VideoMode
 
 from homeassistant.components.unifiprotect.const import DEFAULT_ATTRIBUTION
 from homeassistant.components.unifiprotect.switch import (

--- a/tests/components/unifiprotect/test_text.py
+++ b/tests/components/unifiprotect/test_text.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, Mock
 
-from pyunifiprotect.data import Camera, DoorbellMessageType, LCDMessage
+from uiprotect.data import Camera, DoorbellMessageType, LCDMessage
 
 from homeassistant.components.unifiprotect.const import DEFAULT_ATTRIBUTION
 from homeassistant.components.unifiprotect.text import CAMERA

--- a/tests/components/unifiprotect/test_views.py
+++ b/tests/components/unifiprotect/test_views.py
@@ -6,8 +6,8 @@ from unittest.mock import AsyncMock, Mock
 
 from aiohttp import ClientResponse
 import pytest
-from pyunifiprotect.data import Camera, Event, EventType
-from pyunifiprotect.exceptions import ClientError
+from uiprotect.data import Camera, Event, EventType
+from uiprotect.exceptions import ClientError
 
 from homeassistant.components.unifiprotect.views import (
     async_generate_event_video_url,

--- a/tests/components/unifiprotect/utils.py
+++ b/tests/components/unifiprotect/utils.py
@@ -8,8 +8,8 @@ from datetime import timedelta
 from typing import Any
 from unittest.mock import Mock
 
-from pyunifiprotect import ProtectApiClient
-from pyunifiprotect.data import (
+from uiprotect import ProtectApiClient
+from uiprotect.data import (
     Bootstrap,
     Camera,
     Event,
@@ -18,8 +18,8 @@ from pyunifiprotect.data import (
     ProtectAdoptableDeviceModel,
     WSSubscriptionMessage,
 )
-from pyunifiprotect.data.bootstrap import ProtectDeviceRef
-from pyunifiprotect.test_util.anonymize import random_hex
+from uiprotect.data.bootstrap import ProtectDeviceRef
+from uiprotect.test_util.anonymize import random_hex
 
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, split_entity_id

--- a/tests/components/workday/test_binary_sensor.py
+++ b/tests/components/workday/test_binary_sensor.py
@@ -10,6 +10,7 @@ from homeassistant.components.workday.binary_sensor import SERVICE_CHECK_DATE
 from homeassistant.components.workday.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
 from homeassistant.util.dt import UTC
 
 from . import (
@@ -144,13 +145,54 @@ async def test_setup_add_holiday(
     assert state.state == "off"
 
 
+@pytest.mark.parametrize(
+    "time_zone", ["Asia/Tokyo", "Europe/Berlin", "America/Chicago", "US/Hawaii"]
+)
 async def test_setup_no_country_weekend(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
+    time_zone: str,
 ) -> None:
     """Test setup shows weekend as non-workday with no country."""
-    freezer.move_to(datetime(2020, 2, 23, 12, tzinfo=UTC))  # Sunday
+    await hass.config.async_set_time_zone(time_zone)
+    zone = await dt_util.async_get_time_zone(time_zone)
+    freezer.move_to(datetime(2020, 2, 22, 0, 1, 1, tzinfo=zone))  # Saturday
     await init_integration(hass, TEST_CONFIG_NO_COUNTRY)
+
+    state = hass.states.get("binary_sensor.workday_sensor")
+    assert state is not None
+    assert state.state == "off"
+
+    freezer.move_to(datetime(2020, 2, 24, 23, 59, 59, tzinfo=zone))  # Monday
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.workday_sensor")
+    assert state is not None
+    assert state.state == "on"
+
+
+@pytest.mark.parametrize(
+    "time_zone", ["Asia/Tokyo", "Europe/Berlin", "America/Chicago", "US/Hawaii"]
+)
+async def test_setup_no_country_weekday(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    time_zone: str,
+) -> None:
+    """Test setup shows a weekday as a workday with no country."""
+    await hass.config.async_set_time_zone(time_zone)
+    zone = await dt_util.async_get_time_zone(time_zone)
+    freezer.move_to(datetime(2020, 2, 21, 23, 59, 59, tzinfo=zone))  # Friday
+    await init_integration(hass, TEST_CONFIG_NO_COUNTRY)
+
+    state = hass.states.get("binary_sensor.workday_sensor")
+    assert state is not None
+    assert state.state == "on"
+
+    freezer.move_to(datetime(2020, 2, 22, 23, 59, 59, tzinfo=zone))  # Saturday
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.workday_sensor")
     assert state is not None

--- a/tests/components/workday/test_binary_sensor.py
+++ b/tests/components/workday/test_binary_sensor.py
@@ -1,6 +1,6 @@
 """Tests the Home Assistant workday binary sensor."""
 
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
 from freezegun.api import FrozenDateTimeFactory
@@ -68,7 +68,9 @@ async def test_setup(
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test setup from various configs."""
-    freezer.move_to(datetime(2022, 4, 15, 12, tzinfo=UTC))  # Friday
+    # Start on a Friday
+    await hass.config.async_set_time_zone("Europe/Paris")
+    freezer.move_to(datetime(2022, 4, 15, 0, tzinfo=timezone(timedelta(hours=1))))
     await init_integration(hass, config)
 
     state = hass.states.get("binary_sensor.workday_sensor")

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -249,6 +249,39 @@ async def test_assist_api_get_timer_tools(
     assert "HassStartTimer" in [tool.name for tool in api.tools]
 
 
+async def test_assist_api_tools(
+    hass: HomeAssistant, llm_context: llm.LLMContext
+) -> None:
+    """Test getting timer tools with Assist API."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, "intent", {})
+
+    llm_context.device_id = "test_device"
+
+    async_register_timer_handler(hass, "test_device", lambda *args: None)
+
+    class MyIntentHandler(intent.IntentHandler):
+        intent_type = "Super crazy intent with unique nåme"
+        description = "my intent handler"
+
+    intent.async_register(hass, MyIntentHandler())
+
+    api = await llm.async_get_api(hass, "assist", llm_context)
+    assert [tool.name for tool in api.tools] == [
+        "HassTurnOn",
+        "HassTurnOff",
+        "HassSetPosition",
+        "HassStartTimer",
+        "HassCancelTimer",
+        "HassIncreaseTimer",
+        "HassDecreaseTimer",
+        "HassPauseTimer",
+        "HassUnpauseTimer",
+        "HassTimerStatus",
+        "Super_crazy_intent_with_unique_name",
+    ]
+
+
 async def test_assist_api_description(
     hass: HomeAssistant, llm_context: llm.LLMContext
 ) -> None:


### PR DESCRIPTION
- Fix statistic_during_period wrongly prioritizing ST statistics over LT ([@karwosts] - [#115291]) ([recorder docs])
- Bump pyElectra to 1.2.1 ([@rubeecube] - [#118958]) ([electrasmart docs]) (dependency)
- Update gardena library to 1.4.2 ([@elupus] - [#119010]) ([gardena_bluetooth docs])
- Calculate attributes when entity information available in Group sensor ([@gjohansson-ST] - [#119021]) ([group docs])
- Bump google-generativeai to 0.6.0 ([@tronikos] - [#119062]) ([google_generative_ai_conversation docs]) (dependency)
- Fix Azure data explorer ([@kaareseras] - [#119089]) ([azure_data_explorer docs])
- Ensure multiple executions of a restart automation in the same event loop iteration are allowed ([@bdraco] - [#119100]) ([automation docs])
- Fix control 4 on os 2 ([@adrum] - [#119104]) ([control4 docs])
- Properly handle escaped unicode characters passed to tools in Google Generative AI ([@tronikos] - [#119117]) ([google_generative_ai_conversation docs])
- Catch GoogleAPICallError in Google Generative AI ([@tronikos] - [#119118]) ([google_generative_ai_conversation docs])
- Bump aioshelly to 10.0.1 ([@thecode] - [#119123]) ([shelly docs]) (dependency)
- Bump aiowaqi to 3.1.0 ([@joostlek] - [#119124]) ([waqi docs]) (dependency)
- Ensure intent tools have safe names ([@balloob] - [#119144])
- Fix workday timezone ([@TomBrien] - [#119148]) ([workday docs])
- Bump py-synologydsm-api to 2.4.4 ([@mib1185] - [#119156]) ([synology_dsm docs]) (dependency)
- Use more conservative timeout values in Synology DSM ([@mib1185] - [#119169]) ([synology_dsm docs])
- Handle Shelly BLE errors during connect and disconnect ([@thecode] - [#119174]) ([shelly docs])
- Fix elgato light color detection ([@LapsTimeOFF] - [#119177]) ([elgato docs])
- Bump opower to 0.4.7 ([@tronikos] - [#119183]) ([opower docs]) (dependency)
- Add fallback to entry_id when no mac address is retrieved in enigma2 ([@autinerd] - [#119185]) ([enigma2 docs])
- Fix envisalink alarm ([@gjohansson-ST] - [#119212]) ([envisalink docs])
- Fixes crashes when receiving malformed decoded payloads ([@angelnu] - [#119216]) ([thethingsnetwork docs]) (dependency)
- Fix Glances v4 network and container issues (glances-api 0.8.0) ([@wittypluck] - [#119226]) ([glances docs])
- Bump python-roborock to 2.3.0 ([@ethemcemozkan] - [#119228]) ([roborock docs]) (dependency)
- Revert SamsungTV migration ([@epenet] - [#119234]) ([samsungtv docs])
- Always provide a currentArmLevel in Google assistant ([@elupus] - [#119238]) ([google_assistant docs])
- Remove myself as codeowner for unifiprotect ([@bdraco] - [#118824]) ([unifiprotect docs])
- Switch unifiprotect lib to use uiprotect ([@bdraco] - [#119243]) ([unifiprotect docs]) (dependency)
- Fix wrong arg name in Idasen Desk config flow ([@abmantis] - [#119247]) ([idasen_desk docs])
- Fix climate on/off in nexia ([@bdraco] - [#119254]) ([nexia docs])
- Bump google-nest-sdm to 4.0.5 ([@allenporter] - [#119255]) ([nest docs]) (dependency)
- Bump uiprotect to 0.4.0 ([@bdraco] - [#119256]) ([unifiprotect docs]) (dependency)
- Improve workday test coverage ([@bdraco] - [#119259]) ([workday docs])
- Fix persistence on OpenWeatherMap raised repair issue ([@frenck] - [#119289]) ([openweathermap docs])
- Bump uiprotect to 0.4.1 ([@bdraco] - [#119308]) ([unifiprotect docs]) (dependency)
- Add more debug logging to Ping integration ([@jpbede] - [#119318]) ([ping docs])
- Update frontend to 20240610.0 ([@bramkragten] - [#119320]) ([frontend docs])
- Fix statistic_during_period after core restart ([@emontnemery] - [#119323]) ([recorder docs])
- Fix AladdinConnect OAuth domain ([@swcloudgenie] - [#119336]) ([aladdin_connect docs])
- Bump `imgw-pib` backend library to version 1.0.5 ([@bieniu] - [#119360]) ([imgw_pib docs]) (dependency)

[#115291]: https://github.com/home-assistant/core/pull/115291
[#118400]: https://github.com/home-assistant/core/pull/118400
[#118824]: https://github.com/home-assistant/core/pull/118824
[#118958]: https://github.com/home-assistant/core/pull/118958
[#119010]: https://github.com/home-assistant/core/pull/119010
[#119021]: https://github.com/home-assistant/core/pull/119021
[#119062]: https://github.com/home-assistant/core/pull/119062
[#119089]: https://github.com/home-assistant/core/pull/119089
[#119096]: https://github.com/home-assistant/core/pull/119096
[#119100]: https://github.com/home-assistant/core/pull/119100
[#119104]: https://github.com/home-assistant/core/pull/119104
[#119117]: https://github.com/home-assistant/core/pull/119117
[#119118]: https://github.com/home-assistant/core/pull/119118
[#119123]: https://github.com/home-assistant/core/pull/119123
[#119124]: https://github.com/home-assistant/core/pull/119124
[#119144]: https://github.com/home-assistant/core/pull/119144
[#119148]: https://github.com/home-assistant/core/pull/119148
[#119156]: https://github.com/home-assistant/core/pull/119156
[#119169]: https://github.com/home-assistant/core/pull/119169
[#119174]: https://github.com/home-assistant/core/pull/119174
[#119177]: https://github.com/home-assistant/core/pull/119177
[#119183]: https://github.com/home-assistant/core/pull/119183
[#119185]: https://github.com/home-assistant/core/pull/119185
[#119212]: https://github.com/home-assistant/core/pull/119212
[#119216]: https://github.com/home-assistant/core/pull/119216
[#119226]: https://github.com/home-assistant/core/pull/119226
[#119228]: https://github.com/home-assistant/core/pull/119228
[#119234]: https://github.com/home-assistant/core/pull/119234
[#119238]: https://github.com/home-assistant/core/pull/119238
[#119243]: https://github.com/home-assistant/core/pull/119243
[#119247]: https://github.com/home-assistant/core/pull/119247
[#119254]: https://github.com/home-assistant/core/pull/119254
[#119255]: https://github.com/home-assistant/core/pull/119255
[#119256]: https://github.com/home-assistant/core/pull/119256
[#119259]: https://github.com/home-assistant/core/pull/119259
[#119289]: https://github.com/home-assistant/core/pull/119289
[#119308]: https://github.com/home-assistant/core/pull/119308
[#119318]: https://github.com/home-assistant/core/pull/119318
[#119320]: https://github.com/home-assistant/core/pull/119320
[#119323]: https://github.com/home-assistant/core/pull/119323
[#119336]: https://github.com/home-assistant/core/pull/119336
[#119360]: https://github.com/home-assistant/core/pull/119360
[@LapsTimeOFF]: https://github.com/LapsTimeOFF
[@TomBrien]: https://github.com/TomBrien
[@abmantis]: https://github.com/abmantis
[@adrum]: https://github.com/adrum
[@allenporter]: https://github.com/allenporter
[@angelnu]: https://github.com/angelnu
[@autinerd]: https://github.com/autinerd
[@balloob]: https://github.com/balloob
[@bdraco]: https://github.com/bdraco
[@bieniu]: https://github.com/bieniu
[@bramkragten]: https://github.com/bramkragten
[@elupus]: https://github.com/elupus
[@emontnemery]: https://github.com/emontnemery
[@epenet]: https://github.com/epenet
[@ethemcemozkan]: https://github.com/ethemcemozkan
[@frenck]: https://github.com/frenck
[@gjohansson-ST]: https://github.com/gjohansson-ST
[@joostlek]: https://github.com/joostlek
[@jpbede]: https://github.com/jpbede
[@kaareseras]: https://github.com/kaareseras
[@karwosts]: https://github.com/karwosts
[@mib1185]: https://github.com/mib1185
[@rubeecube]: https://github.com/rubeecube
[@swcloudgenie]: https://github.com/swcloudgenie
[@thecode]: https://github.com/thecode
[@tronikos]: https://github.com/tronikos
[@wittypluck]: https://github.com/wittypluck
[aladdin_connect docs]: https://www.home-assistant.io/integrations/aladdin_connect/
[automation docs]: https://www.home-assistant.io/integrations/automation/
[azure_data_explorer docs]: https://www.home-assistant.io/integrations/azure_data_explorer/
[control4 docs]: https://www.home-assistant.io/integrations/control4/
[electrasmart docs]: https://www.home-assistant.io/integrations/electrasmart/
[elgato docs]: https://www.home-assistant.io/integrations/elgato/
[enigma2 docs]: https://www.home-assistant.io/integrations/enigma2/
[envisalink docs]: https://www.home-assistant.io/integrations/envisalink/
[frontend docs]: https://www.home-assistant.io/integrations/frontend/
[gardena_bluetooth docs]: https://www.home-assistant.io/integrations/gardena_bluetooth/
[glances docs]: https://www.home-assistant.io/integrations/glances/
[google_assistant docs]: https://www.home-assistant.io/integrations/google_assistant/
[google_generative_ai_conversation docs]: https://www.home-assistant.io/integrations/google_generative_ai_conversation/
[group docs]: https://www.home-assistant.io/integrations/group/
[idasen_desk docs]: https://www.home-assistant.io/integrations/idasen_desk/
[imgw_pib docs]: https://www.home-assistant.io/integrations/imgw_pib/
[nest docs]: https://www.home-assistant.io/integrations/nest/
[nexia docs]: https://www.home-assistant.io/integrations/nexia/
[openweathermap docs]: https://www.home-assistant.io/integrations/openweathermap/
[opower docs]: https://www.home-assistant.io/integrations/opower/
[ping docs]: https://www.home-assistant.io/integrations/ping/
[recorder docs]: https://www.home-assistant.io/integrations/recorder/
[roborock docs]: https://www.home-assistant.io/integrations/roborock/
[samsungtv docs]: https://www.home-assistant.io/integrations/samsungtv/
[shelly docs]: https://www.home-assistant.io/integrations/shelly/
[synology_dsm docs]: https://www.home-assistant.io/integrations/synology_dsm/
[thethingsnetwork docs]: https://www.home-assistant.io/integrations/thethingsnetwork/
[unifiprotect docs]: https://www.home-assistant.io/integrations/unifiprotect/
[waqi docs]: https://www.home-assistant.io/integrations/waqi/
[workday docs]: https://www.home-assistant.io/integrations/workday/