### PR TITLE
Support time entities in time conditions

### DIFF
--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -827,9 +827,11 @@ def time(
                 after_entity.attributes.get("minute", 59),
                 after_entity.attributes.get("second", 59),
             )
-        elif after_entity.attributes.get(
-            ATTR_DEVICE_CLASS
-        ) == SensorDeviceClass.TIMESTAMP and after_entity.state not in (
+        elif (
+            after_entity.domain == "time"
+            or after_entity.attributes.get(ATTR_DEVICE_CLASS)
+            == SensorDeviceClass.TIMESTAMP
+        ) and after_entity.state not in (
             STATE_UNAVAILABLE,
             STATE_UNKNOWN,
         ):
@@ -851,9 +853,11 @@ def time(
                 before_entity.attributes.get("minute", 59),
                 before_entity.attributes.get("second", 59),
             )
-        elif before_entity.attributes.get(
-            ATTR_DEVICE_CLASS
-        ) == SensorDeviceClass.TIMESTAMP and before_entity.state not in (
+        elif (
+            before_entity.domain == "time"
+            or before_entity.attributes.get(ATTR_DEVICE_CLASS)
+            == SensorDeviceClass.TIMESTAMP
+        ) and before_entity.state not in (
             STATE_UNAVAILABLE,
             STATE_UNKNOWN,
         ):

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1437,10 +1437,10 @@ TIME_CONDITION_SCHEMA = vol.All(
             **CONDITION_BASE_SCHEMA,
             vol.Required(CONF_CONDITION): "time",
             vol.Optional("before"): vol.Any(
-                time, vol.All(str, entity_domain(["input_datetime", "sensor"]))
+                time, vol.All(str, entity_domain(["input_datetime", "time", "sensor"]))
             ),
             vol.Optional("after"): vol.Any(
-                time, vol.All(str, entity_domain(["input_datetime", "sensor"]))
+                time, vol.All(str, entity_domain(["input_datetime", "time", "sensor"]))
             ),
             vol.Optional("weekday"): weekdays,
         }

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -992,6 +992,79 @@ async def test_time_using_input_datetime(hass: HomeAssistant) -> None:
         condition.time(hass, before="input_datetime.not_existing")
 
 
+async def test_time_using_time(hass: HomeAssistant) -> None:
+    """Test time conditions using time entities."""
+    hass.states.async_set(
+        "time.am",
+        "2021-06-03 13:00:00.000000+00:00",  # 6 am local time
+    )
+    hass.states.async_set(
+        "time.pm",
+        "2020-06-01 01:00:00.000000+00:00",  # 6 pm local time
+    )
+    hass.states.async_set(
+        "time.invalid_timestamp",
+        "This is not a timestamp",
+    )
+
+    with patch(
+        "homeassistant.helpers.condition.dt_util.now",
+        return_value=dt_util.now().replace(hour=3),
+    ):
+        assert not condition.time(hass, after="time.am", before="time.pm")
+        assert condition.time(hass, after="time.pm", before="time.am")
+
+    with patch(
+        "homeassistant.helpers.condition.dt_util.now",
+        return_value=dt_util.now().replace(hour=9),
+    ):
+        assert condition.time(hass, after="time.am", before="time.pm")
+        assert not condition.time(hass, after="time.pm", before="time.am")
+
+    with patch(
+        "homeassistant.helpers.condition.dt_util.now",
+        return_value=dt_util.now().replace(hour=15),
+    ):
+        assert condition.time(hass, after="time.am", before="time.pm")
+        assert not condition.time(hass, after="time.pm", before="time.am")
+
+    with patch(
+        "homeassistant.helpers.condition.dt_util.now",
+        return_value=dt_util.now().replace(hour=21),
+    ):
+        assert not condition.time(hass, after="time.am", before="time.pm")
+        assert condition.time(hass, after="time.pm", before="time.am")
+
+    # Trigger on PM time
+    with patch(
+        "homeassistant.helpers.condition.dt_util.now",
+        return_value=dt_util.now().replace(hour=18, minute=0, second=0),
+    ):
+        assert condition.time(hass, after="time.pm", before="time.am")
+        assert not condition.time(hass, after="time.am", before="time.pm")
+        assert condition.time(hass, after="time.pm")
+        assert not condition.time(hass, before="time.pm")
+
+    # Trigger on AM time
+    with patch(
+        "homeassistant.helpers.condition.dt_util.now",
+        return_value=dt_util.now().replace(hour=6, minute=0, second=0),
+    ):
+        assert not condition.time(hass, after="time.pm", before="time.am")
+        assert condition.time(hass, after="time.am", before="time.pm")
+        assert condition.time(hass, after="time.am")
+        assert not condition.time(hass, before="time.am")
+
+    assert not condition.time(hass, after="time.invalid_timestamp")
+    assert not condition.time(hass, before="time.invalid_timestamp")
+
+    with pytest.raises(ConditionError):
+        condition.time(hass, after="time.not_existing")
+
+    with pytest.raises(ConditionError):
+        condition.time(hass, before="time.not_existing")
+
+
 async def test_time_using_sensor(hass: HomeAssistant) -> None:
     """Test time conditions using sensor entities."""
     hass.states.async_set(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow the new time entities introduced in 2023.6 to be used in automation 'time' conditions, just like input_datetime helpers and sensors with timestamp device class.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
I'll file PRs to update the documentation, and to the frontend to update the selectors in the automation editor for time entities.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#33217

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
