### PR TITLE
Ignore broad-exception-raised pylint warnings in tests

### DIFF
--- a/tests/components/bluetooth/test_passive_update_processor.py
+++ b/tests/components/bluetooth/test_passive_update_processor.py
@@ -583,6 +583,7 @@ async def test_exception_from_update_method(
         nonlocal run_count
         run_count += 1
         if run_count == 2:
+            # pylint: disable-next=broad-exception-raised
             raise Exception("Test exception")
         return GENERIC_PASSIVE_BLUETOOTH_DATA_UPDATE
 
@@ -1417,6 +1418,7 @@ async def test_exception_from_coordinator_update_method(
         nonlocal run_count
         run_count += 1
         if run_count == 2:
+            # pylint: disable-next=broad-exception-raised
             raise Exception("Test exception")
         return {"test": "data"}
 

--- a/tests/components/notify/test_legacy.py
+++ b/tests/components/notify/test_legacy.py
@@ -261,7 +261,7 @@ async def test_platform_setup_with_error(
 
     async def async_get_service(hass, config, discovery_info=None):
         """Return None for an invalid notify service."""
-        raise Exception("Setup error")
+        raise Exception("Setup error")  # pylint: disable=broad-exception-raised
 
     mock_notify_platform(
         hass, tmp_path, "testnotify", async_get_service=async_get_service

--- a/tests/components/profiler/test_init.py
+++ b/tests/components/profiler/test_init.py
@@ -181,7 +181,7 @@ async def test_dump_log_object(
 
         def __repr__(self):
             if self.fail:
-                raise Exception("failed")
+                raise Exception("failed")  # pylint: disable=broad-exception-raised
             return "<DumpLogDummy success>"
 
     obj1 = DumpLogDummy(False)

--- a/tests/components/roon/test_config_flow.py
+++ b/tests/components/roon/test_config_flow.py
@@ -48,7 +48,7 @@ class RoonApiMockException(RoonApiMock):
     @property
     def token(self):
         """Throw exception."""
-        raise Exception
+        raise Exception  # pylint: disable=broad-exception-raised
 
 
 class RoonDiscoveryMock:

--- a/tests/components/system_health/test_init.py
+++ b/tests/components/system_health/test_init.py
@@ -110,7 +110,7 @@ async def test_info_endpoint_register_callback_exc(
     """Test that the info endpoint requires auth."""
 
     async def mock_info(hass):
-        raise Exception("TEST ERROR")
+        raise Exception("TEST ERROR")  # pylint: disable=broad-exception-raised
 
     async_register_info(hass, "lovelace", mock_info)
     assert await async_setup_component(hass, "system_health", {})

--- a/tests/components/system_log/test_init.py
+++ b/tests/components/system_log/test_init.py
@@ -35,7 +35,7 @@ async def get_error_log(hass_ws_client):
 
 def _generate_and_log_exception(exception, log):
     try:
-        raise Exception(exception)
+        raise Exception(exception)  # pylint: disable=broad-exception-raised
     except Exception:
         _LOGGER.exception(log)
 

--- a/tests/helpers/test_dispatcher.py
+++ b/tests/helpers/test_dispatcher.py
@@ -188,6 +188,7 @@ async def test_callback_exception_gets_logged(
     @callback
     def bad_handler(*args):
         """Record calls."""
+        # pylint: disable-next=broad-exception-raised
         raise Exception("This is a bad message callback")
 
     # wrap in partial to test message logging.
@@ -208,6 +209,7 @@ async def test_coro_exception_gets_logged(
 
     async def bad_async_handler(*args):
         """Record calls."""
+        # pylint: disable-next=broad-exception-raised
         raise Exception("This is a bad message in a coro")
 
     # wrap in partial to test message logging.

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -576,7 +576,7 @@ async def test_remove_entry_raises(
 
     async def mock_unload_entry(hass, entry):
         """Mock unload entry function."""
-        raise Exception("BROKEN")
+        raise Exception("BROKEN")  # pylint: disable=broad-exception-raised
 
     mock_integration(hass, MockModule("comp", async_unload_entry=mock_unload_entry))
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -423,11 +423,11 @@ async def test_async_get_hass_can_be_called(hass: HomeAssistant) -> None:
         try:
             if ha.async_get_hass() is hass:
                 return True
-            raise Exception
+            raise Exception  # pylint: disable=broad-exception-raised
         except HomeAssistantError:
             return False
 
-        raise Exception
+        raise Exception  # pylint: disable=broad-exception-raised
 
     # Test scheduling a coroutine which calls async_get_hass via hass.async_create_task
     async def _async_create_task() -> None:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -104,7 +104,7 @@ def test_run_does_not_block_forever_with_shielded_task(
             try:
                 await asyncio.sleep(2)
             except asyncio.CancelledError:
-                raise Exception
+                raise Exception  # pylint: disable=broad-exception-raised
 
         async def async_shielded(*_):
             try:
@@ -141,6 +141,7 @@ async def test_unhandled_exception_traceback(
 
     async def _unhandled_exception():
         raised.set()
+        # pylint: disable-next=broad-exception-raised
         raise Exception("This is unhandled")
 
     try:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -328,7 +328,7 @@ async def test_component_exception_setup(hass: HomeAssistant) -> None:
 
     def exception_setup(hass, config):
         """Raise exception."""
-        raise Exception("fail!")
+        raise Exception("fail!")  # pylint: disable=broad-exception-raised
 
     mock_integration(hass, MockModule("comp", setup=exception_setup))
 
@@ -342,7 +342,7 @@ async def test_component_base_exception_setup(hass: HomeAssistant) -> None:
 
     def exception_setup(hass, config):
         """Raise exception."""
-        raise BaseException("fail!")
+        raise BaseException("fail!")  # pylint: disable=broad-exception-raised
 
     mock_integration(hass, MockModule("comp", setup=exception_setup))
 
@@ -362,6 +362,7 @@ async def test_component_setup_with_validation_and_dependency(
         """Test that config is passed in."""
         if config.get("comp_a", {}).get("valid", False):
             return True
+        # pylint: disable-next=broad-exception-raised
         raise Exception(f"Config not passed in: {config}")
 
     platform = MockPlatform()

--- a/tests/util/test_logging.py
+++ b/tests/util/test_logging.py
@@ -80,6 +80,7 @@ async def test_async_create_catching_coro(
     """Test exception logging of wrapped coroutine."""
 
     async def job():
+        # pylint: disable-next=broad-exception-raised
         raise Exception("This is a bad coroutine")
 
     hass.async_create_task(logging_util.async_create_catching_coro(job()))


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #119279
https://github.com/home-assistant/core/actions/runs/9479192360/job/26117227241?pr=119279

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
