### PR TITLE
Update pydantic to 1.10.17

### DIFF
--- a/homeassistant/components/sfr_box/diagnostics.py
+++ b/homeassistant/components/sfr_box/diagnostics.py
@@ -28,27 +28,19 @@ async def async_get_config_entry_diagnostics(
         },
         "data": {
             "dsl": async_redact_data(
-                dataclasses.asdict(
-                    await data.system.box.dsl_get_info()  # type:ignore [call-overload]
-                ),
+                dataclasses.asdict(await data.system.box.dsl_get_info()),
                 TO_REDACT,
             ),
             "ftth": async_redact_data(
-                dataclasses.asdict(
-                    await data.system.box.ftth_get_info()  # type:ignore [call-overload]
-                ),
+                dataclasses.asdict(await data.system.box.ftth_get_info()),
                 TO_REDACT,
             ),
             "system": async_redact_data(
-                dataclasses.asdict(
-                    await data.system.box.system_get_info()  # type:ignore [call-overload]
-                ),
+                dataclasses.asdict(await data.system.box.system_get_info()),
                 TO_REDACT,
             ),
             "wan": async_redact_data(
-                dataclasses.asdict(
-                    await data.system.box.wan_get_info()  # type:ignore [call-overload]
-                ),
+                dataclasses.asdict(await data.system.box.wan_get_info()),
                 TO_REDACT,
             ),
         },

--- a/homeassistant/components/xbox/media_source.py
+++ b/homeassistant/components/xbox/media_source.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from contextlib import suppress
 from dataclasses import dataclass
 
-from pydantic.error_wrappers import ValidationError
+from pydantic import ValidationError
 from xbox.webapi.api.client import XboxLiveClient
 from xbox.webapi.api.provider.catalog.models import FieldsTemplate, Image
 from xbox.webapi.api.provider.gameclips.models import GameclipsResponse

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -133,7 +133,7 @@ backoff>=2.0
 
 # Required to avoid breaking (#101042).
 # v2 has breaking changes (#99218).
-pydantic==1.10.15
+pydantic==1.10.16
 
 # Breaks asyncio
 # https://github.com/pubnub/python/issues/130

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -133,7 +133,7 @@ backoff>=2.0
 
 # Required to avoid breaking (#101042).
 # v2 has breaking changes (#99218).
-pydantic==1.10.16
+pydantic==1.10.17
 
 # Breaks asyncio
 # https://github.com/pubnub/python/issues/130

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,7 +13,7 @@ freezegun==1.5.0
 mock-open==1.4.0
 mypy-dev==1.11.0a6
 pre-commit==3.7.1
-pydantic==1.10.15
+pydantic==1.10.16
 pylint==3.2.2
 pylint-per-file-ignores==1.3.2
 pipdeptree==2.19.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,7 +13,7 @@ freezegun==1.5.0
 mock-open==1.4.0
 mypy-dev==1.11.0a6
 pre-commit==3.7.1
-pydantic==1.10.16
+pydantic==1.10.17
 pylint==3.2.2
 pylint-per-file-ignores==1.3.2
 pipdeptree==2.19.0

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -155,7 +155,7 @@ backoff>=2.0
 
 # Required to avoid breaking (#101042).
 # v2 has breaking changes (#99218).
-pydantic==1.10.15
+pydantic==1.10.16
 
 # Breaks asyncio
 # https://github.com/pubnub/python/issues/130

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -155,7 +155,7 @@ backoff>=2.0
 
 # Required to avoid breaking (#101042).
 # v2 has breaking changes (#99218).
-pydantic==1.10.16
+pydantic==1.10.17
 
 # Breaks asyncio
 # https://github.com/pubnub/python/issues/130

--- a/tests/components/lametric/conftest.py
+++ b/tests/components/lametric/conftest.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from demetriek import CloudDevice, Device
-from pydantic import parse_raw_as
+from pydantic import parse_raw_as  # pylint: disable=no-name-in-module
 import pytest
 from typing_extensions import Generator
 


### PR DESCRIPTION
## Proposed change
https://github.com/pydantic/pydantic/releases/tag/v1.10.16
https://github.com/pydantic/pydantic/compare/v1.10.15...v1.10.16
https://github.com/pydantic/pydantic/releases/tag/v1.10.17
https://github.com/pydantic/pydantic/compare/v1.10.16...v1.10.17

https://github.com/home-assistant/core/actions/runs/9471830653
https://github.com/home-assistant/core/actions/runs/9599604587
https://wheels.home-assistant.io/musllinux/

_Last bump: #116401_

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
