### PR TITLE
Prefer mp4 playback in Reolink

### DIFF
--- a/homeassistant/components/reolink/media_source.py
+++ b/homeassistant/components/reolink/media_source.py
@@ -59,13 +59,13 @@ class ReolinkVODMediaSource(MediaSource):
         data: dict[str, ReolinkData] = self.hass.data[DOMAIN]
         host = data[config_entry_id].host
 
-    def get_vod_type() -> VodRequestType:
-        if filename.endswith(".mp4"):
-            return VodRequestType.PLAYBACK
-        if host.api.is_nvr:
-            return VodRequestType.FLV
-        return VodRequestType.RTMP
-    vod_type = get_vod_type()
+        def get_vod_type() -> VodRequestType:
+            if filename.endswith(".mp4"):
+                return VodRequestType.PLAYBACK
+            if host.api.is_nvr:
+                return VodRequestType.FLV
+            return VodRequestType.RTMP
+        vod_type = get_vod_type()
 
         mime_type, url = await host.api.get_vod_source(
             channel, filename, stream_res, vod_type

--- a/homeassistant/components/reolink/media_source.py
+++ b/homeassistant/components/reolink/media_source.py
@@ -59,11 +59,13 @@ class ReolinkVODMediaSource(MediaSource):
         data: dict[str, ReolinkData] = self.hass.data[DOMAIN]
         host = data[config_entry_id].host
 
-        vod_type = VodRequestType.PLAYBACK
-        if not filename.endswith(".mp4"):
-            vod_type = VodRequestType.RTMP
-            if host.api.is_nvr:
-                vod_type = VodRequestType.FLV
+    def get_vod_type() -> VodRequestType:
+        if filename.endswith(".mp4"):
+            return VodRequestType.PLAYBACK
+        if host.api.is_nvr:
+            return VodRequestType.FLV
+        return VodRequestType.RTMP
+    vod_type = get_vod_type()
 
         mime_type, url = await host.api.get_vod_source(
             channel, filename, stream_res, vod_type

--- a/homeassistant/components/reolink/media_source.py
+++ b/homeassistant/components/reolink/media_source.py
@@ -69,10 +69,11 @@ class ReolinkVODMediaSource(MediaSource):
             channel, filename, stream_res, vod_type
         )
         if _LOGGER.isEnabledFor(logging.DEBUG):
-            if "&user=" in url:
-                url_log = f"{url.split('&user=')[0]}&user=xxxxx&password=xxxxx"
-            if "&token=" in url:
-                url_log = f"{url.split('&token=')[0]}&token=xxxxx"
+            url_log = url
+            if "&user=" in url_log:
+                url_log = f"{url_log.split('&user=')[0]}&user=xxxxx&password=xxxxx"
+            if "&token=" in url_log:
+                url_log = f"{url_log.split('&token=')[0]}&token=xxxxx"
             _LOGGER.debug(
                 "Opening VOD stream from %s: %s", host.api.camera_name(channel), url_log
             )

--- a/homeassistant/components/reolink/media_source.py
+++ b/homeassistant/components/reolink/media_source.py
@@ -75,7 +75,7 @@ class ReolinkVODMediaSource(MediaSource):
             url_log = url
             if "&user=" in url_log:
                 url_log = f"{url_log.split('&user=')[0]}&user=xxxxx&password=xxxxx"
-            if "&token=" in url_log:
+            elif "&token=" in url_log:
                 url_log = f"{url_log.split('&token=')[0]}&token=xxxxx"
             _LOGGER.debug(
                 "Opening VOD stream from %s: %s", host.api.camera_name(channel), url_log

--- a/homeassistant/components/reolink/media_source.py
+++ b/homeassistant/components/reolink/media_source.py
@@ -65,6 +65,7 @@ class ReolinkVODMediaSource(MediaSource):
             if host.api.is_nvr:
                 return VodRequestType.FLV
             return VodRequestType.RTMP
+
         vod_type = get_vod_type()
 
         mime_type, url = await host.api.get_vod_source(

--- a/tests/components/reolink/test_media_source.py
+++ b/tests/components/reolink/test_media_source.py
@@ -55,7 +55,9 @@ TEST_STREAM = "main"
 TEST_CHANNEL = "0"
 
 TEST_MIME_TYPE = "application/x-mpegURL"
-TEST_URL = "http:test_url"
+TEST_MIME_TYPE_MP4 = "video/mp4"
+TEST_URL = "http:test_url&user=admin&password=test"
+TEST_URL2 = "http:test_url&token=test"
 
 
 @pytest.fixture(autouse=True)
@@ -86,18 +88,22 @@ async def test_resolve(
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    reolink_connect.get_vod_source.return_value = (TEST_MIME_TYPE, TEST_URL)
     caplog.set_level(logging.DEBUG)
-
     file_id = (
         f"FILE|{config_entry.entry_id}|{TEST_CHANNEL}|{TEST_STREAM}|{TEST_FILE_NAME}"
     )
 
+    reolink_connect.get_vod_source.return_value = (TEST_MIME_TYPE, TEST_URL)
     play_media = await async_resolve_media(
         hass, f"{URI_SCHEME}{DOMAIN}/{file_id}", None
     )
-
     assert play_media.mime_type == TEST_MIME_TYPE
+
+    reolink_connect.get_vod_source.return_value = (TEST_MIME_TYPE_MP4, TEST_URL2)
+    play_media = await async_resolve_media(
+        hass, f"{URI_SCHEME}{DOMAIN}/{file_id}", None
+    )
+    assert play_media.mime_type == TEST_MIME_TYPE_MP4
 
 
 async def test_browsing(

--- a/tests/components/reolink/test_media_source.py
+++ b/tests/components/reolink/test_media_source.py
@@ -51,6 +51,7 @@ TEST_DAY2 = 15
 TEST_HOUR = 13
 TEST_MINUTE = 12
 TEST_FILE_NAME = f"{TEST_YEAR}{TEST_MONTH}{TEST_DAY}{TEST_HOUR}{TEST_MINUTE}00"
+TEST_FILE_NAME_MP4 = f"{TEST_YEAR}{TEST_MONTH}{TEST_DAY}{TEST_HOUR}{TEST_MINUTE}00.mp4"
 TEST_STREAM = "main"
 TEST_CHANNEL = "0"
 
@@ -87,23 +88,36 @@ async def test_resolve(
     """Test resolving Reolink media items."""
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
-
     caplog.set_level(logging.DEBUG)
+
     file_id = (
         f"FILE|{config_entry.entry_id}|{TEST_CHANNEL}|{TEST_STREAM}|{TEST_FILE_NAME}"
     )
-
     reolink_connect.get_vod_source.return_value = (TEST_MIME_TYPE, TEST_URL)
+
     play_media = await async_resolve_media(
         hass, f"{URI_SCHEME}{DOMAIN}/{file_id}", None
     )
     assert play_media.mime_type == TEST_MIME_TYPE
 
+    file_id = f"FILE|{config_entry.entry_id}|{TEST_CHANNEL}|{TEST_STREAM}|{TEST_FILE_NAME_MP4}"
     reolink_connect.get_vod_source.return_value = (TEST_MIME_TYPE_MP4, TEST_URL2)
+
     play_media = await async_resolve_media(
         hass, f"{URI_SCHEME}{DOMAIN}/{file_id}", None
     )
     assert play_media.mime_type == TEST_MIME_TYPE_MP4
+
+    file_id = (
+        f"FILE|{config_entry.entry_id}|{TEST_CHANNEL}|{TEST_STREAM}|{TEST_FILE_NAME}"
+    )
+    reolink_connect.get_vod_source.return_value = (TEST_MIME_TYPE, TEST_URL)
+    reolink_connect.is_nvr = False
+
+    play_media = await async_resolve_media(
+        hass, f"{URI_SCHEME}{DOMAIN}/{file_id}", None
+    )
+    assert play_media.mime_type == TEST_MIME_TYPE
 
 
 async def test_browsing(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Prefer mp4 playback if possible in Reolink, this loads faster and will give you the option to skip forward instead of having to await the stream.

This is needed for the Reolink Home Hub which only supports playback of mp4 files, it does not provide FLV streams for playback.

As a added bonus the mp4 playback supports using the token in the URL which is only valid for 15 minutes (refreshed automatically) as opposed the the username and password.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
