### PR TITLE
Fix Jewish Calendar unique id migration

### DIFF
--- a/homeassistant/components/jewish_calendar/__init__.py
+++ b/homeassistant/components/jewish_calendar/__init__.py
@@ -72,11 +72,14 @@ def get_unique_prefix(
     havdalah_offset: int | None,
 ) -> str:
     """Create a prefix for unique ids."""
+    # location.altitude was unset before 2024.6 when this method
+    # was used to create the unique id. As such it would always
+    # use the default altitude of 754.
     config_properties = [
         location.latitude,
         location.longitude,
         location.timezone,
-        location.altitude,
+        754,
         location.diaspora,
         language,
         candle_lighting_offset,

--- a/tests/components/jewish_calendar/test_init.py
+++ b/tests/components/jewish_calendar/test_init.py
@@ -38,7 +38,6 @@ async def test_import_unique_id_migration(hass: HomeAssistant) -> None:
         latitude=yaml_conf[DOMAIN][CONF_LATITUDE],
         longitude=yaml_conf[DOMAIN][CONF_LONGITUDE],
         timezone=hass.config.time_zone,
-        altitude=hass.config.elevation,
         diaspora=DEFAULT_DIASPORA,
     )
     old_prefix = get_unique_prefix(location, DEFAULT_LANGUAGE, 20, 50)

--- a/tests/components/jewish_calendar/test_init.py
+++ b/tests/components/jewish_calendar/test_init.py
@@ -1,5 +1,7 @@
 """Tests for the Jewish Calendar component's init."""
 
+import logging
+
 from hdate import Location
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSORS
@@ -17,6 +19,8 @@ from homeassistant.core import HomeAssistant
 import homeassistant.helpers.entity_registry as er
 from homeassistant.setup import async_setup_component
 
+_LOGGER = logging.getLogger(__name__)
+
 
 async def test_import_unique_id_migration(hass: HomeAssistant) -> None:
     """Test unique_id migration."""
@@ -27,8 +31,8 @@ async def test_import_unique_id_migration(hass: HomeAssistant) -> None:
             CONF_LANGUAGE: DEFAULT_LANGUAGE,
             CONF_CANDLE_LIGHT_MINUTES: 20,
             CONF_HAVDALAH_OFFSET_MINUTES: 50,
-            CONF_LATITUDE: 31.76,
-            CONF_LONGITUDE: 35.235,
+            CONF_LATITUDE: hass.config.latitude,
+            CONF_LONGITUDE: hass.config.longitude,
         }
     }
 
@@ -38,8 +42,12 @@ async def test_import_unique_id_migration(hass: HomeAssistant) -> None:
         latitude=yaml_conf[DOMAIN][CONF_LATITUDE],
         longitude=yaml_conf[DOMAIN][CONF_LONGITUDE],
         timezone=hass.config.time_zone,
-        altitude=hass.config.elevation,
         diaspora=DEFAULT_DIASPORA,
+    )
+    _LOGGER.info(
+        "Location elevation: %d HASS elevation: %d",
+        location.altitude,
+        hass.config.elevation,
     )
     old_prefix = get_unique_prefix(location, DEFAULT_LANGUAGE, 20, 50)
     sample_entity = ent_reg.async_get_or_create(

--- a/tests/components/jewish_calendar/test_init.py
+++ b/tests/components/jewish_calendar/test_init.py
@@ -1,7 +1,5 @@
 """Tests for the Jewish Calendar component's init."""
 
-import logging
-
 from hdate import Location
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSORS
@@ -19,8 +17,6 @@ from homeassistant.core import HomeAssistant
 import homeassistant.helpers.entity_registry as er
 from homeassistant.setup import async_setup_component
 
-_LOGGER = logging.getLogger(__name__)
-
 
 async def test_import_unique_id_migration(hass: HomeAssistant) -> None:
     """Test unique_id migration."""
@@ -31,8 +27,8 @@ async def test_import_unique_id_migration(hass: HomeAssistant) -> None:
             CONF_LANGUAGE: DEFAULT_LANGUAGE,
             CONF_CANDLE_LIGHT_MINUTES: 20,
             CONF_HAVDALAH_OFFSET_MINUTES: 50,
-            CONF_LATITUDE: hass.config.latitude,
-            CONF_LONGITUDE: hass.config.longitude,
+            CONF_LATITUDE: 31.76,
+            CONF_LONGITUDE: 35.235,
         }
     }
 
@@ -42,12 +38,8 @@ async def test_import_unique_id_migration(hass: HomeAssistant) -> None:
         latitude=yaml_conf[DOMAIN][CONF_LATITUDE],
         longitude=yaml_conf[DOMAIN][CONF_LONGITUDE],
         timezone=hass.config.time_zone,
+        altitude=hass.config.elevation,
         diaspora=DEFAULT_DIASPORA,
-    )
-    _LOGGER.info(
-        "Location elevation: %d HASS elevation: %d",
-        location.altitude,
-        hass.config.elevation,
     )
     old_prefix = get_unique_prefix(location, DEFAULT_LANGUAGE, 20, 50)
     sample_entity = ent_reg.async_get_or_create(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Previously to #84464 we would not pass the altitude to the Location class. This created a default unique id with altitude 754 meters. As such all the unique IDs had the same altitude, causing bugs during the migration to 2024.6.
This fix changes the behavior of the get_unique_id_prefix to always return latitude of 754. The method will be deprecated with the removal of the rest of the unique id migration code in 2024.12.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #119657 
- This PR is related to issue: #117985 #84464
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
