### PR TITLE
Fix dangerous-default-value warnings in integration tests

### DIFF
--- a/tests/components/integration/test_sensor.py
+++ b/tests/components/integration/test_sensor.py
@@ -1,6 +1,7 @@
 """The tests for the integration sensor platform."""
 
 from datetime import timedelta
+from typing import Any
 
 from freezegun import freeze_time
 import pytest
@@ -32,6 +33,8 @@ from tests.common import (
     mock_restore_cache,
     mock_restore_cache_with_extra_data,
 )
+
+DEFAULT_MAX_SUB_INTERVAL = {"minutes": 1}
 
 
 @pytest.mark.parametrize("method", ["trapezoidal", "left", "right"])
@@ -752,7 +755,7 @@ async def test_device_id(
     assert integration_entity.device_id == source_entity.device_id
 
 
-def _integral_sensor_config(max_sub_interval: dict[str, int] | None = {"minutes": 1}):
+def _integral_sensor_config(max_sub_interval: dict[str, int] | None) -> dict[str, Any]:
     sensor = {
         "platform": "integration",
         "name": "integration",
@@ -765,7 +768,7 @@ def _integral_sensor_config(max_sub_interval: dict[str, int] | None = {"minutes"
 
 
 async def _setup_integral_sensor(
-    hass: HomeAssistant, max_sub_interval: dict[str, int] | None = {"minutes": 1}
+    hass: HomeAssistant, max_sub_interval: dict[str, int] | None
 ) -> None:
     await async_setup_component(
         hass, "sensor", _integral_sensor_config(max_sub_interval=max_sub_interval)
@@ -775,7 +778,9 @@ async def _setup_integral_sensor(
 
 async def _update_source_sensor(hass: HomeAssistant, value: int | str) -> None:
     hass.states.async_set(
-        _integral_sensor_config()["sensor"]["source"],
+        _integral_sensor_config(max_sub_interval=DEFAULT_MAX_SUB_INTERVAL)["sensor"][
+            "source"
+        ],
         value,
         {ATTR_UNIT_OF_MEASUREMENT: UnitOfPower.KILO_WATT},
         force_update=True,
@@ -790,7 +795,7 @@ async def test_on_valid_source_expect_update_on_time(
     start_time = dt_util.utcnow()
 
     with freeze_time(start_time) as freezer:
-        await _setup_integral_sensor(hass)
+        await _setup_integral_sensor(hass, max_sub_interval=DEFAULT_MAX_SUB_INTERVAL)
         await _update_source_sensor(hass, 100)
         state_before_max_sub_interval_exceeded = hass.states.get("sensor.integration")
 
@@ -816,7 +821,7 @@ async def test_on_unvailable_source_expect_no_update_on_time(
 
     start_time = dt_util.utcnow()
     with freeze_time(start_time) as freezer:
-        await _setup_integral_sensor(hass)
+        await _setup_integral_sensor(hass, max_sub_interval=DEFAULT_MAX_SUB_INTERVAL)
         await _update_source_sensor(hass, 100)
         freezer.tick(61)
         async_fire_time_changed(hass, dt_util.now())
@@ -843,7 +848,7 @@ async def test_on_statechanges_source_expect_no_update_on_time(
 
     start_time = dt_util.utcnow()
     with freeze_time(start_time) as freezer:
-        await _setup_integral_sensor(hass)
+        await _setup_integral_sensor(hass, max_sub_interval=DEFAULT_MAX_SUB_INTERVAL)
         await _update_source_sensor(hass, 100)
 
         freezer.tick(30)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #119279
https://github.com/home-assistant/core/actions/runs/9494234441/job/26164229710?pr=119279

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
