### PR TITLE
Remove deprecated imports in config tests

### DIFF
--- a/tests/components/config/test_core.py
+++ b/tests/components/config/test_core.py
@@ -9,11 +9,6 @@ from homeassistant.bootstrap import async_setup_component
 from homeassistant.components import config
 from homeassistant.components.config import core
 from homeassistant.components.websocket_api import TYPE_RESULT
-from homeassistant.const import (
-    CONF_UNIT_SYSTEM,
-    CONF_UNIT_SYSTEM_IMPERIAL,
-    CONF_UNIT_SYSTEM_METRIC,
-)
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util, location
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
@@ -140,7 +135,7 @@ async def test_websocket_core_update(hass: HomeAssistant, client) -> None:
                 "longitude": 50,
                 "elevation": 25,
                 "location_name": "Huis",
-                CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_IMPERIAL,
+                "unit_system": "imperial",
                 "time_zone": "America/New_York",
                 "external_url": "https://www.example.com",
                 "internal_url": "http://example.local",
@@ -181,7 +176,7 @@ async def test_websocket_core_update(hass: HomeAssistant, client) -> None:
             {
                 "id": 6,
                 "type": "config/core/update",
-                CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_METRIC,
+                "unit_system": "metric",
                 "update_units": True,
             }
         )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,7 +16,7 @@ import voluptuous as vol
 from voluptuous import Invalid, MultipleInvalid
 import yaml
 
-from homeassistant import config, loader
+from homeassistant import loader
 import homeassistant.config as config_util
 from homeassistant.const import (
     ATTR_ASSUMED_STATE,
@@ -27,9 +27,6 @@ from homeassistant.const import (
     CONF_LATITUDE,
     CONF_LONGITUDE,
     CONF_NAME,
-    CONF_UNIT_SYSTEM,
-    CONF_UNIT_SYSTEM_IMPERIAL,
-    CONF_UNIT_SYSTEM_METRIC,
     __version__,
 )
 from homeassistant.core import (
@@ -49,7 +46,6 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import Integration, async_get_integration
 from homeassistant.setup import async_setup_component
 from homeassistant.util.unit_system import (
-    _CONF_UNIT_SYSTEM_US_CUSTOMARY,
     METRIC_SYSTEM,
     US_CUSTOMARY_SYSTEM,
     UnitSystem,
@@ -511,7 +507,7 @@ async def test_create_default_config_returns_none_if_write_error(
 def test_core_config_schema() -> None:
     """Test core config schema."""
     for value in (
-        {CONF_UNIT_SYSTEM: "K"},
+        {"unit_system": "K"},
         {"time_zone": "non-exist"},
         {"latitude": "91"},
         {"longitude": -181},
@@ -534,7 +530,7 @@ def test_core_config_schema() -> None:
             "longitude": "123.45",
             "external_url": "https://www.example.com",
             "internal_url": "http://example.local",
-            CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_METRIC,
+            "unit_system": "metric",
             "currency": "USD",
             "customize": {"sensor.temperature": {"hidden": True}},
             "country": "SE",
@@ -850,7 +846,7 @@ async def test_loading_configuration(hass: HomeAssistant) -> None:
             "longitude": 50,
             "elevation": 25,
             "name": "Huis",
-            CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_IMPERIAL,
+            "unit_system": "imperial",
             "time_zone": "America/New_York",
             "allowlist_external_dirs": "/etc",
             "external_url": "https://www.example.com",
@@ -982,7 +978,7 @@ async def test_loading_configuration_from_packages(hass: HomeAssistant) -> None:
             "longitude": -1,
             "elevation": 500,
             "name": "Huis",
-            CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_METRIC,
+            "unit_system": "metric",
             "time_zone": "Europe/Madrid",
             "external_url": "https://www.example.com",
             "internal_url": "http://example.local",
@@ -1006,7 +1002,7 @@ async def test_loading_configuration_from_packages(hass: HomeAssistant) -> None:
                 "longitude": -1,
                 "elevation": 500,
                 "name": "Huis",
-                CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_METRIC,
+                "unit_system": "metric",
                 "time_zone": "Europe/Madrid",
                 "packages": {"empty_package": None},
             },
@@ -1016,9 +1012,9 @@ async def test_loading_configuration_from_packages(hass: HomeAssistant) -> None:
 @pytest.mark.parametrize(
     ("unit_system_name", "expected_unit_system"),
     [
-        (CONF_UNIT_SYSTEM_METRIC, METRIC_SYSTEM),
-        (CONF_UNIT_SYSTEM_IMPERIAL, US_CUSTOMARY_SYSTEM),
-        (_CONF_UNIT_SYSTEM_US_CUSTOMARY, US_CUSTOMARY_SYSTEM),
+        ("metric", METRIC_SYSTEM),
+        ("imperial", US_CUSTOMARY_SYSTEM),
+        ("us_customary", US_CUSTOMARY_SYSTEM),
     ],
 )
 async def test_loading_configuration_unit_system(
@@ -1295,7 +1291,7 @@ async def test_merge_customize(hass: HomeAssistant) -> None:
         "longitude": 50,
         "elevation": 25,
         "name": "Huis",
-        CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_IMPERIAL,
+        "unit_system": "imperial",
         "time_zone": "GMT",
         "customize": {"a.a": {"friendly_name": "A"}},
         "packages": {
@@ -1314,7 +1310,7 @@ async def test_auth_provider_config(hass: HomeAssistant) -> None:
         "longitude": 50,
         "elevation": 25,
         "name": "Huis",
-        CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_IMPERIAL,
+        "unit_system": "imperial",
         "time_zone": "GMT",
         CONF_AUTH_PROVIDERS: [
             {"type": "homeassistant"},
@@ -1341,7 +1337,7 @@ async def test_auth_provider_config_default(hass: HomeAssistant) -> None:
         "longitude": 50,
         "elevation": 25,
         "name": "Huis",
-        CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_IMPERIAL,
+        "unit_system": "imperial",
         "time_zone": "GMT",
     }
     if hasattr(hass, "auth"):
@@ -1361,7 +1357,7 @@ async def test_disallowed_auth_provider_config(hass: HomeAssistant) -> None:
         "longitude": 50,
         "elevation": 25,
         "name": "Huis",
-        CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_IMPERIAL,
+        "unit_system": "imperial",
         "time_zone": "GMT",
         CONF_AUTH_PROVIDERS: [
             {
@@ -1387,7 +1383,7 @@ async def test_disallowed_duplicated_auth_provider_config(hass: HomeAssistant) -
         "longitude": 50,
         "elevation": 25,
         "name": "Huis",
-        CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_IMPERIAL,
+        "unit_system": "imperial",
         "time_zone": "GMT",
         CONF_AUTH_PROVIDERS: [{"type": "homeassistant"}, {"type": "homeassistant"}],
     }
@@ -1402,7 +1398,7 @@ async def test_disallowed_auth_mfa_module_config(hass: HomeAssistant) -> None:
         "longitude": 50,
         "elevation": 25,
         "name": "Huis",
-        CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_IMPERIAL,
+        "unit_system": "imperial",
         "time_zone": "GMT",
         CONF_AUTH_MFA_MODULES: [
             {
@@ -1424,7 +1420,7 @@ async def test_disallowed_duplicated_auth_mfa_module_config(
         "longitude": 50,
         "elevation": 25,
         "name": "Huis",
-        CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_IMPERIAL,
+        "unit_system": "imperial",
         "time_zone": "GMT",
         CONF_AUTH_MFA_MODULES: [{"type": "totp"}, {"type": "totp"}],
     }
@@ -2459,7 +2455,7 @@ async def test_loading_platforms_gathers(hass: HomeAssistant) -> None:
         _load_platform,
     ):
         light_task = hass.async_create_task(
-            config.async_process_component_config(
+            config_util.async_process_component_config(
                 hass,
                 {
                     "light": [
@@ -2472,7 +2468,7 @@ async def test_loading_platforms_gathers(hass: HomeAssistant) -> None:
             eager_start=True,
         )
         sensor_task = hass.async_create_task(
-            config.async_process_component_config(
+            config_util.async_process_component_config(
                 hass,
                 {
                     "sensor": [


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #119279
https://github.com/home-assistant/core/actions/runs/9466185681/job/26077340605?pr=119279

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
