### PR TITLE
Remove the switch entity for Shelly Gas Valve

### DIFF
--- a/homeassistant/components/shelly/valve.py
+++ b/homeassistant/components/shelly/valve.py
@@ -23,7 +23,7 @@ from .entity import (
     ShellyBlockAttributeEntity,
     async_setup_block_attribute_entities,
 )
-from .utils import get_device_entry_gen
+from .utils import async_remove_shelly_entity, get_device_entry_gen
 
 
 @dataclass(kw_only=True, frozen=True)
@@ -67,6 +67,9 @@ def async_setup_block_entry(
             {("valve", "valve"): GAS_VALVE},
             BlockShellyValve,
         )
+        # Remove deprecated switch entity for gas valve
+        unique_id = f"{coordinator.mac}-valve_0-valve"
+        async_remove_shelly_entity(hass, "switch", unique_id)
 
 
 class BlockShellyValve(ShellyBlockAttributeEntity, ValveEntity):

--- a/tests/components/shelly/test_switch.py
+++ b/tests/components/shelly/test_switch.py
@@ -7,10 +7,7 @@ from aioshelly.const import MODEL_GAS
 from aioshelly.exceptions import DeviceConnectionError, InvalidAuthError, RpcCallError
 import pytest
 
-from homeassistant.components import automation, script
-from homeassistant.components.automation import automations_with_entity
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
-from homeassistant.components.script import scripts_with_entity
 from homeassistant.components.shelly.const import (
     DOMAIN,
     MODEL_WALL_DISPLAY,
@@ -30,8 +27,6 @@ from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceRegistry
 from homeassistant.helpers.entity_registry import EntityRegistry
-import homeassistant.helpers.issue_registry as ir
-from homeassistant.setup import async_setup_component
 
 from . import get_entity_state, init_integration, register_device, register_entity
 
@@ -388,13 +383,12 @@ async def test_rpc_auth_error(
     assert flow["context"].get("entry_id") == entry.entry_id
 
 
-async def test_block_device_gas_valve(
+async def test_remove_gas_valve_switch(
     hass: HomeAssistant,
     mock_block_device: Mock,
     entity_registry: EntityRegistry,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test block device Shelly Gas with Valve addon."""
+    """Test removing deprecated switch entity for Shelly Gas Valve."""
     entity_id = register_entity(
         hass,
         SWITCH_DOMAIN,
@@ -403,41 +397,7 @@ async def test_block_device_gas_valve(
     )
     await init_integration(hass, 1, MODEL_GAS)
 
-    entry = entity_registry.async_get(entity_id)
-    assert entry
-    assert entry.unique_id == "123456789ABC-valve_0-valve"
-
-    assert hass.states.get(entity_id).state == STATE_OFF  # valve is closed
-
-    await hass.services.async_call(
-        SWITCH_DOMAIN,
-        SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: entity_id},
-        blocking=True,
-    )
-
-    state = hass.states.get(entity_id)
-    assert state
-    assert state.state == STATE_ON  # valve is open
-
-    await hass.services.async_call(
-        SWITCH_DOMAIN,
-        SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: entity_id},
-        blocking=True,
-    )
-
-    state = hass.states.get(entity_id)
-    assert state
-    assert state.state == STATE_OFF  # valve is closed
-
-    monkeypatch.setattr(mock_block_device.blocks[GAS_VALVE_BLOCK_ID], "valve", "opened")
-    mock_block_device.mock_update()
-    await hass.async_block_till_done()
-
-    state = hass.states.get(entity_id)
-    assert state
-    assert state.state == STATE_ON  # valve is open
+    assert entity_registry.async_get(entity_id) is None
 
 
 async def test_wall_display_relay_mode(
@@ -470,63 +430,3 @@ async def test_wall_display_relay_mode(
     entry = entity_registry.async_get(switch_entity_id)
     assert entry
     assert entry.unique_id == "123456789ABC-switch:0"
-
-
-@pytest.mark.usefixtures("entity_registry_enabled_by_default")
-async def test_create_issue_valve_switch(
-    hass: HomeAssistant,
-    mock_block_device: Mock,
-    monkeypatch: pytest.MonkeyPatch,
-    issue_registry: ir.IssueRegistry,
-) -> None:
-    """Test we create an issue when an automation or script is using a deprecated entity."""
-    monkeypatch.setitem(mock_block_device.status, "cloud", {"connected": False})
-    entity_id = register_entity(
-        hass,
-        SWITCH_DOMAIN,
-        "test_name_valve",
-        "valve_0-valve",
-    )
-
-    assert await async_setup_component(
-        hass,
-        automation.DOMAIN,
-        {
-            automation.DOMAIN: {
-                "alias": "test",
-                "trigger": {"platform": "state", "entity_id": entity_id},
-                "action": {"service": "switch.turn_on", "entity_id": entity_id},
-            }
-        },
-    )
-    assert await async_setup_component(
-        hass,
-        script.DOMAIN,
-        {
-            script.DOMAIN: {
-                "test": {
-                    "sequence": [
-                        {
-                            "service": "switch.turn_on",
-                            "data": {"entity_id": entity_id},
-                        },
-                    ],
-                }
-            }
-        },
-    )
-
-    await init_integration(hass, 1, MODEL_GAS)
-
-    assert automations_with_entity(hass, entity_id)[0] == "automation.test"
-    assert scripts_with_entity(hass, entity_id)[0] == "script.test"
-
-    assert issue_registry.async_get_issue(DOMAIN, "deprecated_valve_switch")
-    assert issue_registry.async_get_issue(
-        DOMAIN, "deprecated_valve_switch.test_name_valve_automation.test"
-    )
-    assert issue_registry.async_get_issue(
-        DOMAIN, "deprecated_valve_switch.test_name_valve_script.test"
-    )
-
-    assert len(issue_registry.issues) == 3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The switch entity for Shelly Gas Valve Add-on is removed, the valve entity is available instead. Please adjust any automations or scripts.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As announced here [#106087](https://github.com/home-assistant/core/pull/106087), the switch entity for Shelly Gas Valve is removed and replaced with the valve entity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33299

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
