### PR TITLE
Bring back auto on off switches to lamarzocco

### DIFF
--- a/homeassistant/components/lamarzocco/strings.json
+++ b/homeassistant/components/lamarzocco/strings.json
@@ -139,6 +139,9 @@
       }
     },
     "switch": {
+      "auto_on_off": {
+        "name": "Auto on/off ({id})"
+      },
       "steam_boiler": {
         "name": "Steam boiler"
       }
@@ -150,12 +153,6 @@
       "gateway_firmware": {
         "name": "Gateway firmware"
       }
-    }
-  },
-  "issues": {
-    "unsupported_gateway_firmware": {
-      "title": "Unsupported gateway firmware",
-      "description": "Gateway firmware {gateway_version} is no longer supported by this integration, please update."
     }
   }
 }

--- a/homeassistant/components/lamarzocco/strings.json
+++ b/homeassistant/components/lamarzocco/strings.json
@@ -154,5 +154,11 @@
         "name": "Gateway firmware"
       }
     }
+  },
+  "issues": {
+    "unsupported_gateway_firmware": {
+      "title": "Unsupported gateway firmware",
+      "description": "Gateway firmware {gateway_version} is no longer supported by this integration, please update."
+    }
   }
 }

--- a/homeassistant/components/lamarzocco/switch.py
+++ b/homeassistant/components/lamarzocco/switch.py
@@ -14,7 +14,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .entity import LaMarzoccoEntity, LaMarzoccoEntityDescription
+from .coordinator import LaMarzoccoUpdateCoordinator
+from .entity import LaMarzoccoBaseEntity, LaMarzoccoEntity, LaMarzoccoEntityDescription
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -53,11 +54,20 @@ async def async_setup_entry(
     """Set up switch entities and services."""
 
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
-    async_add_entities(
+
+    entities: list[SwitchEntity] = []
+    entities.extend(
         LaMarzoccoSwitchEntity(coordinator, description)
         for description in ENTITIES
         if description.supported_fn(coordinator)
     )
+
+    entities.extend(
+        LaMarzoccoAutoOnOffSwitchEntity(coordinator, wake_up_sleep_entry_id)
+        for wake_up_sleep_entry_id in coordinator.device.config.wake_up_sleep_entries
+    )
+
+    async_add_entities(entities)
 
 
 class LaMarzoccoSwitchEntity(LaMarzoccoEntity, SwitchEntity):
@@ -79,3 +89,46 @@ class LaMarzoccoSwitchEntity(LaMarzoccoEntity, SwitchEntity):
     def is_on(self) -> bool:
         """Return true if device is on."""
         return self.entity_description.is_on_fn(self.coordinator.device.config)
+
+
+class LaMarzoccoAutoOnOffSwitchEntity(LaMarzoccoBaseEntity, SwitchEntity):
+    """Switch representing espresso machine auto on/off."""
+
+    coordinator: LaMarzoccoUpdateCoordinator
+    _attr_translation_key = "auto_on_off"
+
+    def __init__(
+        self,
+        coordinator: LaMarzoccoUpdateCoordinator,
+        identifier: str,
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator, f"auto_on_off_{identifier}")
+        self._identifier = identifier
+        self._attr_translation_placeholders = {"id": identifier}
+
+    async def _async_enable(self, state: bool) -> None:
+        """Enable or disable the auto on/off schedule."""
+        wake_up_sleep_entry = self.coordinator.device.config.wake_up_sleep_entries[
+            self._identifier
+        ]
+        wake_up_sleep_entry.enabled = state
+        await self.coordinator.device.set_wake_up_sleep(wake_up_sleep_entry)
+        self.async_write_ha_state()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn switch on."""
+        await self._async_enable(True)
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn switch off."""
+        await self._async_enable(False)
+        self.async_write_ha_state()
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if switch is on."""
+        return self.coordinator.device.config.wake_up_sleep_entries[
+            self._identifier
+        ].enabled

--- a/homeassistant/components/lamarzocco/switch.py
+++ b/homeassistant/components/lamarzocco/switch.py
@@ -118,12 +118,10 @@ class LaMarzoccoAutoOnOffSwitchEntity(LaMarzoccoBaseEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn switch on."""
         await self._async_enable(True)
-        self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn switch off."""
         await self._async_enable(False)
-        self.async_write_ha_state()
 
     @property
     def is_on(self) -> bool:

--- a/tests/components/lamarzocco/snapshots/test_switch.ambr
+++ b/tests/components/lamarzocco/snapshots/test_switch.ambr
@@ -1,4 +1,96 @@
 # serializer version: 1
+# name: test_auto_on_off_switches[entry.auto_on_off_Os2OswX]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.gs01234_auto_on_off_os2oswx',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Auto on/off (Os2OswX)',
+    'platform': 'lamarzocco',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'auto_on_off',
+    'unique_id': 'GS01234_auto_on_off_Os2OswX',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_auto_on_off_switches[entry.auto_on_off_aXFz5bJ]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.gs01234_auto_on_off_axfz5bj',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Auto on/off (aXFz5bJ)',
+    'platform': 'lamarzocco',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'auto_on_off',
+    'unique_id': 'GS01234_auto_on_off_aXFz5bJ',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_auto_on_off_switches[state.auto_on_off_Os2OswX]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'GS01234 Auto on/off (Os2OswX)',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.gs01234_auto_on_off_os2oswx',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_auto_on_off_switches[state.auto_on_off_aXFz5bJ]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'GS01234 Auto on/off (aXFz5bJ)',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.gs01234_auto_on_off_axfz5bj',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_device
   DeviceRegistryEntrySnapshot({
     'area_id': None,

--- a/tests/components/lamarzocco/test_switch.py
+++ b/tests/components/lamarzocco/test_switch.py
@@ -14,7 +14,7 @@ from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from . import async_init_integration
+from . import WAKE_UP_SLEEP_ENTRY_IDS, async_init_integration
 
 from tests.common import MockConfigEntry
 
@@ -106,3 +106,55 @@ async def test_device(
     device = device_registry.async_get(entry.device_id)
     assert device
     assert device == snapshot
+
+
+async def test_auto_on_off_switches(
+    hass: HomeAssistant,
+    mock_lamarzocco: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the auto on off/switches."""
+
+    await async_init_integration(hass, mock_config_entry)
+
+    serial_number = mock_lamarzocco.serial_number
+
+    for wake_up_sleep_entry_id in WAKE_UP_SLEEP_ENTRY_IDS:
+        state = hass.states.get(
+            f"switch.{serial_number}_auto_on_off_{wake_up_sleep_entry_id}"
+        )
+        assert state
+        assert state == snapshot(name=f"state.auto_on_off_{wake_up_sleep_entry_id}")
+
+        entry = entity_registry.async_get(state.entity_id)
+        assert entry
+        assert entry == snapshot(name=f"entry.auto_on_off_{wake_up_sleep_entry_id}")
+
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {
+                ATTR_ENTITY_ID: f"switch.{serial_number}_auto_on_off_{wake_up_sleep_entry_id}",
+            },
+            blocking=True,
+        )
+
+        wake_up_sleep_entry = mock_lamarzocco.config.wake_up_sleep_entries[
+            wake_up_sleep_entry_id
+        ]
+        wake_up_sleep_entry.enabled = False
+
+        mock_lamarzocco.set_wake_up_sleep.assert_called_with(wake_up_sleep_entry)
+
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {
+                ATTR_ENTITY_ID: f"switch.{serial_number}_auto_on_off_{wake_up_sleep_entry_id}",
+            },
+            blocking=True,
+        )
+        wake_up_sleep_entry.enabled = True
+        mock_lamarzocco.set_wake_up_sleep.assert_called_with(wake_up_sleep_entry)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Brings back the auto on/off switches that were removed in #113935 , but updated to support the new calendar entities introduced in #113935

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
