### PR TITLE
Move fixtures to decorators in core tests

### DIFF
--- a/tests/components/sensirion_ble/test_sensor.py
+++ b/tests/components/sensirion_ble/test_sensor.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from homeassistant.components.sensirion_ble.const import DOMAIN
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
@@ -13,7 +15,8 @@ from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
 
 
-async def test_sensors(enable_bluetooth: None, hass: HomeAssistant) -> None:
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_sensors(hass: HomeAssistant) -> None:
     """Test the Sensirion BLE sensors."""
     entry = MockConfigEntry(domain=DOMAIN, unique_id=SENSIRION_SERVICE_INFO.address)
     entry.add_to_hass(hass)

--- a/tests/helpers/test_config_entry_oauth2_flow.py
+++ b/tests/helpers/test_config_entry_oauth2_flow.py
@@ -133,8 +133,9 @@ async def test_missing_credentials_for_domain(
     assert result["reason"] == "missing_credentials"
 
 
+@pytest.mark.usefixtures("current_request_with_host")
 async def test_abort_if_authorization_timeout(
-    hass: HomeAssistant, flow_handler, local_impl, current_request_with_host: None
+    hass: HomeAssistant, flow_handler, local_impl
 ) -> None:
     """Check timeout generating authorization url."""
     flow_handler.async_register_implementation(hass, local_impl)
@@ -152,8 +153,9 @@ async def test_abort_if_authorization_timeout(
     assert result["reason"] == "authorize_url_timeout"
 
 
+@pytest.mark.usefixtures("current_request_with_host")
 async def test_abort_if_no_url_available(
-    hass: HomeAssistant, flow_handler, local_impl, current_request_with_host: None
+    hass: HomeAssistant, flow_handler, local_impl
 ) -> None:
     """Check no_url_available generating authorization url."""
     flow_handler.async_register_implementation(hass, local_impl)
@@ -171,13 +173,13 @@ async def test_abort_if_no_url_available(
 
 
 @pytest.mark.parametrize("expires_in_dict", [{}, {"expires_in": "badnumber"}])
+@pytest.mark.usefixtures("current_request_with_host")
 async def test_abort_if_oauth_error(
     hass: HomeAssistant,
     flow_handler,
     local_impl,
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
-    current_request_with_host: None,
     expires_in_dict: dict[str, str],
 ) -> None:
     """Check bad oauth token."""
@@ -234,13 +236,12 @@ async def test_abort_if_oauth_error(
     assert result["reason"] == "oauth_error"
 
 
+@pytest.mark.usefixtures("current_request_with_host")
 async def test_abort_if_oauth_rejected(
     hass: HomeAssistant,
     flow_handler,
     local_impl,
     hass_client_no_auth: ClientSessionGenerator,
-    aioclient_mock: AiohttpClientMocker,
-    current_request_with_host: None,
 ) -> None:
     """Check bad oauth token."""
     flow_handler.async_register_implementation(hass, local_impl)
@@ -289,13 +290,13 @@ async def test_abort_if_oauth_rejected(
     assert result["description_placeholders"] == {"error": "access_denied"}
 
 
+@pytest.mark.usefixtures("current_request_with_host")
 async def test_abort_on_oauth_timeout_error(
     hass: HomeAssistant,
     flow_handler,
     local_impl,
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
-    current_request_with_host: None,
 ) -> None:
     """Check timeout during oauth token exchange."""
     flow_handler.async_register_implementation(hass, local_impl)
@@ -423,13 +424,13 @@ async def test_abort_discovered_multiple(
         ),
     ],
 )
+@pytest.mark.usefixtures("current_request_with_host")
 async def test_abort_if_oauth_token_error(
     hass: HomeAssistant,
     flow_handler,
     local_impl,
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
-    current_request_with_host: None,
     status_code: HTTPStatus,
     error_body: dict[str, Any],
     error_reason: str,
@@ -487,13 +488,13 @@ async def test_abort_if_oauth_token_error(
     assert error_log in caplog.text
 
 
+@pytest.mark.usefixtures("current_request_with_host")
 async def test_abort_if_oauth_token_closing_error(
     hass: HomeAssistant,
     flow_handler,
     local_impl,
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
-    current_request_with_host: None,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Check error when obtaining an oauth token."""
@@ -573,13 +574,13 @@ async def test_abort_discovered_existing_entries(
     assert result["reason"] == "already_configured"
 
 
+@pytest.mark.usefixtures("current_request_with_host")
 async def test_full_flow(
     hass: HomeAssistant,
     flow_handler,
     local_impl,
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
-    current_request_with_host: None,
 ) -> None:
     """Check full flow."""
     flow_handler.async_register_implementation(hass, local_impl)

--- a/tests/helpers/test_translation.py
+++ b/tests/helpers/test_translation.py
@@ -126,9 +126,9 @@ def test_load_translations_files_by_language(
         ),
     ],
 )
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_load_translations_files_invalid_localized_placeholders(
     hass: HomeAssistant,
-    enable_custom_integrations: None,
     caplog: pytest.LogCaptureFixture,
     language: str,
     expected_translation: dict,
@@ -151,9 +151,8 @@ async def test_load_translations_files_invalid_localized_placeholders(
         )
 
 
-async def test_get_translations(
-    hass: HomeAssistant, mock_config_flows, enable_custom_integrations: None
-) -> None:
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_get_translations(hass: HomeAssistant, mock_config_flows) -> None:
     """Test the get translations helper."""
     translations = await translation.async_get_translations(hass, "en", "entity")
     assert translations == {}
@@ -484,18 +483,16 @@ async def test_caching(hass: HomeAssistant) -> None:
         assert len(mock_build.mock_calls) > 1
 
 
-async def test_custom_component_translations(
-    hass: HomeAssistant, enable_custom_integrations: None
-) -> None:
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_custom_component_translations(hass: HomeAssistant) -> None:
     """Test getting translation from custom components."""
     hass.config.components.add("test_embedded")
     hass.config.components.add("test_package")
     assert await translation.async_get_translations(hass, "en", "state") == {}
 
 
-async def test_get_cached_translations(
-    hass: HomeAssistant, mock_config_flows, enable_custom_integrations: None
-) -> None:
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_get_cached_translations(hass: HomeAssistant, mock_config_flows) -> None:
     """Test the get cached translations helper."""
     translations = await translation.async_get_translations(hass, "en", "entity")
     assert translations == {}

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -1,6 +1,5 @@
 """Test check_config script."""
 
-from asyncio import AbstractEventLoop
 import logging
 from unittest.mock import patch
 
@@ -56,9 +55,8 @@ def normalize_yaml_files(check_dict):
 
 
 @pytest.mark.parametrize("hass_config_yaml", [BAD_CORE_CONFIG])
-def test_bad_core_config(
-    mock_is_file: None, event_loop: AbstractEventLoop, mock_hass_config_yaml: None
-) -> None:
+@pytest.mark.usefixtures("mock_is_file", "event_loop", "mock_hass_config_yaml")
+def test_bad_core_config() -> None:
     """Test a bad core config setup."""
     res = check_config.check(get_test_config_dir())
     assert res["except"].keys() == {"homeassistant"}
@@ -67,9 +65,8 @@ def test_bad_core_config(
 
 
 @pytest.mark.parametrize("hass_config_yaml", [BASE_CONFIG + "light:\n  platform: demo"])
-def test_config_platform_valid(
-    mock_is_file: None, event_loop: AbstractEventLoop, mock_hass_config_yaml: None
-) -> None:
+@pytest.mark.usefixtures("mock_is_file", "event_loop", "mock_hass_config_yaml")
+def test_config_platform_valid() -> None:
     """Test a valid platform setup."""
     res = check_config.check(get_test_config_dir())
     assert res["components"].keys() == {"homeassistant", "light"}
@@ -99,13 +96,8 @@ def test_config_platform_valid(
         ),
     ],
 )
-def test_component_platform_not_found(
-    mock_is_file: None,
-    event_loop: AbstractEventLoop,
-    mock_hass_config_yaml: None,
-    platforms: set[str],
-    error: str,
-) -> None:
+@pytest.mark.usefixtures("mock_is_file", "event_loop", "mock_hass_config_yaml")
+def test_component_platform_not_found(platforms: set[str], error: str) -> None:
     """Test errors if component or platform not found."""
     # Make sure they don't exist
     res = check_config.check(get_test_config_dir())
@@ -129,9 +121,8 @@ def test_component_platform_not_found(
         }
     ],
 )
-def test_secrets(
-    mock_is_file: None, event_loop: AbstractEventLoop, mock_hass_config_yaml: None
-) -> None:
+@pytest.mark.usefixtures("mock_is_file", "event_loop", "mock_hass_config_yaml")
+def test_secrets() -> None:
     """Test secrets config checking method."""
     res = check_config.check(get_test_config_dir(), True)
 
@@ -160,9 +151,8 @@ def test_secrets(
 @pytest.mark.parametrize(
     "hass_config_yaml", [BASE_CONFIG + '  packages:\n    p1:\n      group: ["a"]']
 )
-def test_package_invalid(
-    mock_is_file: None, event_loop: AbstractEventLoop, mock_hass_config_yaml: None
-) -> None:
+@pytest.mark.usefixtures("mock_is_file", "event_loop", "mock_hass_config_yaml")
+def test_package_invalid() -> None:
     """Test an invalid package."""
     res = check_config.check(get_test_config_dir())
 
@@ -178,9 +168,8 @@ def test_package_invalid(
 @pytest.mark.parametrize(
     "hass_config_yaml", [BASE_CONFIG + "automation: !include no.yaml"]
 )
-def test_bootstrap_error(
-    event_loop: AbstractEventLoop, mock_hass_config_yaml: None
-) -> None:
+@pytest.mark.usefixtures("event_loop", "mock_hass_config_yaml")
+def test_bootstrap_error() -> None:
     """Test a valid platform setup."""
     res = check_config.check(get_test_config_dir(YAML_CONFIG_FILE))
     err = res["except"].pop(check_config.ERROR_STR)

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -139,8 +139,8 @@ async def test_config_does_not_turn_off_debug(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize("hass_config", [{"frontend": {}}])
+@pytest.mark.usefixtures("mock_hass_config")
 async def test_asyncio_debug_on_turns_hass_debug_on(
-    mock_hass_config: None,
     mock_enable_logging: Mock,
     mock_is_virtual_env: Mock,
     mock_mount_local_lib_path: AsyncMock,
@@ -632,8 +632,8 @@ def mock_ensure_config_exists() -> Generator[AsyncMock]:
 
 
 @pytest.mark.parametrize("hass_config", [{"browser": {}, "frontend": {}}])
+@pytest.mark.usefixtures("mock_hass_config")
 async def test_setup_hass(
-    mock_hass_config: None,
     mock_enable_logging: Mock,
     mock_is_virtual_env: Mock,
     mock_mount_local_lib_path: AsyncMock,
@@ -685,8 +685,8 @@ async def test_setup_hass(
 
 
 @pytest.mark.parametrize("hass_config", [{"browser": {}, "frontend": {}}])
+@pytest.mark.usefixtures("mock_hass_config")
 async def test_setup_hass_takes_longer_than_log_slow_startup(
-    mock_hass_config: None,
     mock_enable_logging: Mock,
     mock_is_virtual_env: Mock,
     mock_mount_local_lib_path: AsyncMock,
@@ -815,8 +815,8 @@ async def test_setup_hass_recovery_mode(
     assert len(browser_setup.mock_calls) == 0
 
 
+@pytest.mark.usefixtures("mock_hass_config")
 async def test_setup_hass_safe_mode(
-    mock_hass_config: None,
     mock_enable_logging: Mock,
     mock_is_virtual_env: Mock,
     mock_mount_local_lib_path: AsyncMock,
@@ -850,8 +850,8 @@ async def test_setup_hass_safe_mode(
     assert "Starting in safe mode" in caplog.text
 
 
+@pytest.mark.usefixtures("mock_hass_config")
 async def test_setup_hass_recovery_mode_and_safe_mode(
-    mock_hass_config: None,
     mock_enable_logging: Mock,
     mock_is_virtual_env: Mock,
     mock_mount_local_lib_path: AsyncMock,
@@ -886,8 +886,8 @@ async def test_setup_hass_recovery_mode_and_safe_mode(
 
 
 @pytest.mark.parametrize("hass_config", [{"homeassistant": {"non-existing": 1}}])
+@pytest.mark.usefixtures("mock_hass_config")
 async def test_setup_hass_invalid_core_config(
-    mock_hass_config: None,
     mock_enable_logging: Mock,
     mock_is_virtual_env: Mock,
     mock_mount_local_lib_path: AsyncMock,
@@ -925,8 +925,8 @@ async def test_setup_hass_invalid_core_config(
         }
     ],
 )
+@pytest.mark.usefixtures("mock_hass_config")
 async def test_setup_recovery_mode_if_no_frontend(
-    mock_hass_config: None,
     mock_enable_logging: Mock,
     mock_is_virtual_env: Mock,
     mock_mount_local_lib_path: AsyncMock,
@@ -1372,10 +1372,9 @@ async def test_bootstrap_does_not_preload_stage_1_integrations() -> None:
 
 
 @pytest.mark.parametrize("load_registries", [False])
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_cancellation_does_not_leak_upward_from_async_setup(
-    hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
-    enable_custom_integrations: None,
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test setting up an integration that raises asyncio.CancelledError."""
     await bootstrap.async_setup_multi_components(
@@ -1390,10 +1389,9 @@ async def test_cancellation_does_not_leak_upward_from_async_setup(
 
 
 @pytest.mark.parametrize("load_registries", [False])
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_cancellation_does_not_leak_upward_from_async_setup_entry(
-    hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
-    enable_custom_integrations: None,
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test setting up an integration that raises asyncio.CancelledError."""
     entry = MockConfigEntry(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1071,9 +1071,8 @@ async def test_check_ha_config_file_wrong(mock_check, hass: HomeAssistant) -> No
         }
     ],
 )
-async def test_async_hass_config_yaml_merge(
-    merge_log_err, hass: HomeAssistant, mock_hass_config: None
-) -> None:
+@pytest.mark.usefixtures("mock_hass_config")
+async def test_async_hass_config_yaml_merge(merge_log_err, hass: HomeAssistant) -> None:
     """Test merge during async config reload."""
     conf = await config_util.async_hass_config_yaml(hass)
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -106,9 +106,8 @@ async def test_helpers_wrapper(hass: HomeAssistant) -> None:
     assert result == ["hello"]
 
 
-async def test_custom_component_name(
-    hass: HomeAssistant, enable_custom_integrations: None
-) -> None:
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_custom_component_name(hass: HomeAssistant) -> None:
     """Test the name attribute of custom components."""
     with pytest.raises(loader.IntegrationNotFound):
         await loader.async_get_integration(hass, "test_standalone")
@@ -137,10 +136,9 @@ async def test_custom_component_name(
     assert TEST == 5
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_log_warning_custom_component(
-    hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
-    enable_custom_integrations: None,
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test that we log a warning when loading a custom component."""
 
@@ -151,10 +149,9 @@ async def test_log_warning_custom_component(
     assert "We found a custom integration test " in caplog.text
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_custom_integration_version_not_valid(
-    hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
-    enable_custom_integrations: None,
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test that we log a warning when custom integrations have a invalid version."""
     with pytest.raises(loader.IntegrationNotFound):
@@ -180,10 +177,10 @@ async def test_custom_integration_version_not_valid(
         loader.BlockedIntegration(AwesomeVersion("2.0.0"), "breaks Home Assistant"),
     ],
 )
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_custom_integration_version_blocked(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    enable_custom_integrations: None,
     blocked_versions,
 ) -> None:
     """Test that we log a warning when custom integrations have a blocked version."""
@@ -207,10 +204,10 @@ async def test_custom_integration_version_blocked(
         loader.BlockedIntegration(AwesomeVersion("1.0.0"), "breaks Home Assistant"),
     ],
 )
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_custom_integration_version_not_blocked(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    enable_custom_integrations: None,
     blocked_versions,
 ) -> None:
     """Test that we log a warning when custom integrations have a blocked version."""
@@ -493,9 +490,8 @@ async def test_async_get_platforms_caches_failures_when_component_loaded(
     assert integration.get_platform_cached("light") is None
 
 
-async def test_get_integration_legacy(
-    hass: HomeAssistant, enable_custom_integrations: None
-) -> None:
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_get_integration_legacy(hass: HomeAssistant) -> None:
     """Test resolving integration."""
     integration = await loader.async_get_integration(hass, "test_embedded")
     assert integration.get_component().DOMAIN == "test_embedded"
@@ -503,9 +499,8 @@ async def test_get_integration_legacy(
     assert integration.get_platform_cached("switch") is not None
 
 
-async def test_get_integration_custom_component(
-    hass: HomeAssistant, enable_custom_integrations: None
-) -> None:
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_get_integration_custom_component(hass: HomeAssistant) -> None:
     """Test resolving integration."""
     integration = await loader.async_get_integration(hass, "test_package")
 
@@ -802,9 +797,8 @@ def _get_test_integration_with_usb_matcher(hass, name, config_flow):
     )
 
 
-async def test_get_custom_components(
-    hass: HomeAssistant, enable_custom_integrations: None
-) -> None:
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_get_custom_components(hass: HomeAssistant) -> None:
     """Verify that custom components are cached."""
     test_1_integration = _get_test_integration(hass, "test_1", False)
     test_2_integration = _get_test_integration(hass, "test_2", True)
@@ -1000,9 +994,8 @@ async def test_get_mqtt(hass: HomeAssistant) -> None:
         assert mqtt["test_2"] == ["test_2/discovery"]
 
 
-async def test_import_platform_executor(
-    hass: HomeAssistant, enable_custom_integrations: None
-) -> None:
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_import_platform_executor(hass: HomeAssistant) -> None:
     """Test import a platform in the executor."""
     integration = await loader.async_get_integration(
         hass, "test_package_loaded_executor"
@@ -1342,10 +1335,9 @@ async def test_async_get_component_preloads_config_and_config_flow(
     }
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_async_get_component_loads_loop_if_already_in_sys_modules(
-    hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
-    enable_custom_integrations: None,
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Verify async_get_component does not create an executor job if the module is already in sys.modules."""
     integration = await loader.async_get_integration(
@@ -1407,10 +1399,8 @@ async def test_async_get_component_loads_loop_if_already_in_sys_modules(
     assert module is module_mock
 
 
-async def test_async_get_component_concurrent_loads(
-    hass: HomeAssistant,
-    enable_custom_integrations: None,
-) -> None:
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_async_get_component_concurrent_loads(hass: HomeAssistant) -> None:
     """Verify async_get_component waits if the first load if called again when still in progress."""
     integration = await loader.async_get_integration(
         hass, "test_package_loaded_executor"
@@ -1720,9 +1710,8 @@ async def test_async_get_platform_raises_after_import_failure(
     assert "loaded_executor=False" not in caplog.text
 
 
-async def test_platforms_exists(
-    hass: HomeAssistant, enable_custom_integrations: None
-) -> None:
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_platforms_exists(hass: HomeAssistant) -> None:
     """Test platforms_exists."""
     original_os_listdir = os.listdir
 
@@ -1778,10 +1767,9 @@ async def test_platforms_exists(
     assert integration.platforms_are_loaded(["other"]) is False
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_async_get_platforms_loads_loop_if_already_in_sys_modules(
-    hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
-    enable_custom_integrations: None,
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Verify async_get_platforms does not create an executor job.
 
@@ -1881,10 +1869,8 @@ async def test_async_get_platforms_loads_loop_if_already_in_sys_modules(
     assert integration.get_platform_cached("light") is light_module_mock
 
 
-async def test_async_get_platforms_concurrent_loads(
-    hass: HomeAssistant,
-    enable_custom_integrations: None,
-) -> None:
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_async_get_platforms_concurrent_loads(hass: HomeAssistant) -> None:
     """Verify async_get_platforms waits if the first load if called again.
 
     Case is for when when a second load is called
@@ -1945,10 +1931,9 @@ async def test_async_get_platforms_concurrent_loads(
     assert integration.get_platform_cached("button") is button_module_mock
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_integration_warnings(
-    hass: HomeAssistant,
-    enable_custom_integrations: None,
-    caplog: pytest.LogCaptureFixture,
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test integration warnings."""
     await loader.async_get_integration(hass, "test_package_loaded_loop")

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1177,19 +1177,17 @@ async def test_loading_component_loads_translations(hass: HomeAssistant) -> None
     assert translation.async_translations_loaded(hass, {"comp"}) is True
 
 
-async def test_importing_integration_in_executor(
-    hass: HomeAssistant, enable_custom_integrations: None
-) -> None:
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_importing_integration_in_executor(hass: HomeAssistant) -> None:
     """Test we can import an integration in an executor."""
     assert await setup.async_setup_component(hass, "test_package_loaded_executor", {})
     assert await setup.async_setup_component(hass, "test_package_loaded_executor", {})
     await hass.async_block_till_done()
 
 
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_async_prepare_setup_platform(
-    hass: HomeAssistant,
-    enable_custom_integrations: None,
-    caplog: pytest.LogCaptureFixture,
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test we can prepare a platform setup."""
     integration = await loader.async_get_integration(hass, "test")

--- a/tests/test_test_fixtures.py
+++ b/tests/test_test_fixtures.py
@@ -20,7 +20,8 @@ def test_sockets_disabled() -> None:
         socket.socket()
 
 
-def test_sockets_enabled(socket_enabled: None) -> None:
+@pytest.mark.usefixtures("socket_enabled")
+def test_sockets_enabled() -> None:
     """Test we can't connect to an address different from 127.0.0.1."""
     mysocket = socket.socket()
     with pytest.raises(pytest_socket.SocketConnectBlockedError):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #119279
https://github.com/home-assistant/core/actions/runs/9512021973/job/26219261590


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
