### PR TITLE
Deprecate register_static_path in favor of async_register_static_paths

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -34,7 +34,7 @@ from homeassistant.components.network import async_get_source_ip
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, SERVER_PORT
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import storage
+from homeassistant.helpers import frame, storage
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.http import (
     KEY_ALLOW_CONFIGRED_CORS,
@@ -480,6 +480,15 @@ class HomeAssistantHTTP:
         self, url_path: str, path: str, cache_headers: bool = True
     ) -> None:
         """Register a folder or file to serve as a static path."""
+        frame.report(
+            "calls hass.http.register_static_path which is deprecated because "
+            "it does blocking I/O in the event loop, instead "
+            "call `await hass.http.async_register_static_path("
+            f'[StaticPathConfig("{url_path}", "{path}", {cache_headers})])`',
+            exclude_integrations={"http"},
+            error_if_core=False,
+            error_if_integration=False,
+        )
         configs = [StaticPathConfig(url_path, path, cache_headers)]
         resources = self._make_static_resources(configs)
         self._async_register_static_paths(configs, resources)

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -484,8 +484,8 @@ class HomeAssistantHTTP:
             "calls hass.http.register_static_path which is deprecated because "
             "it does blocking I/O in the event loop, instead "
             "call `await hass.http.async_register_static_path("
-            f'[StaticPathConfig("{url_path}", "{path}", {cache_headers})])`;'
-            "  This function will be removed in 2025.7",
+            f'[StaticPathConfig("{url_path}", "{path}", {cache_headers})])`; '
+            "This function will be removed in 2025.7",
             exclude_integrations={"http"},
             error_if_core=False,
             error_if_integration=False,

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -484,7 +484,8 @@ class HomeAssistantHTTP:
             "calls hass.http.register_static_path which is deprecated because "
             "it does blocking I/O in the event loop, instead "
             "call `await hass.http.async_register_static_path("
-            f'[StaticPathConfig("{url_path}", "{path}", {cache_headers})])`',
+            f'[StaticPathConfig("{url_path}", "{path}", {cache_headers})])`;'
+            "  This function will be removed in 2025.7",
             exclude_integrations={"http"},
             error_if_core=False,
             error_if_integration=False,

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -526,3 +526,24 @@ async def test_logging(
     response = await client.get("/api/states/logging.entity")
     assert response.status == HTTPStatus.OK
     assert "GET /api/states/logging.entity" not in caplog.text
+
+
+async def test_register_static_paths(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test registering a static path with old api."""
+    assert await async_setup_component(hass, "frontend", {})
+    path = str(Path(__file__).parent)
+    hass.http.register_static_path("/something", path)
+    client = await hass_client()
+    resp = await client.get("/something/__init__.py")
+    assert resp.status == HTTPStatus.OK
+
+    assert (
+        "Detected code that calls hass.http.register_static_path "
+        "which is deprecated because it does blocking I/O in the "
+        "event loop, instead call "
+        "`await hass.http.async_register_static_path"
+    ) in caplog.text


### PR DESCRIPTION
blog post https://github.com/home-assistant/developers.home-assistant/pull/2222

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`hass.http.register_static_path` is deprecated because it does blocking I/O in the event loop, instead call `await hass.http.async_register_static_paths([StaticPathConfig(url_path, path, cache_headers)])`

The arguments to `async_register_static_path` are the same as `register_static_path` except they are wrapped in the `StaticPathConfig` `dataclass` and an `Iterable` of them is accepted to allow registering multiple paths at once to avoid multiple executor jobs.

For example, if your integration called
`hass.http.register_static_path("/integrations/photos","/config/photos",True)`, it should now call `await hass.http.async_register_static_paths([StaticPathConfig("/integrations/photos","/config/photos",True)])`

The `StaticPathConfig` `dataclass` should be imported from `homeassistant.components.http`

`hass.http.register_static_path` will be removed in 2025.7

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
