### PR TITLE
Improve error messages when config entry is in wrong state

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1813,8 +1813,8 @@ class ConfigEntries:
         if entry.state is not ConfigEntryState.NOT_LOADED:
             raise OperationNotAllowed(
                 f"The config entry '{entry.title}' ({entry.domain}) with entry_id"
-                f" {entry.entry_id} cannot be set up because it is in state "
-                f"{entry.state}, but needs to be in state {ConfigEntryState.NOT_LOADED}"
+                f" '{entry.entry_id}' cannot be set up because it is in state "
+                f"{entry.state}, but needs to be in the {ConfigEntryState.NOT_LOADED} state"
             )
 
         # Setup Component if not set up yet
@@ -1845,7 +1845,7 @@ class ConfigEntries:
         if not entry.state.recoverable:
             raise OperationNotAllowed(
                 f"The config entry '{entry.title}' ({entry.domain}) with entry_id"
-                f" {entry.entry_id} cannot be unloaded because it is in the non"
+                f" '{entry.entry_id}' cannot be unloaded because it is in the non"
                 f" recoverable state {entry.state}"
             )
 
@@ -2050,9 +2050,9 @@ class ConfigEntries:
                 if entry.state is not ConfigEntryState.LOADED:
                     raise OperationNotAllowed(
                         f"The config entry '{entry.title}' ({entry.domain}) with "
-                        f"entry_id {entry.entry_id} cannot forward setup for "
+                        f"entry_id '{entry.entry_id}' cannot forward setup for "
                         f"{platforms} because it is in state {entry.state}, but needs "
-                        f"to be in state {ConfigEntryState.LOADED}"
+                        f"to be in the {ConfigEntryState.LOADED} state"
                     )
                 await self._async_forward_entry_setups_locked(entry, platforms)
         else:
@@ -2110,9 +2110,9 @@ class ConfigEntries:
                 if entry.state is not ConfigEntryState.LOADED:
                     raise OperationNotAllowed(
                         f"The config entry '{entry.title}' ({entry.domain}) with "
-                        f"entry_id {entry.entry_id} cannot forward setup for "
+                        f"entry_id '{entry.entry_id}' cannot forward setup for "
                         f"{domain} because it is in state {entry.state}, but needs "
-                        f"to be in state {ConfigEntryState.LOADED}"
+                        f"to be in the {ConfigEntryState.LOADED} state"
                     )
                 return await self._async_forward_entry_setup(entry, domain, True)
         result = await self._async_forward_entry_setup(entry, domain, True)

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1812,9 +1812,9 @@ class ConfigEntries:
 
         if entry.state is not ConfigEntryState.NOT_LOADED:
             raise OperationNotAllowed(
-                f"The config entry {entry.title} ({entry.domain}) with entry_id"
-                f" {entry.entry_id} cannot be set up because it is already loaded"
-                f" in the {entry.state} state"
+                f"The config entry '{entry.title}' ({entry.domain}) with entry_id"
+                f" {entry.entry_id} cannot be set up because it is in state "
+                f"{entry.state}, but needs to be in state {ConfigEntryState.NOT_LOADED}"
             )
 
         # Setup Component if not set up yet
@@ -1844,9 +1844,9 @@ class ConfigEntries:
 
         if not entry.state.recoverable:
             raise OperationNotAllowed(
-                f"The config entry {entry.title} ({entry.domain}) with entry_id"
-                f" {entry.entry_id} cannot be unloaded because it is not in a"
-                f" recoverable state ({entry.state})"
+                f"The config entry '{entry.title}' ({entry.domain}) with entry_id"
+                f" {entry.entry_id} cannot be unloaded because it is in the non"
+                f" recoverable state {entry.state}"
             )
 
         if _lock:
@@ -2049,9 +2049,10 @@ class ConfigEntries:
             async with entry.setup_lock:
                 if entry.state is not ConfigEntryState.LOADED:
                     raise OperationNotAllowed(
-                        f"The config entry {entry.title} ({entry.domain}) with entry_id"
-                        f" {entry.entry_id} cannot forward setup for {platforms} because it"
-                        f" is not loaded in the {entry.state} state"
+                        f"The config entry '{entry.title}' ({entry.domain}) with "
+                        f"entry_id {entry.entry_id} cannot forward setup for "
+                        f"{platforms} because it is in state {entry.state}, but needs "
+                        f"to be in state {ConfigEntryState.LOADED}"
                     )
                 await self._async_forward_entry_setups_locked(entry, platforms)
         else:
@@ -2108,9 +2109,10 @@ class ConfigEntries:
             async with entry.setup_lock:
                 if entry.state is not ConfigEntryState.LOADED:
                     raise OperationNotAllowed(
-                        f"The config entry {entry.title} ({entry.domain}) with entry_id"
-                        f" {entry.entry_id} cannot forward setup for {domain} because it"
-                        f" is not loaded in the {entry.state} state"
+                        f"The config entry '{entry.title}' ({entry.domain}) with "
+                        f"entry_id {entry.entry_id} cannot forward setup for "
+                        f"{domain} because it is in state {entry.state}, but needs "
+                        f"to be in state {ConfigEntryState.LOADED}"
                     )
                 return await self._async_forward_entry_setup(entry, domain, True)
         result = await self._async_forward_entry_setup(entry, domain, True)

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -5606,9 +5606,10 @@ async def test_config_entry_unloaded_during_platform_setups(
     del task
 
     assert (
-        "OperationNotAllowed: The config entry Mock Title (test) with "
-        "entry_id test2 cannot forward setup for ['light'] because it is "
-        "not loaded in the ConfigEntryState.NOT_LOADED state"
+        "OperationNotAllowed: The config entry 'Mock Title' (test) with "
+        "entry_id 'test2' cannot forward setup for ['light'] because it is "
+        "in state ConfigEntryState.NOT_LOADED, but needs to be in the "
+        "ConfigEntryState.LOADED state"
     ) in caplog.text
 
 
@@ -5824,9 +5825,10 @@ async def test_config_entry_unloaded_during_platform_setup(
     del task
 
     assert (
-        "OperationNotAllowed: The config entry Mock Title (test) with "
-        "entry_id test2 cannot forward setup for light because it is "
-        "not loaded in the ConfigEntryState.NOT_LOADED state"
+        "OperationNotAllowed: The config entry 'Mock Title' (test) with "
+        "entry_id 'test2' cannot forward setup for light because it is "
+        "in state ConfigEntryState.NOT_LOADED, but needs to be in the "
+        "ConfigEntryState.LOADED state"
     ) in caplog.text
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
