### PR TITLE
Remove create_list from StorageCollectionWebsocket.async_setup

### DIFF
--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -1609,11 +1609,10 @@ class PipelineStorageCollectionWebsocket(
         self,
         hass: HomeAssistant,
         *,
-        create_list: bool = True,
         create_create: bool = True,
     ) -> None:
         """Set up the websocket commands."""
-        super().async_setup(hass, create_list=create_list, create_create=create_create)
+        super().async_setup(hass, create_create=create_create)
 
         websocket_api.async_register_command(
             hass,

--- a/homeassistant/components/lovelace/dashboard.py
+++ b/homeassistant/components/lovelace/dashboard.py
@@ -310,7 +310,7 @@ class DashboardsCollectionWebSocket(collection.DictStorageCollectionWebsocket):
         connection: websocket_api.ActiveConnection,
         msg: dict[str, Any],
     ) -> None:
-        """Send Lovelace UI resources over WebSocket configuration."""
+        """Send Lovelace UI resources over WebSocket connection."""
         connection.send_result(
             msg["id"],
             [

--- a/homeassistant/components/lovelace/dashboard.py
+++ b/homeassistant/components/lovelace/dashboard.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import voluptuous as vol
 
+from homeassistant.components import websocket_api
 from homeassistant.components.frontend import DATA_PANELS
 from homeassistant.const import CONF_FILENAME
 from homeassistant.core import HomeAssistant, callback
@@ -297,3 +298,24 @@ class DashboardsCollection(collection.DictStorageCollection):
             updated.pop(CONF_ICON)
 
         return updated
+
+
+class DashboardsCollectionWebSocket(collection.DictStorageCollectionWebsocket):
+    """Class to expose storage collection management over websocket."""
+
+    @callback
+    def ws_list_item(
+        self,
+        hass: HomeAssistant,
+        connection: websocket_api.ActiveConnection,
+        msg: dict[str, Any],
+    ) -> None:
+        """Send Lovelace UI resources over WebSocket configuration."""
+        connection.send_result(
+            msg["id"],
+            [
+                dashboard.config
+                for dashboard in hass.data[DOMAIN]["dashboards"].values()
+                if dashboard.config
+            ],
+        )

--- a/homeassistant/components/lovelace/resources.py
+++ b/homeassistant/components/lovelace/resources.py
@@ -8,6 +8,7 @@ import uuid
 
 import voluptuous as vol
 
+from homeassistant.components import websocket_api
 from homeassistant.const import CONF_ID, CONF_RESOURCES, CONF_TYPE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
@@ -21,6 +22,7 @@ from .const import (
     RESOURCE_UPDATE_FIELDS,
 )
 from .dashboard import LovelaceConfig
+from .websocket import websocket_lovelace_resources_impl
 
 RESOURCE_STORAGE_KEY = f"{DOMAIN}_resources"
 RESOURCES_STORAGE_VERSION = 1
@@ -125,3 +127,38 @@ class ResourceStorageCollection(collection.DictStorageCollection):
             update_data[CONF_TYPE] = update_data.pop(CONF_RESOURCE_TYPE_WS)
 
         return {**item, **update_data}
+
+
+class ResourceStorageCollectionWebsocket(collection.DictStorageCollectionWebsocket):
+    """Class to expose storage collection management over websocket."""
+
+    @callback
+    def async_setup(
+        self,
+        hass: HomeAssistant,
+        *,
+        create_create: bool = True,
+    ) -> None:
+        """Set up the websocket commands."""
+        super().async_setup(hass, create_create=create_create)
+
+        # Register lovelace/resources for backwards compatibility, remove in
+        # Home Assistant Core 2025.1
+        websocket_api.async_register_command(
+            hass,
+            self.api_prefix,
+            self.ws_list_item,
+            websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
+                {vol.Required("type"): f"{self.api_prefix}"}
+            ),
+        )
+
+    @staticmethod
+    @websocket_api.async_response
+    async def ws_list_item(
+        hass: HomeAssistant,
+        connection: websocket_api.ActiveConnection,
+        msg: dict[str, Any],
+    ) -> None:
+        """Send Lovelace UI resources over WebSocket connection."""
+        await websocket_lovelace_resources_impl(hass, connection, msg)

--- a/homeassistant/components/lovelace/websocket.py
+++ b/homeassistant/components/lovelace/websocket.py
@@ -8,7 +8,7 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant.components import websocket_api
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.json import json_fragment
@@ -52,14 +52,28 @@ def _handle_errors(func):
     return send_with_error_handling
 
 
-@websocket_api.websocket_command({"type": "lovelace/resources"})
 @websocket_api.async_response
 async def websocket_lovelace_resources(
     hass: HomeAssistant,
     connection: websocket_api.ActiveConnection,
     msg: dict[str, Any],
 ) -> None:
-    """Send Lovelace UI resources over WebSocket configuration."""
+    """Send Lovelace UI resources over WebSocket connection.
+
+    This function is used in YAML mode.
+    """
+    await websocket_lovelace_resources_impl(hass, connection, msg)
+
+
+async def websocket_lovelace_resources_impl(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Help send Lovelace UI resources over WebSocket connection.
+
+    This function is called by both Storage and YAML mode WS handlers.
+    """
     resources = hass.data[DOMAIN]["resources"]
 
     if hass.config.safe_mode:
@@ -129,21 +143,3 @@ async def websocket_lovelace_delete_config(
 ) -> None:
     """Delete Lovelace UI configuration."""
     await config.async_delete()
-
-
-@websocket_api.websocket_command({"type": "lovelace/dashboards/list"})
-@callback
-def websocket_lovelace_dashboards(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
-    """Send Lovelace dashboard configuration."""
-    connection.send_result(
-        msg["id"],
-        [
-            dashboard.config
-            for dashboard in hass.data[DOMAIN]["dashboards"].values()
-            if dashboard.config
-        ],
-    )

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -24,7 +24,6 @@ from homeassistant.const import (
     ATTR_NAME,
     CONF_ID,
     CONF_NAME,
-    CONF_TYPE,
     EVENT_HOMEASSISTANT_START,
     SERVICE_RELOAD,
     STATE_HOME,
@@ -307,6 +306,23 @@ class PersonStorageCollection(collection.DictStorageCollection):
                 raise ValueError("User already taken")
 
 
+class PersonStorageCollectionWebsocket(collection.DictStorageCollectionWebsocket):
+    """Class to expose storage collection management over websocket."""
+
+    def ws_list_item(
+        self,
+        hass: HomeAssistant,
+        connection: websocket_api.ActiveConnection,
+        msg: dict[str, Any],
+    ) -> None:
+        """List persons."""
+        yaml, storage, _ = hass.data[DOMAIN]
+        connection.send_result(
+            msg[ATTR_ID],
+            {"storage": storage.async_items(), "config": yaml.async_items()},
+        )
+
+
 async def filter_yaml_data(hass: HomeAssistant, persons: list[dict]) -> list[dict]:
     """Validate YAML data that we can't validate via schema."""
     filtered = []
@@ -370,11 +386,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     hass.data[DOMAIN] = (yaml_collection, storage_collection, entity_component)
 
-    collection.DictStorageCollectionWebsocket(
+    PersonStorageCollectionWebsocket(
         storage_collection, DOMAIN, DOMAIN, CREATE_FIELDS, UPDATE_FIELDS
-    ).async_setup(hass, create_list=False)
-
-    websocket_api.async_register_command(hass, ws_list_person)
+    ).async_setup(hass)
 
     async def _handle_user_removed(event: Event) -> None:
         """Handle a user being removed."""
@@ -568,19 +582,6 @@ class Person(
             data[ATTR_USER_ID] = user_id
 
         self._attr_extra_state_attributes = data
-
-
-@websocket_api.websocket_command({vol.Required(CONF_TYPE): "person/list"})
-def ws_list_person(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict[str, Any],
-) -> None:
-    """List persons."""
-    yaml, storage, _ = hass.data[DOMAIN]
-    connection.send_result(
-        msg[ATTR_ID], {"storage": storage.async_items(), "config": yaml.async_items()}
-    )
 
 
 def _get_latest(prev: State | None, curr: State) -> State:

--- a/homeassistant/helpers/collection.py
+++ b/homeassistant/helpers/collection.py
@@ -541,19 +541,17 @@ class StorageCollectionWebsocket[_StorageCollectionT: StorageCollection]:
         self,
         hass: HomeAssistant,
         *,
-        create_list: bool = True,
         create_create: bool = True,
     ) -> None:
         """Set up the websocket commands."""
-        if create_list:
-            websocket_api.async_register_command(
-                hass,
-                f"{self.api_prefix}/list",
-                self.ws_list_item,
-                websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
-                    {vol.Required("type"): f"{self.api_prefix}/list"}
-                ),
-            )
+        websocket_api.async_register_command(
+            hass,
+            f"{self.api_prefix}/list",
+            self.ws_list_item,
+            websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
+                {vol.Required("type"): f"{self.api_prefix}/list"}
+            ),
+        )
 
         if create_create:
             websocket_api.async_register_command(

--- a/tests/components/lovelace/test_resources.py
+++ b/tests/components/lovelace/test_resources.py
@@ -5,6 +5,8 @@ from typing import Any
 from unittest.mock import patch
 import uuid
 
+import pytest
+
 from homeassistant.components.lovelace import dashboard, resources
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -17,8 +19,9 @@ RESOURCE_EXAMPLES = [
 ]
 
 
+@pytest.mark.parametrize("list_cmd", ["lovelace/resources", "lovelace/resources/list"])
 async def test_yaml_resources(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, list_cmd: str
 ) -> None:
     """Test defining resources in configuration.yaml."""
     assert await async_setup_component(
@@ -28,14 +31,15 @@ async def test_yaml_resources(
     client = await hass_ws_client(hass)
 
     # Fetch data
-    await client.send_json({"id": 5, "type": "lovelace/resources"})
+    await client.send_json({"id": 5, "type": list_cmd})
     response = await client.receive_json()
     assert response["success"]
     assert response["result"] == RESOURCE_EXAMPLES
 
 
+@pytest.mark.parametrize("list_cmd", ["lovelace/resources", "lovelace/resources/list"])
 async def test_yaml_resources_backwards(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, list_cmd: str
 ) -> None:
     """Test defining resources in YAML ll config (legacy)."""
     with patch(
@@ -49,16 +53,18 @@ async def test_yaml_resources_backwards(
     client = await hass_ws_client(hass)
 
     # Fetch data
-    await client.send_json({"id": 5, "type": "lovelace/resources"})
+    await client.send_json({"id": 5, "type": list_cmd})
     response = await client.receive_json()
     assert response["success"]
     assert response["result"] == RESOURCE_EXAMPLES
 
 
+@pytest.mark.parametrize("list_cmd", ["lovelace/resources", "lovelace/resources/list"])
 async def test_storage_resources(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     hass_storage: dict[str, Any],
+    list_cmd: str,
 ) -> None:
     """Test defining resources in storage config."""
     resource_config = [{**item, "id": uuid.uuid4().hex} for item in RESOURCE_EXAMPLES]
@@ -72,16 +78,18 @@ async def test_storage_resources(
     client = await hass_ws_client(hass)
 
     # Fetch data
-    await client.send_json({"id": 5, "type": "lovelace/resources"})
+    await client.send_json({"id": 5, "type": list_cmd})
     response = await client.receive_json()
     assert response["success"]
     assert response["result"] == resource_config
 
 
+@pytest.mark.parametrize("list_cmd", ["lovelace/resources", "lovelace/resources/list"])
 async def test_storage_resources_import(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     hass_storage: dict[str, Any],
+    list_cmd: str,
 ) -> None:
     """Test importing resources from storage config."""
     assert await async_setup_component(hass, "lovelace", {})
@@ -94,7 +102,7 @@ async def test_storage_resources_import(
     client = await hass_ws_client(hass)
 
     # Fetch data
-    await client.send_json({"id": 5, "type": "lovelace/resources"})
+    await client.send_json({"id": 5, "type": list_cmd})
     response = await client.receive_json()
     assert response["success"]
     assert (
@@ -118,7 +126,7 @@ async def test_storage_resources_import(
     response = await client.receive_json()
     assert response["success"]
 
-    await client.send_json({"id": 7, "type": "lovelace/resources"})
+    await client.send_json({"id": 7, "type": list_cmd})
     response = await client.receive_json()
     assert response["success"]
 
@@ -141,7 +149,7 @@ async def test_storage_resources_import(
     response = await client.receive_json()
     assert response["success"]
 
-    await client.send_json({"id": 9, "type": "lovelace/resources"})
+    await client.send_json({"id": 9, "type": list_cmd})
     response = await client.receive_json()
     assert response["success"]
 
@@ -160,7 +168,7 @@ async def test_storage_resources_import(
     response = await client.receive_json()
     assert response["success"]
 
-    await client.send_json({"id": 11, "type": "lovelace/resources"})
+    await client.send_json({"id": 11, "type": list_cmd})
     response = await client.receive_json()
     assert response["success"]
 
@@ -168,10 +176,12 @@ async def test_storage_resources_import(
     assert first_item["id"] not in (item["id"] for item in response["result"])
 
 
+@pytest.mark.parametrize("list_cmd", ["lovelace/resources", "lovelace/resources/list"])
 async def test_storage_resources_import_invalid(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     hass_storage: dict[str, Any],
+    list_cmd: str,
 ) -> None:
     """Test importing resources from storage config."""
     assert await async_setup_component(hass, "lovelace", {})
@@ -184,7 +194,7 @@ async def test_storage_resources_import_invalid(
     client = await hass_ws_client(hass)
 
     # Fetch data
-    await client.send_json({"id": 5, "type": "lovelace/resources"})
+    await client.send_json({"id": 5, "type": list_cmd})
     response = await client.receive_json()
     assert response["success"]
     assert response["result"] == []
@@ -194,10 +204,12 @@ async def test_storage_resources_import_invalid(
     )
 
 
+@pytest.mark.parametrize("list_cmd", ["lovelace/resources", "lovelace/resources/list"])
 async def test_storage_resources_safe_mode(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     hass_storage: dict[str, Any],
+    list_cmd: str,
 ) -> None:
     """Test defining resources in storage config."""
 
@@ -213,7 +225,7 @@ async def test_storage_resources_safe_mode(
     hass.config.safe_mode = True
 
     # Fetch data
-    await client.send_json({"id": 5, "type": "lovelace/resources"})
+    await client.send_json({"id": 5, "type": list_cmd})
     response = await client.receive_json()
     assert response["success"]
     assert response["result"] == []


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove `create_list` from `StorageCollectionWebsocket.async_setup`

Rationale:

 - Simplify the base class. Derived classes in which the standard way of listing items is unsuitable can just override the list handler.
 - PR https://github.com/home-assistant/core/pull/119481 adds the possibility to subscribe to collection changes via WS. When starting the subscription, we should send an initial event with the current items. This requires a standard way of listing items.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
