### PR TITLE
Add LLM API to get travel time and directions from Google Maps (directions api)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -543,6 +543,7 @@ build.json @home-assistant/supervisor
 /tests/components/google_tasks/ @allenporter
 /homeassistant/components/google_travel_time/ @eifinger
 /tests/components/google_travel_time/ @eifinger
+/homeassistant/components/google_travel_time_llm_api/ @fjfricke
 /homeassistant/components/govee_ble/ @bdraco @PierreAronnax
 /tests/components/govee_ble/ @bdraco @PierreAronnax
 /homeassistant/components/govee_light_local/ @Galorhallen

--- a/homeassistant/components/google_travel_time_llm_api/__init__.py
+++ b/homeassistant/components/google_travel_time_llm_api/__init__.py
@@ -1,0 +1,35 @@
+"""The Google Travel Time LLM API integration."""
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import llm
+
+from .const import DOMAIN
+from .llm_api import GoogleMapsTravelTimeAPI
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Google Travel Time LLM API from a config entry."""
+    api_key = entry.data.get("api_key")
+    if not api_key:
+        return False
+
+    api_instance = GoogleMapsTravelTimeAPI(hass, api_key)
+    await async_setup_api(hass, api_instance)
+
+    hass.data[DOMAIN] = {}
+    hass.data[DOMAIN][entry.entry_id] = api_instance
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    hass.data[DOMAIN].pop(entry.entry_id)
+    return True
+
+
+async def async_setup_api(
+    hass: HomeAssistant, api_instance: GoogleMapsTravelTimeAPI
+) -> None:
+    """Register the API with Home Assistant."""
+    llm.async_register_api(hass, api_instance)

--- a/homeassistant/components/google_travel_time_llm_api/config_flow.py
+++ b/homeassistant/components/google_travel_time_llm_api/config_flow.py
@@ -1,0 +1,64 @@
+"""Config flow for Google Travel Time LLM API integration."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_API_KEY
+from homeassistant.core import HomeAssistant
+import homeassistant.helpers.config_validation as cv
+
+from .const import DOMAIN
+from .helpers import InvalidApiKeyException, validate_config_entry
+
+_LOGGER = logging.getLogger(__name__)
+
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_API_KEY): cv.string,
+    }
+)
+
+
+class GoogleTravelTimeConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Google Maps Travel Time and LLM API."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input=None) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] | None = None
+        user_input = user_input or {}
+        if user_input:
+            errors = await validate_input(self.hass, user_input)
+            if not errors:
+                return self.async_create_entry(
+                    title="Google Travel Time LLM API", data=user_input
+                )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=self.add_suggested_values_to_schema(CONFIG_SCHEMA, user_input),
+            errors=errors,
+        )
+
+
+async def validate_input(
+    hass: HomeAssistant, user_input: dict[str, Any]
+) -> dict[str, str] | None:
+    """Validate the user input allows us to connect."""
+    try:
+        await hass.async_add_executor_job(
+            validate_config_entry,
+            hass,
+            user_input[CONF_API_KEY],
+        )
+    except InvalidApiKeyException:
+        return {"base": "invalid_auth"}
+
+    return None

--- a/homeassistant/components/google_travel_time_llm_api/const.py
+++ b/homeassistant/components/google_travel_time_llm_api/const.py
@@ -1,0 +1,3 @@
+"""Constants for the Google Travel Time LLM API integration."""
+
+DOMAIN = "google_travel_time_llm_api"

--- a/homeassistant/components/google_travel_time_llm_api/helpers.py
+++ b/homeassistant/components/google_travel_time_llm_api/helpers.py
@@ -1,0 +1,22 @@
+"""Helpers for Google Time Travel integration."""
+
+import logging
+
+from googlemaps import Client
+
+from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def validate_config_entry(hass: HomeAssistant, api_key: str) -> None:
+    """Return whether the config entry data is valid."""
+    try:
+        Client(api_key, timeout=10)
+    except ValueError as value_error:
+        _LOGGER.error("Malformed API key")
+        raise InvalidApiKeyException from value_error
+
+
+class InvalidApiKeyException(Exception):
+    """Invalid API Key Error."""

--- a/homeassistant/components/google_travel_time_llm_api/llm_api.py
+++ b/homeassistant/components/google_travel_time_llm_api/llm_api.py
@@ -1,0 +1,114 @@
+"""Support for LLM Google travel time tool use."""
+
+import logging
+
+from googlemaps import Client
+from googlemaps.exceptions import ApiError, HTTPError, Timeout, TransportError
+import voluptuous as vol
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import llm
+from homeassistant.util import dt as dt_util
+from homeassistant.util.json import JsonObjectType
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class GoogleMapsTravelTimeTool(llm.Tool):
+    """Representation of a Google travel LLM tool."""
+
+    name = "GetTravelTimeFromGoogleMaps"
+    description = "Returns the travel time and itinerary from Google Maps based on origin and destination."
+    parameters = vol.Schema(
+        {
+            vol.Required("origin", description="Origin address or station"): str,
+            vol.Required(
+                "destination", description="Destination address or station"
+            ): str,
+            vol.Required("mode", default="driving"): vol.In(
+                ["driving", "walking", "bicycling", "transit"]
+            ),
+            vol.Optional(
+                "departure_time",
+                description="Departure time. Takes current time if not present.",
+            ): vol.Datetime(),
+            vol.Required(
+                "only_time",
+                description="Only return the travel time",
+                default=False,
+            ): vol.Boolean(),
+        }
+    )
+
+    def __init__(self, client: Client) -> None:
+        """Initialize the tool."""
+        self._client = client
+
+    async def async_call(
+        self,
+        hass: HomeAssistant,
+        tool_input: llm.ToolInput,
+        llm_context: llm.LLMContext,
+    ) -> JsonObjectType:
+        """Perform the asynchronous call to the Google travel LLM tool."""
+        # check if tool input follows the schema
+        origin = tool_input.tool_args["origin"]
+        destination = tool_input.tool_args["destination"]
+        mode = tool_input.tool_args.get("mode", "driving")
+        if "departure_time" in tool_input.tool_args:
+            departure_time = dt_util.parse_datetime(
+                tool_input.tool_args["departure_time"]
+            )
+        else:
+            departure_time = None
+        only_time = tool_input.tool_args.get("only_time", False)
+
+        def call_directions():
+            return self._client.directions(
+                origin,
+                destination,
+                mode=mode,
+                departure_time=departure_time,
+            )
+
+        try:
+            directions_result = await hass.async_add_executor_job(call_directions)
+        except (ApiError, HTTPError, Timeout, TransportError) as error:
+            _LOGGER.error("Error getting directions from Google Maps: %s", error)
+            return {
+                "error": f"Error getting directions from Google Maps. Error details: {error}"
+            }
+        if only_time:
+            try:
+                return {
+                    "travel_time": directions_result[0]["legs"][0]["duration"]["text"]
+                }
+            except KeyError as error:
+                _LOGGER.error("Error getting travel time from Google Maps: %s", error)
+                return directions_result
+
+        return directions_result
+
+
+class GoogleMapsTravelTimeAPI(llm.API):
+    """Google Maps Travel Time API for LLMs."""
+
+    def __init__(self, hass: HomeAssistant, api_key: str) -> None:
+        """Initialize the API."""
+        super().__init__(
+            hass=hass,
+            id="google_travel_time",
+            name="Google Travel Time API",
+        )
+        self._client = Client(api_key, timeout=10)
+
+    async def async_get_api_instance(
+        self, llm_context: llm.LLMContext
+    ) -> llm.APIInstance:
+        """Return the instance of the API."""
+        return llm.APIInstance(
+            api=self,
+            api_prompt="Call the tools to get travel time and itinerary from Google Maps.",
+            llm_context=llm_context,
+            tools=[GoogleMapsTravelTimeTool(client=self._client)],
+        )

--- a/homeassistant/components/google_travel_time_llm_api/manifest.json
+++ b/homeassistant/components/google_travel_time_llm_api/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "google_travel_time_llm_api",
+  "name": "Google Travel Time LLM API",
+  "codeowners": ["@fjfricke"],
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/google_travel_time_llm_api",
+  "iot_class": "cloud_polling",
+  "loggers": ["googlemaps"],
+  "requirements": ["googlemaps==2.5.1"]
+}

--- a/homeassistant/components/google_travel_time_llm_api/strings.json
+++ b/homeassistant/components/google_travel_time_llm_api/strings.json
@@ -1,0 +1,21 @@
+{
+  "title": "Google Maps Travel Time LLM Api",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "name": "[%key:common::config_flow::data::name%]",
+          "api_key": "[%key:common::config_flow::data::api_key%]"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -215,6 +215,7 @@ FLOWS = {
         "google_tasks",
         "google_translate",
         "google_travel_time",
+        "google_travel_time_llm_api",
         "govee_ble",
         "govee_light_local",
         "gpsd",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -2364,6 +2364,11 @@
         }
       }
     },
+    "google_travel_time_llm_api": {
+      "integration_type": "hub",
+      "config_flow": true,
+      "iot_class": "cloud_polling"
+    },
     "govee": {
       "name": "Govee",
       "integrations": {
@@ -7256,6 +7261,7 @@
     "garages_amsterdam",
     "generic",
     "google_travel_time",
+    "google_travel_time_llm_api",
     "group",
     "growatt_server",
     "holiday",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -983,6 +983,7 @@ google-generativeai==0.6.0
 google-nest-sdm==4.0.5
 
 # homeassistant.components.google_travel_time
+# homeassistant.components.google_travel_time_llm_api
 googlemaps==2.5.1
 
 # homeassistant.components.slide

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -809,6 +809,7 @@ google-generativeai==0.6.0
 google-nest-sdm==4.0.5
 
 # homeassistant.components.google_travel_time
+# homeassistant.components.google_travel_time_llm_api
 googlemaps==2.5.1
 
 # homeassistant.components.tailwind


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR is different to others as it does not add a new entity but instead adds a LLM API exposing one tool to Conversation entities. This tool can be used to get directions and the travel time from the Google Maps directions API.
The LLM API key can be added using the config flow.

I know that LLM APIs are new to Home Assistant and as such, I have not seen examples of them being added yet. I would like to know your opinion on the approach and it would be great to hear your feedback on how this should potentially be done differently.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
I have not added tests yet as the approach is as I believe not common yet. So I would like to hear your change requests before finishing up the PR.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
