### PR TITLE
Fix fan-only mode on Samsung ACs which use "wind" instead of "fanOnly"

### DIFF
--- a/homeassistant/components/smartthings/climate.py
+++ b/homeassistant/components/smartthings/climate.py
@@ -401,10 +401,10 @@ class SmartThingsAirConditioner(SmartThingsEntity, ClimateEntity):
         self.async_write_ha_state()
 
     def _get_ac_mode_for_state(self, state):
-        # some samsung air conditioners appear to use the string "wind" for
-        # fan-only mode. handle this specially here, where we have access to
-        # supported_ac_modes, and fall back to the static mapping for all
-        # other states.
+        # Some Samsung air conditioners appear to use the string "wind" for
+        # fan-only mode. To handle this specifically here, where we have
+        # access to supported_ac_modes, and fall back to the static mapping
+        # for all other states.
         if state == HVACMode.FAN_ONLY:
             if "wind" in self._device.status.supported_ac_modes:
                 return "wind"


### PR DESCRIPTION
## Proposed change

Some Samsung ACs use the mode string `wind` instead of `fanOnly` for fan-only mode. Mine is one of these:

```sh-session
$ curl https://api.smartthings.com/devices/.../status | jq '.components.main.airConditionerMode.supportedAcModes'
{
  "value": [
    "auto",
    "cool",
    "dry",
    "wind",
    "heat"
  ],
  "timestamp": "2023-06-15T06:06:51.793Z"
}
```

As a result, fan-only mode is not available in the UI, and setting fan-only mode via the SmartThings app causes the AC to go into an unknown state, with this message being written to the logs:

```
2024-06-14 11:09:46.507 DEBUG (MainThread) [homeassistant.components.smartthings.climate] Device Air Conditioner (...) returned an invalid supported AC mode: wind
```

I assume that other Samsung ACs use `fanOnly` instead, but I cannot test this. Instead, I've modified the logic to check for the presence of the `wind` mode in the `supported_ac_modes` list.

After this change, fan-only mode works as expected for my Samsung AC in Home Assistant:

![image](https://github.com/home-assistant/core/assets/179065/0d98ba65-1475-45f2-9fda-7e91e785b8f9)

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

n/a

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
