### PR TITLE
Add state icons to incomfort water_heater entities

### DIFF
--- a/homeassistant/components/incomfort/icons.json
+++ b/homeassistant/components/incomfort/icons.json
@@ -19,6 +19,47 @@
           "on": "mdi:water-pump"
         }
       }
+    },
+    "water_heater": {
+      "boiler": {
+        "state": {
+          "unknown": "mdi:water-boiler-alert",
+          "opentherm": "mdi:radiator",
+          "boiler_ext": "mdi:water-boiler",
+          "frost": "mdi:snowflake-thermometer",
+          "central_heating_rf": "mdi:radiator",
+          "tapwater_int": "mdi:faucet",
+          "sensor_test": "mdi:thermometer-check",
+          "central_heating": "mdi:radiator",
+          "standby": "mdi:water-boiler-off",
+          "postrun_boyler": "mdi:water-boiler-auto",
+          "service": "mdi:progress-wrench",
+          "tapwater": "mdi:faucet",
+          "postrun_ch": "mdi:radiator-disabled",
+          "boiler_int": "mdi:water-boiler",
+          "buffer": "mdi:water-boiler-auto",
+          "sensor_fault_after_self_check_e0": "mdi:thermometer-alert",
+          "cv_temperature_too_high_e1": "mdi:thermometer-alert",
+          "s1_and_s2_interchanged_e2": "mdi:thermometer-alert",
+          "no_flame_signal_e4": "mdi:fire-alert",
+          "poor_flame_signal_e5": "mdi:fire-alert",
+          "flame_detection_fault_e6": "mdi:fire-alert",
+          "incorrect_fan_speed_e8": "mdi:water-boiler-alert",
+          "sensor_fault_s1_e10": "mdi:water-boiler-alert",
+          "sensor_fault_s1_e11": "mdi:water-boiler-alert",
+          "sensor_fault_s1_e12": "mdi:water-boiler-alert",
+          "sensor_fault_s1_e13": "mdi:water-boiler-alert",
+          "sensor_fault_s1_e14": "mdi:water-boiler-alert",
+          "sensor_fault_s2_e20": "mdi:water-boiler-alert",
+          "sensor_fault_s2_e21": "mdi:water-boiler-alert",
+          "sensor_fault_s2_e22": "mdi:water-boiler-alert",
+          "sensor_fault_s2_e23": "mdi:water-boiler-alert",
+          "sensor_fault_s2_e24": "mdi:water-boiler-alert",
+          "shortcut_outside_sensor_temperature_e27": "mdi:thermometer-alert",
+          "gas_valve_relay_faulty_e29": "mdi:water-boiler-alert",
+          "gas_valve_relay_faulty_e30": "mdi:water-boiler-alert"
+        }
+      }
     }
   }
 }

--- a/homeassistant/components/incomfort/water_heater.py
+++ b/homeassistant/components/incomfort/water_heater.py
@@ -49,11 +49,6 @@ class IncomfortWaterHeater(IncomfortBoilerEntity, WaterHeaterEntity):
         self._attr_unique_id = heater.serial_no
 
     @property
-    def icon(self) -> str:
-        """Return the icon of the water_heater device."""
-        return "mdi:thermometer-lines"
-
-    @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the device state attributes."""
         return {k: v for k, v in self._heater.status.items() if k in HEATER_ATTRS}

--- a/tests/components/incomfort/snapshots/test_water_heater.ambr
+++ b/tests/components/incomfort/snapshots/test_water_heater.ambr
@@ -25,7 +25,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:thermometer-lines',
+    'original_icon': None,
     'original_name': None,
     'platform': 'incomfort',
     'previous_unique_id': None,
@@ -42,7 +42,6 @@
       'display_code': <DisplayCode.STANDBY: 126>,
       'display_text': 'standby',
       'friendly_name': 'Boiler',
-      'icon': 'mdi:thermometer-lines',
       'is_burning': False,
       'max_temp': 80.0,
       'min_temp': 30.0,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add state icons to inconfort water_heater boiler entities

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
