### PR TITLE
Drop use of deprecated constant in zha tests

### DIFF
--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -1,5 +1,6 @@
 """Test ZHA sensor."""
 
+from collections.abc import Callable
 from datetime import timedelta
 import math
 from typing import Any
@@ -23,8 +24,6 @@ from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_UNIT_OF_MEASUREMENT,
     CONF_UNIT_SYSTEM,
-    CONF_UNIT_SYSTEM_IMPERIAL,
-    CONF_UNIT_SYSTEM_METRIC,
     LIGHT_LUX,
     PERCENTAGE,
     STATE_UNAVAILABLE,
@@ -633,10 +632,10 @@ def assert_state(hass: HomeAssistant, entity_id, state, unit_of_measurement):
 
 
 @pytest.fixture
-def hass_ms(hass: HomeAssistant):
+def hass_ms(hass: HomeAssistant) -> Callable[[str], HomeAssistant]:
     """Hass instance with measurement system."""
 
-    async def _hass_ms(meas_sys):
+    async def _hass_ms(meas_sys: str) -> HomeAssistant:
         await config_util.async_process_ha_core_config(
             hass, {CONF_UNIT_SYSTEM: meas_sys}
         )
@@ -688,11 +687,11 @@ def core_rs(hass_storage: dict[str, Any]):
 )
 async def test_temp_uom(
     hass: HomeAssistant,
-    uom,
-    raw_temp,
-    expected,
-    restore,
-    hass_ms,
+    uom: UnitOfTemperature,
+    raw_temp: int,
+    expected: int,
+    restore: bool,
+    hass_ms: Callable[[str], HomeAssistant],
     core_rs,
     zigpy_device_mock,
     zha_device_restored,
@@ -704,11 +703,7 @@ async def test_temp_uom(
         core_rs(entity_id, uom, state=(expected - 2))
         await async_mock_load_restore_state_from_storage(hass)
 
-    hass = await hass_ms(
-        CONF_UNIT_SYSTEM_METRIC
-        if uom == UnitOfTemperature.CELSIUS
-        else CONF_UNIT_SYSTEM_IMPERIAL
-    )
+    hass = await hass_ms("metric" if uom == UnitOfTemperature.CELSIUS else "imperial")
 
     zigpy_device = zigpy_device_mock(
         {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #119279
https://github.com/home-assistant/core/actions/runs/9466423324/job/26078097728?pr=119279

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
