### PR TITLE
Improve logging use of deprecated `schema` option for mqtt vacuum

### DIFF
--- a/homeassistant/components/mqtt/vacuum.py
+++ b/homeassistant/components/mqtt/vacuum.py
@@ -170,6 +170,15 @@ def _fail_legacy_config(discovery: bool) -> Callable[[ConfigType], ConfigType]:
             )
 
         if discovery:
+            _LOGGER.warning(
+                "The `schema` option is deprecated for MQTT %s, but "
+                "it was used in a discovery payload. Please contact the maintainer "
+                "of the integration or service that supplies the config, and suggest "
+                "to remove the option. Got %s at discovery topic %s",
+                vacuum.DOMAIN,
+                config,
+                getattr(config, "discovery_data")["discovery_topic"],
+            )
             return config
 
         translation_key = "deprecation_mqtt_schema_vacuum_yaml"

--- a/tests/components/mqtt/test_vacuum.py
+++ b/tests/components/mqtt/test_vacuum.py
@@ -2,6 +2,7 @@
 
 from copy import deepcopy
 import json
+import logging
 from typing import Any
 from unittest.mock import patch
 
@@ -12,7 +13,6 @@ from homeassistant.components.mqtt import vacuum as mqttvacuum
 from homeassistant.components.mqtt.const import CONF_COMMAND_TOPIC, CONF_STATE_TOPIC
 from homeassistant.components.mqtt.vacuum import (
     ALL_SERVICES,
-    CONF_SCHEMA,
     MQTT_VACUUM_ATTRIBUTES_BLOCKED,
     SERVICE_TO_STRING,
     services_to_strings,
@@ -77,7 +77,6 @@ STATE_TOPIC = "vacuum/state"
 DEFAULT_CONFIG = {
     mqtt.DOMAIN: {
         vacuum.DOMAIN: {
-            CONF_SCHEMA: "state",
             CONF_NAME: "mqtttest",
             CONF_COMMAND_TOPIC: COMMAND_TOPIC,
             mqttvacuum.CONF_SEND_COMMAND_TOPIC: SEND_COMMAND_TOPIC,
@@ -88,7 +87,7 @@ DEFAULT_CONFIG = {
     }
 }
 
-DEFAULT_CONFIG_2 = {mqtt.DOMAIN: {vacuum.DOMAIN: {"schema": "state", "name": "test"}}}
+DEFAULT_CONFIG_2 = {mqtt.DOMAIN: {vacuum.DOMAIN: {"name": "test"}}}
 
 CONFIG_ALL_SERVICES = help_custom_config(
     vacuum.DOMAIN,
@@ -101,6 +100,35 @@ CONFIG_ALL_SERVICES = help_custom_config(
         },
     ),
 )
+
+
+async def test_warning_schema_option(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test the warning on use of deprecated schema option."""
+    await mqtt_mock_entry()
+    # Send discovery message with deprecated schema option
+    async_fire_mqtt_message(
+        hass,
+        f"homeassistant/{vacuum.DOMAIN}/bla/config",
+        '{"name": "test", "schema": "state", "o": {"name": "Bla2MQTT", "sw": "0.99", "url":"https://example.com/support"}}',
+    )
+    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get("vacuum.test")
+    assert state is not None
+    with caplog.at_level(logging.WARNING):
+        assert (
+            "The `schema` option is deprecated for MQTT vacuum, but it was used in a "
+            "discovery payload. Please contact the maintainer of the integration or "
+            "service that supplies the config, and suggest to remove the option."
+            in caplog.text
+        )
+        assert "https://example.com/support" in caplog.text
+        assert "at discovery topic homeassistant/vacuum/bla/config" in caplog.text
 
 
 @pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
@@ -261,7 +289,6 @@ async def test_commands_without_supported_features(
             "mqtt": {
                 "vacuum": {
                     "name": "test",
-                    "schema": "state",
                     mqttvacuum.CONF_SUPPORTED_FEATURES: services_to_strings(
                         ALL_SERVICES, SERVICE_TO_STRING
                     ),
@@ -525,13 +552,11 @@ async def test_discovery_update_attr(
             mqtt.DOMAIN: {
                 vacuum.DOMAIN: [
                     {
-                        "schema": "state",
                         "name": "Test 1",
                         "command_topic": "command-topic",
                         "unique_id": "TOTALLY_UNIQUE",
                     },
                     {
-                        "schema": "state",
                         "name": "Test 2",
                         "command_topic": "command-topic",
                         "unique_id": "TOTALLY_UNIQUE",
@@ -554,7 +579,7 @@ async def test_discovery_removal_vacuum(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test removal of discovered vacuum."""
-    data = '{ "schema": "state", "name": "test", "command_topic": "test_topic"}'
+    data = '{"name": "test", "command_topic": "test_topic"}'
     await help_test_discovery_removal(
         hass, mqtt_mock_entry, caplog, vacuum.DOMAIN, data
     )
@@ -566,8 +591,8 @@ async def test_discovery_update_vacuum(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test update of discovered vacuum."""
-    config1 = {"schema": "state", "name": "Beer", "command_topic": "test_topic"}
-    config2 = {"schema": "state", "name": "Milk", "command_topic": "test_topic"}
+    config1 = {"name": "Beer", "command_topic": "test_topic"}
+    config2 = {"name": "Milk", "command_topic": "test_topic"}
     await help_test_discovery_update(
         hass, mqtt_mock_entry, caplog, vacuum.DOMAIN, config1, config2
     )
@@ -579,7 +604,7 @@ async def test_discovery_update_unchanged_vacuum(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test update of discovered vacuum."""
-    data1 = '{ "schema": "state", "name": "Beer", "command_topic": "test_topic"}'
+    data1 = '{"name": "Beer", "command_topic": "test_topic"}'
     with patch(
         "homeassistant.components.mqtt.vacuum.MqttStateVacuum.discovery_update"
     ) as discovery_update:
@@ -600,8 +625,8 @@ async def test_discovery_broken(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test handling of bad discovery message."""
-    data1 = '{ "schema": "state", "name": "Beer", "command_topic": "test_topic#"}'
-    data2 = '{ "schema": "state", "name": "Milk", "command_topic": "test_topic"}'
+    data1 = '{"name": "Beer", "command_topic": "test_topic#"}'
+    data2 = '{"name": "Milk", "command_topic": "test_topic"}'
     await help_test_discovery_broken(
         hass, mqtt_mock_entry, caplog, vacuum.DOMAIN, data1, data2
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve logging when deprecated `schema` option is used in van MQTT discovery for an MQTT state vacuum.
The PR also adds logging of the config (inclusing origin info, if that is available) and the discovery topic.

The depreated `schema` option was also removed from the existing tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #119718
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
