### PR TITLE
Fix typo in KEY_ALLOW_CONFIGRED_CORS

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -37,7 +37,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import storage
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.http import (
-    KEY_ALLOW_CONFIGRED_CORS,
+    KEY_ALLOW_CONFIGURED_CORS,
     KEY_AUTHENTICATED,  # noqa: F401
     KEY_HASS,
     HomeAssistantView,
@@ -427,7 +427,7 @@ class HomeAssistantHTTP:
             # Should be instance of aiohttp.web_exceptions._HTTPMove.
             raise redirect_exc(redirect_to)  # type: ignore[arg-type,misc]
 
-        self.app[KEY_ALLOW_CONFIGRED_CORS](
+        self.app[KEY_ALLOW_CONFIGURED_CORS](
             self.app.router.add_route("GET", url, redirect)
         )
 
@@ -461,7 +461,7 @@ class HomeAssistantHTTP:
     ) -> None:
         """Register a folders or files to serve as a static path."""
         app = self.app
-        allow_cors = app[KEY_ALLOW_CONFIGRED_CORS]
+        allow_cors = app[KEY_ALLOW_CONFIGURED_CORS]
         for config in configs:
             if resource := resources[config.url_path]:
                 app.router.register_resource(resource)

--- a/homeassistant/components/http/cors.py
+++ b/homeassistant/components/http/cors.py
@@ -19,7 +19,7 @@ from homeassistant.const import HTTP_HEADER_X_REQUESTED_WITH
 from homeassistant.core import callback
 from homeassistant.helpers.http import (
     KEY_ALLOW_ALL_CORS,
-    KEY_ALLOW_CONFIGRED_CORS,
+    KEY_ALLOW_CONFIGURED_CORS,
     AllowCorsType,
 )
 
@@ -82,6 +82,6 @@ def setup_cors(app: Application, origins: list[str]) -> None:
     )
 
     if origins:
-        app[KEY_ALLOW_CONFIGRED_CORS] = cast(AllowCorsType, _allow_cors)
+        app[KEY_ALLOW_CONFIGURED_CORS] = cast(AllowCorsType, _allow_cors)
     else:
-        app[KEY_ALLOW_CONFIGRED_CORS] = lambda _: None
+        app[KEY_ALLOW_CONFIGURED_CORS] = lambda _: None

--- a/homeassistant/helpers/http.py
+++ b/homeassistant/helpers/http.py
@@ -33,7 +33,7 @@ _LOGGER = logging.getLogger(__name__)
 type AllowCorsType = Callable[[AbstractRoute | AbstractResource], None]
 KEY_AUTHENTICATED: Final = "ha_authenticated"
 KEY_ALLOW_ALL_CORS = AppKey[AllowCorsType]("allow_all_cors")
-KEY_ALLOW_CONFIGRED_CORS = AppKey[AllowCorsType]("allow_configured_cors")
+KEY_ALLOW_CONFIGURED_CORS = AppKey[AllowCorsType]("allow_configured_cors")
 KEY_HASS: AppKey[HomeAssistant] = AppKey("hass")
 
 current_request: ContextVar[Request | None] = ContextVar(
@@ -181,7 +181,7 @@ class HomeAssistantView:
         if self.cors_allowed:
             allow_cors = app.get(KEY_ALLOW_ALL_CORS)
         else:
-            allow_cors = app.get(KEY_ALLOW_CONFIGRED_CORS)
+            allow_cors = app.get(KEY_ALLOW_CONFIGURED_CORS)
 
         if allow_cors:
             for route in routes:

--- a/tests/components/http/test_cors.py
+++ b/tests/components/http/test_cors.py
@@ -20,7 +20,7 @@ import pytest
 from homeassistant.components.http.cors import setup_cors
 from homeassistant.components.http.view import HomeAssistantView
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.http import KEY_ALLOW_CONFIGRED_CORS
+from homeassistant.helpers.http import KEY_ALLOW_CONFIGURED_CORS
 from homeassistant.setup import async_setup_component
 
 from . import HTTP_HEADER_HA_AUTH
@@ -62,7 +62,7 @@ def client(
     """Fixture to set up a web.Application."""
     app = web.Application()
     setup_cors(app, [TRUSTED_ORIGIN])
-    app[KEY_ALLOW_CONFIGRED_CORS](app.router.add_get("/", mock_handler))
+    app[KEY_ALLOW_CONFIGURED_CORS](app.router.add_get("/", mock_handler))
     return event_loop.run_until_complete(aiohttp_client(app))
 
 

--- a/tests/components/http/test_data_validator.py
+++ b/tests/components/http/test_data_validator.py
@@ -8,7 +8,7 @@ import voluptuous as vol
 
 from homeassistant.components.http import KEY_HASS, HomeAssistantView
 from homeassistant.components.http.data_validator import RequestDataValidator
-from homeassistant.helpers.http import KEY_ALLOW_CONFIGRED_CORS
+from homeassistant.helpers.http import KEY_ALLOW_CONFIGURED_CORS
 
 from tests.typing import ClientSessionGenerator
 
@@ -17,7 +17,7 @@ async def get_client(aiohttp_client, validator):
     """Generate a client that hits a view decorated with validator."""
     app = web.Application()
     app[KEY_HASS] = Mock(is_stopping=False)
-    app[KEY_ALLOW_CONFIGRED_CORS] = lambda _: None
+    app[KEY_ALLOW_CONFIGURED_CORS] = lambda _: None
 
     class TestView(HomeAssistantView):
         url = "/"

--- a/tests/components/http/test_static.py
+++ b/tests/components/http/test_static.py
@@ -10,7 +10,7 @@ import pytest
 from homeassistant.components.http import StaticPathConfig
 from homeassistant.components.http.static import CachingStaticResource, _get_file_path
 from homeassistant.core import EVENT_HOMEASSISTANT_START, HomeAssistant
-from homeassistant.helpers.http import KEY_ALLOW_CONFIGRED_CORS
+from homeassistant.helpers.http import KEY_ALLOW_CONFIGURED_CORS
 from homeassistant.setup import async_setup_component
 
 from tests.typing import ClientSessionGenerator
@@ -51,7 +51,7 @@ async def test_static_path_blocks_anchors(
     resource = CachingStaticResource(url, str(tmp_path))
     assert resource.canonical == canonical_url
     app.router.register_resource(resource)
-    app[KEY_ALLOW_CONFIGRED_CORS](resource)
+    app[KEY_ALLOW_CONFIGURED_CORS](resource)
 
     resp = await mock_http_client.get(canonical_url, allow_redirects=False)
     assert resp.status == 403


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It should have been KEY_ALLOW_CONFIGURED_CORS


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
