### PR TITLE
Add UniFi sensor for number of clients connected to a device

### DIFF
--- a/homeassistant/components/unifi/sensor.py
+++ b/homeassistant/components/unifi/sensor.py
@@ -109,6 +109,27 @@ def async_wlan_client_value_fn(hub: UnifiHub, wlan: Wlan) -> int:
 
 
 @callback
+def async_device_clients_value_fn(hub: UnifiHub, device: Device) -> int:
+    """Calculate the amount of clients connected to a device."""
+
+    return len(
+        [
+            client.mac
+            for client in hub.api.clients.values()
+            if (
+                (
+                    client.access_point_mac != ""
+                    and client.access_point_mac == device.mac
+                )
+                or (client.access_point_mac == "" and client.switch_mac == device.mac)
+            )
+            and dt_util.utcnow() - dt_util.utc_from_timestamp(client.last_seen or 0)
+            < hub.config.option_detection_time
+        ]
+    )
+
+
+@callback
 def async_device_uptime_value_fn(hub: UnifiHub, device: Device) -> datetime | None:
     """Calculate the approximate time the device started (based on uptime returned from API, in seconds)."""
     if device.uptime <= 0:
@@ -301,6 +322,20 @@ ENTITY_DESCRIPTIONS: tuple[UnifiSensorEntityDescription, ...] = (
         should_poll=True,
         unique_id_fn=lambda hub, obj_id: f"wlan_clients-{obj_id}",
         value_fn=async_wlan_client_value_fn,
+    ),
+    UnifiSensorEntityDescription[Devices, Device](
+        key="Device clients",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+        api_handler_fn=lambda api: api.devices,
+        available_fn=async_device_available_fn,
+        device_info_fn=async_device_device_info_fn,
+        name_fn=lambda device: "Clients",
+        object_fn=lambda api, obj_id: api.devices[obj_id],
+        should_poll=True,
+        unique_id_fn=lambda hub, obj_id: f"device_clients_-{obj_id}",
+        value_fn=async_device_clients_value_fn,
     ),
     UnifiSensorEntityDescription[Outlets, Outlet](
         key="Outlet power metering",

--- a/homeassistant/components/unifi/sensor.py
+++ b/homeassistant/components/unifi/sensor.py
@@ -334,7 +334,7 @@ ENTITY_DESCRIPTIONS: tuple[UnifiSensorEntityDescription, ...] = (
         name_fn=lambda device: "Clients",
         object_fn=lambda api, obj_id: api.devices[obj_id],
         should_poll=True,
-        unique_id_fn=lambda hub, obj_id: f"device_clients_-{obj_id}",
+        unique_id_fn=lambda hub, obj_id: f"device_clients-{obj_id}",
         value_fn=async_device_clients_value_fn,
     ),
     UnifiSensorEntityDescription[Outlets, Outlet](

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -1225,3 +1225,106 @@ async def test_bandwidth_port_sensors(
     assert hass.states.get("sensor.mock_name_port_1_tx") is None
     assert hass.states.get("sensor.mock_name_port_2_rx") is None
     assert hass.states.get("sensor.mock_name_port_2_tx") is None
+
+
+async def test_device_client_sensors(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    aioclient_mock: AiohttpClientMocker,
+    mock_unifi_websocket,
+    websocket_mock,
+) -> None:
+    """Verify that WLAN client sensors are working as expected."""
+    wired_device = {
+        "device_id": "mock-id1",
+        "mac": "01:00:00:00:00:00",
+        "model": "US16P150",
+        "name": "Wired Device",
+        "state": 1,
+        "version": "4.0.42.10433",
+    }
+    wireless_device = {
+        "device_id": "mock-id2",
+        "mac": "02:00:00:00:00:00",
+        "model": "US16P150",
+        "name": "Wireless Device",
+        "state": 1,
+        "version": "4.0.42.10433",
+    }
+
+    wired_client_1 = {
+        "hostname": "Wired client 1",
+        "is_wired": True,
+        "mac": "00:00:00:00:00:01",
+        "oui": "Producer",
+        "sw_mac": "01:00:00:00:00:00",
+        "last_seen": dt_util.as_timestamp(dt_util.utcnow()),
+    }
+    wired_client_2 = {
+        "hostname": "Wired client 2",
+        "is_wired": True,
+        "mac": "00:00:00:00:00:02",
+        "oui": "Producer",
+        "sw_mac": "01:00:00:00:00:00",
+        "last_seen": dt_util.as_timestamp(dt_util.utcnow()),
+    }
+    wireless_client_1 = {
+        "is_wired": False,
+        "mac": "00:00:00:00:00:03",
+        "name": "Wireless client 1",
+        "oui": "Producer",
+        "ap_mac": "02:00:00:00:00:00",
+        "sw_mac": "01:00:00:00:00:00",
+        "last_seen": dt_util.as_timestamp(dt_util.utcnow()),
+    }
+
+    await setup_unifi_integration(
+        hass,
+        aioclient_mock,
+        clients_response=[wired_client_1, wired_client_2, wireless_client_1],
+        devices_response=[wireless_device, wired_device],
+    )
+
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 4
+
+    device_clients = entity_registry.async_get("sensor.wired_device_clients")
+    assert device_clients.disabled_by == RegistryEntryDisabler.INTEGRATION
+    assert device_clients.entity_category is EntityCategory.DIAGNOSTIC
+
+    device_clients = entity_registry.async_get("sensor.wireless_device_clients")
+    assert device_clients.disabled_by == RegistryEntryDisabler.INTEGRATION
+    assert device_clients.entity_category is EntityCategory.DIAGNOSTIC
+
+    # Enable entity
+    entity_registry.async_update_entity(
+        entity_id="sensor.wired_device_clients", disabled_by=None
+    )
+    entity_registry.async_update_entity(
+        entity_id="sensor.wireless_device_clients", disabled_by=None
+    )
+
+    await hass.async_block_till_done()
+
+    async_fire_time_changed(
+        hass,
+        dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+    )
+    await hass.async_block_till_done()
+
+    # Validate state object
+    assert len(hass.states.async_all()) == 13
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 6
+
+    assert hass.states.get("sensor.wired_device_clients").state == "2"
+    assert hass.states.get("sensor.wireless_device_clients").state == "1"
+
+    # Verify state update - decreasing number
+
+    wireless_client_1["last_seen"] = 0
+    mock_unifi_websocket(message=MessageKey.CLIENT, data=wireless_client_1)
+
+    async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.wired_device_clients").state == "2"
+    assert hass.states.get("sensor.wireless_device_clients").state == "0"

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -1227,73 +1227,77 @@ async def test_bandwidth_port_sensors(
     assert hass.states.get("sensor.mock_name_port_2_tx") is None
 
 
+@pytest.mark.parametrize(
+    "device_payload",
+    [
+        [
+            {
+                "device_id": "mock-id1",
+                "mac": "01:00:00:00:00:00",
+                "model": "US16P150",
+                "name": "Wired Device",
+                "state": 1,
+                "version": "4.0.42.10433",
+            },
+            {
+                "device_id": "mock-id2",
+                "mac": "02:00:00:00:00:00",
+                "model": "US16P150",
+                "name": "Wireless Device",
+                "state": 1,
+                "version": "4.0.42.10433",
+            },
+        ]
+    ],
+)
 async def test_device_client_sensors(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    aioclient_mock: AiohttpClientMocker,
-    mock_unifi_websocket,
-    websocket_mock,
+    config_entry_factory,
+    mock_websocket_message,
+    client_payload,
 ) -> None:
     """Verify that WLAN client sensors are working as expected."""
-    wired_device = {
-        "device_id": "mock-id1",
-        "mac": "01:00:00:00:00:00",
-        "model": "US16P150",
-        "name": "Wired Device",
-        "state": 1,
-        "version": "4.0.42.10433",
-    }
-    wireless_device = {
-        "device_id": "mock-id2",
-        "mac": "02:00:00:00:00:00",
-        "model": "US16P150",
-        "name": "Wireless Device",
-        "state": 1,
-        "version": "4.0.42.10433",
-    }
-
-    wired_client_1 = {
-        "hostname": "Wired client 1",
-        "is_wired": True,
-        "mac": "00:00:00:00:00:01",
-        "oui": "Producer",
-        "sw_mac": "01:00:00:00:00:00",
-        "last_seen": dt_util.as_timestamp(dt_util.utcnow()),
-    }
-    wired_client_2 = {
-        "hostname": "Wired client 2",
-        "is_wired": True,
-        "mac": "00:00:00:00:00:02",
-        "oui": "Producer",
-        "sw_mac": "01:00:00:00:00:00",
-        "last_seen": dt_util.as_timestamp(dt_util.utcnow()),
-    }
-    wireless_client_1 = {
-        "is_wired": False,
-        "mac": "00:00:00:00:00:03",
-        "name": "Wireless client 1",
-        "oui": "Producer",
-        "ap_mac": "02:00:00:00:00:00",
-        "sw_mac": "01:00:00:00:00:00",
-        "last_seen": dt_util.as_timestamp(dt_util.utcnow()),
-    }
-
-    await setup_unifi_integration(
-        hass,
-        aioclient_mock,
-        clients_response=[wired_client_1, wired_client_2, wireless_client_1],
-        devices_response=[wireless_device, wired_device],
-    )
+    client_payload += [
+        {
+            "hostname": "Wired client 1",
+            "is_wired": True,
+            "mac": "00:00:00:00:00:01",
+            "oui": "Producer",
+            "sw_mac": "01:00:00:00:00:00",
+            "last_seen": dt_util.as_timestamp(dt_util.utcnow()),
+        },
+        {
+            "hostname": "Wired client 2",
+            "is_wired": True,
+            "mac": "00:00:00:00:00:02",
+            "oui": "Producer",
+            "sw_mac": "01:00:00:00:00:00",
+            "last_seen": dt_util.as_timestamp(dt_util.utcnow()),
+        },
+        {
+            "is_wired": False,
+            "mac": "00:00:00:00:00:03",
+            "name": "Wireless client 1",
+            "oui": "Producer",
+            "ap_mac": "02:00:00:00:00:00",
+            "sw_mac": "01:00:00:00:00:00",
+            "last_seen": dt_util.as_timestamp(dt_util.utcnow()),
+        },
+    ]
+    await config_entry_factory()
 
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 4
 
-    device_clients = entity_registry.async_get("sensor.wired_device_clients")
-    assert device_clients.disabled_by == RegistryEntryDisabler.INTEGRATION
-    assert device_clients.entity_category is EntityCategory.DIAGNOSTIC
+    ent_reg_entry = entity_registry.async_get("sensor.wired_device_clients")
+    assert ent_reg_entry.disabled_by == RegistryEntryDisabler.INTEGRATION
+    assert ent_reg_entry.entity_category is EntityCategory.DIAGNOSTIC
+    assert ent_reg_entry.unique_id == "device_clients-01:00:00:00:00:00"
 
-    device_clients = entity_registry.async_get("sensor.wireless_device_clients")
-    assert device_clients.disabled_by == RegistryEntryDisabler.INTEGRATION
-    assert device_clients.entity_category is EntityCategory.DIAGNOSTIC
+    ent_reg_entry = entity_registry.async_get("sensor.wireless_device_clients")
+    assert ent_reg_entry.disabled_by == RegistryEntryDisabler.INTEGRATION
+    assert ent_reg_entry.entity_category is EntityCategory.DIAGNOSTIC
+    assert ent_reg_entry.unique_id == "device_clients-02:00:00:00:00:00"
 
     # Enable entity
     entity_registry.async_update_entity(
@@ -1319,9 +1323,9 @@ async def test_device_client_sensors(
     assert hass.states.get("sensor.wireless_device_clients").state == "1"
 
     # Verify state update - decreasing number
-
+    wireless_client_1 = client_payload[2]
     wireless_client_1["last_seen"] = 0
-    mock_unifi_websocket(message=MessageKey.CLIENT, data=wireless_client_1)
+    mock_websocket_message(message=MessageKey.CLIENT, data=wireless_client_1)
 
     async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR aims to add a sensor to a Unifi device, so it's possible to see how many clients are connected to it.
New PR as I screwed up trying to help with @kimdv original PR (https://github.com/home-assistant/core/pull/117207)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
