### PR TITLE
Fix attribute-defined-outside-init pylint warning in anova tests

### DIFF
--- a/tests/components/anova/conftest.py
+++ b/tests/components/anova/conftest.py
@@ -78,7 +78,9 @@ class MockedAnovaWebsocketHandler(AnovaWebsocketHandler):
         self.ws = MockedAnovaWebsocketStream(self.connect_messages)
         await self.message_listener()
         self.ws = MockedAnovaWebsocketStream(self.post_connect_messages)
-        self.fut = asyncio.ensure_future(self.message_listener())
+        # pylint: disable-next=fixme
+        # TODO: fix RUF006 in parent library (AnovaWebsocketHandler)
+        asyncio.ensure_future(self.message_listener())  # noqa: RUF006
 
 
 def anova_api_mock(

--- a/tests/components/anova/conftest.py
+++ b/tests/components/anova/conftest.py
@@ -78,7 +78,7 @@ class MockedAnovaWebsocketHandler(AnovaWebsocketHandler):
         self.ws = MockedAnovaWebsocketStream(self.connect_messages)
         await self.message_listener()
         self.ws = MockedAnovaWebsocketStream(self.post_connect_messages)
-        # TODO: fix RUF006 in parent library (AnovaWebsocketHandler)
+        # RUF006 ignored as it replicates the parent library
         asyncio.ensure_future(self.message_listener())  # noqa: RUF006
 
 

--- a/tests/components/anova/conftest.py
+++ b/tests/components/anova/conftest.py
@@ -78,7 +78,6 @@ class MockedAnovaWebsocketHandler(AnovaWebsocketHandler):
         self.ws = MockedAnovaWebsocketStream(self.connect_messages)
         await self.message_listener()
         self.ws = MockedAnovaWebsocketStream(self.post_connect_messages)
-        # pylint: disable-next=fixme
         # TODO: fix RUF006 in parent library (AnovaWebsocketHandler)
         asyncio.ensure_future(self.message_listener())  # noqa: RUF006
 

--- a/tests/components/anova/conftest.py
+++ b/tests/components/anova/conftest.py
@@ -79,6 +79,7 @@ class MockedAnovaWebsocketHandler(AnovaWebsocketHandler):
         await self.message_listener()
         self.ws = MockedAnovaWebsocketStream(self.post_connect_messages)
         # RUF006 ignored as it replicates the parent library
+        # https://github.com/Lash-L/anova_wifi/issues/35
         asyncio.ensure_future(self.message_listener())  # noqa: RUF006
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #119279
https://github.com/home-assistant/core/actions/runs/9479928788/job/26119556111?pr=119279

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
