### PR TITLE
Allow arm levels be in order for google assistant

### DIFF
--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -1553,19 +1553,20 @@ class ArmDisArmTrait(_Trait):
 
     state_to_service = {
         STATE_ALARM_ARMED_HOME: SERVICE_ALARM_ARM_HOME,
-        STATE_ALARM_ARMED_AWAY: SERVICE_ALARM_ARM_AWAY,
         STATE_ALARM_ARMED_NIGHT: SERVICE_ALARM_ARM_NIGHT,
+        STATE_ALARM_ARMED_AWAY: SERVICE_ALARM_ARM_AWAY,
         STATE_ALARM_ARMED_CUSTOM_BYPASS: SERVICE_ALARM_ARM_CUSTOM_BYPASS,
         STATE_ALARM_TRIGGERED: SERVICE_ALARM_TRIGGER,
     }
 
     state_to_support = {
         STATE_ALARM_ARMED_HOME: AlarmControlPanelEntityFeature.ARM_HOME,
-        STATE_ALARM_ARMED_AWAY: AlarmControlPanelEntityFeature.ARM_AWAY,
         STATE_ALARM_ARMED_NIGHT: AlarmControlPanelEntityFeature.ARM_NIGHT,
+        STATE_ALARM_ARMED_AWAY: AlarmControlPanelEntityFeature.ARM_AWAY,
         STATE_ALARM_ARMED_CUSTOM_BYPASS: AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS,
         STATE_ALARM_TRIGGERED: AlarmControlPanelEntityFeature.TRIGGER,
     }
+    """The list of states to support in increasing security state."""
 
     @staticmethod
     def supported(domain, features, device_class, _):
@@ -1592,7 +1593,7 @@ class ArmDisArmTrait(_Trait):
         if STATE_ALARM_TRIGGERED in states:
             states.remove(STATE_ALARM_TRIGGERED)
 
-        if len(states) != 1:
+        if not states:
             raise SmartHomeError(ERR_NOT_SUPPORTED, "ArmLevel missing")
 
         return states[0]
@@ -1614,7 +1615,7 @@ class ArmDisArmTrait(_Trait):
             }
             levels.append(level)
 
-        response["availableArmLevels"] = {"levels": levels, "ordered": False}
+        response["availableArmLevels"] = {"levels": levels, "ordered": True}
         return response
 
     def query_attributes(self):
@@ -1631,8 +1632,8 @@ class ArmDisArmTrait(_Trait):
     async def execute(self, command, data, params, challenge):
         """Execute an ArmDisarm command."""
         if params["arm"] and not params.get("cancel"):
-            # If no arm level given, we can only arm it if there is
-            # only one supported arm type. We never default to triggered.
+            # If no arm level given, we we arm the first supported
+            # level in state_to_support.
             if not (arm_level := params.get("armLevel")):
                 arm_level = self._default_arm_state()
 

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1763,7 +1763,7 @@ async def test_arm_disarm_arm_away(hass: HomeAssistant) -> None:
                     ],
                 },
             ],
-            "ordered": False,
+            "ordered": True,
         }
     }
 
@@ -1905,7 +1905,8 @@ async def test_arm_disarm_disarm(hass: HomeAssistant) -> None:
             {
                 alarm_control_panel.ATTR_CODE_ARM_REQUIRED: True,
                 ATTR_SUPPORTED_FEATURES: AlarmControlPanelEntityFeature.TRIGGER
-                | AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS,
+                | AlarmControlPanelEntityFeature.ARM_HOME
+                | AlarmControlPanelEntityFeature.ARM_AWAY,
             },
         ),
         PIN_CONFIG,
@@ -1914,10 +1915,19 @@ async def test_arm_disarm_disarm(hass: HomeAssistant) -> None:
         "availableArmLevels": {
             "levels": [
                 {
-                    "level_name": "armed_custom_bypass",
+                    "level_name": "armed_home",
                     "level_values": [
                         {
-                            "level_synonym": ["armed custom bypass", "custom"],
+                            "level_synonym": ["armed home", "home"],
+                            "lang": "en",
+                        }
+                    ],
+                },
+                {
+                    "level_name": "armed_away",
+                    "level_values": [
+                        {
+                            "level_synonym": ["armed away", "away"],
                             "lang": "en",
                         }
                     ],
@@ -1927,12 +1937,12 @@ async def test_arm_disarm_disarm(hass: HomeAssistant) -> None:
                     "level_values": [{"level_synonym": ["triggered"], "lang": "en"}],
                 },
             ],
-            "ordered": False,
+            "ordered": True,
         }
     }
 
     assert trt.query_attributes() == {
-        "currentArmLevel": "armed_custom_bypass",
+        "currentArmLevel": "armed_home",
         "isArmed": False,
     }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Let arm levels be in order for google assistant, and allow lowest level be armed without specifying a level. This also allow alarm systems with multiple levels to report a current level, when not armed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #119400
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
