### PR TITLE
Fix consider-using-tuple pylint warnings in core tests

### DIFF
--- a/tests/components/alarm_control_panel/test_device_action.py
+++ b/tests/components/alarm_control_panel/test_device_action.py
@@ -174,7 +174,7 @@ async def test_get_actions_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for action in ["disarm", "arm_away"]
+        for action in ("disarm", "arm_away")
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id

--- a/tests/components/alarm_control_panel/test_device_condition.py
+++ b/tests/components/alarm_control_panel/test_device_condition.py
@@ -167,7 +167,7 @@ async def test_get_conditions_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for condition in ["is_disarmed", "is_triggered"]
+        for condition in ("is_disarmed", "is_triggered")
     ]
     conditions = await async_get_device_automations(
         hass, DeviceAutomationType.CONDITION, device_entry.id

--- a/tests/components/alarm_control_panel/test_device_trigger.py
+++ b/tests/components/alarm_control_panel/test_device_trigger.py
@@ -162,7 +162,7 @@ async def test_get_triggers_hidden_auxiliary(
             "entity_id": entry.id,
             "metadata": {"secondary": True},
         }
-        for trigger in ["triggered", "disarmed", "arming"]
+        for trigger in ("triggered", "disarmed", "arming")
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id

--- a/tests/components/binary_sensor/test_device_condition.py
+++ b/tests/components/binary_sensor/test_device_condition.py
@@ -122,7 +122,7 @@ async def test_get_conditions_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for condition in ["is_on", "is_off"]
+        for condition in ("is_on", "is_off")
     ]
     conditions = await async_get_device_automations(
         hass, DeviceAutomationType.CONDITION, device_entry.id

--- a/tests/components/binary_sensor/test_device_trigger.py
+++ b/tests/components/binary_sensor/test_device_trigger.py
@@ -122,7 +122,7 @@ async def test_get_triggers_hidden_auxiliary(
             "entity_id": entry.id,
             "metadata": {"secondary": True},
         }
-        for trigger in ["turned_on", "turned_off"]
+        for trigger in ("turned_on", "turned_off")
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id

--- a/tests/components/button/test_device_action.py
+++ b/tests/components/button/test_device_action.py
@@ -88,7 +88,7 @@ async def test_get_actions_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for action in ["press"]
+        for action in ("press",)
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id

--- a/tests/components/button/test_device_trigger.py
+++ b/tests/components/button/test_device_trigger.py
@@ -97,7 +97,7 @@ async def test_get_triggers_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for trigger in ["pressed"]
+        for trigger in ("pressed",)
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id

--- a/tests/components/climate/common.py
+++ b/tests/components/climate/common.py
@@ -86,13 +86,13 @@ async def async_set_temperature(
     """Set new target temperature."""
     kwargs = {
         key: value
-        for key, value in [
+        for key, value in (
             (ATTR_TEMPERATURE, temperature),
             (ATTR_TARGET_TEMP_HIGH, target_temp_high),
             (ATTR_TARGET_TEMP_LOW, target_temp_low),
             (ATTR_ENTITY_ID, entity_id),
             (ATTR_HVAC_MODE, hvac_mode),
-        ]
+        )
         if value is not None
     }
     _LOGGER.debug("set_temperature start data=%s", kwargs)
@@ -113,13 +113,13 @@ def set_temperature(
     """Set new target temperature."""
     kwargs = {
         key: value
-        for key, value in [
+        for key, value in (
             (ATTR_TEMPERATURE, temperature),
             (ATTR_TARGET_TEMP_HIGH, target_temp_high),
             (ATTR_TARGET_TEMP_LOW, target_temp_low),
             (ATTR_ENTITY_ID, entity_id),
             (ATTR_HVAC_MODE, hvac_mode),
-        ]
+        )
         if value is not None
     }
     _LOGGER.debug("set_temperature start data=%s", kwargs)

--- a/tests/components/climate/test_device_action.py
+++ b/tests/components/climate/test_device_action.py
@@ -136,7 +136,7 @@ async def test_get_actions_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for action in ["set_hvac_mode"]
+        for action in ("set_hvac_mode",)
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id

--- a/tests/components/climate/test_device_condition.py
+++ b/tests/components/climate/test_device_condition.py
@@ -139,7 +139,7 @@ async def test_get_conditions_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for condition in ["is_hvac_mode"]
+        for condition in ("is_hvac_mode",)
     ]
     conditions = await async_get_device_automations(
         hass, DeviceAutomationType.CONDITION, device_entry.id

--- a/tests/components/climate/test_device_trigger.py
+++ b/tests/components/climate/test_device_trigger.py
@@ -74,11 +74,11 @@ async def test_get_triggers(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
-        for trigger in [
+        for trigger in (
             "hvac_mode_changed",
             "current_temperature_changed",
             "current_humidity_changed",
-        ]
+        )
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id
@@ -135,11 +135,11 @@ async def test_get_triggers_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for trigger in [
+        for trigger in (
             "hvac_mode_changed",
             "current_temperature_changed",
             "current_humidity_changed",
-        ]
+        )
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id

--- a/tests/components/cover/test_device_action.py
+++ b/tests/components/cover/test_device_action.py
@@ -136,7 +136,7 @@ async def test_get_actions_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for action in ["close"]
+        for action in ("close",)
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id

--- a/tests/components/cover/test_device_condition.py
+++ b/tests/components/cover/test_device_condition.py
@@ -165,7 +165,7 @@ async def test_get_conditions_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for condition in ["is_open", "is_closed", "is_opening", "is_closing"]
+        for condition in ("is_open", "is_closed", "is_opening", "is_closing")
     ]
     conditions = await async_get_device_automations(
         hass, DeviceAutomationType.CONDITION, device_entry.id

--- a/tests/components/cover/test_device_trigger.py
+++ b/tests/components/cover/test_device_trigger.py
@@ -166,7 +166,7 @@ async def test_get_triggers_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for trigger in ["opened", "closed", "opening", "closing"]
+        for trigger in ("opened", "closed", "opening", "closing")
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id

--- a/tests/components/device_tracker/test_device_condition.py
+++ b/tests/components/device_tracker/test_device_condition.py
@@ -54,7 +54,7 @@ async def test_get_conditions(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
-        for condition in ["is_not_home", "is_home"]
+        for condition in ("is_not_home", "is_home")
     ]
     conditions = await async_get_device_automations(
         hass, DeviceAutomationType.CONDITION, device_entry.id
@@ -102,7 +102,7 @@ async def test_get_conditions_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for condition in ["is_not_home", "is_home"]
+        for condition in ("is_not_home", "is_home")
     ]
     conditions = await async_get_device_automations(
         hass, DeviceAutomationType.CONDITION, device_entry.id

--- a/tests/components/device_tracker/test_device_trigger.py
+++ b/tests/components/device_tracker/test_device_trigger.py
@@ -85,7 +85,7 @@ async def test_get_triggers(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
-        for trigger in ["leaves", "enters"]
+        for trigger in ("leaves", "enters")
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id
@@ -133,7 +133,7 @@ async def test_get_triggers_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for trigger in ["leaves", "enters"]
+        for trigger in ("leaves", "enters")
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id

--- a/tests/components/fan/common.py
+++ b/tests/components/fan/common.py
@@ -38,11 +38,11 @@ async def async_turn_on(
     """Turn all or specified fan on."""
     data = {
         key: value
-        for key, value in [
+        for key, value in (
             (ATTR_ENTITY_ID, entity_id),
             (ATTR_PERCENTAGE, percentage),
             (ATTR_PRESET_MODE, preset_mode),
-        ]
+        )
         if value is not None
     }
 
@@ -64,10 +64,10 @@ async def async_oscillate(
     """Set oscillation on all or specified fan."""
     data = {
         key: value
-        for key, value in [
+        for key, value in (
             (ATTR_ENTITY_ID, entity_id),
             (ATTR_OSCILLATING, should_oscillate),
-        ]
+        )
         if value is not None
     }
 
@@ -81,7 +81,7 @@ async def async_set_preset_mode(
     """Set preset mode for all or specified fan."""
     data = {
         key: value
-        for key, value in [(ATTR_ENTITY_ID, entity_id), (ATTR_PRESET_MODE, preset_mode)]
+        for key, value in ((ATTR_ENTITY_ID, entity_id), (ATTR_PRESET_MODE, preset_mode))
         if value is not None
     }
 
@@ -95,7 +95,7 @@ async def async_set_percentage(
     """Set percentage for all or specified fan."""
     data = {
         key: value
-        for key, value in [(ATTR_ENTITY_ID, entity_id), (ATTR_PERCENTAGE, percentage)]
+        for key, value in ((ATTR_ENTITY_ID, entity_id), (ATTR_PERCENTAGE, percentage))
         if value is not None
     }
 
@@ -109,10 +109,10 @@ async def async_increase_speed(
     """Increase speed for all or specified fan."""
     data = {
         key: value
-        for key, value in [
+        for key, value in (
             (ATTR_ENTITY_ID, entity_id),
             (ATTR_PERCENTAGE_STEP, percentage_step),
-        ]
+        )
         if value is not None
     }
 
@@ -126,10 +126,10 @@ async def async_decrease_speed(
     """Decrease speed for all or specified fan."""
     data = {
         key: value
-        for key, value in [
+        for key, value in (
             (ATTR_ENTITY_ID, entity_id),
             (ATTR_PERCENTAGE_STEP, percentage_step),
-        ]
+        )
         if value is not None
     }
 
@@ -143,7 +143,7 @@ async def async_set_direction(
     """Set direction for all or specified fan."""
     data = {
         key: value
-        for key, value in [(ATTR_ENTITY_ID, entity_id), (ATTR_DIRECTION, direction)]
+        for key, value in ((ATTR_ENTITY_ID, entity_id), (ATTR_DIRECTION, direction))
         if value is not None
     }
 

--- a/tests/components/fan/test_device_action.py
+++ b/tests/components/fan/test_device_action.py
@@ -48,7 +48,7 @@ async def test_get_actions(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
-        for action in ["turn_on", "turn_off", "toggle"]
+        for action in ("turn_on", "turn_off", "toggle")
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id
@@ -96,7 +96,7 @@ async def test_get_actions_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for action in ["turn_on", "turn_off", "toggle"]
+        for action in ("turn_on", "turn_off", "toggle")
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id

--- a/tests/components/fan/test_device_condition.py
+++ b/tests/components/fan/test_device_condition.py
@@ -54,7 +54,7 @@ async def test_get_conditions(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
-        for condition in ["is_off", "is_on"]
+        for condition in ("is_off", "is_on")
     ]
     conditions = await async_get_device_automations(
         hass, DeviceAutomationType.CONDITION, device_entry.id
@@ -102,7 +102,7 @@ async def test_get_conditions_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for condition in ["is_off", "is_on"]
+        for condition in ("is_off", "is_on")
     ]
     conditions = await async_get_device_automations(
         hass, DeviceAutomationType.CONDITION, device_entry.id

--- a/tests/components/fan/test_device_trigger.py
+++ b/tests/components/fan/test_device_trigger.py
@@ -59,7 +59,7 @@ async def test_get_triggers(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
-        for trigger in ["turned_off", "turned_on", "changed_states"]
+        for trigger in ("turned_off", "turned_on", "changed_states")
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id
@@ -107,7 +107,7 @@ async def test_get_triggers_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for trigger in ["turned_off", "turned_on", "changed_states"]
+        for trigger in ("turned_off", "turned_on", "changed_states")
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id

--- a/tests/components/group/common.py
+++ b/tests/components/group/common.py
@@ -64,13 +64,13 @@ def async_set_group(
     """Create/Update a group."""
     data = {
         key: value
-        for key, value in [
+        for key, value in (
             (ATTR_OBJECT_ID, object_id),
             (ATTR_NAME, name),
             (ATTR_ENTITIES, entity_ids),
             (ATTR_ICON, icon),
             (ATTR_ADD_ENTITIES, add),
-        ]
+        )
         if value is not None
     }
 

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -1236,7 +1236,7 @@ async def test_group_mixed_domains_on(hass: HomeAssistant) -> None:
     hass.states.async_set("binary_sensor.alexander_garage_side_door_open", "on")
     hass.states.async_set("cover.small_garage_door", "open")
 
-    for domain in ["lock", "binary_sensor", "cover"]:
+    for domain in ("lock", "binary_sensor", "cover"):
         assert await async_setup_component(hass, domain, {})
     assert await async_setup_component(
         hass,
@@ -1261,7 +1261,7 @@ async def test_group_mixed_domains_off(hass: HomeAssistant) -> None:
     hass.states.async_set("binary_sensor.alexander_garage_side_door_open", "off")
     hass.states.async_set("cover.small_garage_door", "closed")
 
-    for domain in ["lock", "binary_sensor", "cover"]:
+    for domain in ("lock", "binary_sensor", "cover"):
         assert await async_setup_component(hass, domain, {})
     assert await async_setup_component(
         hass,

--- a/tests/components/humidifier/test_device_condition.py
+++ b/tests/components/humidifier/test_device_condition.py
@@ -141,7 +141,7 @@ async def test_get_conditions_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for condition in ["is_off", "is_on"]
+        for condition in ("is_off", "is_on")
     ]
     conditions = await async_get_device_automations(
         hass, DeviceAutomationType.CONDITION, device_entry.id

--- a/tests/components/light/common.py
+++ b/tests/components/light/common.py
@@ -101,7 +101,7 @@ async def async_turn_on(
     """Turn all or specified light on."""
     data = {
         key: value
-        for key, value in [
+        for key, value in (
             (ATTR_ENTITY_ID, entity_id),
             (ATTR_PROFILE, profile),
             (ATTR_TRANSITION, transition),
@@ -118,7 +118,7 @@ async def async_turn_on(
             (ATTR_EFFECT, effect),
             (ATTR_COLOR_NAME, color_name),
             (ATTR_WHITE, white),
-        ]
+        )
         if value is not None
     }
 
@@ -135,11 +135,11 @@ async def async_turn_off(hass, entity_id=ENTITY_MATCH_ALL, transition=None, flas
     """Turn all or specified light off."""
     data = {
         key: value
-        for key, value in [
+        for key, value in (
             (ATTR_ENTITY_ID, entity_id),
             (ATTR_TRANSITION, transition),
             (ATTR_FLASH, flash),
-        ]
+        )
         if value is not None
     }
 
@@ -202,7 +202,7 @@ async def async_toggle(
     """Turn all or specified light on."""
     data = {
         key: value
-        for key, value in [
+        for key, value in (
             (ATTR_ENTITY_ID, entity_id),
             (ATTR_PROFILE, profile),
             (ATTR_TRANSITION, transition),
@@ -216,7 +216,7 @@ async def async_toggle(
             (ATTR_FLASH, flash),
             (ATTR_EFFECT, effect),
             (ATTR_COLOR_NAME, color_name),
-        ]
+        )
         if value is not None
     }
 

--- a/tests/components/light/test_device_action.py
+++ b/tests/components/light/test_device_action.py
@@ -66,14 +66,14 @@ async def test_get_actions(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
-        for action in [
+        for action in (
             "brightness_decrease",
             "brightness_increase",
             "flash",
             "turn_off",
             "turn_on",
             "toggle",
-        ]
+        )
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id
@@ -123,7 +123,7 @@ async def test_get_actions_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for action in ["turn_on", "turn_off", "toggle"]
+        for action in ("turn_on", "turn_off", "toggle")
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id

--- a/tests/components/light/test_device_condition.py
+++ b/tests/components/light/test_device_condition.py
@@ -62,7 +62,7 @@ async def test_get_conditions(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
-        for condition in ["is_off", "is_on"]
+        for condition in ("is_off", "is_on")
     ]
     conditions = await async_get_device_automations(
         hass, DeviceAutomationType.CONDITION, device_entry.id
@@ -110,7 +110,7 @@ async def test_get_conditions_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for condition in ["is_off", "is_on"]
+        for condition in ("is_off", "is_on")
     ]
     conditions = await async_get_device_automations(
         hass, DeviceAutomationType.CONDITION, device_entry.id

--- a/tests/components/light/test_device_trigger.py
+++ b/tests/components/light/test_device_trigger.py
@@ -67,7 +67,7 @@ async def test_get_triggers(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
-        for trigger in ["changed_states", "turned_off", "turned_on"]
+        for trigger in ("changed_states", "turned_off", "turned_on")
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id
@@ -115,7 +115,7 @@ async def test_get_triggers_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for trigger in ["changed_states", "turned_off", "turned_on"]
+        for trigger in ("changed_states", "turned_off", "turned_on")
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id

--- a/tests/components/lock/test_device_action.py
+++ b/tests/components/lock/test_device_action.py
@@ -129,7 +129,7 @@ async def test_get_actions_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for action in ["lock", "unlock"]
+        for action in ("lock", "unlock")
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id

--- a/tests/components/lock/test_device_condition.py
+++ b/tests/components/lock/test_device_condition.py
@@ -63,7 +63,7 @@ async def test_get_conditions(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
-        for condition in [
+        for condition in (
             "is_locked",
             "is_unlocked",
             "is_unlocking",
@@ -71,7 +71,7 @@ async def test_get_conditions(
             "is_jammed",
             "is_open",
             "is_opening",
-        ]
+        )
     ]
     conditions = await async_get_device_automations(
         hass, DeviceAutomationType.CONDITION, device_entry.id
@@ -119,7 +119,7 @@ async def test_get_conditions_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for condition in [
+        for condition in (
             "is_locked",
             "is_unlocked",
             "is_unlocking",
@@ -127,7 +127,7 @@ async def test_get_conditions_hidden_auxiliary(
             "is_jammed",
             "is_open",
             "is_opening",
-        ]
+        )
     ]
     conditions = await async_get_device_automations(
         hass, DeviceAutomationType.CONDITION, device_entry.id

--- a/tests/components/lock/test_device_trigger.py
+++ b/tests/components/lock/test_device_trigger.py
@@ -72,7 +72,7 @@ async def test_get_triggers(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
-        for trigger in [
+        for trigger in (
             "locked",
             "unlocked",
             "unlocking",
@@ -80,7 +80,7 @@ async def test_get_triggers(
             "jammed",
             "open",
             "opening",
-        ]
+        )
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id
@@ -129,7 +129,7 @@ async def test_get_triggers_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for trigger in [
+        for trigger in (
             "locked",
             "unlocked",
             "unlocking",
@@ -137,7 +137,7 @@ async def test_get_triggers_hidden_auxiliary(
             "jammed",
             "open",
             "opening",
-        ]
+        )
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id

--- a/tests/components/remote/test_device_action.py
+++ b/tests/components/remote/test_device_action.py
@@ -53,7 +53,7 @@ async def test_get_actions(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
-        for action in ["turn_off", "turn_on", "toggle"]
+        for action in ("turn_off", "turn_on", "toggle")
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id
@@ -101,7 +101,7 @@ async def test_get_actions_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for action in ["turn_off", "turn_on", "toggle"]
+        for action in ("turn_off", "turn_on", "toggle")
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id

--- a/tests/components/remote/test_device_condition.py
+++ b/tests/components/remote/test_device_condition.py
@@ -59,7 +59,7 @@ async def test_get_conditions(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
-        for condition in ["is_off", "is_on"]
+        for condition in ("is_off", "is_on")
     ]
     conditions = await async_get_device_automations(
         hass, DeviceAutomationType.CONDITION, device_entry.id
@@ -107,7 +107,7 @@ async def test_get_conditions_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for condition in ["is_off", "is_on"]
+        for condition in ("is_off", "is_on")
     ]
     conditions = await async_get_device_automations(
         hass, DeviceAutomationType.CONDITION, device_entry.id

--- a/tests/components/remote/test_device_trigger.py
+++ b/tests/components/remote/test_device_trigger.py
@@ -59,7 +59,7 @@ async def test_get_triggers(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
-        for trigger in ["changed_states", "turned_off", "turned_on"]
+        for trigger in ("changed_states", "turned_off", "turned_on")
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id
@@ -107,7 +107,7 @@ async def test_get_triggers_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for trigger in ["changed_states", "turned_off", "turned_on"]
+        for trigger in ("changed_states", "turned_off", "turned_on")
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id

--- a/tests/components/select/test_device_action.py
+++ b/tests/components/select/test_device_action.py
@@ -47,13 +47,13 @@ async def test_get_actions(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
-        for action in [
+        for action in (
             "select_first",
             "select_last",
             "select_next",
             "select_option",
             "select_previous",
-        ]
+        )
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id
@@ -101,13 +101,13 @@ async def test_get_actions_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for action in [
+        for action in (
             "select_first",
             "select_last",
             "select_next",
             "select_option",
             "select_previous",
-        ]
+        )
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id

--- a/tests/components/select/test_device_condition.py
+++ b/tests/components/select/test_device_condition.py
@@ -105,7 +105,7 @@ async def test_get_conditions_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for condition in ["selected_option"]
+        for condition in ("selected_option",)
     ]
     conditions = await async_get_device_automations(
         hass, DeviceAutomationType.CONDITION, device_entry.id

--- a/tests/components/select/test_device_trigger.py
+++ b/tests/components/select/test_device_trigger.py
@@ -105,7 +105,7 @@ async def test_get_triggers_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for trigger in ["current_option_changed"]
+        for trigger in ("current_option_changed",)
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id

--- a/tests/components/sensor/test_device_condition.py
+++ b/tests/components/sensor/test_device_condition.py
@@ -171,7 +171,7 @@ async def test_get_conditions_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for condition in ["is_value"]
+        for condition in ("is_value",)
     ]
     conditions = await async_get_device_automations(
         hass, DeviceAutomationType.CONDITION, device_entry.id

--- a/tests/components/sensor/test_device_trigger.py
+++ b/tests/components/sensor/test_device_trigger.py
@@ -173,7 +173,7 @@ async def test_get_triggers_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for trigger in ["value"]
+        for trigger in ("value",)
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -2413,7 +2413,7 @@ async def test_list_statistic_ids(
             "unit_class": unit_class,
         },
     ]
-    for stat_type in ["mean", "sum", "dogs"]:
+    for stat_type in ("mean", "sum", "dogs"):
         statistic_ids = await async_list_statistic_ids(hass, statistic_type=stat_type)
         if statistic_type == stat_type:
             assert statistic_ids == [
@@ -3887,12 +3887,12 @@ async def test_compile_statistics_hourly_daily_monthly_summary(
     start = zero
     end = zero + timedelta(minutes=5)
     for i in range(24):
-        for entity_id in [
+        for entity_id in (
             "sensor.test1",
             "sensor.test2",
             "sensor.test3",
             "sensor.test4",
-        ]:
+        ):
             expected_average = (
                 expected_averages[entity_id][i]
                 if entity_id in expected_averages
@@ -3936,12 +3936,12 @@ async def test_compile_statistics_hourly_daily_monthly_summary(
     start = zero
     end = zero + timedelta(hours=1)
     for i in range(2):
-        for entity_id in [
+        for entity_id in (
             "sensor.test1",
             "sensor.test2",
             "sensor.test3",
             "sensor.test4",
-        ]:
+        ):
             expected_average = (
                 mean(expected_averages[entity_id][i * 12 : (i + 1) * 12])
                 if entity_id in expected_averages
@@ -3993,12 +3993,12 @@ async def test_compile_statistics_hourly_daily_monthly_summary(
     start = dt_util.parse_datetime("2021-08-31T06:00:00+00:00")
     end = start + timedelta(days=1)
     for i in range(2):
-        for entity_id in [
+        for entity_id in (
             "sensor.test1",
             "sensor.test2",
             "sensor.test3",
             "sensor.test4",
-        ]:
+        ):
             expected_average = (
                 mean(expected_averages[entity_id][i * 12 : (i + 1) * 12])
                 if entity_id in expected_averages
@@ -4050,12 +4050,12 @@ async def test_compile_statistics_hourly_daily_monthly_summary(
     start = dt_util.parse_datetime("2021-08-01T06:00:00+00:00")
     end = dt_util.parse_datetime("2021-09-01T06:00:00+00:00")
     for i in range(2):
-        for entity_id in [
+        for entity_id in (
             "sensor.test1",
             "sensor.test2",
             "sensor.test3",
             "sensor.test4",
-        ]:
+        ):
             expected_average = (
                 mean(expected_averages[entity_id][i * 12 : (i + 1) * 12])
                 if entity_id in expected_averages

--- a/tests/components/switch/test_device_action.py
+++ b/tests/components/switch/test_device_action.py
@@ -54,7 +54,7 @@ async def test_get_actions(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
-        for action in ["turn_off", "turn_on", "toggle"]
+        for action in ("turn_off", "turn_on", "toggle")
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id
@@ -102,7 +102,7 @@ async def test_get_actions_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for action in ["turn_off", "turn_on", "toggle"]
+        for action in ("turn_off", "turn_on", "toggle")
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id

--- a/tests/components/switch/test_device_condition.py
+++ b/tests/components/switch/test_device_condition.py
@@ -59,7 +59,7 @@ async def test_get_conditions(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
-        for condition in ["is_off", "is_on"]
+        for condition in ("is_off", "is_on")
     ]
     conditions = await async_get_device_automations(
         hass, DeviceAutomationType.CONDITION, device_entry.id
@@ -107,7 +107,7 @@ async def test_get_conditions_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for condition in ["is_off", "is_on"]
+        for condition in ("is_off", "is_on")
     ]
     conditions = await async_get_device_automations(
         hass, DeviceAutomationType.CONDITION, device_entry.id

--- a/tests/components/switch/test_device_trigger.py
+++ b/tests/components/switch/test_device_trigger.py
@@ -59,7 +59,7 @@ async def test_get_triggers(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
-        for trigger in ["changed_states", "turned_off", "turned_on"]
+        for trigger in ("changed_states", "turned_off", "turned_on")
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id
@@ -107,7 +107,7 @@ async def test_get_triggers_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for trigger in ["changed_states", "turned_off", "turned_on"]
+        for trigger in ("changed_states", "turned_off", "turned_on")
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id

--- a/tests/components/vacuum/test_device_action.py
+++ b/tests/components/vacuum/test_device_action.py
@@ -47,7 +47,7 @@ async def test_get_actions(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
-        for action in ["clean", "dock"]
+        for action in ("clean", "dock")
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id
@@ -95,7 +95,7 @@ async def test_get_actions_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for action in ["clean", "dock"]
+        for action in ("clean", "dock")
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id

--- a/tests/components/vacuum/test_device_condition.py
+++ b/tests/components/vacuum/test_device_condition.py
@@ -59,7 +59,7 @@ async def test_get_conditions(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
-        for condition in ["is_cleaning", "is_docked"]
+        for condition in ("is_cleaning", "is_docked")
     ]
     conditions = await async_get_device_automations(
         hass, DeviceAutomationType.CONDITION, device_entry.id
@@ -107,7 +107,7 @@ async def test_get_conditions_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for condition in ["is_cleaning", "is_docked"]
+        for condition in ("is_cleaning", "is_docked")
     ]
     conditions = await async_get_device_automations(
         hass, DeviceAutomationType.CONDITION, device_entry.id

--- a/tests/components/vacuum/test_device_trigger.py
+++ b/tests/components/vacuum/test_device_trigger.py
@@ -59,7 +59,7 @@ async def test_get_triggers(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
-        for trigger in ["cleaning", "docked"]
+        for trigger in ("cleaning", "docked")
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id
@@ -107,7 +107,7 @@ async def test_get_triggers_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for trigger in ["cleaning", "docked"]
+        for trigger in ("cleaning", "docked")
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id

--- a/tests/components/water_heater/common.py
+++ b/tests/components/water_heater/common.py
@@ -35,11 +35,11 @@ async def async_set_temperature(
     """Set new target temperature."""
     kwargs = {
         key: value
-        for key, value in [
+        for key, value in (
             (ATTR_TEMPERATURE, temperature),
             (ATTR_ENTITY_ID, entity_id),
             (ATTR_OPERATION_MODE, operation_mode),
-        ]
+        )
         if value is not None
     }
     _LOGGER.debug("set_temperature start data=%s", kwargs)

--- a/tests/components/water_heater/test_device_action.py
+++ b/tests/components/water_heater/test_device_action.py
@@ -47,7 +47,7 @@ async def test_get_actions(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
-        for action in ["turn_on", "turn_off"]
+        for action in ("turn_on", "turn_off")
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id
@@ -95,7 +95,7 @@ async def test_get_actions_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for action in ["turn_on", "turn_off"]
+        for action in ("turn_on", "turn_off")
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -768,7 +768,7 @@ def test_date() -> None:
     """Test date validation."""
     schema = vol.Schema(cv.date)
 
-    for value in ["Not a date", "23:42", "2016-11-23T18:59:08"]:
+    for value in ("Not a date", "23:42", "2016-11-23T18:59:08"):
         with pytest.raises(vol.Invalid):
             schema(value)
 
@@ -780,7 +780,7 @@ def test_time() -> None:
     """Test date validation."""
     schema = vol.Schema(cv.time)
 
-    for value in ["Not a time", "2016-11-23", "2016-11-23T18:59:08"]:
+    for value in ("Not a time", "2016-11-23", "2016-11-23T18:59:08"):
         with pytest.raises(vol.Invalid):
             schema(value)
 
@@ -792,7 +792,7 @@ def test_time() -> None:
 def test_datetime() -> None:
     """Test date time validation."""
     schema = vol.Schema(cv.datetime)
-    for value in [date.today(), "Wrong DateTime"]:
+    for value in (date.today(), "Wrong DateTime"):
         with pytest.raises(vol.MultipleInvalid):
             schema(value)
 
@@ -1307,7 +1307,7 @@ def test_uuid4_hex(caplog: pytest.LogCaptureFixture) -> None:
     """Test uuid validation."""
     schema = vol.Schema(cv.uuid4_hex)
 
-    for value in ["Not a hex string", "0", 0]:
+    for value in ("Not a hex string", "0", 0):
         with pytest.raises(vol.Invalid):
             schema(value)
 

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -613,7 +613,7 @@ async def test_async_remove_with_platform_update_finishes(hass: HomeAssistant) -
     # Add, remove, and make sure no updates
     # cause the entity to reappear after removal and
     # that we can add another entity with the same entity_id
-    for entity in [entity1, entity2]:
+    for entity in (entity1, entity2):
         update_called = asyncio.Event()
         update_done = asyncio.Event()
         await component.async_add_entities([entity])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -192,13 +192,13 @@ async def mock_non_adr_0007_integration_with_docs(hass: HomeAssistant) -> None:
 async def mock_adr_0007_integrations(hass: HomeAssistant) -> list[Integration]:
     """Mock ADR-0007 compliant integrations."""
     integrations = []
-    for domain in [
+    for domain in (
         "adr_0007_1",
         "adr_0007_2",
         "adr_0007_3",
         "adr_0007_4",
         "adr_0007_5",
-    ]:
+    ):
         adr_0007_config_schema = vol.Schema(
             {
                 domain: vol.Schema(
@@ -225,13 +225,13 @@ async def mock_adr_0007_integrations_with_docs(
 ) -> list[Integration]:
     """Mock ADR-0007 compliant integrations."""
     integrations = []
-    for domain in [
+    for domain in (
         "adr_0007_1",
         "adr_0007_2",
         "adr_0007_3",
         "adr_0007_4",
         "adr_0007_5",
-    ]:
+    ):
         adr_0007_config_schema = vol.Schema(
             {
                 domain: vol.Schema(
@@ -293,10 +293,10 @@ async def mock_custom_validator_integrations(hass: HomeAssistant) -> list[Integr
             Mock(async_validate_config=gen_async_validate_config(domain)),
         )
 
-    for domain, exception in [
+    for domain, exception in (
         ("custom_validator_bad_1", HomeAssistantError("broken")),
         ("custom_validator_bad_2", ValueError("broken")),
-    ]:
+    ):
         integrations.append(mock_integration(hass, MockModule(domain)))
         mock_platform(
             hass,
@@ -352,10 +352,10 @@ async def mock_custom_validator_integrations_with_docs(
             Mock(async_validate_config=gen_async_validate_config(domain)),
         )
 
-    for domain, exception in [
+    for domain, exception in (
         ("custom_validator_bad_1", HomeAssistantError("broken")),
         ("custom_validator_bad_2", ValueError("broken")),
-    ]:
+    ):
         integrations.append(
             mock_integration(
                 hass,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2230,7 +2230,7 @@ async def test_async_run_job_starts_coro_eagerly(hass: HomeAssistant) -> None:
 
 def test_valid_entity_id() -> None:
     """Test valid entity ID."""
-    for invalid in [
+    for invalid in (
         "_light.kitchen",
         ".kitchen",
         ".light.kitchen",
@@ -2243,10 +2243,10 @@ def test_valid_entity_id() -> None:
         "Light.kitchen",
         "light.Kitchen",
         "lightkitchen",
-    ]:
+    ):
         assert not ha.valid_entity_id(invalid), invalid
 
-    for valid in [
+    for valid in (
         "1.a",
         "1light.kitchen",
         "a.1",
@@ -2255,13 +2255,13 @@ def test_valid_entity_id() -> None:
         "light.1kitchen",
         "light.kitchen",
         "light.something_yoo",
-    ]:
+    ):
         assert ha.valid_entity_id(valid), valid
 
 
 def test_valid_domain() -> None:
     """Test valid domain."""
-    for invalid in [
+    for invalid in (
         "_light",
         ".kitchen",
         ".light.kitchen",
@@ -2272,16 +2272,16 @@ def test_valid_domain() -> None:
         "light.kitchen_yo_",
         "light.kitchen.",
         "Light",
-    ]:
+    ):
         assert not ha.valid_domain(invalid), invalid
 
-    for valid in [
+    for valid in (
         "1",
         "1light",
         "a",
         "input_boolean",
         "light",
-    ]:
+    ):
         assert ha.valid_domain(valid), valid
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #119279
https://github.com/home-assistant/core/actions/runs/9477454436/job/26112034466?pr=119279

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
