### PR TITLE
Move fixtures to decorators in netgear_lte tests

### DIFF
--- a/tests/components/netgear_lte/test_init.py
+++ b/tests/components/netgear_lte/test_init.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from unittest.mock import patch
 
 from eternalegypt.eternalegypt import Error
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.netgear_lte.const import DOMAIN
@@ -18,7 +19,8 @@ from .conftest import CONF_DATA
 from tests.common import async_fire_time_changed
 
 
-async def test_setup_unload(hass: HomeAssistant, setup_integration: None) -> None:
+@pytest.mark.usefixtures("setup_integration")
+async def test_setup_unload(hass: HomeAssistant) -> None:
     """Test setup and unload."""
     entry = hass.config_entries.async_entries(DOMAIN)[0]
     assert entry.state is ConfigEntryState.LOADED
@@ -31,19 +33,18 @@ async def test_setup_unload(hass: HomeAssistant, setup_integration: None) -> Non
     assert not hass.data.get(DOMAIN)
 
 
-async def test_async_setup_entry_not_ready(
-    hass: HomeAssistant, setup_cannot_connect: None
-) -> None:
+@pytest.mark.usefixtures("setup_cannot_connect")
+async def test_async_setup_entry_not_ready(hass: HomeAssistant) -> None:
     """Test that it throws ConfigEntryNotReady when exception occurs during setup."""
     entry = hass.config_entries.async_entries(DOMAIN)[0]
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
+@pytest.mark.usefixtures("setup_integration")
 async def test_device(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
-    setup_integration: None,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test device info."""
@@ -53,11 +54,8 @@ async def test_device(
     assert device == snapshot
 
 
-async def test_update_failed(
-    hass: HomeAssistant,
-    entity_registry_enabled_by_default: None,
-    setup_integration: None,
-) -> None:
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "setup_integration")
+async def test_update_failed(hass: HomeAssistant) -> None:
     """Test coordinator throws UpdateFailed after failed update."""
     with patch(
         "homeassistant.components.netgear_lte.eternalegypt.Modem.information",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #119279
```
************* Module tests.components.netgear_lte.test_init
tests/components/netgear_lte/test_init.py:58:4: W7433: Argument entity_registry_enabled_by_default is of type None and could be moved to `@pytest.mark.usefixtures` decorator in test_update_failed (hass-consider-usefixtures-decorator)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
