### PR TITLE
Cleanup unifiprotect entity model

### DIFF
--- a/homeassistant/components/unifiprotect/button.py
+++ b/homeassistant/components/unifiprotect/button.py
@@ -23,7 +23,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DEVICES_THAT_ADOPT, DISPATCH_ADD, DOMAIN
 from .data import ProtectData, UFPConfigEntry
 from .entity import ProtectDeviceEntity, async_all_device_entities
-from .models import PermRequired, ProtectRequiredKeysMixin, ProtectSetableKeysMixin, T
+from .models import PermRequired, ProtectEntityDescription, ProtectSetableKeysMixin, T
 from .utils import async_dispatch_id as _ufpd
 
 _LOGGER = logging.getLogger(__name__)
@@ -95,7 +95,7 @@ CHIME_BUTTONS: tuple[ProtectButtonEntityDescription, ...] = (
 )
 
 
-_MODEL_DESCRIPTIONS: dict[ModelType, Sequence[ProtectRequiredKeysMixin]] = {
+_MODEL_DESCRIPTIONS: dict[ModelType, Sequence[ProtectEntityDescription]] = {
     ModelType.CHIME: CHIME_BUTTONS,
     ModelType.SENSOR: SENSOR_BUTTONS,
 }

--- a/homeassistant/components/unifiprotect/camera.py
+++ b/homeassistant/components/unifiprotect/camera.py
@@ -158,6 +158,9 @@ async def async_setup_entry(
     async_add_entities(_async_camera_entities(hass, entry, data))
 
 
+_EMPTY_CAMERA_FEATURES = CameraEntityFeature(0)
+
+
 class ProtectCamera(ProtectDeviceEntity, Camera):
     """A Ubiquiti UniFi Protect Camera."""
 
@@ -206,13 +209,12 @@ class ProtectCamera(ProtectDeviceEntity, Camera):
         rtsp_url = channel.rtsps_url if self._secure else channel.rtsp_url
 
         # _async_set_stream_source called by __init__
-        self._stream_source = (  # pylint: disable=attribute-defined-outside-init
-            None if disable_stream else rtsp_url
-        )
+        # pylint: disable-next=attribute-defined-outside-init
+        self._stream_source = None if disable_stream else rtsp_url
         if self._stream_source:
             self._attr_supported_features = CameraEntityFeature.STREAM
         else:
-            self._attr_supported_features = CameraEntityFeature(0)
+            self._attr_supported_features = _EMPTY_CAMERA_FEATURES
 
     @callback
     def _async_update_device_from_protect(self, device: ProtectModelWithId) -> None:

--- a/homeassistant/components/unifiprotect/entity.py
+++ b/homeassistant/components/unifiprotect/entity.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Sequence
 from functools import partial
 import logging
 from operator import attrgetter
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from uiprotect.data import (
     NVR,
@@ -310,14 +310,9 @@ class ProtectNVREntity(BaseProtectEntity):
 class EventEntityMixin(ProtectDeviceEntity):
     """Adds motion event attributes to sensor."""
 
-    _unrecorded_attributes = frozenset({ATTR_EVENT_ID, ATTR_EVENT_SCORE})
-
     entity_description: ProtectEventMixin
-
-    def __init__(self, *args: Any, **kwarg: Any) -> None:
-        """Init an sensor that has event thumbnails."""
-        super().__init__(*args, **kwarg)
-        self._event: Event | None = None
+    _unrecorded_attributes = frozenset({ATTR_EVENT_ID, ATTR_EVENT_SCORE})
+    _event: Event | None = None
 
     @callback
     def _async_update_device_from_protect(self, device: ProtectModelWithId) -> None:

--- a/homeassistant/components/unifiprotect/entity.py
+++ b/homeassistant/components/unifiprotect/entity.py
@@ -31,7 +31,7 @@ from .const import (
     DOMAIN,
 )
 from .data import ProtectData
-from .models import PermRequired, ProtectEventMixin, ProtectRequiredKeysMixin
+from .models import PermRequired, ProtectEntityDescription, ProtectEventMixin
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,8 +41,8 @@ def _async_device_entities(
     data: ProtectData,
     klass: type[BaseProtectEntity],
     model_type: ModelType,
-    descs: Sequence[ProtectRequiredKeysMixin],
-    unadopted_descs: Sequence[ProtectRequiredKeysMixin] | None = None,
+    descs: Sequence[ProtectEntityDescription],
+    unadopted_descs: Sequence[ProtectEntityDescription] | None = None,
     ufp_device: ProtectAdoptableDeviceModel | None = None,
 ) -> list[BaseProtectEntity]:
     if not descs and not unadopted_descs:
@@ -119,11 +119,11 @@ _ALL_MODEL_TYPES = (
 @callback
 def _combine_model_descs(
     model_type: ModelType,
-    model_descriptions: dict[ModelType, Sequence[ProtectRequiredKeysMixin]] | None,
-    all_descs: Sequence[ProtectRequiredKeysMixin] | None,
-) -> list[ProtectRequiredKeysMixin]:
+    model_descriptions: dict[ModelType, Sequence[ProtectEntityDescription]] | None,
+    all_descs: Sequence[ProtectEntityDescription] | None,
+) -> list[ProtectEntityDescription]:
     """Combine all the descriptions with descriptions a model type."""
-    descs: list[ProtectRequiredKeysMixin] = list(all_descs) if all_descs else []
+    descs: list[ProtectEntityDescription] = list(all_descs) if all_descs else []
     if model_descriptions and (model_descs := model_descriptions.get(model_type)):
         descs.extend(model_descs)
     return descs
@@ -133,10 +133,10 @@ def _combine_model_descs(
 def async_all_device_entities(
     data: ProtectData,
     klass: type[BaseProtectEntity],
-    model_descriptions: dict[ModelType, Sequence[ProtectRequiredKeysMixin]]
+    model_descriptions: dict[ModelType, Sequence[ProtectEntityDescription]]
     | None = None,
-    all_descs: Sequence[ProtectRequiredKeysMixin] | None = None,
-    unadopted_descs: list[ProtectRequiredKeysMixin] | None = None,
+    all_descs: Sequence[ProtectEntityDescription] | None = None,
+    unadopted_descs: list[ProtectEntityDescription] | None = None,
     ufp_device: ProtectAdoptableDeviceModel | None = None,
 ) -> list[BaseProtectEntity]:
     """Generate a list of all the device entities."""
@@ -191,7 +191,7 @@ class BaseProtectEntity(Entity):
                 else ""
             )
             self._attr_name = f"{self.device.display_name} {name.title()}"
-            if isinstance(description, ProtectRequiredKeysMixin):
+            if isinstance(description, ProtectEntityDescription):
                 self._async_get_ufp_enabled = description.get_ufp_enabled
 
         self._attr_attribution = DEFAULT_ATTRIBUTION

--- a/homeassistant/components/unifiprotect/entity.py
+++ b/homeassistant/components/unifiprotect/entity.py
@@ -301,8 +301,7 @@ class ProtectNVREntity(BaseProtectEntity):
     @callback
     def _async_update_device_from_protect(self, device: ProtectModelWithId) -> None:
         data = self.data
-        last_update_success = data.last_update_success
-        if last_update_success:
+        if last_update_success := data.last_update_success:
             self.device = data.api.bootstrap.nvr
 
         self._attr_available = last_update_success
@@ -315,24 +314,19 @@ class EventEntityMixin(ProtectDeviceEntity):
 
     entity_description: ProtectEventMixin
 
-    def __init__(
-        self,
-        *args: Any,
-        **kwarg: Any,
-    ) -> None:
+    def __init__(self, *args: Any, **kwarg: Any) -> None:
         """Init an sensor that has event thumbnails."""
         super().__init__(*args, **kwarg)
         self._event: Event | None = None
 
     @callback
     def _async_update_device_from_protect(self, device: ProtectModelWithId) -> None:
-        event = self.entity_description.get_event_obj(device)
-        if event is not None:
+        if (event := self.entity_description.get_event_obj(device)) is None:
+            self._attr_extra_state_attributes = {}
+        else:
             self._attr_extra_state_attributes = {
                 ATTR_EVENT_ID: event.id,
                 ATTR_EVENT_SCORE: event.score,
             }
-        else:
-            self._attr_extra_state_attributes = {}
         self._event = event
         super()._async_update_device_from_protect(device)

--- a/homeassistant/components/unifiprotect/entity.py
+++ b/homeassistant/components/unifiprotect/entity.py
@@ -163,6 +163,7 @@ class BaseProtectEntity(Entity):
     device: ProtectAdoptableDeviceModel | NVR
 
     _attr_should_poll = False
+    _attr_attribution = DEFAULT_ATTRIBUTION
     _state_attrs: tuple[str, ...] = ("_attr_available",)
 
     def __init__(
@@ -194,7 +195,6 @@ class BaseProtectEntity(Entity):
             if isinstance(description, ProtectEntityDescription):
                 self._async_get_ufp_enabled = description.get_ufp_enabled
 
-        self._attr_attribution = DEFAULT_ATTRIBUTION
         self._async_set_device_info()
         self._async_update_device_from_protect(device)
         self._state_getters = tuple(

--- a/homeassistant/components/unifiprotect/models.py
+++ b/homeassistant/components/unifiprotect/models.py
@@ -40,7 +40,10 @@ class ProtectEntityDescription(EntityDescription, Generic[T]):
     ufp_perm: PermRequired | None = None
 
     def get_ufp_value(self, obj: T) -> Any:
-        """Return value from UniFi Protect device."""
+        """Return value from UniFi Protect device.
+
+        May be overridden by ufp_value or ufp_value_fn.
+        """
         # ufp_value or ufp_value_fn is required, the
         # RuntimeError is to catch any issues in the code
         # with new descriptions.
@@ -49,11 +52,17 @@ class ProtectEntityDescription(EntityDescription, Generic[T]):
         )
 
     def has_required(self, obj: T) -> bool:
-        """Return if required field is set."""
+        """Return if required field is set.
+
+        May be overridden by ufp_required_field.
+        """
         return True
 
     def get_ufp_enabled(self, obj: T) -> bool:
-        """Return if entity is enabled."""
+        """Return if entity is enabled.
+
+        May be overridden by ufp_enabled.
+        """
         return True
 
     def __post_init__(self) -> None:

--- a/homeassistant/components/unifiprotect/models.py
+++ b/homeassistant/components/unifiprotect/models.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from enum import Enum
+from functools import partial
 import logging
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
@@ -37,7 +38,7 @@ class PermRequired(int, Enum):
 
 
 @dataclass(frozen=True, kw_only=True)
-class ProtectRequiredKeysMixin(EntityDescription, Generic[T]):
+class ProtectEntityDescription(EntityDescription, Generic[T]):
     """Mixin for required keys."""
 
     # `ufp_required_field`, `ufp_value`, and `ufp_enabled` are defined as
@@ -50,59 +51,46 @@ class ProtectRequiredKeysMixin(EntityDescription, Generic[T]):
     ufp_enabled: tuple[str, ...] | str | None = None
     ufp_perm: PermRequired | None = None
 
-    def __post_init__(self) -> None:
-        """Pre-convert strings to tuples for faster get_nested_attr."""
-        object.__setattr__(
-            self, "ufp_required_field", split_tuple(self.ufp_required_field)
-        )
-        object.__setattr__(self, "ufp_value", split_tuple(self.ufp_value))
-        object.__setattr__(self, "ufp_enabled", split_tuple(self.ufp_enabled))
-
     def get_ufp_value(self, obj: T) -> Any:
         """Return value from UniFi Protect device."""
-        if (ufp_value := self.ufp_value) is not None:
-            if TYPE_CHECKING:
-                # `ufp_value` is defined as a `str` in the dataclass, but
-                # `__post_init__` converts it to a `tuple[str, ...]` to avoid
-                # doing it at run time in `get_nested_attr` which is usually called
-                # millions of times per day. This tells mypy that it's a tuple.
-                assert isinstance(ufp_value, tuple)
-            return get_nested_attr(obj, ufp_value)
-        if (ufp_value_fn := self.ufp_value_fn) is not None:
-            return ufp_value_fn(obj)
-
-        # reminder for future that one is required
-        raise RuntimeError(  # pragma: no cover
+        raise RuntimeError(
             "`ufp_value` or `ufp_value_fn` is required"
-        )
-
-    def get_ufp_enabled(self, obj: T) -> bool:
-        """Return value from UniFi Protect device."""
-        if (ufp_enabled := self.ufp_enabled) is not None:
-            if TYPE_CHECKING:
-                # `ufp_enabled` is defined as a `str` in the dataclass, but
-                # `__post_init__` converts it to a `tuple[str, ...]` to avoid
-                # doing it at run time in `get_nested_attr` which is usually called
-                # millions of times per day. This tells mypy that it's a tuple.
-                assert isinstance(ufp_enabled, tuple)
-            return bool(get_nested_attr(obj, ufp_enabled))
-        return True
+        )  # pragma: no cover
 
     def has_required(self, obj: T) -> bool:
-        """Return if has required field."""
-        if (ufp_required_field := self.ufp_required_field) is None:
-            return True
-        if TYPE_CHECKING:
-            # `ufp_required_field` is defined as a `str` in the dataclass, but
-            # `__post_init__` converts it to a `tuple[str, ...]` to avoid
-            # doing it at run time in `get_nested_attr` which is usually called
-            # millions of times per day. This tells mypy that it's a tuple.
+        """Return if required field is set."""
+        return True
+
+    def get_ufp_enabled(self, obj: T) -> bool:
+        """Return if entity is enabled."""
+        return True
+
+    def __post_init__(self) -> None:
+        """Pre-convert strings to tuples for faster get_nested_attr."""
+        _setter = partial(object.__setattr__, self)
+        if (_ufp_value := self.ufp_value) is not None:
+            ufp_value = split_tuple(_ufp_value)
+            assert isinstance(ufp_value, tuple)
+            _setter("get_ufp_value", partial(get_nested_attr, attrs=ufp_value))
+        elif (ufp_value_fn := self.ufp_value_fn) is not None:
+            _setter("get_ufp_value", ufp_value_fn)
+
+        if (_ufp_enabled := self.ufp_enabled) is not None:
+            ufp_enabled = split_tuple(_ufp_enabled)
+            assert isinstance(ufp_enabled, tuple)
+            _setter("get_ufp_enabled", partial(get_nested_attr, attrs=ufp_enabled))
+
+        if (_ufp_required_field := self.ufp_required_field) is not None:
+            ufp_required_field = split_tuple(_ufp_required_field)
             assert isinstance(ufp_required_field, tuple)
-        return bool(get_nested_attr(obj, ufp_required_field))
+            _setter(
+                "has_required",
+                lambda obj: bool(get_nested_attr(obj, ufp_required_field)),
+            )
 
 
 @dataclass(frozen=True, kw_only=True)
-class ProtectEventMixin(ProtectRequiredKeysMixin[T]):
+class ProtectEventMixin(ProtectEntityDescription[T]):
     """Mixin for events."""
 
     ufp_event_obj: str | None = None
@@ -122,7 +110,7 @@ class ProtectEventMixin(ProtectRequiredKeysMixin[T]):
 
 
 @dataclass(frozen=True, kw_only=True)
-class ProtectSetableKeysMixin(ProtectRequiredKeysMixin[T]):
+class ProtectSetableKeysMixin(ProtectEntityDescription[T]):
     """Mixin for settable values."""
 
     ufp_set_method: str | None = None

--- a/homeassistant/components/unifiprotect/models.py
+++ b/homeassistant/components/unifiprotect/models.py
@@ -31,7 +31,7 @@ class PermRequired(int, Enum):
 
 @dataclass(frozen=True, kw_only=True)
 class ProtectEntityDescription(EntityDescription, Generic[T]):
-    """Mixin for required keys."""
+    """Base class for protect entity descriptions."""
 
     ufp_required_field: str | None = None
     ufp_value: str | None = None

--- a/homeassistant/components/unifiprotect/models.py
+++ b/homeassistant/components/unifiprotect/models.py
@@ -66,14 +66,7 @@ class ProtectEntityDescription(EntityDescription, Generic[T]):
         return True
 
     def __post_init__(self) -> None:
-        """Pre-convert strings to tuples for faster get_nested_attr.
-
-        get_ufp_value/has_required/get_ufp_enabled are overridden based
-        on what is defined in the dataclass so they only have to be
-        worked out once.
-        """
-        # Setter to be able to mutate the frozen dataclass methods
-        # but not the data itself.
+        """Override get_ufp_value, has_required, and get_ufp_enabled if required."""
         _setter = partial(object.__setattr__, self)
         if (_ufp_value := self.ufp_value) is not None:
             ufp_value = tuple(_ufp_value.split("."))

--- a/homeassistant/components/unifiprotect/models.py
+++ b/homeassistant/components/unifiprotect/models.py
@@ -20,10 +20,8 @@ _LOGGER = logging.getLogger(__name__)
 T = TypeVar("T", bound=ProtectAdoptableDeviceModel | NVR)
 
 
-def split_tuple(value: tuple[str, ...] | str | None) -> tuple[str, ...] | None:
+def split_tuple(value: tuple[str, ...] | str) -> tuple[str, ...]:
     """Split string to tuple."""
-    if value is None:
-        return None
     if TYPE_CHECKING:
         assert isinstance(value, str)
     return tuple(value.split("."))
@@ -70,19 +68,16 @@ class ProtectEntityDescription(EntityDescription, Generic[T]):
         _setter = partial(object.__setattr__, self)
         if (_ufp_value := self.ufp_value) is not None:
             ufp_value = split_tuple(_ufp_value)
-            assert isinstance(ufp_value, tuple)
             _setter("get_ufp_value", partial(get_nested_attr, attrs=ufp_value))
         elif (ufp_value_fn := self.ufp_value_fn) is not None:
             _setter("get_ufp_value", ufp_value_fn)
 
         if (_ufp_enabled := self.ufp_enabled) is not None:
             ufp_enabled = split_tuple(_ufp_enabled)
-            assert isinstance(ufp_enabled, tuple)
             _setter("get_ufp_enabled", partial(get_nested_attr, attrs=ufp_enabled))
 
         if (_ufp_required_field := self.ufp_required_field) is not None:
             ufp_required_field = split_tuple(_ufp_required_field)
-            assert isinstance(ufp_required_field, tuple)
             _setter(
                 "has_required",
                 lambda obj: bool(get_nested_attr(obj, ufp_required_field)),

--- a/homeassistant/components/unifiprotect/models.py
+++ b/homeassistant/components/unifiprotect/models.py
@@ -63,21 +63,17 @@ class ProtectEntityDescription(EntityDescription, Generic[T]):
         on what is defined in the dataclass so they only have to be
         worked out once.
         """
-
-        # Setter to be able to mutate the frozen dataclass
-        # in __post_init__.
+        # Setter to be able to mutate the frozen dataclass methods
+        # but not the data itself.
         _setter = partial(object.__setattr__, self)
-
         if (_ufp_value := self.ufp_value) is not None:
             ufp_value = tuple(_ufp_value.split("."))
             _setter("get_ufp_value", partial(get_nested_attr, attrs=ufp_value))
         elif (ufp_value_fn := self.ufp_value_fn) is not None:
             _setter("get_ufp_value", ufp_value_fn)
-
         if (_ufp_enabled := self.ufp_enabled) is not None:
             ufp_enabled = tuple(_ufp_enabled.split("."))
             _setter("get_ufp_enabled", partial(get_nested_attr, attrs=ufp_enabled))
-
         if (_ufp_required_field := self.ufp_required_field) is not None:
             ufp_required_field = tuple(_ufp_required_field.split("."))
             _setter(

--- a/homeassistant/components/unifiprotect/models.py
+++ b/homeassistant/components/unifiprotect/models.py
@@ -64,8 +64,17 @@ class ProtectEntityDescription(EntityDescription, Generic[T]):
         return True
 
     def __post_init__(self) -> None:
-        """Pre-convert strings to tuples for faster get_nested_attr."""
+        """Pre-convert strings to tuples for faster get_nested_attr.
+
+        get_ufp_value/has_required/get_ufp_enabled are overridden based
+        on what is defined in the dataclass so they only have to be
+        worked out once.
+        """
+
+        # Setter to be able to mutate the frozen dataclass
+        # in __post_init__.
         _setter = partial(object.__setattr__, self)
+
         if (_ufp_value := self.ufp_value) is not None:
             ufp_value = split_tuple(_ufp_value)
             _setter("get_ufp_value", partial(get_nested_attr, attrs=ufp_value))

--- a/homeassistant/components/unifiprotect/number.py
+++ b/homeassistant/components/unifiprotect/number.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import timedelta
-import logging
 
 from uiprotect.data import (
     Camera,
@@ -24,8 +23,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .data import ProtectData, UFPConfigEntry
 from .entity import ProtectDeviceEntity, async_all_device_entities
 from .models import PermRequired, ProtectEntityDescription, ProtectSetableKeysMixin, T
-
-_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/homeassistant/components/unifiprotect/number.py
+++ b/homeassistant/components/unifiprotect/number.py
@@ -23,7 +23,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .data import ProtectData, UFPConfigEntry
 from .entity import ProtectDeviceEntity, async_all_device_entities
-from .models import PermRequired, ProtectRequiredKeysMixin, ProtectSetableKeysMixin, T
+from .models import PermRequired, ProtectEntityDescription, ProtectSetableKeysMixin, T
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -213,7 +213,7 @@ CHIME_NUMBERS: tuple[ProtectNumberEntityDescription, ...] = (
         ufp_perm=PermRequired.WRITE,
     ),
 )
-_MODEL_DESCRIPTIONS: dict[ModelType, Sequence[ProtectRequiredKeysMixin]] = {
+_MODEL_DESCRIPTIONS: dict[ModelType, Sequence[ProtectEntityDescription]] = {
     ModelType.CAMERA: CAMERA_NUMBERS,
     ModelType.LIGHT: LIGHT_NUMBERS,
     ModelType.SENSOR: SENSE_NUMBERS,

--- a/homeassistant/components/unifiprotect/select.py
+++ b/homeassistant/components/unifiprotect/select.py
@@ -35,7 +35,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import TYPE_EMPTY_VALUE
 from .data import ProtectData, UFPConfigEntry
 from .entity import ProtectDeviceEntity, async_all_device_entities
-from .models import PermRequired, ProtectRequiredKeysMixin, ProtectSetableKeysMixin, T
+from .models import PermRequired, ProtectEntityDescription, ProtectSetableKeysMixin, T
 from .utils import async_get_light_motion_current
 
 _LOGGER = logging.getLogger(__name__)
@@ -319,7 +319,7 @@ VIEWER_SELECTS: tuple[ProtectSelectEntityDescription, ...] = (
     ),
 )
 
-_MODEL_DESCRIPTIONS: dict[ModelType, Sequence[ProtectRequiredKeysMixin]] = {
+_MODEL_DESCRIPTIONS: dict[ModelType, Sequence[ProtectEntityDescription]] = {
     ModelType.CAMERA: CAMERA_SELECTS,
     ModelType.LIGHT: LIGHT_SELECTS,
     ModelType.SENSOR: SENSE_SELECTS,

--- a/homeassistant/components/unifiprotect/sensor.py
+++ b/homeassistant/components/unifiprotect/sensor.py
@@ -47,7 +47,7 @@ from .entity import (
     ProtectNVREntity,
     async_all_device_entities,
 )
-from .models import PermRequired, ProtectEventMixin, ProtectRequiredKeysMixin, T
+from .models import PermRequired, ProtectEntityDescription, ProtectEventMixin, T
 from .utils import async_get_light_motion_current
 
 _LOGGER = logging.getLogger(__name__)
@@ -56,7 +56,7 @@ OBJECT_TYPE_NONE = "none"
 
 @dataclass(frozen=True, kw_only=True)
 class ProtectSensorEntityDescription(
-    ProtectRequiredKeysMixin[T], SensorEntityDescription
+    ProtectEntityDescription[T], SensorEntityDescription
 ):
     """Describes UniFi Protect Sensor entity."""
 
@@ -608,7 +608,7 @@ VIEWER_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
     ),
 )
 
-_MODEL_DESCRIPTIONS: dict[ModelType, Sequence[ProtectRequiredKeysMixin]] = {
+_MODEL_DESCRIPTIONS: dict[ModelType, Sequence[ProtectEntityDescription]] = {
     ModelType.CAMERA: CAMERA_SENSORS + CAMERA_DISABLED_SENSORS,
     ModelType.SENSOR: SENSE_SENSORS,
     ModelType.LIGHT: LIGHT_SENSORS,

--- a/homeassistant/components/unifiprotect/switch.py
+++ b/homeassistant/components/unifiprotect/switch.py
@@ -538,21 +538,20 @@ class ProtectPrivacyModeSwitch(RestoreEntity, ProtectSwitch):
     def __init__(
         self,
         data: ProtectData,
-        device: ProtectAdoptableDeviceModel,
+        device: Camera,
         description: ProtectSwitchEntityDescription,
     ) -> None:
         """Initialize an UniFi Protect Switch."""
         super().__init__(data, device, description)
-
-        if self.device.is_privacy_on:
+        if device.is_privacy_on:
             extra_state = self.extra_state_attributes or {}
             self._previous_mic_level = extra_state.get(ATTR_PREV_MIC, 100)
             self._previous_record_mode = extra_state.get(
                 ATTR_PREV_RECORD, RecordingMode.ALWAYS
             )
         else:
-            self._previous_mic_level = self.device.mic_volume
-            self._previous_record_mode = self.device.recording_settings.mode
+            self._previous_mic_level = device.mic_volume
+            self._previous_record_mode = device.recording_settings.mode
 
     @callback
     def _update_previous_attr(self) -> None:

--- a/homeassistant/components/unifiprotect/switch.py
+++ b/homeassistant/components/unifiprotect/switch.py
@@ -30,7 +30,7 @@ from .entity import (
     ProtectNVREntity,
     async_all_device_entities,
 )
-from .models import PermRequired, ProtectRequiredKeysMixin, ProtectSetableKeysMixin, T
+from .models import PermRequired, ProtectEntityDescription, ProtectSetableKeysMixin, T
 
 _LOGGER = logging.getLogger(__name__)
 ATTR_PREV_MIC = "prev_mic_level"
@@ -459,7 +459,7 @@ NVR_SWITCHES: tuple[ProtectSwitchEntityDescription, ...] = (
     ),
 )
 
-_MODEL_DESCRIPTIONS: dict[ModelType, Sequence[ProtectRequiredKeysMixin]] = {
+_MODEL_DESCRIPTIONS: dict[ModelType, Sequence[ProtectEntityDescription]] = {
     ModelType.CAMERA: CAMERA_SWITCHES,
     ModelType.LIGHT: LIGHT_SWITCHES,
     ModelType.SENSOR: SENSE_SWITCHES,
@@ -467,7 +467,7 @@ _MODEL_DESCRIPTIONS: dict[ModelType, Sequence[ProtectRequiredKeysMixin]] = {
     ModelType.VIEWPORT: VIEWER_SWITCHES,
 }
 
-_PRIVACY_MODEL_DESCRIPTIONS: dict[ModelType, Sequence[ProtectRequiredKeysMixin]] = {
+_PRIVACY_MODEL_DESCRIPTIONS: dict[ModelType, Sequence[ProtectEntityDescription]] = {
     ModelType.CAMERA: [PRIVACY_MODE_SWITCH]
 }
 

--- a/homeassistant/components/unifiprotect/switch.py
+++ b/homeassistant/components/unifiprotect/switch.py
@@ -487,7 +487,6 @@ class ProtectSwitch(ProtectDeviceEntity, SwitchEntity):
         """Initialize an UniFi Protect Switch."""
         super().__init__(data, device, description)
         self._attr_name = f"{self.device.display_name} {self.entity_description.name}"
-        self._switch_type = self.entity_description.key
 
     def _async_update_device_from_protect(self, device: ProtectModelWithId) -> None:
         super()._async_update_device_from_protect(device)

--- a/homeassistant/components/unifiprotect/text.py
+++ b/homeassistant/components/unifiprotect/text.py
@@ -18,7 +18,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .data import ProtectData, UFPConfigEntry
+from .data import UFPConfigEntry
 from .entity import ProtectDeviceEntity, async_all_device_entities
 from .models import PermRequired, ProtectEntityDescription, ProtectSetableKeysMixin, T
 
@@ -87,15 +87,6 @@ class ProtectDeviceText(ProtectDeviceEntity, TextEntity):
 
     entity_description: ProtectTextEntityDescription
     _state_attrs = ("_attr_available", "_attr_native_value")
-
-    def __init__(
-        self,
-        data: ProtectData,
-        device: ProtectAdoptableDeviceModel,
-        description: ProtectTextEntityDescription,
-    ) -> None:
-        """Initialize an UniFi Protect sensor."""
-        super().__init__(data, device, description)
 
     @callback
     def _async_update_device_from_protect(self, device: ProtectModelWithId) -> None:

--- a/homeassistant/components/unifiprotect/text.py
+++ b/homeassistant/components/unifiprotect/text.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .data import ProtectData, UFPConfigEntry
 from .entity import ProtectDeviceEntity, async_all_device_entities
-from .models import PermRequired, ProtectRequiredKeysMixin, ProtectSetableKeysMixin, T
+from .models import PermRequired, ProtectEntityDescription, ProtectSetableKeysMixin, T
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -50,7 +50,7 @@ CAMERA: tuple[ProtectTextEntityDescription, ...] = (
     ),
 )
 
-_MODEL_DESCRIPTIONS: dict[ModelType, Sequence[ProtectRequiredKeysMixin]] = {
+_MODEL_DESCRIPTIONS: dict[ModelType, Sequence[ProtectEntityDescription]] = {
     ModelType.CAMERA: CAMERA,
 }
 


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Cleanup unifiprotect entity model

The key change here is that instead of overriding the types from string to tuples, we build the functions instead so all the types line up nicely and we don't have to work out how the attribute is fetched every time `get_ufp_value`, `get_ufp_enabled`, or `has_required` is called since the function always knows what to do. The same is true for `get_event_obj`

The `ProtectEventMixin` was no longer a mixin so it was renamed to `ProtectEntityDescription` 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
