### PR TITLE
Fix use-implicit-booleaness-not-comparison in core tests

### DIFF
--- a/tests/helpers/test_collection.py
+++ b/tests/helpers/test_collection.py
@@ -118,7 +118,7 @@ def test_id_manager() -> None:
 async def test_observable_collection() -> None:
     """Test observerable collection."""
     coll = collection.ObservableCollection(None)
-    assert not coll.async_items()
+    assert coll.async_items() == []  # pylint: disable=use-implicit-booleaness-not-comparison
     coll.data["bla"] = 1
     assert coll.async_items() == [1]
 

--- a/tests/helpers/test_collection.py
+++ b/tests/helpers/test_collection.py
@@ -118,7 +118,7 @@ def test_id_manager() -> None:
 async def test_observable_collection() -> None:
     """Test observerable collection."""
     coll = collection.ObservableCollection(None)
-    assert coll.async_items() == []
+    assert not coll.async_items()
     coll.data["bla"] = 1
     assert coll.async_items() == [1]
 

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -299,7 +299,6 @@ async def test_async_async_request_call_with_lock(hass: HomeAssistant) -> None:
         hass.async_create_task(job2)
 
         assert len(updates) == 0
-        assert updates == []
         assert test_semaphore._value == 0
 
         test_semaphore.release()
@@ -834,7 +833,7 @@ async def test_setup_source(hass: HomeAssistant) -> None:
 
     await platform.async_reset()
 
-    assert entity.entity_sources(hass) == {}
+    assert not entity.entity_sources(hass)
 
 
 async def test_removing_entity_unavailable(hass: HomeAssistant) -> None:

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -1213,9 +1213,9 @@ async def test_track_template_result_super_template(hass: HomeAssistant) -> None
     assert specific_runs_availability == [False]
     assert wildcard_runs_availability == [False]
     assert wildercard_runs_availability == [False]
-    assert specific_runs == []
-    assert wildcard_runs == []
-    assert wildercard_runs == []
+    assert not specific_runs
+    assert not wildcard_runs
+    assert not wildercard_runs
 
     hass.states.async_set("sensor.test", 5)
     await hass.async_block_till_done()
@@ -1366,12 +1366,12 @@ async def test_track_template_result_super_template_initially_false(
     )
     await hass.async_block_till_done()
 
-    assert specific_runs_availability == []
-    assert wildcard_runs_availability == []
-    assert wildercard_runs_availability == []
-    assert specific_runs == []
-    assert wildcard_runs == []
-    assert wildercard_runs == []
+    assert not specific_runs_availability
+    assert not wildcard_runs_availability
+    assert not wildercard_runs_availability
+    assert not specific_runs
+    assert not wildcard_runs
+    assert not wildercard_runs
 
     hass.states.async_set("sensor.test", 5)
     await hass.async_block_till_done()
@@ -1549,9 +1549,9 @@ async def test_track_template_result_super_template_2(
     assert specific_runs_availability == [False]
     assert wildcard_runs_availability == [False]
     assert wildercard_runs_availability == [False]
-    assert specific_runs == []
-    assert wildcard_runs == []
-    assert wildercard_runs == []
+    assert not specific_runs
+    assert not wildcard_runs
+    assert not wildercard_runs
 
     hass.states.async_set("sensor.test", 5)
     hass.states.async_set("sensor.test2", "available")
@@ -1698,12 +1698,12 @@ async def test_track_template_result_super_template_2_initially_false(
     )
     await hass.async_block_till_done()
 
-    assert specific_runs_availability == []
-    assert wildcard_runs_availability == []
-    assert wildercard_runs_availability == []
-    assert specific_runs == []
-    assert wildcard_runs == []
-    assert wildercard_runs == []
+    assert not specific_runs_availability
+    assert not wildcard_runs_availability
+    assert not wildercard_runs_availability
+    assert not specific_runs
+    assert not wildcard_runs
+    assert not wildercard_runs
 
     hass.states.async_set("sensor.test", 5)
     hass.states.async_set("sensor.test2", "available")
@@ -2358,7 +2358,7 @@ async def test_track_template_result_transient_errors(
     )
     await hass.async_block_till_done()
 
-    assert sometimes_error_runs == []
+    assert not sometimes_error_runs
     assert "ValueError" in caplog.text
     assert "ValueError" in repr(info)
     caplog.clear()
@@ -2569,10 +2569,10 @@ async def test_track_template_rate_limit_super_2(hass: HomeAssistant) -> None:
     info.async_refresh()
     await hass.async_block_till_done()
 
-    assert refresh_runs == []
+    assert not refresh_runs
     hass.states.async_set("sensor.one", "any")
     await hass.async_block_till_done()
-    assert refresh_runs == []
+    assert not refresh_runs
     info.async_refresh()
     assert refresh_runs == [1]
     hass.states.async_set("sensor.two", "any")
@@ -2641,10 +2641,10 @@ async def test_track_template_rate_limit_super_3(hass: HomeAssistant) -> None:
     info.async_refresh()
     await hass.async_block_till_done()
 
-    assert refresh_runs == []
+    assert not refresh_runs
     hass.states.async_set("sensor.ONE", "any")
     await hass.async_block_till_done()
-    assert refresh_runs == []
+    assert not refresh_runs
     info.async_refresh()
     assert refresh_runs == [1]
     hass.states.async_set("sensor.two", "any")
@@ -3226,7 +3226,7 @@ async def test_async_track_template_result_multiple_templates_mixing_domain(
     hass.states.async_set("binary_sensor.test", "off")
     await hass.async_block_till_done()
 
-    assert refresh_runs == []
+    assert not refresh_runs
 
     refresh_runs = []
     hass.states.async_set("switch.new", "off")

--- a/tests/helpers/test_group.py
+++ b/tests/helpers/test_group.py
@@ -67,7 +67,7 @@ async def test_expand_entity_ids_recursive(hass: HomeAssistant) -> None:
 
 async def test_expand_entity_ids_ignores_non_strings(hass: HomeAssistant) -> None:
     """Test that non string elements in lists are ignored."""
-    assert group.expand_entity_ids(hass, [5, True]) == []
+    assert not group.expand_entity_ids(hass, [5, True])
 
 
 async def test_get_entity_ids(hass: HomeAssistant) -> None:

--- a/tests/helpers/test_json.py
+++ b/tests/helpers/test_json.py
@@ -280,9 +280,9 @@ def test_default_encoder_is_passed(tmp_path: Path) -> None:
 
 def test_find_unserializable_data() -> None:
     """Find unserializeable data."""
-    assert find_paths_unserializable_data(1) == {}
-    assert find_paths_unserializable_data([1, 2]) == {}
-    assert find_paths_unserializable_data({"something": "yo"}) == {}
+    assert not find_paths_unserializable_data(1)
+    assert not find_paths_unserializable_data([1, 2])
+    assert not find_paths_unserializable_data({"something": "yo"})
 
     assert find_paths_unserializable_data({"something": set()}) == {
         "$.something": set()

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -63,7 +63,7 @@ def test_bad_core_config(
     res = check_config.check(get_test_config_dir())
     assert res["except"].keys() == {"homeassistant"}
     assert res["except"]["homeassistant"][1] == {"unit_system": "bad"}
-    assert res["warn"] == {}
+    assert not res["warn"]
 
 
 @pytest.mark.parametrize("hass_config_yaml", [BASE_CONFIG + "light:\n  platform: demo"])
@@ -74,10 +74,10 @@ def test_config_platform_valid(
     res = check_config.check(get_test_config_dir())
     assert res["components"].keys() == {"homeassistant", "light"}
     assert res["components"]["light"] == [{"platform": "demo"}]
-    assert res["except"] == {}
-    assert res["secret_cache"] == {}
-    assert res["secrets"] == {}
-    assert res["warn"] == {}
+    assert not res["except"]
+    assert not res["secret_cache"]
+    assert not res["secrets"]
+    assert not res["warn"]
     assert len(res["yaml_files"]) == 1
 
 
@@ -110,9 +110,9 @@ def test_component_platform_not_found(
     # Make sure they don't exist
     res = check_config.check(get_test_config_dir())
     assert res["components"].keys() == platforms
-    assert res["except"] == {}
-    assert res["secret_cache"] == {}
-    assert res["secrets"] == {}
+    assert not res["except"]
+    assert not res["secret_cache"]
+    assert not res["secrets"]
     assert res["warn"] == {check_config.WARNING_STR: [error]}
     assert len(res["yaml_files"]) == 1
 
@@ -135,7 +135,7 @@ def test_secrets(
     """Test secrets config checking method."""
     res = check_config.check(get_test_config_dir(), True)
 
-    assert res["except"] == {}
+    assert not res["except"]
     assert res["components"].keys() == {"homeassistant", "http"}
     assert res["components"]["http"] == {
         "cors_allowed_origins": ["http://google.com"],
@@ -150,7 +150,7 @@ def test_secrets(
         get_test_config_dir("secrets.yaml"): {"http_pw": "http://google.com"}
     }
     assert res["secrets"] == {"http_pw": "http://google.com"}
-    assert res["warn"] == {}
+    assert not res["warn"]
     assert normalize_yaml_files(res) == [
         ".../configuration.yaml",
         ".../secrets.yaml",
@@ -166,10 +166,10 @@ def test_package_invalid(
     """Test an invalid package."""
     res = check_config.check(get_test_config_dir())
 
-    assert res["except"] == {}
+    assert not res["except"]
     assert res["components"].keys() == {"homeassistant"}
-    assert res["secret_cache"] == {}
-    assert res["secrets"] == {}
+    assert not res["secret_cache"]
+    assert not res["secrets"]
     assert res["warn"].keys() == {"homeassistant.packages.p1.group"}
     assert res["warn"]["homeassistant.packages.p1.group"][1] == {"group": ["a"]}
     assert len(res["yaml_files"]) == 1
@@ -185,9 +185,9 @@ def test_bootstrap_error(
     res = check_config.check(get_test_config_dir(YAML_CONFIG_FILE))
     err = res["except"].pop(check_config.ERROR_STR)
     assert len(err) == 1
-    assert res["except"] == {}
-    assert res["components"] == {}  # No components, load failed
-    assert res["secret_cache"] == {}
-    assert res["secrets"] == {}
-    assert res["warn"] == {}
-    assert res["yaml_files"] == {}
+    assert not res["except"]
+    assert not res["components"]  # No components, load failed
+    assert not res["secret_cache"]
+    assert not res["secrets"]
+    assert not res["warn"]
+    assert not res["yaml_files"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2410,14 +2410,14 @@ def test_extract_platform_integrations() -> None:
     assert config_util.extract_platform_integrations(config, {"zone"}) == {
         "zone": {"hello", "hello 2"}
     }
-    assert config_util.extract_platform_integrations(config, {"switch"}) == {}
-    assert config_util.extract_platform_integrations(config, {"zonex"}) == {}
-    assert config_util.extract_platform_integrations(config, {"zoney"}) == {}
+    assert not config_util.extract_platform_integrations(config, {"switch"})
+    assert not config_util.extract_platform_integrations(config, {"zonex"})
+    assert not config_util.extract_platform_integrations(config, {"zoney"})
     assert config_util.extract_platform_integrations(
         config, {"zone", "not_valid", "notzone"}
     ) == {"zone": {"hello 2", "hello"}, "notzone": {"nothello"}}
-    assert config_util.extract_platform_integrations(config, {"zoneq"}) == {}
-    assert config_util.extract_platform_integrations(config, {"zoneempty"}) == {}
+    assert not config_util.extract_platform_integrations(config, {"zoneq"})
+    assert not config_util.extract_platform_integrations(config, {"zoneempty"})
 
 
 @pytest.mark.parametrize("load_registries", [False])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1922,13 +1922,13 @@ async def test_config_defaults() -> None:
     assert config.external_url is None
     assert config.config_source is ha.ConfigSource.DEFAULT
     assert config.skip_pip is False
-    assert config.skip_pip_packages == []
+    assert config.skip_pip_packages == []  # pylint: disable=use-implicit-booleaness-not-comparison
     assert config.components == set()
     assert config.api is None
     assert config.config_dir == "/test/ha-config"
     assert config.allowlist_external_dirs == set()
     assert config.allowlist_external_urls == set()
-    assert config.media_dirs == {}
+    assert config.media_dirs == {}  # pylint: disable=use-implicit-booleaness-not-comparison
     assert config.recovery_mode is False
     assert config.legacy_templates is False
     assert config.currency == "EUR"

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -571,7 +571,7 @@ async def test_when_setup_already_loaded(hass: HomeAssistant) -> None:
 
     setup.async_when_setup(hass, "test", mock_callback)
     await hass.async_block_till_done()
-    assert calls == []
+    assert not calls
 
     hass.config.components.add("test")
     hass.bus.async_fire(EVENT_COMPONENT_LOADED, {"component": "test"})
@@ -599,7 +599,7 @@ async def test_async_when_setup_or_start_already_loaded(hass: HomeAssistant) -> 
 
     setup.async_when_setup_or_start(hass, "test", mock_callback)
     await hass.async_block_till_done()
-    assert calls == []
+    assert not calls
 
     hass.config.components.add("test")
     hass.bus.async_fire(EVENT_COMPONENT_LOADED, {"component": "test"})


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #119279
https://github.com/home-assistant/core/actions/runs/9494234441/job/26164229710?pr=119279

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
