### PR TITLE
Partially revert "Add more debug logging to Ping integration"

### DIFF
--- a/homeassistant/components/ping/helpers.py
+++ b/homeassistant/components/ping/helpers.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any
 from icmplib import NameLookupError, async_ping
 
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from .const import ICMP_TIMEOUT, PING_TIMEOUT
 
@@ -59,9 +58,10 @@ class PingDataICMPLib(PingData):
                 timeout=ICMP_TIMEOUT,
                 privileged=self._privileged,
             )
-        except NameLookupError as err:
+        except NameLookupError:
+            _LOGGER.debug("Error resolving host: %s", self.ip_address)
             self.is_alive = False
-            raise UpdateFailed(f"Error resolving host: {self.ip_address}") from err
+            return
 
         _LOGGER.debug(
             "async_ping returned: reachable=%s sent=%i received=%s",
@@ -152,17 +152,22 @@ class PingDataSubProcess(PingData):
             if TYPE_CHECKING:
                 assert match is not None
             rtt_min, rtt_avg, rtt_max, rtt_mdev = match.groups()
-        except TimeoutError as err:
+        except TimeoutError:
+            _LOGGER.debug(
+                "Timed out running command: `%s`, after: %s",
+                " ".join(self._ping_cmd),
+                self._count + PING_TIMEOUT,
+            )
+
             if pinger:
                 with suppress(TypeError):
                     await pinger.kill()  # type: ignore[func-returns-value]
                 del pinger
 
-            raise UpdateFailed(
-                f"Timed out running command: `{self._ping_cmd}`, after: {self._count + PING_TIMEOUT}s"
-            ) from err
+            return None
         except AttributeError as err:
-            raise UpdateFailed from err
+            _LOGGER.debug("Error matching ping output: %s", err)
+            return None
         return {"min": rtt_min, "avg": rtt_avg, "max": rtt_max, "mdev": rtt_mdev}
 
     async def async_update(self) -> None:


### PR DESCRIPTION
## Proposed change
Revert the raise of `UpdateFailed` in the Ping helper functions. Under some circumstances this leads the entity to be unavailable instead of disconnected.

Better log this and show the entity as disconnected.

/cc @MartinHjelmare because of post-merge comment (https://github.com/home-assistant/core/pull/119318#pullrequestreview-2109175707)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #119462
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
