### PR TITLE
Add capability to exclude all attributes from recording

### DIFF
--- a/homeassistant/components/recorder/db_schema.py
+++ b/homeassistant/components/recorder/db_schema.py
@@ -585,13 +585,13 @@ class StateAttributes(Base):
         if (state := event.data["new_state"]) is None:
             return b"{}"
         if state_info := state.state_info:
+            unrecorded_attributes = state_info["unrecorded_attributes"]
             exclude_attrs = {
                 *ALL_DOMAIN_EXCLUDE_ATTRS,
-                *state_info["unrecorded_attributes"],
+                *unrecorded_attributes,
             }
-            if MATCH_ALL in state_info["unrecorded_attributes"]:
-                for attribute in state.attributes:
-                    exclude_attrs.add(attribute)
+            if MATCH_ALL in unrecorded_attributes:
+                exclude_attrs.update(state.attributes)
 
         else:
             exclude_attrs = ALL_DOMAIN_EXCLUDE_ATTRS

--- a/homeassistant/components/recorder/db_schema.py
+++ b/homeassistant/components/recorder/db_schema.py
@@ -36,6 +36,7 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, aliased, mapped_column, rela
 from sqlalchemy.types import TypeDecorator
 
 from homeassistant.const import (
+    MATCH_ALL,
     MAX_LENGTH_EVENT_EVENT_TYPE,
     MAX_LENGTH_STATE_ENTITY_ID,
     MAX_LENGTH_STATE_STATE,
@@ -588,6 +589,10 @@ class StateAttributes(Base):
                 *ALL_DOMAIN_EXCLUDE_ATTRS,
                 *state_info["unrecorded_attributes"],
             }
+            if MATCH_ALL in state_info["unrecorded_attributes"]:
+                for attribute in state.attributes:
+                    exclude_attrs.add(attribute)
+
         else:
             exclude_attrs = ALL_DOMAIN_EXCLUDE_ATTRS
         encoder = json_bytes_strip_null if dialect == PSQL_DIALECT else json_bytes

--- a/homeassistant/components/recorder/db_schema.py
+++ b/homeassistant/components/recorder/db_schema.py
@@ -35,7 +35,11 @@ from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import DeclarativeBase, Mapped, aliased, mapped_column, relationship
 from sqlalchemy.types import TypeDecorator
 
+from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_FRIENDLY_NAME,
+    ATTR_UNIT_OF_MEASUREMENT,
     MATCH_ALL,
     MAX_LENGTH_EVENT_EVENT_TYPE,
     MAX_LENGTH_STATE_ENTITY_ID,
@@ -591,7 +595,20 @@ class StateAttributes(Base):
                 *unrecorded_attributes,
             }
             if MATCH_ALL in unrecorded_attributes:
-                exclude_attrs.update(state.attributes)
+                # Don't exclude device class, state class, unit of measurement
+                # or friendly name when using the MATCH_ALL exclude constant
+                _exclude_attributes = {
+                    k: v
+                    for k, v in state.attributes.items()
+                    if k
+                    not in (
+                        ATTR_DEVICE_CLASS,
+                        ATTR_STATE_CLASS,
+                        ATTR_UNIT_OF_MEASUREMENT,
+                        ATTR_FRIENDLY_NAME,
+                    )
+                }
+                exclude_attrs.update(_exclude_attributes)
 
         else:
             exclude_attrs = ALL_DOMAIN_EXCLUDE_ATTRS

--- a/tests/components/recorder/db_schema_42.py
+++ b/tests/components/recorder/db_schema_42.py
@@ -54,7 +54,11 @@ from homeassistant.components.recorder.models import (
     ulid_to_bytes_or_none,
     uuid_hex_to_bytes_or_none,
 )
+from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_FRIENDLY_NAME,
+    ATTR_UNIT_OF_MEASUREMENT,
     MATCH_ALL,
     MAX_LENGTH_EVENT_EVENT_TYPE,
     MAX_LENGTH_STATE_ENTITY_ID,
@@ -584,7 +588,20 @@ class StateAttributes(Base):
                 *unrecorded_attributes,
             }
             if MATCH_ALL in unrecorded_attributes:
-                exclude_attrs.update(state.attributes)
+                # Don't exclude device class, state class, unit of measurement
+                # or friendly name when using the MATCH_ALL exclude constant
+                _exclude_attributes = {
+                    k: v
+                    for k, v in state.attributes.items()
+                    if k
+                    not in (
+                        ATTR_DEVICE_CLASS,
+                        ATTR_STATE_CLASS,
+                        ATTR_UNIT_OF_MEASUREMENT,
+                        ATTR_FRIENDLY_NAME,
+                    )
+                }
+                exclude_attrs.update(_exclude_attributes)
 
         else:
             exclude_attrs = ALL_DOMAIN_EXCLUDE_ATTRS

--- a/tests/components/recorder/db_schema_42.py
+++ b/tests/components/recorder/db_schema_42.py
@@ -55,6 +55,7 @@ from homeassistant.components.recorder.models import (
     uuid_hex_to_bytes_or_none,
 )
 from homeassistant.const import (
+    MATCH_ALL,
     MAX_LENGTH_EVENT_EVENT_TYPE,
     MAX_LENGTH_STATE_ENTITY_ID,
     MAX_LENGTH_STATE_STATE,
@@ -581,6 +582,10 @@ class StateAttributes(Base):
                 *ALL_DOMAIN_EXCLUDE_ATTRS,
                 *state_info["unrecorded_attributes"],
             }
+            if MATCH_ALL in state_info["unrecorded_attributes"]:
+                for attribute in state.attributes:
+                    exclude_attrs.add(attribute)
+
         else:
             exclude_attrs = ALL_DOMAIN_EXCLUDE_ATTRS
         encoder = json_bytes_strip_null if dialect == PSQL_DIALECT else json_bytes

--- a/tests/components/recorder/db_schema_42.py
+++ b/tests/components/recorder/db_schema_42.py
@@ -578,13 +578,13 @@ class StateAttributes(Base):
         if state is None:
             return b"{}"
         if state_info := state.state_info:
+            unrecorded_attributes = state_info["unrecorded_attributes"]
             exclude_attrs = {
                 *ALL_DOMAIN_EXCLUDE_ATTRS,
-                *state_info["unrecorded_attributes"],
+                *unrecorded_attributes,
             }
-            if MATCH_ALL in state_info["unrecorded_attributes"]:
-                for attribute in state.attributes:
-                    exclude_attrs.add(attribute)
+            if MATCH_ALL in unrecorded_attributes:
+                exclude_attrs.update(state.attributes)
 
         else:
             exclude_attrs = ALL_DOMAIN_EXCLUDE_ATTRS

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -2427,7 +2427,15 @@ async def test_excluding_all_attributes_by_integration(
 ) -> None:
     """Test that an entity can exclude all attributes from being recorded using MATCH_ALL."""
     state = "restoring_from_db"
-    attributes = {"test_attr": 5, "excluded_component": 10, "excluded_integration": 20}
+    attributes = {
+        "test_attr": 5,
+        "excluded_component": 10,
+        "excluded_integration": 20,
+        "device_class": "test",
+        "state_class": "test",
+        "friendly_name": "Test entity",
+        "unit_of_measurement": "mm",
+    }
     mock_platform(
         hass,
         "fake_integration.recorder",
@@ -2468,7 +2476,12 @@ async def test_excluding_all_attributes_by_integration(
         assert db_states[0].event_id is None
 
     expected = _state_with_context(hass, entity_id)
-    expected.attributes = {}
+    expected.attributes = {
+        "device_class": "test",
+        "state_class": "test",
+        "friendly_name": "Test entity",
+        "unit_of_measurement": "mm",
+    }
     assert state.as_dict() == expected.as_dict()
 
 

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -2420,6 +2420,58 @@ async def test_excluding_attributes_by_integration(
     assert state.as_dict() == expected.as_dict()
 
 
+async def test_excluding_all_attributes_by_integration(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    setup_recorder: None,
+) -> None:
+    """Test that an entity can exclude all attributes from being recorded using MATCH_ALL."""
+    state = "restoring_from_db"
+    attributes = {"test_attr": 5, "excluded_component": 10, "excluded_integration": 20}
+    mock_platform(
+        hass,
+        "fake_integration.recorder",
+        Mock(exclude_attributes=lambda hass: {"excluded"}),
+    )
+    hass.config.components.add("fake_integration")
+    hass.bus.async_fire(EVENT_COMPONENT_LOADED, {"component": "fake_integration"})
+    await hass.async_block_till_done()
+
+    class EntityWithExcludedAttributes(MockEntity):
+        _unrecorded_attributes = frozenset({MATCH_ALL})
+
+    entity_id = "test.fake_integration_recorder"
+    entity_platform = MockEntityPlatform(hass, platform_name="fake_integration")
+    entity = EntityWithExcludedAttributes(
+        entity_id=entity_id,
+        extra_state_attributes=attributes,
+    )
+    await entity_platform.async_add_entities([entity])
+    await hass.async_block_till_done()
+
+    await async_wait_recording_done(hass)
+
+    with session_scope(hass=hass, read_only=True) as session:
+        db_states = []
+        for db_state, db_state_attributes, states_meta in (
+            session.query(States, StateAttributes, StatesMeta)
+            .outerjoin(
+                StateAttributes, States.attributes_id == StateAttributes.attributes_id
+            )
+            .outerjoin(StatesMeta, States.metadata_id == StatesMeta.metadata_id)
+        ):
+            db_state.entity_id = states_meta.entity_id
+            db_states.append(db_state)
+            state = db_state.to_native()
+            state.attributes = db_state_attributes.to_native()
+        assert len(db_states) == 1
+        assert db_states[0].event_id is None
+
+    expected = _state_with_context(hass, entity_id)
+    expected.attributes = {}
+    assert state.as_dict() == expected.as_dict()
+
+
 async def test_lru_increases_with_many_entities(
     small_cache_size: None, hass: HomeAssistant, setup_recorder: None
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds capability to exclude a state's all attributes from recording by using the `MATCH_ALL` constant.
For example useful in the `sql` integration where we don't know which attributes there are.

Dev docs PR: https://github.com/home-assistant/developers.home-assistant/pull/2229

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 