### PR TITLE
Remove set default doorbell text service from unifiprotect

### DIFF
--- a/homeassistant/components/unifiprotect/icons.json
+++ b/homeassistant/components/unifiprotect/icons.json
@@ -2,7 +2,6 @@
   "services": {
     "add_doorbell_text": "mdi:message-plus",
     "remove_doorbell_text": "mdi:message-minus",
-    "set_default_doorbell_text": "mdi:message-processing",
     "set_chime_paired_doorbells": "mdi:bell-cog",
     "remove_privacy_zone": "mdi:eye-minus"
   }

--- a/homeassistant/components/unifiprotect/services.py
+++ b/homeassistant/components/unifiprotect/services.py
@@ -32,13 +32,11 @@ SERVICE_ADD_DOORBELL_TEXT = "add_doorbell_text"
 SERVICE_REMOVE_DOORBELL_TEXT = "remove_doorbell_text"
 SERVICE_SET_PRIVACY_ZONE = "set_privacy_zone"
 SERVICE_REMOVE_PRIVACY_ZONE = "remove_privacy_zone"
-SERVICE_SET_DEFAULT_DOORBELL_TEXT = "set_default_doorbell_text"
 SERVICE_SET_CHIME_PAIRED = "set_chime_paired_doorbells"
 
 ALL_GLOBAL_SERIVCES = [
     SERVICE_ADD_DOORBELL_TEXT,
     SERVICE_REMOVE_DOORBELL_TEXT,
-    SERVICE_SET_DEFAULT_DOORBELL_TEXT,
     SERVICE_SET_CHIME_PAIRED,
     SERVICE_REMOVE_PRIVACY_ZONE,
 ]
@@ -145,12 +143,6 @@ async def remove_doorbell_text(hass: HomeAssistant, call: ServiceCall) -> None:
     await _async_service_call_nvr(hass, call, "remove_custom_doorbell_message", message)
 
 
-async def set_default_doorbell_text(hass: HomeAssistant, call: ServiceCall) -> None:
-    """Set the default doorbell text message."""
-    message: str = call.data[ATTR_MESSAGE]
-    await _async_service_call_nvr(hass, call, "set_default_doorbell_message", message)
-
-
 async def remove_privacy_zone(hass: HomeAssistant, call: ServiceCall) -> None:
     """Remove privacy zone from camera."""
 
@@ -229,11 +221,6 @@ def async_setup_services(hass: HomeAssistant) -> None:
         (
             SERVICE_REMOVE_DOORBELL_TEXT,
             functools.partial(remove_doorbell_text, hass),
-            DOORBELL_TEXT_SCHEMA,
-        ),
-        (
-            SERVICE_SET_DEFAULT_DOORBELL_TEXT,
-            functools.partial(set_default_doorbell_text, hass),
             DOORBELL_TEXT_SCHEMA,
         ),
         (

--- a/homeassistant/components/unifiprotect/services.yaml
+++ b/homeassistant/components/unifiprotect/services.yaml
@@ -22,18 +22,6 @@ remove_doorbell_text:
       required: true
       selector:
         text:
-set_default_doorbell_text:
-  fields:
-    device_id:
-      required: true
-      selector:
-        device:
-          integration: unifiprotect
-    message:
-      example: Welcome!
-      required: true
-      selector:
-        text:
 set_chime_paired_doorbells:
   fields:
     device_id:

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -168,20 +168,6 @@
         }
       }
     },
-    "set_default_doorbell_text": {
-      "name": "Set default doorbell text",
-      "description": "Sets the default doorbell message. This will be the message that is automatically selected when a message \"expires\".",
-      "fields": {
-        "device_id": {
-          "name": "[%key:component::unifiprotect::services::add_doorbell_text::fields::device_id::name%]",
-          "description": "[%key:component::unifiprotect::services::add_doorbell_text::fields::device_id::description%]"
-        },
-        "message": {
-          "name": "Default message",
-          "description": "The default message for your doorbell. Must be less than 30 characters."
-        }
-      }
-    },
     "set_chime_paired_doorbells": {
       "name": "Set chime paired doorbells",
       "description": "Use to set the paired doorbell(s) with a smart chime.",

--- a/tests/components/unifiprotect/test_services.py
+++ b/tests/components/unifiprotect/test_services.py
@@ -15,7 +15,6 @@ from homeassistant.components.unifiprotect.services import (
     SERVICE_REMOVE_DOORBELL_TEXT,
     SERVICE_REMOVE_PRIVACY_ZONE,
     SERVICE_SET_CHIME_PAIRED,
-    SERVICE_SET_DEFAULT_DOORBELL_TEXT,
 )
 from homeassistant.config_entries import ConfigEntryDisabler
 from homeassistant.const import ATTR_DEVICE_ID, ATTR_ENTITY_ID, ATTR_NAME
@@ -123,24 +122,6 @@ async def test_remove_doorbell_text(
         blocking=True,
     )
     nvr.remove_custom_doorbell_message.assert_called_once_with("Test Message")
-
-
-async def test_set_default_doorbell_text(
-    hass: HomeAssistant, device: dr.DeviceEntry, ufp: MockUFPFixture
-) -> None:
-    """Test set_default_doorbell_text service."""
-
-    nvr = ufp.api.bootstrap.nvr
-    nvr.__fields__["set_default_doorbell_message"] = Mock(final=False)
-    nvr.set_default_doorbell_message = AsyncMock()
-
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_SET_DEFAULT_DOORBELL_TEXT,
-        {ATTR_DEVICE_ID: device.id, ATTR_MESSAGE: "Test Message"},
-        blocking=True,
-    )
-    nvr.set_default_doorbell_message.assert_called_once_with("Test Message")
 
 
 async def test_add_doorbell_text_disabled_config_entry(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
UI has removed this functionality in UI Protect 4.x

Its still possible to set a custom message using the other services (`unifiprotect.add_doorbell_text` and `unifiprotect.remove_doorbell_text`, and setting it via the `select` entity), but there is no longer a default.

discovered via https://github.com/uilibs/uiprotect/issues/57


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: closes #119571 closes https://github.com/uilibs/uiprotect/issues/57
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
