### PR TITLE
Device automation extra fields translation for KNX

### DIFF
--- a/homeassistant/components/knx/device_trigger.py
+++ b/homeassistant/components/knx/device_trigger.py
@@ -21,8 +21,12 @@ from .const import DOMAIN
 from .project import KNXProject
 from .trigger import (
     CONF_KNX_DESTINATION,
+    CONF_KNX_GROUP_VALUE_READ,
+    CONF_KNX_GROUP_VALUE_RESPONSE,
+    CONF_KNX_GROUP_VALUE_WRITE,
+    CONF_KNX_INCOMING,
+    CONF_KNX_OUTGOING,
     PLATFORM_TYPE_TRIGGER_TELEGRAM,
-    TELEGRAM_TRIGGER_OPTIONS,
     TELEGRAM_TRIGGER_SCHEMA,
     TRIGGER_SCHEMA as TRIGGER_TRIGGER_SCHEMA,
 )
@@ -79,7 +83,21 @@ async def async_get_trigger_capabilities(
                         options=options,
                     ),
                 ),
-                **TELEGRAM_TRIGGER_OPTIONS,
+                vol.Optional(
+                    CONF_KNX_GROUP_VALUE_WRITE, default=True
+                ): selector.BooleanSelector(),
+                vol.Optional(
+                    CONF_KNX_GROUP_VALUE_RESPONSE, default=True
+                ): selector.BooleanSelector(),
+                vol.Optional(
+                    CONF_KNX_GROUP_VALUE_READ, default=True
+                ): selector.BooleanSelector(),
+                vol.Optional(
+                    CONF_KNX_INCOMING, default=True
+                ): selector.BooleanSelector(),
+                vol.Optional(
+                    CONF_KNX_OUTGOING, default=True
+                ): selector.BooleanSelector(),
             }
         )
     }
@@ -98,7 +116,7 @@ async def async_attach_trigger(
     } | {CONF_PLATFORM: PLATFORM_TYPE_TRIGGER_TELEGRAM}
 
     try:
-        TRIGGER_TRIGGER_SCHEMA(trigger_config)
+        trigger_config = TRIGGER_TRIGGER_SCHEMA(trigger_config)
     except vol.Invalid as err:
         raise InvalidDeviceAutomationConfig(f"{err}") from err
 

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -296,7 +296,23 @@
   },
   "device_automation": {
     "trigger_type": {
-      "telegram": "Telegram sent or received"
+      "telegram": "Telegram"
+    },
+    "extra_fields": {
+      "destination": "Group addresses",
+      "group_value_write": "GroupValueWrite",
+      "group_value_read": "GroupValueRead",
+      "group_value_response": "GroupValueResponse",
+      "incoming": "Incoming",
+      "outgoing": "Outgoing"
+    },
+    "extra_fields_descriptions": {
+      "destination": "The trigger will listen to telegrams sent or received on these group addresses. If no address is selected, the trigger will fire for every group address.",
+      "group_value_write": "Listen on GroupValueWrite telegrams.",
+      "group_value_read": "Listen on GroupValueRead telegrams.",
+      "group_value_response": "Listen on GroupValueResponse telegrams.",
+      "incoming": "Listen on incoming telegrams.",
+      "outgoing": "Listen on outgoing telegrams."
     }
   },
   "services": {

--- a/homeassistant/components/knx/trigger.py
+++ b/homeassistant/components/knx/trigger.py
@@ -31,19 +31,14 @@ CONF_KNX_GROUP_VALUE_RESPONSE: Final = "group_value_response"
 CONF_KNX_INCOMING: Final = "incoming"
 CONF_KNX_OUTGOING: Final = "outgoing"
 
-TELEGRAM_TRIGGER_OPTIONS: Final = {
+
+TELEGRAM_TRIGGER_SCHEMA: Final = {
+    vol.Optional(CONF_KNX_DESTINATION): vol.All(cv.ensure_list, [ga_validator]),
     vol.Optional(CONF_KNX_GROUP_VALUE_WRITE, default=True): cv.boolean,
     vol.Optional(CONF_KNX_GROUP_VALUE_RESPONSE, default=True): cv.boolean,
     vol.Optional(CONF_KNX_GROUP_VALUE_READ, default=True): cv.boolean,
     vol.Optional(CONF_KNX_INCOMING, default=True): cv.boolean,
     vol.Optional(CONF_KNX_OUTGOING, default=True): cv.boolean,
-}
-TELEGRAM_TRIGGER_SCHEMA: Final = {
-    vol.Optional(CONF_KNX_DESTINATION): vol.All(
-        cv.ensure_list,
-        [ga_validator],
-    ),
-    **TELEGRAM_TRIGGER_OPTIONS,
 }
 # TRIGGER_SCHEMA is exclusive to triggers, the above are used in device triggers too
 TRIGGER_SCHEMA = cv.TRIGGER_BASE_SCHEMA.extend(

--- a/tests/components/knx/test_device_trigger.py
+++ b/tests/components/knx/test_device_trigger.py
@@ -319,31 +319,41 @@ async def test_get_trigger_capabilities(
             "name": "group_value_write",
             "optional": True,
             "default": True,
-            "type": "boolean",
+            "selector": {
+                "boolean": {},
+            },
         },
         {
             "name": "group_value_response",
             "optional": True,
             "default": True,
-            "type": "boolean",
+            "selector": {
+                "boolean": {},
+            },
         },
         {
             "name": "group_value_read",
             "optional": True,
             "default": True,
-            "type": "boolean",
+            "selector": {
+                "boolean": {},
+            },
         },
         {
             "name": "incoming",
             "optional": True,
             "default": True,
-            "type": "boolean",
+            "selector": {
+                "boolean": {},
+            },
         },
         {
             "name": "outgoing",
             "optional": True,
             "default": True,
-            "type": "boolean",
+            "selector": {
+                "boolean": {},
+            },
         },
     ]
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Translate extra fields of KNX telegram device trigger.
Use`selector.BooleanSelector` instead of `cv.boolean` in device triggers to get descriptions support.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #115892
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
