### PR TITLE
Ignore super-init-not-called pylint warnings in tests

### DIFF
--- a/tests/components/baf/__init__.py
+++ b/tests/components/baf/__init__.py
@@ -11,6 +11,7 @@ MOCK_NAME = "Living Room Fan"
 class MockBAFDevice(Device):
     """A simple mock for a BAF Device."""
 
+    # pylint: disable-next=super-init-not-called
     def __init__(self, async_wait_available_side_effect=None):
         """Init simple mock."""
         self._async_wait_available_side_effect = async_wait_available_side_effect

--- a/tests/components/devolo_home_control/mocks.py
+++ b/tests/components/devolo_home_control/mocks.py
@@ -25,7 +25,7 @@ from devolo_home_control_api.publisher.publisher import Publisher
 class BinarySensorPropertyMock(BinarySensorProperty):
     """devolo Home Control binary sensor mock."""
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(self, **kwargs: Any) -> None:  # pylint: disable=super-init-not-called
         """Initialize the mock."""
         self._logger = MagicMock()
         self.element_uid = "Test"
@@ -38,7 +38,7 @@ class BinarySensorPropertyMock(BinarySensorProperty):
 class BinarySwitchPropertyMock(BinarySwitchProperty):
     """devolo Home Control binary sensor mock."""
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(self, **kwargs: Any) -> None:  # pylint: disable=super-init-not-called
         """Initialize the mock."""
         self._logger = MagicMock()
         self.element_uid = "Test"
@@ -48,7 +48,7 @@ class BinarySwitchPropertyMock(BinarySwitchProperty):
 class ConsumptionPropertyMock(ConsumptionProperty):
     """devolo Home Control binary sensor mock."""
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(self, **kwargs: Any) -> None:  # pylint: disable=super-init-not-called
         """Initialize the mock."""
         self._logger = MagicMock()
         self.element_uid = "devolo.Meter:Test"
@@ -61,7 +61,7 @@ class ConsumptionPropertyMock(ConsumptionProperty):
 class MultiLevelSensorPropertyMock(MultiLevelSensorProperty):
     """devolo Home Control multi level sensor mock."""
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(self, **kwargs: Any) -> None:  # pylint: disable=super-init-not-called
         """Initialize the mock."""
         self.element_uid = "Test"
         self.sensor_type = "temperature"
@@ -73,7 +73,7 @@ class MultiLevelSensorPropertyMock(MultiLevelSensorProperty):
 class MultiLevelSwitchPropertyMock(MultiLevelSwitchProperty):
     """devolo Home Control multi level switch mock."""
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(self, **kwargs: Any) -> None:  # pylint: disable=super-init-not-called
         """Initialize the mock."""
         self.element_uid = "Test"
         self.min = 4
@@ -85,7 +85,7 @@ class MultiLevelSwitchPropertyMock(MultiLevelSwitchProperty):
 class SirenPropertyMock(MultiLevelSwitchProperty):
     """devolo Home Control siren mock."""
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(self, **kwargs: Any) -> None:  # pylint: disable=super-init-not-called
         """Initialize the mock."""
         self.element_uid = "Test"
         self.max = 0
@@ -98,7 +98,7 @@ class SirenPropertyMock(MultiLevelSwitchProperty):
 class SettingsMock(SettingsProperty):
     """devolo Home Control settings mock."""
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(self, **kwargs: Any) -> None:  # pylint: disable=super-init-not-called
         """Initialize the mock."""
         self._logger = MagicMock()
         self.name = "Test"
@@ -109,7 +109,7 @@ class SettingsMock(SettingsProperty):
 class DeviceMock(Zwave):
     """devolo Home Control device mock."""
 
-    def __init__(self) -> None:
+    def __init__(self) -> None:  # pylint: disable=super-init-not-called
         """Initialize the mock."""
         self.status = 0
         self.brand = "devolo"
@@ -250,7 +250,7 @@ class SwitchMock(DeviceMock):
 class HomeControlMock(HomeControl):
     """devolo Home Control gateway mock."""
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(self, **kwargs: Any) -> None:  # pylint: disable=super-init-not-called
         """Initialize the mock."""
         self.devices = {}
         self.publisher = MagicMock()

--- a/tests/components/nest/common.py
+++ b/tests/components/nest/common.py
@@ -93,7 +93,7 @@ class FakeSubscriber(GoogleNestSubscriber):
 
     stop_calls = 0
 
-    def __init__(self):
+    def __init__(self):  # pylint: disable=super-init-not-called
         """Initialize Fake Subscriber."""
         self._device_manager = DeviceManager()
 

--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -537,7 +537,7 @@ async def test_manual_config(hass: HomeAssistant, mock_plex_calls) -> None:
     class WrongCertValidaitionException(requests.exceptions.SSLError):
         """Mock the exception showing an unmatched error."""
 
-        def __init__(self):
+        def __init__(self):  # pylint: disable=super-init-not-called
             self.__context__ = ssl.SSLCertVerificationError(
                 "some random message that doesn't match"
             )

--- a/tests/components/plex/test_init.py
+++ b/tests/components/plex/test_init.py
@@ -209,7 +209,7 @@ async def test_setup_when_certificate_changed(
     class WrongCertHostnameException(requests.exceptions.SSLError):
         """Mock the exception showing a mismatched hostname."""
 
-        def __init__(self):
+        def __init__(self):  # pylint: disable=super-init-not-called
             self.__context__ = ssl.SSLCertVerificationError(
                 f"hostname '{old_domain}' doesn't match"
             )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #119279
https://github.com/home-assistant/core/actions/runs/9479928788/job/26119556111?pr=119279

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
