### PR TITLE
Remove deprecated blink refresh service

### DIFF
--- a/homeassistant/components/blink/const.py
+++ b/homeassistant/components/blink/const.py
@@ -21,7 +21,6 @@ TYPE_BATTERY = "battery"
 TYPE_WIFI_STRENGTH = "wifi_strength"
 
 SERVICE_RECORD = "record"
-SERVICE_REFRESH = "blink_update"
 SERVICE_TRIGGER = "trigger_camera"
 SERVICE_SAVE_VIDEO = "save_video"
 SERVICE_SAVE_RECENT_CLIPS = "save_recent_clips"

--- a/homeassistant/components/blink/icons.json
+++ b/homeassistant/components/blink/icons.json
@@ -12,7 +12,6 @@
     }
   },
   "services": {
-    "blink_update": "mdi:update",
     "record": "mdi:video-box",
     "trigger_camera": "mdi:image-refresh",
     "save_video": "mdi:file-video",

--- a/homeassistant/components/blink/services.py
+++ b/homeassistant/components/blink/services.py
@@ -8,13 +8,9 @@ from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import ATTR_DEVICE_ID, CONF_PIN
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
-from homeassistant.helpers import (
-    config_validation as cv,
-    device_registry as dr,
-    issue_registry as ir,
-)
+from homeassistant.helpers import config_validation as cv, device_registry as dr
 
-from .const import ATTR_CONFIG_ENTRY_ID, DOMAIN, SERVICE_REFRESH, SERVICE_SEND_PIN
+from .const import ATTR_CONFIG_ENTRY_ID, DOMAIN, SERVICE_SEND_PIN
 from .coordinator import BlinkUpdateCoordinator
 
 SERVICE_UPDATE_SCHEMA = vol.Schema(
@@ -93,33 +89,9 @@ def setup_services(hass: HomeAssistant) -> None:
                 call.data[CONF_PIN],
             )
 
-    async def blink_refresh(call: ServiceCall):
-        """Call blink to refresh info."""
-        ir.async_create_issue(
-            hass,
-            DOMAIN,
-            "service_deprecation",
-            breaks_in_ha_version="2024.7.0",
-            is_fixable=True,
-            is_persistent=True,
-            severity=ir.IssueSeverity.WARNING,
-            translation_key="service_deprecation",
-        )
-
-        for coordinator in collect_coordinators(call.data[ATTR_DEVICE_ID]):
-            await coordinator.api.refresh(force_cache=True)
-
-    # Register all the above services
-    # Refresh service is deprecated and will be removed in 7/2024
-    service_mapping = [
-        (blink_refresh, SERVICE_REFRESH, SERVICE_UPDATE_SCHEMA),
-        (send_pin, SERVICE_SEND_PIN, SERVICE_SEND_PIN_SCHEMA),
-    ]
-
-    for service_handler, service_name, schema in service_mapping:
-        hass.services.async_register(
-            DOMAIN,
-            service_name,
-            service_handler,
-            schema=schema,
-        )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SEND_PIN,
+        send_pin,
+        schema=SERVICE_SEND_PIN_SCHEMA,
+    )

--- a/homeassistant/components/blink/services.yaml
+++ b/homeassistant/components/blink/services.yaml
@@ -1,13 +1,5 @@
 # Describes the format for available Blink services
 
-blink_update:
-  fields:
-    device_id:
-      required: true
-      selector:
-        device:
-          integration: blink
-
 record:
   target:
     entity:

--- a/homeassistant/components/blink/strings.json
+++ b/homeassistant/components/blink/strings.json
@@ -55,16 +55,6 @@
     }
   },
   "services": {
-    "blink_update": {
-      "name": "Update",
-      "description": "Forces a refresh.",
-      "fields": {
-        "device_id": {
-          "name": "Device ID",
-          "description": "The Blink device id."
-        }
-      }
-    },
     "record": {
       "name": "Record",
       "description": "Requests camera to record a clip."

--- a/tests/components/blink/test_init.py
+++ b/tests/components/blink/test_init.py
@@ -8,7 +8,6 @@ import pytest
 
 from homeassistant.components.blink.const import (
     DOMAIN,
-    SERVICE_REFRESH,
     SERVICE_SAVE_VIDEO,
     SERVICE_SEND_PIN,
 )
@@ -82,7 +81,6 @@ async def test_unload_entry_multiple(
     assert mock_config_entry.state is ConfigEntryState.LOADED
     assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
-    assert hass.services.has_service(DOMAIN, SERVICE_REFRESH)
     assert hass.services.has_service(DOMAIN, SERVICE_SAVE_VIDEO)
     assert hass.services.has_service(DOMAIN, SERVICE_SEND_PIN)
 

--- a/tests/components/blink/test_services.py
+++ b/tests/components/blink/test_services.py
@@ -7,14 +7,12 @@ import pytest
 from homeassistant.components.blink.const import (
     ATTR_CONFIG_ENTRY_ID,
     DOMAIN,
-    SERVICE_REFRESH,
     SERVICE_SEND_PIN,
 )
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import ATTR_DEVICE_ID, CONF_PIN
+from homeassistant.const import CONF_PIN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import device_registry as dr
 
 from tests.common import MockConfigEntry
 
@@ -91,47 +89,6 @@ async def test_service_pin_called_with_non_blink_device(
         )
 
 
-async def test_service_update_called_with_non_blink_device(
-    hass: HomeAssistant,
-    mock_blink_api: MagicMock,
-    device_registry: dr.DeviceRegistry,
-    mock_blink_auth_api: MagicMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test update service calls with non blink device."""
-
-    mock_config_entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    other_domain = "NotBlink"
-    other_config_id = "555"
-    other_mock_config_entry = MockConfigEntry(
-        title="Not Blink", domain=other_domain, entry_id=other_config_id
-    )
-    other_mock_config_entry.add_to_hass(hass)
-
-    device_entry = device_registry.async_get_or_create(
-        config_entry_id=other_config_id,
-        identifiers={
-            (other_domain, 1),
-        },
-    )
-
-    hass.config.is_allowed_path = Mock(return_value=True)
-    mock_blink_api.cameras = {CAMERA_NAME: AsyncMock()}
-
-    parameters = {ATTR_DEVICE_ID: [device_entry.id]}
-
-    with pytest.raises(HomeAssistantError):
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_REFRESH,
-            parameters,
-            blocking=True,
-        )
-
-
 async def test_service_pin_called_with_unloaded_entry(
     hass: HomeAssistant,
     mock_blink_api: MagicMock,
@@ -153,37 +110,6 @@ async def test_service_pin_called_with_unloaded_entry(
         await hass.services.async_call(
             DOMAIN,
             SERVICE_SEND_PIN,
-            parameters,
-            blocking=True,
-        )
-
-
-async def test_service_update_called_with_unloaded_entry(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    mock_blink_api: MagicMock,
-    mock_blink_auth_api: MagicMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test update service calls with not ready config entry."""
-
-    mock_config_entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    mock_config_entry.mock_state(hass, ConfigEntryState.SETUP_ERROR)
-    hass.config.is_allowed_path = Mock(return_value=True)
-    mock_blink_api.cameras = {CAMERA_NAME: AsyncMock()}
-
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "12345")})
-    assert device_entry
-
-    parameters = {ATTR_DEVICE_ID: [device_entry.id]}
-
-    with pytest.raises(HomeAssistantError):
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_REFRESH,
             parameters,
             blocking=True,
         )

--- a/tests/components/blink/test_services.py
+++ b/tests/components/blink/test_services.py
@@ -23,43 +23,6 @@ FILENAME = "blah"
 PIN = "1234"
 
 
-async def test_refresh_service_calls(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    mock_blink_api: MagicMock,
-    mock_blink_auth_api: MagicMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test refrest service calls."""
-
-    mock_config_entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "12345")})
-    assert device_entry
-
-    assert mock_config_entry.state is ConfigEntryState.LOADED
-    assert mock_blink_api.refresh.call_count == 1
-
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_REFRESH,
-        {ATTR_DEVICE_ID: [device_entry.id]},
-        blocking=True,
-    )
-
-    assert mock_blink_api.refresh.call_count == 2
-
-    with pytest.raises(HomeAssistantError):
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_REFRESH,
-            {ATTR_DEVICE_ID: ["bad-device_id"]},
-            blocking=True,
-        )
-
-
 async def test_pin_service_calls(
     hass: HomeAssistant,
     mock_blink_api: MagicMock,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Blink update service has been deprecated and has now been removed

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Removes deprecated service in blink

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 