### PR TITLE
Add work area sensor for Husqvarna Automower

### DIFF
--- a/homeassistant/components/husqvarna_automower/sensor.py
+++ b/homeassistant/components/husqvarna_automower/sensor.py
@@ -339,7 +339,7 @@ SENSOR_TYPES: tuple[AutomowerSensorEntityDescription, ...] = (
         key="work_area",
         translation_key="work_area",
         device_class=SensorDeviceClass.ENUM,
-        exists_fn=lambda data: data.capabilities.work_areas is not None,
+        exists_fn=lambda data: data.capabilities.work_areas,
         option_fn=_get_work_area_names,
         value_fn=_get_current_work_area_name,
     ),

--- a/homeassistant/components/husqvarna_automower/sensor.py
+++ b/homeassistant/components/husqvarna_automower/sensor.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 import logging
+from typing import TYPE_CHECKING
 
 from aioautomower.model import MowerAttributes, MowerModes, RestrictedReasons
 
@@ -14,7 +15,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfLength, UnitOfTime
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
@@ -184,11 +185,31 @@ RESTRICTED_REASONS: list = [
 ]
 
 
+@callback
+def _get_work_area_names(data: MowerAttributes) -> list[str]:
+    """Return a list with all work area names."""
+    if TYPE_CHECKING:
+        # Sensor does not get created if it is None
+        assert data.work_areas is not None
+    return [data.work_areas[work_area_id].name for work_area_id in data.work_areas]
+
+
+@callback
+def _get_current_work_area_name(data: MowerAttributes) -> str:
+    """Return the name of the current work area."""
+    if TYPE_CHECKING:
+        # Sensor does not get created if values are None
+        assert data.work_areas is not None
+        assert data.mower.work_area_id is not None
+    return data.work_areas[data.mower.work_area_id].name
+
+
 @dataclass(frozen=True, kw_only=True)
 class AutomowerSensorEntityDescription(SensorEntityDescription):
     """Describes Automower sensor entity."""
 
     exists_fn: Callable[[MowerAttributes], bool] = lambda _: True
+    option_fn: Callable[[MowerAttributes], list[str] | None] = lambda _: None
     value_fn: Callable[[MowerAttributes], StateType | datetime]
 
 
@@ -204,7 +225,7 @@ SENSOR_TYPES: tuple[AutomowerSensorEntityDescription, ...] = (
         key="mode",
         translation_key="mode",
         device_class=SensorDeviceClass.ENUM,
-        options=[option.lower() for option in list(MowerModes)],
+        option_fn=lambda data: [option.lower() for option in list(MowerModes)],
         value_fn=(
             lambda data: data.mower.mode.lower()
             if data.mower.mode != MowerModes.UNKNOWN
@@ -302,17 +323,25 @@ SENSOR_TYPES: tuple[AutomowerSensorEntityDescription, ...] = (
         key="error",
         translation_key="error",
         device_class=SensorDeviceClass.ENUM,
+        option_fn=lambda data: ERROR_KEY_LIST,
         value_fn=lambda data: (
             "no_error" if data.mower.error_key is None else data.mower.error_key
         ),
-        options=ERROR_KEY_LIST,
     ),
     AutomowerSensorEntityDescription(
         key="restricted_reason",
         translation_key="restricted_reason",
         device_class=SensorDeviceClass.ENUM,
-        options=RESTRICTED_REASONS,
+        option_fn=lambda data: RESTRICTED_REASONS,
         value_fn=lambda data: data.planner.restricted_reason.lower(),
+    ),
+    AutomowerSensorEntityDescription(
+        key="work_area",
+        translation_key="work_area",
+        device_class=SensorDeviceClass.ENUM,
+        exists_fn=lambda data: data.capabilities.work_areas is not None,
+        option_fn=_get_work_area_names,
+        value_fn=_get_current_work_area_name,
     ),
 )
 
@@ -352,3 +381,8 @@ class AutomowerSensorEntity(AutomowerBaseEntity, SensorEntity):
     def native_value(self) -> StateType | datetime:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.mower_attributes)
+
+    @property
+    def options(self) -> list[str] | None:
+        """Return the option of the sensor."""
+        return self.entity_description.option_fn(self.mower_attributes)

--- a/homeassistant/components/husqvarna_automower/strings.json
+++ b/homeassistant/components/husqvarna_automower/strings.json
@@ -243,6 +243,12 @@
           "home": "Home",
           "demo": "Demo"
         }
+      },
+      "work_area": {
+        "name": "Work area",
+        "state": {
+          "my_lawn": "My lawn"
+        }
       }
     },
     "switch": {

--- a/tests/components/husqvarna_automower/snapshots/test_sensor.ambr
+++ b/tests/components/husqvarna_automower/snapshots/test_sensor.ambr
@@ -991,3 +991,61 @@
     'state': '103.000',
   })
 # ---
+# name: test_sensor_snapshot[sensor.test_mower_1_work_area-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'Front lawn',
+        'Back lawn',
+        'my_lawn',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_mower_1_work_area',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Work area',
+    'platform': 'husqvarna_automower',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'work_area',
+    'unique_id': 'c7233734-b219-4287-a173-08e3643f89f0_work_area',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_snapshot[sensor.test_mower_1_work_area-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Test Mower 1 Work area',
+      'options': list([
+        'Front lawn',
+        'Back lawn',
+        'my_lawn',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_mower_1_work_area',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Front lawn',
+  })
+# ---


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds a new sensor, which shows, to which work area the mower is assigned.
In a second PR, a service should be added, to send the mower for a duration of time to a specific work area. Therefore the available options are important, as they are needed for the service as target.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33275

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
