### PR TITLE
Ignore unnecessary-lambda warnings in tests

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -818,6 +818,7 @@ class MockModule:
 
         if setup:
             # We run this in executor, wrap it in function
+            # pylint: disable-next=unnecessary-lambda
             self.setup = lambda *args: setup(*args)
 
         if async_setup is not None:
@@ -875,6 +876,7 @@ class MockPlatform:
 
         if setup_platform is not None:
             # We run this in executor, wrap it in function
+            # pylint: disable-next=unnecessary-lambda
             self.setup_platform = lambda *args: setup_platform(*args)
 
         if async_setup_platform is not None:

--- a/tests/components/bayesian/test_binary_sensor.py
+++ b/tests/components/bayesian/test_binary_sensor.py
@@ -1012,7 +1012,10 @@ async def test_template_triggers(hass: HomeAssistant) -> None:
 
     events = []
     async_track_state_change_event(
-        hass, "binary_sensor.test_binary", callback(lambda event: events.append(event))
+        hass,
+        "binary_sensor.test_binary",
+        # pylint: disable-next=unnecessary-lambda
+        callback(lambda event: events.append(event)),
     )
 
     context = Context()
@@ -1051,7 +1054,10 @@ async def test_state_triggers(hass: HomeAssistant) -> None:
 
     events = []
     async_track_state_change_event(
-        hass, "binary_sensor.test_binary", callback(lambda event: events.append(event))
+        hass,
+        "binary_sensor.test_binary",
+        # pylint: disable-next=unnecessary-lambda
+        callback(lambda event: events.append(event)),
     )
 
     context = Context()

--- a/tests/components/demo/test_update.py
+++ b/tests/components/demo/test_update.py
@@ -134,6 +134,7 @@ async def test_update_with_progress(hass: HomeAssistant) -> None:
     async_track_state_change_event(
         hass,
         "update.demo_update_with_progress",
+        # pylint: disable-next=unnecessary-lambda
         callback(lambda event: events.append(event)),
     )
 
@@ -170,6 +171,7 @@ async def test_update_with_progress_raising(hass: HomeAssistant) -> None:
     events = []
     async_track_state_change_event(
         hass,
+        # pylint: disable-next=unnecessary-lambda
         "update.demo_update_with_progress",
         callback(lambda event: events.append(event)),
     )

--- a/tests/components/pilight/test_init.py
+++ b/tests/components/pilight/test_init.py
@@ -362,6 +362,7 @@ async def test_call_rate_delay_throttle_enabled(hass: HomeAssistant) -> None:
     delay = 5.0
 
     limit = pilight.CallRateDelayThrottle(hass, delay)
+    # pylint: disable-next=unnecessary-lambda
     action = limit.limited(lambda x: runs.append(x))
 
     for i in range(3):
@@ -385,6 +386,7 @@ def test_call_rate_delay_throttle_disabled(hass: HomeAssistant) -> None:
     runs = []
 
     limit = pilight.CallRateDelayThrottle(hass, 0.0)
+    # pylint: disable-next=unnecessary-lambda
     action = limit.limited(lambda x: runs.append(x))
 
     for i in range(3):

--- a/tests/components/rainforest_raven/__init__.py
+++ b/tests/components/rainforest_raven/__init__.py
@@ -27,6 +27,7 @@ def create_mock_device() -> AsyncMock:
     device.get_device_info.return_value = DEVICE_INFO
     device.get_instantaneous_demand.return_value = DEMAND
     device.get_meter_list.return_value = METER_LIST
+    # pylint: disable-next=unnecessary-lambda
     device.get_meter_info.side_effect = lambda meter: METER_INFO.get(meter)
     device.get_network_info.return_value = NETWORK_INFO
 

--- a/tests/components/universal/test_media_player.py
+++ b/tests/components/universal/test_media_player.py
@@ -1271,7 +1271,10 @@ async def test_master_state_with_template(hass: HomeAssistant) -> None:
     events = []
 
     async_track_state_change_event(
-        hass, "media_player.tv", callback(lambda event: events.append(event))
+        hass,
+        "media_player.tv",
+        # pylint: disable-next=unnecessary-lambda
+        callback(lambda event: events.append(event)),
     )
 
     context = Context()

--- a/tests/components/update/test_init.py
+++ b/tests/components/update/test_init.py
@@ -586,7 +586,10 @@ async def test_entity_without_progress_support(
 
     events = []
     async_track_state_change_event(
-        hass, "update.update_available", callback(lambda event: events.append(event))
+        hass,
+        "update.update_available",
+        # pylint: disable-next=unnecessary-lambda
+        callback(lambda event: events.append(event)),
     )
 
     await hass.services.async_call(
@@ -624,7 +627,10 @@ async def test_entity_without_progress_support_raising(
 
     events = []
     async_track_state_change_event(
-        hass, "update.update_available", callback(lambda event: events.append(event))
+        hass,
+        "update.update_available",
+        # pylint: disable-next=unnecessary-lambda
+        callback(lambda event: events.append(event)),
     )
 
     with (

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -61,7 +61,10 @@ async def test_track_point_in_time(hass: HomeAssistant) -> None:
     runs = []
 
     async_track_point_in_utc_time(
-        hass, callback(lambda x: runs.append(x)), birthday_paulus
+        hass,
+        # pylint: disable-next=unnecessary-lambda
+        callback(lambda x: runs.append(x)),
+        birthday_paulus,
     )
 
     async_fire_time_changed(hass, before_birthday)
@@ -78,7 +81,10 @@ async def test_track_point_in_time(hass: HomeAssistant) -> None:
     assert len(runs) == 1
 
     async_track_point_in_utc_time(
-        hass, callback(lambda x: runs.append(x)), birthday_paulus
+        hass,
+        # pylint: disable-next=unnecessary-lambda
+        callback(lambda x: runs.append(x)),
+        birthday_paulus,
     )
 
     async_fire_time_changed(hass, after_birthday)
@@ -86,7 +92,10 @@ async def test_track_point_in_time(hass: HomeAssistant) -> None:
     assert len(runs) == 2
 
     unsub = async_track_point_in_time(
-        hass, callback(lambda x: runs.append(x)), birthday_paulus
+        hass,
+        # pylint: disable-next=unnecessary-lambda
+        callback(lambda x: runs.append(x)),
+        birthday_paulus,
     )
     unsub()
 
@@ -107,6 +116,7 @@ async def test_track_point_in_time_drift_rearm(hass: HomeAssistant) -> None:
 
     async_track_point_in_utc_time(
         hass,
+        # pylint: disable-next=unnecessary-lambda
         callback(lambda x: specific_runs.append(x)),
         time_that_will_not_match_right_away,
     )
@@ -3546,7 +3556,10 @@ async def test_track_time_interval(hass: HomeAssistant) -> None:
 
     utc_now = dt_util.utcnow()
     unsub = async_track_time_interval(
-        hass, callback(lambda x: specific_runs.append(x)), timedelta(seconds=10)
+        hass,
+        # pylint: disable-next=unnecessary-lambda
+        callback(lambda x: specific_runs.append(x)),
+        timedelta(seconds=10),
     )
 
     async_fire_time_changed(hass, utc_now + timedelta(seconds=5))
@@ -3578,6 +3591,7 @@ async def test_track_time_interval_name(hass: HomeAssistant) -> None:
     unique_string = "xZ13"
     unsub = async_track_time_interval(
         hass,
+        # pylint: disable-next=unnecessary-lambda
         callback(lambda x: specific_runs.append(x)),
         timedelta(seconds=10),
         name=unique_string,
@@ -3808,12 +3822,20 @@ async def test_async_track_time_change(
     )
     freezer.move_to(time_that_will_not_match_right_away)
 
-    unsub = async_track_time_change(hass, callback(lambda x: none_runs.append(x)))
+    unsub = async_track_time_change(
+        hass,
+        # pylint: disable-next=unnecessary-lambda
+        callback(lambda x: none_runs.append(x)),
+    )
     unsub_utc = async_track_utc_time_change(
-        hass, callback(lambda x: specific_runs.append(x)), second=[0, 30]
+        hass,
+        # pylint: disable-next=unnecessary-lambda
+        callback(lambda x: specific_runs.append(x)),
+        second=[0, 30],
     )
     unsub_wildcard = async_track_time_change(
         hass,
+        # pylint: disable-next=unnecessary-lambda
         callback(lambda x: wildcard_runs.append(x)),
         second="*",
         minute="*",
@@ -3872,7 +3894,11 @@ async def test_periodic_task_minute(
     freezer.move_to(time_that_will_not_match_right_away)
 
     unsub = async_track_utc_time_change(
-        hass, callback(lambda x: specific_runs.append(x)), minute="/5", second=0
+        hass,
+        # pylint: disable-next=unnecessary-lambda
+        callback(lambda x: specific_runs.append(x)),
+        minute="/5",
+        second=0,
     )
 
     async_fire_time_changed(
@@ -3918,6 +3944,7 @@ async def test_periodic_task_hour(
 
     unsub = async_track_utc_time_change(
         hass,
+        # pylint: disable-next=unnecessary-lambda
         callback(lambda x: specific_runs.append(x)),
         hour="/2",
         minute=0,
@@ -3971,7 +3998,10 @@ async def test_periodic_task_wrong_input(hass: HomeAssistant) -> None:
 
     with pytest.raises(ValueError):
         async_track_utc_time_change(
-            hass, callback(lambda x: specific_runs.append(x)), hour="/two"
+            hass,
+            # pylint: disable-next=unnecessary-lambda
+            callback(lambda x: specific_runs.append(x)),
+            hour="/two",
         )
 
     async_fire_time_changed(
@@ -3995,6 +4025,7 @@ async def test_periodic_task_clock_rollback(
 
     unsub = async_track_utc_time_change(
         hass,
+        # pylint: disable-next=unnecessary-lambda
         callback(lambda x: specific_runs.append(x)),
         hour="/2",
         minute=0,
@@ -4064,6 +4095,7 @@ async def test_periodic_task_duplicate_time(
 
     unsub = async_track_utc_time_change(
         hass,
+        # pylint: disable-next=unnecessary-lambda
         callback(lambda x: specific_runs.append(x)),
         hour="/2",
         minute=0,
@@ -4109,6 +4141,7 @@ async def test_periodic_task_entering_dst(
 
     unsub = async_track_time_change(
         hass,
+        # pylint: disable-next=unnecessary-lambda
         callback(lambda x: specific_runs.append(x)),
         hour=2,
         minute=30,
@@ -4160,6 +4193,7 @@ async def test_periodic_task_entering_dst_2(
 
     unsub = async_track_time_change(
         hass,
+        # pylint: disable-next=unnecessary-lambda
         callback(lambda x: specific_runs.append(x)),
         second=list(range(59)),
     )
@@ -4210,6 +4244,7 @@ async def test_periodic_task_leaving_dst(
 
     unsub = async_track_time_change(
         hass,
+        # pylint: disable-next=unnecessary-lambda
         callback(lambda x: specific_runs.append(x)),
         hour=2,
         minute=30,
@@ -4285,6 +4320,7 @@ async def test_periodic_task_leaving_dst_2(
 
     unsub = async_track_time_change(
         hass,
+        # pylint: disable-next=unnecessary-lambda
         callback(lambda x: specific_runs.append(x)),
         minute=30,
         second=0,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #119279
https://github.com/home-assistant/core/actions/runs/9494234441/job/26164229710?pr=119279

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
