### PR TITLE
Add zwave js services get_lock_usercode and get_lock_usercodes

### DIFF
--- a/homeassistant/components/zwave_js/const.py
+++ b/homeassistant/components/zwave_js/const.py
@@ -101,6 +101,8 @@ ATTR_PARTIAL_DICT_MATCH = "partial_dict_match"
 # service constants
 SERVICE_BULK_SET_PARTIAL_CONFIG_PARAMETERS = "bulk_set_partial_config_parameters"
 SERVICE_CLEAR_LOCK_USERCODE = "clear_lock_usercode"
+SERVICE_GET_LOCK_USERCODE = "get_lock_usercode"
+SERVICE_GET_LOCK_USERCODES = "get_lock_usercodes"
 SERVICE_INVOKE_CC_API = "invoke_cc_api"
 SERVICE_MULTICAST_SET_VALUE = "multicast_set_value"
 SERVICE_PING = "ping"

--- a/homeassistant/components/zwave_js/device_action.py
+++ b/homeassistant/components/zwave_js/device_action.py
@@ -44,6 +44,8 @@ from .const import (
     ATTR_WAIT_FOR_RESULT,
     DOMAIN,
     SERVICE_CLEAR_LOCK_USERCODE,
+    SERVICE_GET_LOCK_USERCODE,
+    SERVICE_GET_LOCK_USERCODES,
     SERVICE_PING,
     SERVICE_REFRESH_VALUE,
     SERVICE_RESET_METER,
@@ -60,6 +62,8 @@ from .helpers import async_get_node_from_device_id, get_value_state_schema
 
 ACTION_TYPES = {
     SERVICE_CLEAR_LOCK_USERCODE,
+    SERVICE_GET_LOCK_USERCODE,
+    SERVICE_GET_LOCK_USERCODES,
     SERVICE_PING,
     SERVICE_REFRESH_VALUE,
     SERVICE_RESET_METER,
@@ -73,6 +77,21 @@ CLEAR_LOCK_USERCODE_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
         vol.Required(CONF_TYPE): SERVICE_CLEAR_LOCK_USERCODE,
         vol.Required(CONF_ENTITY_ID): cv.entity_id_or_uuid,
         vol.Required(ATTR_CODE_SLOT): vol.Coerce(int),
+    }
+)
+
+GET_LOCK_USERCODE_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): SERVICE_GET_LOCK_USERCODE,
+        vol.Required(CONF_ENTITY_ID): cv.entity_id_or_uuid,
+        vol.Required(ATTR_CODE_SLOT): vol.Coerce(int),
+    }
+)
+
+GET_LOCK_USERCODES_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): SERVICE_GET_LOCK_USERCODES,
+        vol.Required(CONF_ENTITY_ID): cv.entity_id_or_uuid,
     }
 )
 
@@ -133,6 +152,8 @@ SET_VALUE_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
 
 _ACTION_SCHEMA = vol.Any(
     CLEAR_LOCK_USERCODE_SCHEMA,
+    GET_LOCK_USERCODE_SCHEMA,
+    GET_LOCK_USERCODES_SCHEMA,
     PING_SCHEMA,
     REFRESH_VALUE_SCHEMA,
     RESET_METER_SCHEMA,
@@ -205,6 +226,8 @@ async def async_get_actions(
         if entry.domain == LOCK_DOMAIN:
             actions.extend(
                 [
+                    {**entity_action, CONF_TYPE: SERVICE_GET_LOCK_USERCODE},
+                    {**entity_action, CONF_TYPE: SERVICE_GET_LOCK_USERCODES},
                     {**entity_action, CONF_TYPE: SERVICE_SET_LOCK_USERCODE},
                     {**entity_action, CONF_TYPE: SERVICE_CLEAR_LOCK_USERCODE},
                 ]
@@ -272,6 +295,8 @@ async def async_call_action_from_config(
     # Entity services (including refresh value which is a fake entity service) expect
     # just an entity ID
     if action_type in (
+        SERVICE_GET_LOCK_USERCODE,
+        SERVICE_GET_LOCK_USERCODES,
         SERVICE_REFRESH_VALUE,
         SERVICE_SET_LOCK_USERCODE,
         SERVICE_CLEAR_LOCK_USERCODE,
@@ -292,6 +317,15 @@ async def async_get_action_capabilities(
 
     # Add additional fields to the automation action UI
     if action_type == SERVICE_CLEAR_LOCK_USERCODE:
+        return {
+            "extra_fields": vol.Schema(
+                {
+                    vol.Required(ATTR_CODE_SLOT): cv.string,
+                }
+            )
+        }
+
+    if action_type == SERVICE_GET_LOCK_USERCODE:
         return {
             "extra_fields": vol.Schema(
                 {

--- a/homeassistant/components/zwave_js/icons.json
+++ b/homeassistant/components/zwave_js/icons.json
@@ -63,6 +63,12 @@
     "clear_lock_usercode": {
       "service": "mdi:eraser"
     },
+    "get_lock_usercode": {
+      "service": "mdi:lock-percent-outline"
+    },
+    "get_lock_usercodes": {
+      "service": "mdi:lock-percent"
+    },
     "invoke_cc_api": {
       "service": "mdi:api"
     },

--- a/homeassistant/components/zwave_js/lock.py
+++ b/homeassistant/components/zwave_js/lock.py
@@ -17,15 +17,22 @@ from zwave_js_server.const.command_class.lock import (
     OperationType,
 )
 from zwave_js_server.exceptions import BaseZwaveJSServerError
-from zwave_js_server.util.lock import clear_usercode, set_configuration, set_usercode
+from zwave_js_server.util.lock import (
+    clear_usercode,
+    get_usercode,
+    get_usercodes,
+    set_configuration,
+    set_usercode,
+)
 
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN, LockEntity, LockState
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant, SupportsResponse, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util.json import JsonValueType
 
 from .const import (
     ATTR_AUTO_RELOCK_TIME,
@@ -38,6 +45,8 @@ from .const import (
     DOMAIN,
     LOGGER,
     SERVICE_CLEAR_LOCK_USERCODE,
+    SERVICE_GET_LOCK_USERCODE,
+    SERVICE_GET_LOCK_USERCODES,
     SERVICE_SET_LOCK_CONFIGURATION,
     SERVICE_SET_LOCK_USERCODE,
 )
@@ -84,6 +93,22 @@ async def async_setup_entry(
     )
 
     platform = entity_platform.async_get_current_platform()
+
+    platform.async_register_entity_service(
+        SERVICE_GET_LOCK_USERCODE,
+        {
+            vol.Required(ATTR_CODE_SLOT): vol.Coerce(int),
+        },
+        "async_get_lock_usercode",
+        supports_response=SupportsResponse.ONLY,
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_GET_LOCK_USERCODES,
+        {},
+        "async_get_lock_usercodes",
+        supports_response=SupportsResponse.ONLY,
+    )
 
     platform.async_register_entity_service(
         SERVICE_SET_LOCK_USERCODE,
@@ -159,6 +184,42 @@ class ZWaveLock(ZWaveBaseEntity, LockEntity):
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the lock."""
         await self._set_lock_state(LockState.UNLOCKED)
+
+    async def async_get_lock_usercode(self, code_slot: int) -> str | None:
+        """Get the usercode at index X on the lock."""
+        try:
+            code_slot_obj = get_usercode(self.info.node, code_slot)
+        except BaseZwaveJSServerError as err:
+            raise HomeAssistantError(
+                f"Unable to get usercode for lock {self.entity_id} code_slot "
+                f"{code_slot}: {err}"
+            ) from err
+        LOGGER.debug(
+            "User code at slot %s on lock %s retrieved", code_slot, self.entity_id
+        )
+        usercode: str | None = code_slot_obj.get(ATTR_USERCODE)  # type: ignore[assignment]
+        return usercode
+
+    async def async_get_lock_usercodes(self) -> dict[str, JsonValueType]:
+        """Get a dictionary of code slots to usercodes for the lock.
+
+        Code slots without usercodes are ignored.
+        """
+        try:
+            code_slots = get_usercodes(self.info.node)
+        except BaseZwaveJSServerError as err:
+            raise HomeAssistantError(
+                f"Unable to get usercodes for lock {self.entity_id}: {err}"
+            ) from err
+        LOGGER.debug("User codes for lock %s retrieved", self.entity_id)
+        usercodes: dict[str, JsonValueType] = {
+            str(code_slot.get(ATTR_CODE_SLOT)): code_slot.get(ATTR_USERCODE)  # type: ignore[misc]
+            for code_slot in code_slots
+            if ATTR_CODE_SLOT in code_slot
+            and ATTR_USERCODE in code_slot
+            and code_slot.get(ATTR_USERCODE)
+        }
+        return usercodes
 
     async def async_set_lock_usercode(self, code_slot: int, usercode: str) -> None:
         """Set the usercode to index X on the lock."""

--- a/homeassistant/components/zwave_js/services.yaml
+++ b/homeassistant/components/zwave_js/services.yaml
@@ -12,6 +12,24 @@ clear_lock_usercode:
       selector:
         text:
 
+get_lock_usercode:
+  target:
+    entity:
+      domain: lock
+      integration: zwave_js
+  fields:
+    code_slot:
+      required: true
+      example: 1
+      selector:
+        text:
+
+get_lock_usercodes:
+  target:
+    entity:
+      domain: lock
+      integration: zwave_js
+
 set_lock_usercode:
   target:
     entity:

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -69,6 +69,8 @@
   "device_automation": {
     "action_type": {
       "clear_lock_usercode": "Clear usercode on {entity_name}",
+      "get_lock_usercode": "Get a usercode for {entity_name}",
+      "get_lock_usercodes": "Get all usercodes for {entity_name}",
       "ping": "Ping device",
       "refresh_value": "Refresh the value(s) for {entity_name}",
       "reset_meter": "Reset meters on {subtype}",
@@ -301,6 +303,21 @@
         }
       },
       "name": "Clear lock user code"
+    },
+    "get_lock_usercode": {
+      "description": "Get a user code for a lock.",
+      "fields": {
+        "code_slot": {
+          "description": "Code slot to get the code.",
+          "name": "[%key:component::zwave_js::services::clear_lock_usercode::fields::code_slot::name%]"
+        }
+      },
+      "name": "Get lock user code"
+    },
+    "get_lock_usercodes": {
+      "description": "Get all user codes for a lock.",
+      "fields": {},
+      "name": "Get lock user codes"
     },
     "invoke_cc_api": {
       "description": "Calls a Command Class API on a node. Some Command Classes can't be fully controlled via the `set_value` action and require direct calls to the Command Class API.",

--- a/tests/components/zwave_js/test_lock.py
+++ b/tests/components/zwave_js/test_lock.py
@@ -21,6 +21,8 @@ from homeassistant.components.zwave_js.const import (
     ATTR_LOCK_TIMEOUT,
     ATTR_OPERATION_TYPE,
     DOMAIN as ZWAVE_JS_DOMAIN,
+    SERVICE_GET_LOCK_USERCODE,
+    SERVICE_GET_LOCK_USERCODES,
 )
 from homeassistant.components.zwave_js.helpers import ZwaveValueMatcher
 from homeassistant.components.zwave_js.lock import (
@@ -140,6 +142,41 @@ async def test_door_lock(
         "propertyKey": 1,
     }
     assert args["value"] == "1234"
+
+    client.async_send_command.reset_mock()
+
+    # Test get usercode service
+    response = await hass.services.async_call(
+        ZWAVE_JS_DOMAIN,
+        SERVICE_GET_LOCK_USERCODE,
+        {
+            ATTR_ENTITY_ID: SCHLAGE_BE469_LOCK_ENTITY,
+            ATTR_CODE_SLOT: 1,
+        },
+        blocking=True,
+        return_response=True,
+    )
+
+    assert response[SCHLAGE_BE469_LOCK_ENTITY] == "**********"
+
+    client.async_send_command.reset_mock()
+
+    # Test get usercodes service
+    response = await hass.services.async_call(
+        ZWAVE_JS_DOMAIN,
+        SERVICE_GET_LOCK_USERCODES,
+        {
+            ATTR_ENTITY_ID: SCHLAGE_BE469_LOCK_ENTITY,
+        },
+        blocking=True,
+        return_response=True,
+    )
+
+    assert response[SCHLAGE_BE469_LOCK_ENTITY] == {
+        "1": "**********",
+        "2": "**********",
+        "3": "**********",
+    }
 
     client.async_send_command.reset_mock()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This resolves a [feature request to add Z-wave JS services for retrieving lock usercodes](https://community.home-assistant.io/t/z-wave-js-get-lock-usercode/731489).

A good use case for these services is creating a Z-wave lock management dashboard card like this:

![lock management widget](https://github.com/home-assistant/core/assets/1024369/a5a44f87-5b85-4d1f-bf09-5361c7139f04)

In the 'Code Slot' section of this card, selecting a code slot index automatically updates the lock code to the current value for that slot (via an automation using `get_lock_usercode`). This can help remind you of the code currently at that slot and possibly avoiding accidental overwrite/clear of a slot you forgot was in use.

Further down the card in the 'All Codes' section, all usercodes from the main lock are shown (via `get_lock_usercodes`) which is handy when reviewing all usercodes at a glance, especially when you have 10+ slots that may not be set sequentially.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR resolves this feature request: https://community.home-assistant.io/t/z-wave-js-get-lock-usercode/731489
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33277

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
