### PR TITLE
Add the ability to change the source entity of the Derivative helper

### DIFF
--- a/homeassistant/components/derivative/__init__.py
+++ b/homeassistant/components/derivative/__init__.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import CONF_SOURCE, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Derivative from a config entry."""
+
+    await async_remove_stale_device_links(
+        hass, entry.entry_id, entry.options[CONF_SOURCE]
+    )
+
     await hass.config_entries.async_forward_entry_setups(entry, (Platform.SENSOR,))
     entry.async_on_unload(entry.add_update_listener(config_entry_update_listener))
     return True
@@ -22,3 +28,27 @@ async def config_entry_update_listener(hass: HomeAssistant, entry: ConfigEntry) 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, (Platform.SENSOR,))
+
+
+async def async_remove_stale_device_links(
+    hass: HomeAssistant, entry_id: str, entity_id: str
+) -> None:
+    """Remove device link for entry, the source device may have changed."""
+
+    device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
+
+    # Resolve source entity device
+    current_device_id = None
+    if ((source_entity := entity_registry.async_get(entity_id)) is not None) and (
+        source_entity.device_id is not None
+    ):
+        current_device_id = source_entity.device_id
+
+    devices_in_entry = device_registry.devices.get_devices_for_config_entry_id(entry_id)
+
+    # Removes all devices from the config entry that are not the same as the current device
+    for device in devices_in_entry:
+        if device.id == current_device_id:
+            continue
+        device_registry.async_update_device(device.id, remove_config_entry_id=entry_id)

--- a/homeassistant/components/derivative/__init__.py
+++ b/homeassistant/components/derivative/__init__.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_SOURCE, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.device import (
+    async_remove_stale_devices_links_keep_entity_device,
+)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Derivative from a config entry."""
 
-    await async_remove_stale_device_links(
+    async_remove_stale_devices_links_keep_entity_device(
         hass, entry.entry_id, entry.options[CONF_SOURCE]
     )
 
@@ -28,27 +30,3 @@ async def config_entry_update_listener(hass: HomeAssistant, entry: ConfigEntry) 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, (Platform.SENSOR,))
-
-
-async def async_remove_stale_device_links(
-    hass: HomeAssistant, entry_id: str, entity_id: str
-) -> None:
-    """Remove device link for entry, the source device may have changed."""
-
-    device_registry = dr.async_get(hass)
-    entity_registry = er.async_get(hass)
-
-    # Resolve source entity device
-    current_device_id = None
-    if ((source_entity := entity_registry.async_get(entity_id)) is not None) and (
-        source_entity.device_id is not None
-    ):
-        current_device_id = source_entity.device_id
-
-    devices_in_entry = device_registry.devices.get_devices_for_config_entry_id(entry_id)
-
-    # Removes all devices from the config entry that are not the same as the current device
-    for device in devices_in_entry:
-        if device.id == current_device_id:
-            continue
-        device_registry.async_update_device(device.id, remove_config_entry_id=entry_id)

--- a/homeassistant/components/derivative/config_flow.py
+++ b/homeassistant/components/derivative/config_flow.py
@@ -44,6 +44,11 @@ TIME_UNITS = [
 
 OPTIONS_SCHEMA = vol.Schema(
     {
+        vol.Required(CONF_SOURCE): selector.EntitySelector(
+            selector.EntitySelectorConfig(
+                domain=[COUNTER_DOMAIN, INPUT_NUMBER_DOMAIN, SENSOR_DOMAIN]
+            ),
+        ),
         vol.Required(CONF_ROUND_DIGITS, default=2): selector.NumberSelector(
             selector.NumberSelectorConfig(
                 min=0,
@@ -67,11 +72,6 @@ OPTIONS_SCHEMA = vol.Schema(
 CONFIG_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_NAME): selector.TextSelector(),
-        vol.Required(CONF_SOURCE): selector.EntitySelector(
-            selector.EntitySelectorConfig(
-                domain=[COUNTER_DOMAIN, INPUT_NUMBER_DOMAIN, SENSOR_DOMAIN]
-            ),
-        ),
     }
 ).extend(OPTIONS_SCHEMA.schema)
 

--- a/homeassistant/components/derivative/config_flow.py
+++ b/homeassistant/components/derivative/config_flow.py
@@ -10,11 +10,19 @@ import voluptuous as vol
 from homeassistant.components.counter import DOMAIN as COUNTER_DOMAIN
 from homeassistant.components.input_number import DOMAIN as INPUT_NUMBER_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.const import CONF_NAME, CONF_SOURCE, UnitOfTime
+from homeassistant.const import (
+    ATTR_UNIT_OF_MEASUREMENT,
+    CONF_NAME,
+    CONF_SOURCE,
+    UnitOfTime,
+)
+from homeassistant.core import callback
 from homeassistant.helpers import selector
 from homeassistant.helpers.schema_config_entry_flow import (
+    SchemaCommonFlowHandler,
     SchemaConfigFlowHandler,
     SchemaFlowFormStep,
+    SchemaOptionsFlowHandler,
 )
 
 from .const import (
@@ -42,13 +50,43 @@ TIME_UNITS = [
     UnitOfTime.DAYS,
 ]
 
-OPTIONS_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_SOURCE): selector.EntitySelector(
-            selector.EntitySelectorConfig(
-                domain=[COUNTER_DOMAIN, INPUT_NUMBER_DOMAIN, SENSOR_DOMAIN]
-            ),
-        ),
+ALLOWED_DOMAINS = [COUNTER_DOMAIN, INPUT_NUMBER_DOMAIN, SENSOR_DOMAIN]
+
+
+@callback
+def entity_selector_compatible(
+    handler: SchemaOptionsFlowHandler,
+) -> selector.EntitySelector:
+    """Return an entity selector which compatible entities."""
+    current = handler.hass.states.get(handler.options[CONF_SOURCE])
+    unit_of_measurement = (
+        current.attributes.get(ATTR_UNIT_OF_MEASUREMENT) if current else None
+    )
+
+    entities = [
+        ent.entity_id
+        for ent in handler.hass.states.async_all(ALLOWED_DOMAINS)
+        if ent.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == unit_of_measurement
+        and ent.domain in ALLOWED_DOMAINS
+    ]
+
+    return selector.EntitySelector(
+        selector.EntitySelectorConfig(include_entities=entities)
+    )
+
+
+async def _get_options_dict(handler: SchemaCommonFlowHandler | None) -> dict:
+    if handler is None or not isinstance(
+        handler.parent_handler, SchemaOptionsFlowHandler
+    ):
+        entity_selector = selector.EntitySelector(
+            selector.EntitySelectorConfig(domain=ALLOWED_DOMAINS)
+        )
+    else:
+        entity_selector = entity_selector_compatible(handler.parent_handler)
+
+    return {
+        vol.Required(CONF_SOURCE): entity_selector,
         vol.Required(CONF_ROUND_DIGITS, default=2): selector.NumberSelector(
             selector.NumberSelectorConfig(
                 min=0,
@@ -67,20 +105,28 @@ OPTIONS_SCHEMA = vol.Schema(
             ),
         ),
     }
-)
 
-CONFIG_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_NAME): selector.TextSelector(),
-    }
-).extend(OPTIONS_SCHEMA.schema)
+
+async def _get_options_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
+    return vol.Schema(await _get_options_dict(handler))
+
+
+async def _get_config_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
+    options = await _get_options_dict(handler)
+    return vol.Schema(
+        {
+            vol.Required(CONF_NAME): selector.TextSelector(),
+            **options,
+        }
+    )
+
 
 CONFIG_FLOW = {
-    "user": SchemaFlowFormStep(CONFIG_SCHEMA),
+    "user": SchemaFlowFormStep(_get_config_schema),
 }
 
 OPTIONS_FLOW = {
-    "init": SchemaFlowFormStep(OPTIONS_SCHEMA),
+    "init": SchemaFlowFormStep(_get_options_schema),
 }
 
 

--- a/homeassistant/components/derivative/sensor.py
+++ b/homeassistant/components/derivative/sensor.py
@@ -20,11 +20,8 @@ from homeassistant.const import (
     UnitOfTime,
 )
 from homeassistant.core import Event, EventStateChangedData, HomeAssistant, callback
-from homeassistant.helpers import (
-    config_validation as cv,
-    device_registry as dr,
-    entity_registry as er,
-)
+from homeassistant.helpers import config_validation as cv, entity_registry as er
+from homeassistant.helpers.device import async_device_info_to_link_from_entity
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
@@ -90,27 +87,10 @@ async def async_setup_entry(
         registry, config_entry.options[CONF_SOURCE]
     )
 
-    source_entity = registry.async_get(source_entity_id)
-    dev_reg = dr.async_get(hass)
-    # Resolve source entity device
-    if (
-        (source_entity is not None)
-        and (source_entity.device_id is not None)
-        and (
-            (
-                device := dev_reg.async_get(
-                    device_id=source_entity.device_id,
-                )
-            )
-            is not None
-        )
-    ):
-        device_info = DeviceInfo(
-            identifiers=device.identifiers,
-            connections=device.connections,
-        )
-    else:
-        device_info = None
+    device_info = async_device_info_to_link_from_entity(
+        hass,
+        source_entity_id,
+    )
 
     if (unit_prefix := config_entry.options.get(CONF_UNIT_PREFIX)) == "none":
         # Before we had support for optional selectors, "none" was used for selecting nothing

--- a/tests/components/derivative/test_config_flow.py
+++ b/tests/components/derivative/test_config_flow.py
@@ -8,6 +8,7 @@ from homeassistant import config_entries
 from homeassistant.components.derivative.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import selector
 
 from tests.common import MockConfigEntry
 
@@ -95,6 +96,10 @@ async def test_options(hass: HomeAssistant, platform) -> None:
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
+    hass.states.async_set("sensor.input", 10, {"unit_of_measurement": "dog"})
+    hass.states.async_set("sensor.valid", 10, {"unit_of_measurement": "dog"})
+    hass.states.async_set("sensor.invalid", 10, {"unit_of_measurement": "cat"})
+
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "init"
@@ -104,10 +109,17 @@ async def test_options(hass: HomeAssistant, platform) -> None:
     assert get_suggested(schema, "unit_prefix") == "k"
     assert get_suggested(schema, "unit_time") == "min"
 
+    source = schema["source"]
+    assert isinstance(source, selector.EntitySelector)
+    assert source.config["include_entities"] == [
+        "sensor.input",
+        "sensor.valid",
+    ]
+
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "source": "sensor.input2",
+            "source": "sensor.valid",
             "round": 2.0,
             "time_window": {"seconds": 10.0},
             "unit_time": "h",
@@ -117,7 +129,7 @@ async def test_options(hass: HomeAssistant, platform) -> None:
     assert result["data"] == {
         "name": "My derivative",
         "round": 2.0,
-        "source": "sensor.input2",
+        "source": "sensor.valid",
         "time_window": {"seconds": 10.0},
         "unit_time": "h",
     }
@@ -125,7 +137,7 @@ async def test_options(hass: HomeAssistant, platform) -> None:
     assert config_entry.options == {
         "name": "My derivative",
         "round": 2.0,
-        "source": "sensor.input2",
+        "source": "sensor.valid",
         "time_window": {"seconds": 10.0},
         "unit_time": "h",
     }
@@ -135,11 +147,11 @@ async def test_options(hass: HomeAssistant, platform) -> None:
     await hass.async_block_till_done()
 
     # Check the entity was updated, no new entity was created
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all()) == 4
 
     # Check the state of the entity has changed as expected
-    hass.states.async_set("sensor.input2", 10, {"unit_of_measurement": "cat"})
-    hass.states.async_set("sensor.input2", 11, {"unit_of_measurement": "cat"})
+    hass.states.async_set("sensor.valid", 10, {"unit_of_measurement": "cat"})
+    hass.states.async_set("sensor.valid", 11, {"unit_of_measurement": "cat"})
     await hass.async_block_till_done()
     state = hass.states.get(f"{platform}.my_derivative")
     assert state.attributes["unit_of_measurement"] == "cat/h"

--- a/tests/components/derivative/test_config_flow.py
+++ b/tests/components/derivative/test_config_flow.py
@@ -107,6 +107,7 @@ async def test_options(hass: HomeAssistant, platform) -> None:
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
+            "source": "sensor.input2",
             "round": 2.0,
             "time_window": {"seconds": 10.0},
             "unit_time": "h",
@@ -115,8 +116,8 @@ async def test_options(hass: HomeAssistant, platform) -> None:
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         "name": "My derivative",
+        "source": "sensor.input2",
         "round": 2.0,
-        "source": "sensor.input",
         "time_window": {"seconds": 10.0},
         "unit_time": "h",
     }
@@ -124,7 +125,7 @@ async def test_options(hass: HomeAssistant, platform) -> None:
     assert config_entry.options == {
         "name": "My derivative",
         "round": 2.0,
-        "source": "sensor.input",
+        "source": "sensor.input2",
         "time_window": {"seconds": 10.0},
         "unit_time": "h",
     }

--- a/tests/components/derivative/test_config_flow.py
+++ b/tests/components/derivative/test_config_flow.py
@@ -116,8 +116,8 @@ async def test_options(hass: HomeAssistant, platform) -> None:
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         "name": "My derivative",
-        "source": "sensor.input2",
         "round": 2.0,
+        "source": "sensor.input2",
         "time_window": {"seconds": 10.0},
         "unit_time": "h",
     }

--- a/tests/components/derivative/test_config_flow.py
+++ b/tests/components/derivative/test_config_flow.py
@@ -138,8 +138,8 @@ async def test_options(hass: HomeAssistant, platform) -> None:
     assert len(hass.states.async_all()) == 1
 
     # Check the state of the entity has changed as expected
-    hass.states.async_set("sensor.input", 10, {"unit_of_measurement": "cat"})
-    hass.states.async_set("sensor.input", 11, {"unit_of_measurement": "cat"})
+    hass.states.async_set("sensor.input2", 10, {"unit_of_measurement": "cat"})
+    hass.states.async_set("sensor.input2", 11, {"unit_of_measurement": "cat"})
     await hass.async_block_till_done()
     state = hass.states.get(f"{platform}.my_derivative")
     assert state.attributes["unit_of_measurement"] == "cat/h"

--- a/tests/components/derivative/test_init.py
+++ b/tests/components/derivative/test_init.py
@@ -4,7 +4,7 @@ import pytest
 
 from homeassistant.components.derivative.const import DOMAIN
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.common import MockConfigEntry
 
@@ -60,3 +60,88 @@ async def test_setup_and_remove_config_entry(
     # Check the state and entity registry entry are removed
     assert hass.states.get(derivative_entity_id) is None
     assert entity_registry.async_get(derivative_entity_id) is None
+
+
+async def test_device_cleaning(hass: HomeAssistant) -> None:
+    """Test for source entity device for Derivative."""
+    device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
+
+    # Source entity device config entry
+    source_config_entry = MockConfigEntry()
+    source_config_entry.add_to_hass(hass)
+
+    # Device entry of the source entity
+    source_device1_entry = device_registry.async_get_or_create(
+        config_entry_id=source_config_entry.entry_id,
+        identifiers={("sensor", "identifier_test1")},
+        connections={("mac", "30:31:32:33:34:01")},
+    )
+
+    # Source entity registry
+    source_entity = entity_registry.async_get_or_create(
+        "sensor",
+        "test",
+        "source",
+        config_entry=source_config_entry,
+        device_id=source_device1_entry.id,
+    )
+    await hass.async_block_till_done()
+    assert entity_registry.async_get("sensor.test_source") is not None
+
+    # Configure the configuration entry for Derivative
+    derivative_config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            "name": "Derivative",
+            "round": 1.0,
+            "source": "sensor.test_source",
+            "time_window": {"seconds": 0.0},
+            "unit_prefix": "k",
+            "unit_time": "min",
+        },
+        title="Derivative",
+    )
+    derivative_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(derivative_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Confirm the link between the source entity device and the derivative sensor
+    derivative_entity = entity_registry.async_get("sensor.derivative")
+    assert derivative_entity is not None
+    assert derivative_entity.device_id == source_entity.device_id
+
+    # Device entry incorrectly linked to Derivative config entry
+    device_registry.async_get_or_create(
+        config_entry_id=derivative_config_entry.entry_id,
+        identifiers={("sensor", "identifier_test2")},
+        connections={("mac", "30:31:32:33:34:02")},
+    )
+    device_registry.async_get_or_create(
+        config_entry_id=derivative_config_entry.entry_id,
+        identifiers={("sensor", "identifier_test3")},
+        connections={("mac", "30:31:32:33:34:03")},
+    )
+    await hass.async_block_till_done()
+
+    # Before reloading the config entry, two devices are expected to be linked
+    devices_before_reload = device_registry.devices.get_devices_for_config_entry_id(
+        derivative_config_entry.entry_id
+    )
+    assert len(devices_before_reload) == 3
+
+    # Config entry reload
+    await hass.config_entries.async_reload(derivative_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Confirm the link between the source entity device and the derivative sensor after reload
+    derivative_entity = entity_registry.async_get("sensor.derivative")
+    assert derivative_entity is not None
+    assert derivative_entity.device_id == source_entity.device_id
+
+    # After reloading the config entry, only one linked device is expected
+    devices_after_reload = device_registry.devices.get_devices_for_config_entry_id(
+        derivative_config_entry.entry_id
+    )
+    assert len(devices_after_reload) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add the ability to change the source entity of the Derivative helper and handles cleanup of stale device links because of the entity change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
