### PR TITLE
Bump ZHA dependencies

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -25,7 +25,7 @@
     "pyserial==3.5",
     "zha-quirks==0.0.116",
     "zigpy-deconz==0.23.1",
-    "zigpy==0.64.0",
+    "zigpy==0.64.1",
     "zigpy-xbee==0.20.1",
     "zigpy-zigate==0.12.0",
     "zigpy-znp==0.12.1",

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -21,7 +21,7 @@
     "universal_silabs_flasher"
   ],
   "requirements": [
-    "bellows==0.39.0",
+    "bellows==0.39.1",
     "pyserial==3.5",
     "zha-quirks==0.0.116",
     "zigpy-deconz==0.23.1",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2990,7 +2990,7 @@ zigpy-zigate==0.12.0
 zigpy-znp==0.12.1
 
 # homeassistant.components.zha
-zigpy==0.64.0
+zigpy==0.64.1
 
 # homeassistant.components.zoneminder
 zm-py==0.5.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -553,7 +553,7 @@ beautifulsoup4==4.12.3
 # beewi-smartclim==0.0.10
 
 # homeassistant.components.zha
-bellows==0.39.0
+bellows==0.39.1
 
 # homeassistant.components.bmw_connected_drive
 bimmer-connected[china]==0.15.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2337,7 +2337,7 @@ zigpy-zigate==0.12.0
 zigpy-znp==0.12.1
 
 # homeassistant.components.zha
-zigpy==0.64.0
+zigpy==0.64.1
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.56.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -478,7 +478,7 @@ base36==0.1.1
 beautifulsoup4==4.12.3
 
 # homeassistant.components.zha
-bellows==0.39.0
+bellows==0.39.1
 
 # homeassistant.components.bmw_connected_drive
 bimmer-connected[china]==0.15.3


### PR DESCRIPTION
## Proposed change
Bumps ZHA dependencies:

- bellows to [0.39.1](https://github.com/zigpy/bellows/releases/tag/0.39.1), full diff: https://github.com/zigpy/bellows/compare/0.39.0...0.39.1
- zigpy to [0.64.1](https://github.com/zigpy/zigpy/releases/tag/0.64.1), full diff: https://github.com/zigpy/zigpy/compare/0.64.0...0.64.1

The bellows release fixes issues with newer EZSP versions (7.4.x) crashing after some time.
A small issue where the event loop is blocked is also fixed.

The zigpy release is a minor bug-fix release to handle listeners that unregister themselves (e.g. on a disconnect).
An additional Third Reality manufacturer ID is also included to make sure all newer OTAs from the ThirdReality provider are recognized for ThirdReality devices.
Do note that the "major" OTA PR mentioned in the changelog was reverted and is NOT included in this bug-fix release.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/119424, fixes https://github.com/home-assistant/core/issues/116862
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
