### PR TITLE
Fix consider-using-tuple pylint warnings in component tests

### DIFF
--- a/tests/components/alexa/test_capabilities.py
+++ b/tests/components/alexa/test_capabilities.py
@@ -817,7 +817,7 @@ async def test_report_climate_state(hass: HomeAssistant) -> None:
             {"value": 34.0, "scale": "CELSIUS"},
         )
 
-    for off_modes in [HVACMode.OFF]:
+    for off_modes in (HVACMode.OFF,):
         hass.states.async_set(
             "climate.downstairs",
             off_modes,
@@ -954,7 +954,7 @@ async def test_report_on_off_climate_state(hass: HomeAssistant) -> None:
             {"value": 34.0, "scale": "CELSIUS"},
         )
 
-    for off_modes in [HVACMode.OFF]:
+    for off_modes in (HVACMode.OFF,):
         hass.states.async_set(
             "climate.onoff",
             off_modes,
@@ -1002,7 +1002,7 @@ async def test_report_water_heater_state(hass: HomeAssistant) -> None:
             {"value": 34.0, "scale": "CELSIUS"},
         )
 
-    for off_mode in [STATE_OFF]:
+    for off_mode in (STATE_OFF,):
         hass.states.async_set(
             "water_heater.boyler",
             off_mode,

--- a/tests/components/alexa/test_entities.py
+++ b/tests/components/alexa/test_entities.py
@@ -130,7 +130,7 @@ async def test_serialize_discovery_partly_fails(
     }
     assert all(
         entity in endpoint_ids
-        for entity in ["switch#bla", "fan#bla", "humidifier#bla", "sensor#bla"]
+        for entity in ("switch#bla", "fan#bla", "humidifier#bla", "sensor#bla")
     )
 
     # Simulate fetching the interfaces fails for fan entity
@@ -147,7 +147,7 @@ async def test_serialize_discovery_partly_fails(
         }
         assert all(
             entity in endpoint_ids
-            for entity in ["switch#bla", "humidifier#bla", "sensor#bla"]
+            for entity in ("switch#bla", "humidifier#bla", "sensor#bla")
         )
         assert "Unable to serialize fan.bla for discovery" in caplog.text
         caplog.clear()
@@ -166,7 +166,7 @@ async def test_serialize_discovery_partly_fails(
         }
         assert all(
             entity in endpoint_ids
-            for entity in ["switch#bla", "humidifier#bla", "fan#bla"]
+            for entity in ("switch#bla", "humidifier#bla", "fan#bla")
         )
         assert "Unable to serialize sensor.bla for discovery" in caplog.text
         caplog.clear()

--- a/tests/components/dlna_dmr/test_config_flow.py
+++ b/tests/components/dlna_dmr/test_config_flow.py
@@ -598,12 +598,12 @@ async def test_ssdp_ignore_device(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "alternative_integration"
 
-    for manufacturer, model in [
+    for manufacturer, model in (
         ("XBMC Foundation", "Kodi"),
         ("Samsung", "Smart TV"),
         ("LG Electronics.", "LG TV"),
         ("Royal Philips Electronics", "Philips TV DMR"),
-    ]:
+    ):
         discovery = dataclasses.replace(MOCK_DISCOVERY)
         discovery.upnp = dict(discovery.upnp)
         discovery.upnp[ssdp.ATTR_UPNP_MANUFACTURER] = manufacturer

--- a/tests/components/dlna_dmr/test_media_player.py
+++ b/tests/components/dlna_dmr/test_media_player.py
@@ -458,7 +458,7 @@ async def test_available_device(
     assert device.name == "device_name"
 
     # Check entity state gets updated when device changes state
-    for dev_state, ent_state in [
+    for dev_state, ent_state in (
         (None, MediaPlayerState.ON),
         (TransportState.STOPPED, MediaPlayerState.IDLE),
         (TransportState.PLAYING, MediaPlayerState.PLAYING),
@@ -468,7 +468,7 @@ async def test_available_device(
         (TransportState.RECORDING, MediaPlayerState.IDLE),
         (TransportState.NO_MEDIA_PRESENT, MediaPlayerState.IDLE),
         (TransportState.VENDOR_DEFINED, ha_const.STATE_UNKNOWN),
-    ]:
+    ):
         dmr_device_mock.profile_device.available = True
         dmr_device_mock.transport_state = dev_state
         await async_update_entity(hass, mock_entity_id)
@@ -595,7 +595,7 @@ async def test_attributes(
     assert attrs[mp.ATTR_MEDIA_EPISODE] == "S1E23"
 
     # shuffle and repeat is based on device's play mode
-    for play_mode, shuffle, repeat in [
+    for play_mode, shuffle, repeat in (
         (PlayMode.NORMAL, False, RepeatMode.OFF),
         (PlayMode.SHUFFLE, True, RepeatMode.OFF),
         (PlayMode.REPEAT_ONE, False, RepeatMode.ONE),
@@ -603,12 +603,12 @@ async def test_attributes(
         (PlayMode.RANDOM, True, RepeatMode.ALL),
         (PlayMode.DIRECT_1, False, RepeatMode.OFF),
         (PlayMode.INTRO, False, RepeatMode.OFF),
-    ]:
+    ):
         dmr_device_mock.play_mode = play_mode
         attrs = await get_attrs(hass, mock_entity_id)
         assert attrs[mp.ATTR_MEDIA_SHUFFLE] is shuffle
         assert attrs[mp.ATTR_MEDIA_REPEAT] == repeat
-    for bad_play_mode in [None, PlayMode.VENDOR_DEFINED]:
+    for bad_play_mode in (None, PlayMode.VENDOR_DEFINED):
         dmr_device_mock.play_mode = bad_play_mode
         attrs = await get_attrs(hass, mock_entity_id)
         assert mp.ATTR_MEDIA_SHUFFLE not in attrs
@@ -944,7 +944,7 @@ async def test_shuffle_repeat_modes(
     """Test setting repeat and shuffle modes."""
     # Test shuffle with all variations of existing play mode
     dmr_device_mock.valid_play_modes = {mode.value for mode in PlayMode}
-    for init_mode, shuffle_set, expect_mode in [
+    for init_mode, shuffle_set, expect_mode in (
         (PlayMode.NORMAL, False, PlayMode.NORMAL),
         (PlayMode.SHUFFLE, False, PlayMode.NORMAL),
         (PlayMode.REPEAT_ONE, False, PlayMode.REPEAT_ONE),
@@ -955,7 +955,7 @@ async def test_shuffle_repeat_modes(
         (PlayMode.REPEAT_ONE, True, PlayMode.RANDOM),
         (PlayMode.REPEAT_ALL, True, PlayMode.RANDOM),
         (PlayMode.RANDOM, True, PlayMode.RANDOM),
-    ]:
+    ):
         dmr_device_mock.play_mode = init_mode
         await hass.services.async_call(
             mp.DOMAIN,
@@ -966,7 +966,7 @@ async def test_shuffle_repeat_modes(
         dmr_device_mock.async_set_play_mode.assert_awaited_with(expect_mode)
 
     # Test repeat with all variations of existing play mode
-    for init_mode, repeat_set, expect_mode in [
+    for init_mode, repeat_set, expect_mode in (
         (PlayMode.NORMAL, RepeatMode.OFF, PlayMode.NORMAL),
         (PlayMode.SHUFFLE, RepeatMode.OFF, PlayMode.SHUFFLE),
         (PlayMode.REPEAT_ONE, RepeatMode.OFF, PlayMode.NORMAL),
@@ -982,7 +982,7 @@ async def test_shuffle_repeat_modes(
         (PlayMode.REPEAT_ONE, RepeatMode.ALL, PlayMode.REPEAT_ALL),
         (PlayMode.REPEAT_ALL, RepeatMode.ALL, PlayMode.REPEAT_ALL),
         (PlayMode.RANDOM, RepeatMode.ALL, PlayMode.RANDOM),
-    ]:
+    ):
         dmr_device_mock.play_mode = init_mode
         await hass.services.async_call(
             mp.DOMAIN,

--- a/tests/components/ecobee/test_climate.py
+++ b/tests/components/ecobee/test_climate.py
@@ -363,13 +363,10 @@ async def test_hold_preference(ecobee_fixture, thermostat) -> None:
     """Test hold preference."""
     ecobee_fixture["settings"]["holdAction"] = "indefinite"
     assert thermostat.hold_preference() == "indefinite"
-    for action in ["useEndTime2hour", "useEndTime4hour"]:
+    for action in ("useEndTime2hour", "useEndTime4hour"):
         ecobee_fixture["settings"]["holdAction"] = action
         assert thermostat.hold_preference() == "holdHours"
-    for action in [
-        "nextPeriod",
-        "askMe",
-    ]:
+    for action in ("nextPeriod", "askMe"):
         ecobee_fixture["settings"]["holdAction"] = action
         assert thermostat.hold_preference() == "nextTransition"
 
@@ -380,11 +377,7 @@ def test_hold_hours(ecobee_fixture, thermostat) -> None:
     assert thermostat.hold_hours() == 2
     ecobee_fixture["settings"]["holdAction"] = "useEndTime4hour"
     assert thermostat.hold_hours() == 4
-    for action in [
-        "nextPeriod",
-        "indefinite",
-        "askMe",
-    ]:
+    for action in ("nextPeriod", "indefinite", "askMe"):
         ecobee_fixture["settings"]["holdAction"] = action
         assert thermostat.hold_hours() is None
 

--- a/tests/components/filter/test_sensor.py
+++ b/tests/components/filter/test_sensor.py
@@ -390,7 +390,7 @@ def test_initial_outlier(values: list[State]) -> None:
     """Test issue #13363."""
     filt = OutlierFilter(window_size=3, precision=2, entity=None, radius=4.0)
     out = State("sensor.test_monitored", "4000")
-    for state in [out, *values]:
+    for state in (out, *values):
         filtered = filt.filter_state(state)
     assert filtered.state == 21
 
@@ -399,7 +399,7 @@ def test_unknown_state_outlier(values: list[State]) -> None:
     """Test issue #32395."""
     filt = OutlierFilter(window_size=3, precision=2, entity=None, radius=4.0)
     out = State("sensor.test_monitored", "unknown")
-    for state in [out, *values, out]:
+    for state in (out, *values, out):
         try:
             filtered = filt.filter_state(state)
         except ValueError:
@@ -419,7 +419,7 @@ def test_lowpass(values: list[State]) -> None:
     """Test if lowpass filter works."""
     filt = LowPassFilter(window_size=10, precision=2, entity=None, time_constant=10)
     out = State("sensor.test_monitored", "unknown")
-    for state in [out, *values, out]:
+    for state in (out, *values, out):
         try:
             filtered = filt.filter_state(state)
         except ValueError:

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -485,7 +485,7 @@ async def test_http_api_event(
     assert response.status == HTTPStatus.OK
     events = await response.json()
     assert len(events) == 1
-    assert {k: events[0].get(k) for k in ["summary", "start", "end"]} == {
+    assert {k: events[0].get(k) for k in ("summary", "start", "end")} == {
         "summary": TEST_EVENT["summary"],
         "start": {"dateTime": "2022-03-27T15:05:00+03:00"},
         "end": {"dateTime": "2022-03-27T15:10:00+03:00"},
@@ -513,7 +513,7 @@ async def test_http_api_all_day_event(
     assert response.status == HTTPStatus.OK
     events = await response.json()
     assert len(events) == 1
-    assert {k: events[0].get(k) for k in ["summary", "start", "end"]} == {
+    assert {k: events[0].get(k) for k in ("summary", "start", "end")} == {
         "summary": TEST_EVENT["summary"],
         "start": {"date": "2022-03-27"},
         "end": {"date": "2022-03-28"},

--- a/tests/components/hddtemp/test_sensor.py
+++ b/tests/components/hddtemp/test_sensor.py
@@ -158,11 +158,11 @@ async def test_hddtemp_multiple_disks(hass: HomeAssistant, telnetmock) -> None:
     assert await async_setup_component(hass, "sensor", VALID_CONFIG_MULTIPLE_DISKS)
     await hass.async_block_till_done()
 
-    for sensor in [
+    for sensor in (
         "sensor.hd_temperature_dev_sda1",
         "sensor.hd_temperature_dev_sdb1",
         "sensor.hd_temperature_dev_sdc1",
-    ]:
+    ):
         state = hass.states.get(sensor)
 
         reference = REFERENCE[state.attributes.get("device")]

--- a/tests/components/homeassistant_hardware/test_silabs_multiprotocol_addon.py
+++ b/tests/components/homeassistant_hardware/test_silabs_multiprotocol_addon.py
@@ -584,7 +584,7 @@ async def test_option_flow_addon_installed_same_device_reconfigure_expected_user
     config_entry.add_to_hass(hass)
 
     mock_multiprotocol_platforms = {}
-    for domain in ["otbr", "zha"]:
+    for domain in ("otbr", "zha"):
         mock_multiprotocol_platform = MockMultiprotocolPlatform()
         mock_multiprotocol_platforms[domain] = mock_multiprotocol_platform
         mock_multiprotocol_platform.channel = configured_channel
@@ -619,7 +619,7 @@ async def test_option_flow_addon_installed_same_device_reconfigure_expected_user
     result = await hass.config_entries.options.async_configure(result["flow_id"], {})
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
-    for domain in ["otbr", "zha"]:
+    for domain in ("otbr", "zha"):
         assert mock_multiprotocol_platforms[domain].change_channel_calls == [(14, 300)]
     assert multipan_manager._channel == 14
 

--- a/tests/components/hue/test_light_v2.py
+++ b/tests/components/hue/test_light_v2.py
@@ -455,11 +455,11 @@ async def test_grouped_lights(
     assert mock_bridge_v2.mock_requests[0]["json"]["dynamics"]["duration"] == 200
 
     # Now generate update events by emitting the json we've sent as incoming events
-    for light_id in [
+    for light_id in (
         "02cba059-9c2c-4d45-97e4-4f79b1bfbaa1",
         "b3fe71ef-d0ef-48de-9355-d9e604377df0",
         "8015b17f-8336-415b-966a-b364bd082397",
-    ]:
+    ):
         event = {
             "id": light_id,
             "type": "light",

--- a/tests/components/husqvarna_automower/test_binary_sensor.py
+++ b/tests/components/husqvarna_automower/test_binary_sensor.py
@@ -45,11 +45,11 @@ async def test_binary_sensor_states(
     assert state is not None
     assert state.state == "off"
 
-    for activity, entity in [
+    for activity, entity in (
         (MowerActivities.CHARGING, "test_mower_1_charging"),
         (MowerActivities.LEAVING, "test_mower_1_leaving_dock"),
         (MowerActivities.GOING_HOME, "test_mower_1_returning_to_dock"),
-    ]:
+    ):
         values[TEST_MOWER_ID].mower.activity = activity
         mock_automower_client.get_status.return_value = values
         freezer.tick(SCAN_INTERVAL)

--- a/tests/components/husqvarna_automower/test_lawn_mower.py
+++ b/tests/components/husqvarna_automower/test_lawn_mower.py
@@ -38,11 +38,11 @@ async def test_lawn_mower_states(
     assert state is not None
     assert state.state == LawnMowerActivity.DOCKED
 
-    for activity, state, expected_state in [
+    for activity, state, expected_state in (
         ("UNKNOWN", "PAUSED", LawnMowerActivity.PAUSED),
         ("MOWING", "NOT_APPLICABLE", LawnMowerActivity.MOWING),
         ("NOT_APPLICABLE", "ERROR", LawnMowerActivity.ERROR),
-    ]:
+    ):
         values[TEST_MOWER_ID].mower.activity = activity
         values[TEST_MOWER_ID].mower.state = state
         mock_automower_client.get_status.return_value = values

--- a/tests/components/husqvarna_automower/test_select.py
+++ b/tests/components/husqvarna_automower/test_select.py
@@ -38,14 +38,14 @@ async def test_select_states(
     assert state is not None
     assert state.state == "evening_only"
 
-    for state, expected_state in [
+    for state, expected_state in (
         (
             HeadlightModes.ALWAYS_OFF,
             "always_off",
         ),
         (HeadlightModes.ALWAYS_ON, "always_on"),
         (HeadlightModes.EVENING_AND_NIGHT, "evening_and_night"),
-    ]:
+    ):
         values[TEST_MOWER_ID].settings.headlight.mode = state
         mock_automower_client.get_status.return_value = values
         freezer.tick(SCAN_INTERVAL)

--- a/tests/components/husqvarna_automower/test_sensor.py
+++ b/tests/components/husqvarna_automower/test_sensor.py
@@ -131,10 +131,10 @@ async def test_error_sensor(
     )
     await setup_integration(hass, mock_config_entry)
 
-    for state, expected_state in [
+    for state, expected_state in (
         (None, "no_error"),
         ("can_error", "can_error"),
-    ]:
+    ):
         values[TEST_MOWER_ID].mower.error_key = state
         mock_automower_client.get_status.return_value = values
         freezer.tick(SCAN_INTERVAL)

--- a/tests/components/husqvarna_automower/test_switch.py
+++ b/tests/components/husqvarna_automower/test_switch.py
@@ -41,10 +41,10 @@ async def test_switch_states(
     )
     await setup_integration(hass, mock_config_entry)
 
-    for state, restricted_reson, expected_state in [
+    for state, restricted_reson, expected_state in (
         (MowerStates.RESTRICTED, RestrictedReasons.NOT_APPLICABLE, "off"),
         (MowerStates.IN_OPERATION, RestrictedReasons.NONE, "on"),
-    ]:
+    ):
         values[TEST_MOWER_ID].mower.state = state
         values[TEST_MOWER_ID].planner.restricted_reason = restricted_reson
         mock_automower_client.get_status.return_value = values

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -346,7 +346,7 @@ async def test_entity_assumed_and_available(
     light = get_aqualink_device(
         system, name="aux_1", cls=IaquaLightSwitch, data={"state": "1"}
     )
-    devices = {d.name: d for d in (light,)}
+    devices = {light.name: light}
     system.get_devices = AsyncMock(return_value=devices)
     system.update = AsyncMock()
 

--- a/tests/components/iaqualink/test_init.py
+++ b/tests/components/iaqualink/test_init.py
@@ -346,7 +346,7 @@ async def test_entity_assumed_and_available(
     light = get_aqualink_device(
         system, name="aux_1", cls=IaquaLightSwitch, data={"state": "1"}
     )
-    devices = {d.name: d for d in [light]}
+    devices = {d.name: d for d in (light,)}
     system.get_devices = AsyncMock(return_value=devices)
     system.update = AsyncMock()
 

--- a/tests/components/influxdb/test_sensor.py
+++ b/tests/components/influxdb/test_sensor.py
@@ -111,7 +111,7 @@ def _make_v1_resultset(*args):
 
 def _make_v1_databases_resultset():
     """Create a mock V1 'show databases' resultset."""
-    for name in [DEFAULT_DATABASE, "db2"]:
+    for name in (DEFAULT_DATABASE, "db2"):
         yield {"name": name}
 
 
@@ -129,7 +129,7 @@ def _make_v2_resultset(*args):
 
 def _make_v2_buckets_resultset():
     """Create a mock V2 'buckets()' resultset."""
-    records = [Record({"name": name}) for name in [DEFAULT_BUCKET, "bucket2"]]
+    records = [Record({"name": name}) for name in (DEFAULT_BUCKET, "bucket2")]
 
     return [Table(records)]
 

--- a/tests/components/insteon/mock_devices.py
+++ b/tests/components/insteon/mock_devices.py
@@ -85,7 +85,7 @@ class MockDevices:
             )
 
             for device in [
-                self._devices[addr] for addr in [addr1, addr2, addr3, addr4, addr5]
+                self._devices[addr] for addr in (addr1, addr2, addr3, addr4, addr5)
             ]:
                 device.async_read_config = AsyncMock()
                 device.aldb.async_write = AsyncMock()
@@ -105,7 +105,7 @@ class MockDevices:
                 )
 
             for device in [
-                self._devices[addr] for addr in [addr2, addr3, addr4, addr5]
+                self._devices[addr] for addr in (addr2, addr3, addr4, addr5)
             ]:
                 device.async_status = AsyncMock()
             self._devices[addr1].async_status = AsyncMock(side_effect=AttributeError)

--- a/tests/components/insteon/test_api_aldb.py
+++ b/tests/components/insteon/test_api_aldb.py
@@ -303,7 +303,7 @@ async def test_bad_address(
     record = _aldb_dict(0)
 
     ws_id = 0
-    for call in ["get", "write", "load", "reset", "add_default_links", "notify"]:
+    for call in ("get", "write", "load", "reset", "add_default_links", "notify"):
         ws_id += 1
         await ws_client.send_json(
             {
@@ -316,7 +316,7 @@ async def test_bad_address(
         assert not msg["success"]
         assert msg["error"]["message"] == INSTEON_DEVICE_NOT_FOUND
 
-    for call in ["change", "create"]:
+    for call in ("change", "create"):
         ws_id += 1
         await ws_client.send_json(
             {

--- a/tests/components/insteon/test_api_properties.py
+++ b/tests/components/insteon/test_api_properties.py
@@ -491,7 +491,7 @@ async def test_bad_address(
     )
 
     ws_id = 0
-    for call in ["get", "write", "load", "reset"]:
+    for call in ("get", "write", "load", "reset"):
         ws_id += 1
         params = {
             ID: ws_id,

--- a/tests/components/integration/test_sensor.py
+++ b/tests/components/integration/test_sensor.py
@@ -326,7 +326,7 @@ async def test_trapezoidal(hass: HomeAssistant) -> None:
     start_time = dt_util.utcnow()
     with freeze_time(start_time) as freezer:
         # Testing a power sensor with non-monotonic intervals and values
-        for time, value in [(20, 10), (30, 30), (40, 5), (50, 0)]:
+        for time, value in ((20, 10), (30, 30), (40, 5), (50, 0)):
             freezer.move_to(start_time + timedelta(minutes=time))
             hass.states.async_set(
                 entity_id,
@@ -365,7 +365,7 @@ async def test_left(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     # Testing a power sensor with non-monotonic intervals and values
-    for time, value in [(20, 10), (30, 30), (40, 5), (50, 0)]:
+    for time, value in ((20, 10), (30, 30), (40, 5), (50, 0)):
         now = dt_util.utcnow() + timedelta(minutes=time)
         with freeze_time(now):
             hass.states.async_set(
@@ -405,7 +405,7 @@ async def test_right(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     # Testing a power sensor with non-monotonic intervals and values
-    for time, value in [(20, 10), (30, 30), (40, 5), (50, 0)]:
+    for time, value in ((20, 10), (30, 30), (40, 5), (50, 0)):
         now = dt_util.utcnow() + timedelta(minutes=time)
         with freeze_time(now):
             hass.states.async_set(

--- a/tests/components/knx/test_interface_device.py
+++ b/tests/components/knx/test_interface_device.py
@@ -22,7 +22,7 @@ async def test_diagnostic_entities(
     """Test diagnostic entities."""
     await knx.setup_integration({})
 
-    for entity_id in [
+    for entity_id in (
         "sensor.knx_interface_individual_address",
         "sensor.knx_interface_connection_established",
         "sensor.knx_interface_connection_type",
@@ -31,14 +31,14 @@ async def test_diagnostic_entities(
         "sensor.knx_interface_outgoing_telegrams",
         "sensor.knx_interface_outgoing_telegram_errors",
         "sensor.knx_interface_telegrams",
-    ]:
+    ):
         entity = entity_registry.async_get(entity_id)
         assert entity.entity_category is EntityCategory.DIAGNOSTIC
 
-    for entity_id in [
+    for entity_id in (
         "sensor.knx_interface_incoming_telegrams",
         "sensor.knx_interface_outgoing_telegrams",
-    ]:
+    ):
         entity = entity_registry.async_get(entity_id)
         assert entity.disabled is True
 
@@ -54,14 +54,14 @@ async def test_diagnostic_entities(
     assert len(events) == 3  # 5 polled sensors - 2 disabled
     events.clear()
 
-    for entity_id, test_state in [
+    for entity_id, test_state in (
         ("sensor.knx_interface_individual_address", "0.0.0"),
         ("sensor.knx_interface_connection_type", "Tunnel TCP"),
         # skipping connected_since timestamp
         ("sensor.knx_interface_incoming_telegram_errors", "1"),
         ("sensor.knx_interface_outgoing_telegram_errors", "2"),
         ("sensor.knx_interface_telegrams", "31"),
-    ]:
+    ):
         assert hass.states.get(entity_id).state == test_state
 
     await knx.xknx.connection_manager.connection_state_changed(
@@ -85,14 +85,14 @@ async def test_diagnostic_entities(
     await hass.async_block_till_done()
     assert len(events) == 6  # all diagnostic sensors - counters are reset on connect
 
-    for entity_id, test_state in [
+    for entity_id, test_state in (
         ("sensor.knx_interface_individual_address", "1.1.1"),
         ("sensor.knx_interface_connection_type", "Tunnel UDP"),
         # skipping connected_since timestamp
         ("sensor.knx_interface_incoming_telegram_errors", "0"),
         ("sensor.knx_interface_outgoing_telegram_errors", "0"),
         ("sensor.knx_interface_telegrams", "0"),
-    ]:
+    ):
         assert hass.states.get(entity_id).state == test_state
 
 

--- a/tests/components/kodi/test_device_trigger.py
+++ b/tests/components/kodi/test_device_trigger.py
@@ -61,7 +61,7 @@ async def test_get_triggers(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
-        for trigger in ["turn_off", "turn_on"]
+        for trigger in ("turn_off", "turn_on")
     ]
 
     # Test triggers are either kodi specific triggers or media_player entity triggers

--- a/tests/components/lcn/test_device_trigger.py
+++ b/tests/components/lcn/test_device_trigger.py
@@ -34,13 +34,13 @@ async def test_get_triggers_module_device(
             CONF_DEVICE_ID: device.id,
             "metadata": {},
         }
-        for trigger in [
+        for trigger in (
             "transmitter",
             "transponder",
             "fingerprint",
             "codelock",
             "send_keys",
-        ]
+        )
     ]
 
     triggers = await async_get_device_automations(

--- a/tests/components/local_calendar/conftest.py
+++ b/tests/components/local_calendar/conftest.py
@@ -129,7 +129,7 @@ def event_fields(data: dict[str, str]) -> dict[str, str]:
     """Filter event API response to minimum fields."""
     return {
         k: data[k]
-        for k in ["summary", "start", "end", "recurrence_id", "location"]
+        for k in ("summary", "start", "end", "recurrence_id", "location")
         if data.get(k)
     }
 

--- a/tests/components/lutron_caseta/test_device_trigger.py
+++ b/tests/components/lutron_caseta/test_device_trigger.py
@@ -148,7 +148,7 @@ async def test_get_triggers(hass: HomeAssistant) -> None:
             CONF_TYPE: "press",
             "metadata": {},
         }
-        for subtype in ["on", "stop", "off", "raise", "lower"]
+        for subtype in ("on", "stop", "off", "raise", "lower")
     ]
     expected_triggers += [
         {
@@ -159,7 +159,7 @@ async def test_get_triggers(hass: HomeAssistant) -> None:
             CONF_TYPE: "release",
             "metadata": {},
         }
-        for subtype in ["on", "stop", "off", "raise", "lower"]
+        for subtype in ("on", "stop", "off", "raise", "lower")
     ]
 
     triggers = await async_get_device_automations(

--- a/tests/components/mailbox/test_init.py
+++ b/tests/components/mailbox/test_init.py
@@ -164,7 +164,7 @@ async def test_delete_from_mailbox(mock_http_client: TestClient) -> None:
     msgsha1 = sha1(msgtxt1.encode("utf-8")).hexdigest()
     msgsha2 = sha1(msgtxt2.encode("utf-8")).hexdigest()
 
-    for msg in [msgsha1, msgsha2]:
+    for msg in (msgsha1, msgsha2):
         url = f"/api/mailbox/delete/TestMailbox/{msg}"
         req = await mock_http_client.delete(url)
         assert req.status == HTTPStatus.OK

--- a/tests/components/media_player/test_device_condition.py
+++ b/tests/components/media_player/test_device_condition.py
@@ -62,14 +62,14 @@ async def test_get_conditions(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
-        for condition in [
+        for condition in (
             "is_buffering",
             "is_off",
             "is_on",
             "is_idle",
             "is_paused",
             "is_playing",
-        ]
+        )
     ]
     conditions = await async_get_device_automations(
         hass, DeviceAutomationType.CONDITION, device_entry.id
@@ -117,14 +117,14 @@ async def test_get_conditions_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for condition in [
+        for condition in (
             "is_buffering",
             "is_off",
             "is_on",
             "is_idle",
             "is_paused",
             "is_playing",
-        ]
+        )
     ]
     conditions = await async_get_device_automations(
         hass, DeviceAutomationType.CONDITION, device_entry.id

--- a/tests/components/microsoft/test_tts.py
+++ b/tests/components/microsoft/test_tts.py
@@ -302,17 +302,17 @@ async def test_service_say_fa_ir_service(
 
 def test_supported_languages() -> None:
     """Test list of supported languages."""
-    for lang in ["en-us", "fa-ir", "en-gb"]:
+    for lang in ("en-us", "fa-ir", "en-gb"):
         assert lang in SUPPORTED_LANGUAGES
     assert "en-US" not in SUPPORTED_LANGUAGES
-    for lang in [
+    for lang in (
         "en",
         "en-uk",
         "english",
         "english (united states)",
         "jennyneural",
         "en-us-jennyneural",
-    ]:
+    ):
         assert lang not in {s.lower() for s in SUPPORTED_LANGUAGES}
     assert len(SUPPORTED_LANGUAGES) > 100
 

--- a/tests/components/modbus/test_binary_sensor.py
+++ b/tests/components/modbus/test_binary_sensor.py
@@ -291,7 +291,7 @@ async def test_config_virtual_binary_sensor(hass: HomeAssistant, mock_modbus) ->
     """Run config test for binary sensor."""
     assert SENSOR_DOMAIN in hass.config.components
 
-    for addon in ["", " 1", " 2", " 3"]:
+    for addon in ("", " 1", " 2", " 3"):
         entity_id = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}{addon}".replace(" ", "_")
         assert hass.states.get(entity_id) is not None
 

--- a/tests/components/mqtt/test_humidifier.py
+++ b/tests/components/mqtt/test_humidifier.py
@@ -106,7 +106,7 @@ async def async_set_mode(
     """Set mode for all or specified humidifier."""
     data = {
         key: value
-        for key, value in [(ATTR_ENTITY_ID, entity_id), (ATTR_MODE, mode)]
+        for key, value in ((ATTR_ENTITY_ID, entity_id), (ATTR_MODE, mode))
         if value is not None
     }
 
@@ -119,7 +119,7 @@ async def async_set_humidity(
     """Set target humidity for all or specified humidifier."""
     data = {
         key: value
-        for key, value in [(ATTR_ENTITY_ID, entity_id), (ATTR_HUMIDITY, humidity)]
+        for key, value in ((ATTR_ENTITY_ID, entity_id), (ATTR_HUMIDITY, humidity))
         if value is not None
     }
 

--- a/tests/components/mqtt/test_water_heater.py
+++ b/tests/components/mqtt/test_water_heater.py
@@ -1286,7 +1286,7 @@ async def test_skipped_async_ha_write_state(
                 },
             ),
         )
-        for value_template in ["value_template", "mode_state_template"]
+        for value_template in ("value_template", "mode_state_template")
     ],
     ids=["value_template", "mode_state_template"],
 )

--- a/tests/components/number/test_device_action.py
+++ b/tests/components/number/test_device_action.py
@@ -100,7 +100,7 @@ async def test_get_actions_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for action in ["set_value"]
+        for action in ("set_value",)
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id

--- a/tests/components/openai_conversation/test_conversation.py
+++ b/tests/components/openai_conversation/test_conversation.py
@@ -429,7 +429,7 @@ async def test_assist_api_tools_conversion(
     mock_init_component,
 ) -> None:
     """Test that we are able to convert actual tools from Assist API."""
-    for component in [
+    for component in (
         "intent",
         "todo",
         "light",
@@ -440,7 +440,7 @@ async def test_assist_api_tools_conversion(
         "vacuum",
         "cover",
         "weather",
-    ]:
+    ):
         assert await async_setup_component(hass, component, {})
 
     agent_id = mock_config_entry_with_assist.entry_id

--- a/tests/components/panel_iframe/test_init.py
+++ b/tests/components/panel_iframe/test_init.py
@@ -104,7 +104,7 @@ async def test_import_config(
         },
     ]
 
-    for url_path in ["api", "ftp", "router", "weather"]:
+    for url_path in ("api", "ftp", "router", "weather"):
         await client.send_json_auto_id(
             {"type": "lovelace/config", "url_path": url_path}
         )

--- a/tests/components/plant/test_init.py
+++ b/tests/components/plant/test_init.py
@@ -153,7 +153,7 @@ async def test_load_from_db(recorder_mock: Recorder, hass: HomeAssistant) -> Non
     is enabled via plant.ENABLE_LOAD_HISTORY.
     """
     plant_name = "wise_plant"
-    for value in [20, 30, 10]:
+    for value in (20, 30, 10):
         hass.states.async_set(
             BRIGHTNESS_ENTITY, value, {ATTR_UNIT_OF_MEASUREMENT: "Lux"}
         )

--- a/tests/components/plex/conftest.py
+++ b/tests/components/plex/conftest.py
@@ -482,7 +482,7 @@ def mock_plex_calls(
 
     url = plex_server_url(entry)
 
-    for server in [url, PLEX_DIRECT_URL]:
+    for server in (url, PLEX_DIRECT_URL):
         requests_mock.get(server, text=plex_server_default)
         requests_mock.get(f"{server}/accounts", text=plex_server_accounts)
 

--- a/tests/components/plex/test_init.py
+++ b/tests/components/plex/test_init.py
@@ -255,7 +255,7 @@ async def test_setup_when_certificate_changed(
     # Test with success
     new_url = PLEX_DIRECT_URL
     requests_mock.get("https://plex.tv/api/v2/resources", text=plextv_resources)
-    for resource_url in [new_url, "http://1.2.3.4:32400"]:
+    for resource_url in (new_url, "http://1.2.3.4:32400"):
         requests_mock.get(resource_url, text=plex_server_default)
     requests_mock.get(f"{new_url}/accounts", text=plex_server_accounts)
     requests_mock.get(f"{new_url}/library", text=empty_library)

--- a/tests/components/proximity/test_init.py
+++ b/tests/components/proximity/test_init.py
@@ -483,7 +483,7 @@ async def test_device_trackers_in_zone(hass: HomeAssistant) -> None:
     state = hass.states.get("sensor.home_nearest_device")
     assert state.state == "test1, test2"
 
-    for device in ["test1", "test2"]:
+    for device in ("test1", "test2"):
         entity_base_name = f"sensor.home_{device}"
         state = hass.states.get(f"{entity_base_name}_distance")
         assert state.state == "0"

--- a/tests/components/rest_command/test_init.py
+++ b/tests/components/rest_command/test_init.py
@@ -215,7 +215,7 @@ async def test_rest_command_headers(
     # provide post request data
     aioclient_mock.post(TEST_URL, content=b"success")
 
-    for test_service in [
+    for test_service in (
         "no_headers_test",
         "content_type_test",
         "headers_test",
@@ -223,7 +223,7 @@ async def test_rest_command_headers(
         "headers_and_content_type_override_test",
         "headers_template_test",
         "headers_and_content_type_override_template_test",
-    ]:
+    ):
         await hass.services.async_call(DOMAIN, test_service, {}, blocking=True)
 
     await hass.async_block_till_done()

--- a/tests/components/rfxtrx/test_device_trigger.py
+++ b/tests/components/rfxtrx/test_device_trigger.py
@@ -65,7 +65,7 @@ async def setup_entry(hass, devices):
             EVENT_LIGHTING_1,
             [
                 {"type": "command", "subtype": subtype}
-                for subtype in [
+                for subtype in (
                     "Off",
                     "On",
                     "Dim",
@@ -74,7 +74,7 @@ async def setup_entry(hass, devices):
                     "All/group On",
                     "Chime",
                     "Illegal command",
-                ]
+                )
             ],
         )
     ],

--- a/tests/components/ruuvitag_ble/test_sensor.py
+++ b/tests/components/ruuvitag_ble/test_sensor.py
@@ -32,12 +32,12 @@ async def test_sensors(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) >= 4
 
-    for sensor, value, unit, state_class in [
+    for sensor, value, unit, state_class in (
         ("temperature", "7.2", "°C", "measurement"),
         ("humidity", "61.84", "%", "measurement"),
         ("pressure", "1013.54", "hPa", "measurement"),
         ("voltage", "2395", "mV", "measurement"),
-    ]:
+    ):
         state = hass.states.get(f"sensor.{CONFIGURED_PREFIX}_{sensor}")
         assert state is not None
         assert state.state == value

--- a/tests/components/sensirion_ble/test_sensor.py
+++ b/tests/components/sensirion_ble/test_sensor.py
@@ -29,11 +29,11 @@ async def test_sensors(enable_bluetooth: None, hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) >= 3
 
-    for sensor, value, unit, state_class in [
+    for sensor, value, unit, state_class in (
         ("carbon_dioxide", "724", "ppm", "measurement"),
         ("humidity", "27.8", "%", "measurement"),
         ("temperature", "20.1", "°C", "measurement"),
-    ]:
+    ):
         state = hass.states.get(f"sensor.{CONFIGURED_PREFIX}_{sensor}")
         assert state is not None
         assert state.state == value

--- a/tests/components/shelly/test_device_trigger.py
+++ b/tests/components/shelly/test_device_trigger.py
@@ -68,7 +68,7 @@ async def test_get_triggers_block_device(
                 CONF_SUBTYPE: "button1",
                 "metadata": {},
             }
-            for type_ in ["single", "long"]
+            for type_ in ("single", "long")
         ]
 
     triggers = await async_get_device_automations(
@@ -94,14 +94,14 @@ async def test_get_triggers_rpc_device(
             CONF_SUBTYPE: "button1",
             "metadata": {},
         }
-        for trigger_type in [
+        for trigger_type in (
             "btn_down",
             "btn_up",
             "single_push",
             "double_push",
             "triple_push",
             "long_push",
-        ]
+        )
     ]
 
     triggers = await async_get_device_automations(
@@ -127,7 +127,7 @@ async def test_get_triggers_button(
             CONF_SUBTYPE: "button",
             "metadata": {},
         }
-        for trigger_type in ["single", "double", "triple", "long"]
+        for trigger_type in ("single", "double", "triple", "long")
     ]
 
     triggers = await async_get_device_automations(

--- a/tests/components/template/test_alarm_control_panel.py
+++ b/tests/components/template/test_alarm_control_panel.py
@@ -103,7 +103,7 @@ TEMPLATE_ALARM_CONFIG = {
 async def test_template_state_text(hass: HomeAssistant, start_ha) -> None:
     """Test the state text of a template."""
 
-    for set_state in [
+    for set_state in (
         STATE_ALARM_ARMED_HOME,
         STATE_ALARM_ARMED_AWAY,
         STATE_ALARM_ARMED_NIGHT,
@@ -113,7 +113,7 @@ async def test_template_state_text(hass: HomeAssistant, start_ha) -> None:
         STATE_ALARM_DISARMED,
         STATE_ALARM_PENDING,
         STATE_ALARM_TRIGGERED,
-    ]:
+    ):
         hass.states.async_set(PANEL_NAME, set_state)
         await hass.async_block_till_done()
         state = hass.states.get(TEMPLATE_NAME)
@@ -144,7 +144,7 @@ async def test_optimistic_states(hass: HomeAssistant, start_ha) -> None:
     await hass.async_block_till_done()
     assert state.state == "unknown"
 
-    for service, set_state in [
+    for service, set_state in (
         ("alarm_arm_away", STATE_ALARM_ARMED_AWAY),
         ("alarm_arm_home", STATE_ALARM_ARMED_HOME),
         ("alarm_arm_night", STATE_ALARM_ARMED_NIGHT),
@@ -152,7 +152,7 @@ async def test_optimistic_states(hass: HomeAssistant, start_ha) -> None:
         ("alarm_arm_custom_bypass", STATE_ALARM_ARMED_CUSTOM_BYPASS),
         ("alarm_disarm", STATE_ALARM_DISARMED),
         ("alarm_trigger", STATE_ALARM_TRIGGERED),
-    ]:
+    ):
         await hass.services.async_call(
             ALARM_DOMAIN,
             service,

--- a/tests/components/template/test_cover.py
+++ b/tests/components/template/test_cover.py
@@ -267,11 +267,11 @@ async def test_template_position(
     hass.states.async_set("cover.test", STATE_OPEN)
     attrs = {}
 
-    for set_state, pos, test_state in [
+    for set_state, pos, test_state in (
         (STATE_CLOSED, 42, STATE_OPEN),
         (STATE_OPEN, 0.0, STATE_CLOSED),
         (STATE_CLOSED, None, STATE_UNKNOWN),
-    ]:
+    ):
         attrs["position"] = pos
         hass.states.async_set("cover.test", set_state, attributes=attrs)
         await hass.async_block_till_done()
@@ -704,12 +704,12 @@ async def test_set_position_optimistic(
     state = hass.states.get("cover.test_template_cover")
     assert state.attributes.get("current_position") == 42.0
 
-    for service, test_state in [
+    for service, test_state in (
         (SERVICE_CLOSE_COVER, STATE_CLOSED),
         (SERVICE_OPEN_COVER, STATE_OPEN),
         (SERVICE_TOGGLE, STATE_CLOSED),
         (SERVICE_TOGGLE, STATE_OPEN),
-    ]:
+    ):
         await hass.services.async_call(
             DOMAIN, service, {ATTR_ENTITY_ID: ENTITY_COVER}, blocking=True
         )
@@ -753,12 +753,12 @@ async def test_set_tilt_position_optimistic(
     state = hass.states.get("cover.test_template_cover")
     assert state.attributes.get("current_tilt_position") == 42.0
 
-    for service, pos in [
+    for service, pos in (
         (SERVICE_CLOSE_COVER_TILT, 0.0),
         (SERVICE_OPEN_COVER_TILT, 100.0),
         (SERVICE_TOGGLE_COVER_TILT, 0.0),
         (SERVICE_TOGGLE_COVER_TILT, 100.0),
-    ]:
+    ):
         await hass.services.async_call(
             DOMAIN, service, {ATTR_ENTITY_ID: ENTITY_COVER}, blocking=True
         )

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -157,13 +157,13 @@ async def test_templates_with_entities(hass: HomeAssistant, start_ha) -> None:
     hass.states.async_set(_PERCENTAGE_INPUT_NUMBER, 66)
     hass.states.async_set(_OSC_INPUT, "True")
 
-    for set_state, set_value, value in [
+    for set_state, set_value, value in (
         (_DIRECTION_INPUT_SELECT, DIRECTION_FORWARD, 66),
         (_PERCENTAGE_INPUT_NUMBER, 33, 33),
         (_PERCENTAGE_INPUT_NUMBER, 66, 66),
         (_PERCENTAGE_INPUT_NUMBER, 100, 100),
         (_PERCENTAGE_INPUT_NUMBER, "dog", 0),
-    ]:
+    ):
         hass.states.async_set(set_state, set_value)
         await hass.async_block_till_done()
         _verify(hass, STATE_ON, value, True, DIRECTION_FORWARD, None)
@@ -266,7 +266,7 @@ async def test_availability_template_with_entities(
     hass: HomeAssistant, start_ha
 ) -> None:
     """Test availability tempalates with values from other entities."""
-    for state, test_assert in [(STATE_ON, True), (STATE_OFF, False)]:
+    for state, test_assert in ((STATE_ON, True), (STATE_OFF, False)):
         hass.states.async_set(_STATE_AVAILABILITY_BOOLEAN, state)
         await hass.async_block_till_done()
         assert (hass.states.get(_TEST_FAN).state != STATE_UNAVAILABLE) == test_assert
@@ -426,7 +426,7 @@ async def test_set_osc(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
 
     await common.async_turn_on(hass, _TEST_FAN)
     expected_calls += 1
-    for state in [True, False]:
+    for state in (True, False):
         await common.async_oscillate(hass, _TEST_FAN, state)
         assert hass.states.get(_OSC_INPUT).state == str(state)
         _verify(hass, STATE_ON, 0, state, None, None)
@@ -444,7 +444,7 @@ async def test_set_direction(hass: HomeAssistant, calls: list[ServiceCall]) -> N
 
     await common.async_turn_on(hass, _TEST_FAN)
     expected_calls += 1
-    for cmd in [DIRECTION_FORWARD, DIRECTION_REVERSE]:
+    for cmd in (DIRECTION_FORWARD, DIRECTION_REVERSE):
         await common.async_set_direction(hass, _TEST_FAN, cmd)
         assert hass.states.get(_DIRECTION_INPUT_SELECT).state == cmd
         _verify(hass, STATE_ON, 0, None, cmd, None)
@@ -462,7 +462,7 @@ async def test_set_invalid_direction(
     await _register_components(hass)
 
     await common.async_turn_on(hass, _TEST_FAN)
-    for cmd in [DIRECTION_FORWARD, "invalid"]:
+    for cmd in (DIRECTION_FORWARD, "invalid"):
         await common.async_set_direction(hass, _TEST_FAN, cmd)
         assert hass.states.get(_DIRECTION_INPUT_SELECT).state == DIRECTION_FORWARD
         _verify(hass, STATE_ON, 0, None, DIRECTION_FORWARD, None)
@@ -475,11 +475,11 @@ async def test_preset_modes(hass: HomeAssistant, calls: list[ServiceCall]) -> No
     )
 
     await common.async_turn_on(hass, _TEST_FAN)
-    for extra, state, expected_calls in [
+    for extra, state, expected_calls in (
         ("auto", "auto", 2),
         ("smart", "smart", 3),
         ("invalid", "smart", 3),
-    ]:
+    ):
         if extra != state:
             with pytest.raises(NotValidPresetModeError):
                 await common.async_set_preset_mode(hass, _TEST_FAN, extra)
@@ -502,11 +502,11 @@ async def test_set_percentage(hass: HomeAssistant, calls: list[ServiceCall]) -> 
 
     await common.async_turn_on(hass, _TEST_FAN)
     expected_calls += 1
-    for state, value in [
+    for state, value in (
         (STATE_ON, 100),
         (STATE_ON, 66),
         (STATE_ON, 0),
-    ]:
+    ):
         await common.async_set_percentage(hass, _TEST_FAN, value)
         assert int(float(hass.states.get(_PERCENTAGE_INPUT_NUMBER).state)) == value
         _verify(hass, state, value, None, None, None)
@@ -528,13 +528,13 @@ async def test_increase_decrease_speed(
     await _register_components(hass, speed_count=3)
 
     await common.async_turn_on(hass, _TEST_FAN)
-    for func, extra, state, value in [
+    for func, extra, state, value in (
         (common.async_set_percentage, 100, STATE_ON, 100),
         (common.async_decrease_speed, None, STATE_ON, 66),
         (common.async_decrease_speed, None, STATE_ON, 33),
         (common.async_decrease_speed, None, STATE_ON, 0),
         (common.async_increase_speed, None, STATE_ON, 33),
-    ]:
+    ):
         await func(hass, _TEST_FAN, extra)
         assert int(float(hass.states.get(_PERCENTAGE_INPUT_NUMBER).state)) == value
         _verify(hass, state, value, None, None, None)
@@ -658,13 +658,13 @@ async def test_increase_decrease_speed_default_speed_count(
     await _register_components(hass)
 
     await common.async_turn_on(hass, _TEST_FAN)
-    for func, extra, state, value in [
+    for func, extra, state, value in (
         (common.async_set_percentage, 100, STATE_ON, 100),
         (common.async_decrease_speed, None, STATE_ON, 99),
         (common.async_decrease_speed, None, STATE_ON, 98),
         (common.async_decrease_speed, 31, STATE_ON, 67),
         (common.async_decrease_speed, None, STATE_ON, 66),
-    ]:
+    ):
         await func(hass, _TEST_FAN, extra)
         assert int(float(hass.states.get(_PERCENTAGE_INPUT_NUMBER).state)) == value
         _verify(hass, state, value, None, None, None)

--- a/tests/components/template/test_weather.py
+++ b/tests/components/template/test_weather.py
@@ -68,7 +68,7 @@ ATTR_FORECAST = "forecast"
 )
 async def test_template_state_text(hass: HomeAssistant, start_ha) -> None:
     """Test the state text of a template."""
-    for attr, v_attr, value in [
+    for attr, v_attr, value in (
         (
             "sensor.attribution",
             ATTR_ATTRIBUTION,
@@ -85,7 +85,7 @@ async def test_template_state_text(hass: HomeAssistant, start_ha) -> None:
         ("sensor.cloud_coverage", ATTR_WEATHER_CLOUD_COVERAGE, 75),
         ("sensor.dew_point", ATTR_WEATHER_DEW_POINT, 2.2),
         ("sensor.apparent_temperature", ATTR_WEATHER_APPARENT_TEMPERATURE, 25),
-    ]:
+    ):
         hass.states.async_set(attr, value)
         await hass.async_block_till_done()
         state = hass.states.get("weather.test")
@@ -125,10 +125,10 @@ async def test_forecasts(
     hass: HomeAssistant, start_ha, snapshot: SnapshotAssertion, service: str
 ) -> None:
     """Test forecast service."""
-    for attr, _v_attr, value in [
+    for attr, _v_attr, value in (
         ("sensor.temperature", ATTR_WEATHER_TEMPERATURE, 22.3),
         ("sensor.humidity", ATTR_WEATHER_HUMIDITY, 60),
-    ]:
+    ):
         hass.states.async_set(attr, value)
         await hass.async_block_till_done()
 
@@ -254,10 +254,10 @@ async def test_forecast_invalid(
     expected: dict[str, Any],
 ) -> None:
     """Test invalid forecasts."""
-    for attr, _v_attr, value in [
+    for attr, _v_attr, value in (
         ("sensor.temperature", ATTR_WEATHER_TEMPERATURE, 22.3),
         ("sensor.humidity", ATTR_WEATHER_HUMIDITY, 60),
-    ]:
+    ):
         hass.states.async_set(attr, value)
         await hass.async_block_till_done()
 
@@ -337,10 +337,10 @@ async def test_forecast_invalid_is_daytime_missing_in_twice_daily(
     expected: dict[str, Any],
 ) -> None:
     """Test forecast service invalid when is_daytime missing in twice_daily forecast."""
-    for attr, _v_attr, value in [
+    for attr, _v_attr, value in (
         ("sensor.temperature", ATTR_WEATHER_TEMPERATURE, 22.3),
         ("sensor.humidity", ATTR_WEATHER_HUMIDITY, 60),
-    ]:
+    ):
         hass.states.async_set(attr, value)
         await hass.async_block_till_done()
 
@@ -406,10 +406,10 @@ async def test_forecast_invalid_datetime_missing(
     expected: dict[str, Any],
 ) -> None:
     """Test forecast service invalid when datetime missing."""
-    for attr, _v_attr, value in [
+    for attr, _v_attr, value in (
         ("sensor.temperature", ATTR_WEATHER_TEMPERATURE, 22.3),
         ("sensor.humidity", ATTR_WEATHER_HUMIDITY, 60),
-    ]:
+    ):
         hass.states.async_set(attr, value)
         await hass.async_block_till_done()
 
@@ -472,10 +472,10 @@ async def test_forecast_format_error(
     hass: HomeAssistant, start_ha, caplog: pytest.LogCaptureFixture, service: str
 ) -> None:
     """Test forecast service invalid on incorrect format."""
-    for attr, _v_attr, value in [
+    for attr, _v_attr, value in (
         ("sensor.temperature", ATTR_WEATHER_TEMPERATURE, 22.3),
         ("sensor.humidity", ATTR_WEATHER_HUMIDITY, 60),
-    ]:
+    ):
         hass.states.async_set(attr, value)
         await hass.async_block_till_done()
 

--- a/tests/components/tessie/test_button.py
+++ b/tests/components/tessie/test_button.py
@@ -21,14 +21,14 @@ async def test_buttons(
 
     assert_entities(hass, entry.entry_id, entity_registry, snapshot)
 
-    for entity_id, func in [
+    for entity_id, func in (
         ("button.test_wake", "wake"),
         ("button.test_flash_lights", "flash_lights"),
         ("button.test_honk_horn", "honk"),
         ("button.test_homelink", "trigger_homelink"),
         ("button.test_keyless_driving", "enable_keyless_driving"),
         ("button.test_play_fart", "boombox"),
-    ]:
+    ):
         with patch(
             f"homeassistant.components.tessie.button.{func}",
         ) as mock_press:

--- a/tests/components/tessie/test_cover.py
+++ b/tests/components/tessie/test_cover.py
@@ -37,12 +37,12 @@ async def test_covers(
 
     assert_entities(hass, entry.entry_id, entity_registry, snapshot)
 
-    for entity_id, openfunc, closefunc in [
+    for entity_id, openfunc, closefunc in (
         ("cover.test_vent_windows", "vent_windows", "close_windows"),
         ("cover.test_charge_port_door", "open_unlock_charge_port", "close_charge_port"),
         ("cover.test_frunk", "open_front_trunk", False),
         ("cover.test_trunk", "open_close_rear_trunk", "open_close_rear_trunk"),
-    ]:
+    ):
         # Test open windows
         if openfunc:
             with patch(

--- a/tests/components/text/test_device_action.py
+++ b/tests/components/text/test_device_action.py
@@ -100,7 +100,7 @@ async def test_get_actions_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for action in ["set_value"]
+        for action in ("set_value",)
     ]
     actions = await async_get_device_automations(
         hass, DeviceAutomationType.ACTION, device_entry.id

--- a/tests/components/trend/test_binary_sensor.py
+++ b/tests/components/trend/test_binary_sensor.py
@@ -197,7 +197,7 @@ async def test_max_samples(
         },
     )
 
-    for val in [0, 1, 2, 3, 2, 1]:
+    for val in (0, 1, 2, 3, 2, 1):
         hass.states.async_set("sensor.test_state", val)
         await hass.async_block_till_done()
 
@@ -212,7 +212,7 @@ async def test_non_numeric(
     """Test for non-numeric sensor."""
     await setup_component({"entity_id": "sensor.test_state"})
 
-    for val in ["Non", "Numeric"]:
+    for val in ("Non", "Numeric"):
         hass.states.async_set("sensor.test_state", val)
         await hass.async_block_till_done()
 
@@ -230,7 +230,7 @@ async def test_missing_attribute(
         },
     )
 
-    for val in [1, 2]:
+    for val in (1, 2):
         hass.states.async_set("sensor.test_state", "State", {"attr": val})
         await hass.async_block_till_done()
 
@@ -311,7 +311,7 @@ async def test_restore_state(
     assert hass.states.get("binary_sensor.test_trend_sensor").state == restored_state
 
     # add not enough samples to trigger calculation
-    for val in [10, 20, 30, 40]:
+    for val in (10, 20, 30, 40):
         freezer.tick(timedelta(seconds=2))
         hass.states.async_set("sensor.test_state", val)
         await hass.async_block_till_done()
@@ -320,7 +320,7 @@ async def test_restore_state(
     assert hass.states.get("binary_sensor.test_trend_sensor").state == restored_state
 
     # add more samples to trigger calculation
-    for val in [50, 60, 70, 80]:
+    for val in (50, 60, 70, 80):
         freezer.tick(timedelta(seconds=2))
         hass.states.async_set("sensor.test_state", val)
         await hass.async_block_till_done()

--- a/tests/components/update/test_device_trigger.py
+++ b/tests/components/update/test_device_trigger.py
@@ -61,7 +61,7 @@ async def test_get_triggers(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": False},
         }
-        for trigger in ["changed_states", "turned_off", "turned_on"]
+        for trigger in ("changed_states", "turned_off", "turned_on")
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id
@@ -109,7 +109,7 @@ async def test_get_triggers_hidden_auxiliary(
             "entity_id": entity_entry.id,
             "metadata": {"secondary": True},
         }
-        for trigger in ["changed_states", "turned_off", "turned_on"]
+        for trigger in ("changed_states", "turned_off", "turned_on")
     ]
     triggers = await async_get_device_automations(
         hass, DeviceAutomationType.TRIGGER, device_entry.id

--- a/tests/components/vulcan/test_config_flow.py
+++ b/tests/components/vulcan/test_config_flow.py
@@ -89,10 +89,10 @@ async def test_config_flow_auth_success_with_multiple_students(
     mock_account.return_value = fake_account
     mock_student.return_value = [
         Student.load(student)
-        for student in [
+        for student in (
             load_fixture("fake_student_1.json", "vulcan"),
             load_fixture("fake_student_2.json", "vulcan"),
-        ]
+        )
     ]
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/xiaomi_miio/test_vacuum.py
+++ b/tests/components/xiaomi_miio/test_vacuum.py
@@ -57,8 +57,6 @@ from . import TEST_MAC
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
-# pylint: disable=consider-using-tuple
-
 # calls made when device status is requested
 STATUS_CALLS = [
     mock.call.status(),
@@ -423,7 +421,7 @@ async def test_xiaomi_vacuum_services(
                 "segments": ["1", "2"],
             },
             "segment_clean",
-            mock.call(segments=[int(i) for i in ["1", "2"]]),
+            mock.call(segments=[int(i) for i in ("1", "2")]),
         ),
         (
             SERVICE_CLEAN_SEGMENT,
@@ -495,7 +493,7 @@ async def test_xiaomi_vacuum_fanspeeds(
     state = hass.states.get(entity_id)
     assert state.attributes.get(ATTR_FAN_SPEED) == "Silent"
     fanspeeds = state.attributes.get(ATTR_FAN_SPEED_LIST)
-    for speed in ["Silent", "Standard", "Medium", "Turbo"]:
+    for speed in ("Silent", "Standard", "Medium", "Turbo"):
         assert speed in fanspeeds
 
     # Set speed service:

--- a/tests/components/zha/test_cluster_handlers.py
+++ b/tests/components/zha/test_cluster_handlers.py
@@ -585,7 +585,7 @@ async def test_ep_cluster_handlers_configure(cluster_handler) -> None:
         await endpoint.async_configure()
         await endpoint.async_initialize(mock.sentinel.from_cache)
 
-    for ch in [*claimed.values(), *client_handlers.values()]:
+    for ch in (*claimed.values(), *client_handlers.values()):
         assert ch.async_initialize.call_count == 1
         assert ch.async_initialize.await_count == 1
         assert ch.async_initialize.call_args[0][0] is mock.sentinel.from_cache

--- a/tests/components/zha/test_device_action.py
+++ b/tests/components/zha/test_device_action.py
@@ -149,19 +149,19 @@ async def test_get_actions(
                 "entity_id": entity_id,
                 "metadata": {"secondary": True},
             }
-            for action in [
+            for action in (
                 "select_first",
                 "select_last",
                 "select_next",
                 "select_option",
                 "select_previous",
-            ]
-            for entity_id in [
+            )
+            for entity_id in (
                 siren_level_select.id,
                 siren_tone_select.id,
                 strobe_level_select.id,
                 strobe_select.id,
-            ]
+            )
         ]
     )
 

--- a/tests/components/zha/test_fan.py
+++ b/tests/components/zha/test_fan.py
@@ -238,7 +238,7 @@ async def async_turn_on(hass, entity_id, percentage=None):
     """Turn fan on."""
     data = {
         key: value
-        for key, value in [(ATTR_ENTITY_ID, entity_id), (ATTR_PERCENTAGE, percentage)]
+        for key, value in ((ATTR_ENTITY_ID, entity_id), (ATTR_PERCENTAGE, percentage))
         if value is not None
     }
 
@@ -256,7 +256,7 @@ async def async_set_percentage(hass, entity_id, percentage=None):
     """Set percentage for specified fan."""
     data = {
         key: value
-        for key, value in [(ATTR_ENTITY_ID, entity_id), (ATTR_PERCENTAGE, percentage)]
+        for key, value in ((ATTR_ENTITY_ID, entity_id), (ATTR_PERCENTAGE, percentage))
         if value is not None
     }
 
@@ -269,7 +269,7 @@ async def async_set_preset_mode(hass, entity_id, preset_mode=None):
     """Set preset_mode for specified fan."""
     data = {
         key: value
-        for key, value in [(ATTR_ENTITY_ID, entity_id), (ATTR_PRESET_MODE, preset_mode)]
+        for key, value in ((ATTR_ENTITY_ID, entity_id), (ATTR_PRESET_MODE, preset_mode))
         if value is not None
     }
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #119279
https://github.com/home-assistant/core/actions/runs/9477454436/job/26112034466?pr=119279

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
