### PR TITLE
Add support for Shelly virtual `boolean` component

### DIFF
--- a/homeassistant/components/shelly/binary_sensor.py
+++ b/homeassistant/components/shelly/binary_sensor.py
@@ -221,8 +221,6 @@ RPC_SENSORS: Final = {
     "boolean": RpcBinarySensorDescription(
         key="boolean",
         sub_key="value",
-        removal_condition=lambda config, _, key: config[key]["meta"]["ui"]["view"]
-        != "label",
     ),
 }
 

--- a/homeassistant/components/shelly/binary_sensor.py
+++ b/homeassistant/components/shelly/binary_sensor.py
@@ -8,6 +8,7 @@ from typing import Final, cast
 from aioshelly.const import RPC_GENERATIONS
 
 from homeassistant.components.binary_sensor import (
+    DOMAIN as BINARY_SENSOR_PLATFORM,
     BinarySensorDeviceClass,
     BinarySensorEntity,
     BinarySensorEntityDescription,
@@ -33,7 +34,9 @@ from .entity import (
     async_setup_entry_rpc,
 )
 from .utils import (
+    async_remove_orphaned_virtual_entities,
     get_device_entry_gen,
+    get_virtual_component_ids,
     is_block_momentary_input,
     is_rpc_momentary_input,
 )
@@ -240,6 +243,21 @@ async def async_setup_entry(
                 RpcSleepingBinarySensor,
             )
         else:
+            coordinator = config_entry.runtime_data.rpc
+            assert coordinator
+
+            virtual_switch_ids = get_virtual_component_ids(
+                coordinator.device.config, BINARY_SENSOR_PLATFORM
+            )
+            async_remove_orphaned_virtual_entities(
+                hass,
+                config_entry.entry_id,
+                coordinator.mac,
+                BINARY_SENSOR_PLATFORM,
+                "boolean",
+                virtual_switch_ids,
+            )
+
             async_setup_entry_rpc(
                 hass, config_entry, async_add_entities, RPC_SENSORS, RpcBinarySensor
             )

--- a/homeassistant/components/shelly/binary_sensor.py
+++ b/homeassistant/components/shelly/binary_sensor.py
@@ -215,6 +215,12 @@ RPC_SENSORS: Final = {
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    "boolean": RpcBinarySensorDescription(
+        key="boolean",
+        sub_key="value",
+        removal_condition=lambda config, _, key: config[key]["meta"]["ui"]["view"]
+        != "label",
+    ),
 }
 
 

--- a/homeassistant/components/shelly/binary_sensor.py
+++ b/homeassistant/components/shelly/binary_sensor.py
@@ -244,9 +244,13 @@ async def async_setup_entry(
             coordinator = config_entry.runtime_data.rpc
             assert coordinator
 
+            async_setup_entry_rpc(
+                hass, config_entry, async_add_entities, RPC_SENSORS, RpcBinarySensor
+            )
+
             # the user can remove virtual components from the device configuration, so
             # we need to remove orphaned entities
-            virtual_switch_ids = get_virtual_component_ids(
+            virtual_binary_sensor_ids = get_virtual_component_ids(
                 coordinator.device.config, BINARY_SENSOR_PLATFORM
             )
             async_remove_orphaned_virtual_entities(
@@ -255,11 +259,7 @@ async def async_setup_entry(
                 coordinator.mac,
                 BINARY_SENSOR_PLATFORM,
                 "boolean",
-                virtual_switch_ids,
-            )
-
-            async_setup_entry_rpc(
-                hass, config_entry, async_add_entities, RPC_SENSORS, RpcBinarySensor
+                virtual_binary_sensor_ids,
             )
         return
 

--- a/homeassistant/components/shelly/binary_sensor.py
+++ b/homeassistant/components/shelly/binary_sensor.py
@@ -246,6 +246,8 @@ async def async_setup_entry(
             coordinator = config_entry.runtime_data.rpc
             assert coordinator
 
+            # the user can remove virtual components from the device configuration, so
+            # we need to remove orphaned entities
             virtual_switch_ids = get_virtual_component_ids(
                 coordinator.device.config, BINARY_SENSOR_PLATFORM
             )

--- a/homeassistant/components/shelly/binary_sensor.py
+++ b/homeassistant/components/shelly/binary_sensor.py
@@ -221,6 +221,7 @@ RPC_SENSORS: Final = {
     "boolean": RpcBinarySensorDescription(
         key="boolean",
         sub_key="value",
+        has_entity_name=True,
     ),
 }
 

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -238,3 +238,8 @@ DEVICES_WITHOUT_FIRMWARE_CHANGELOG = (
 CONF_GEN = "gen"
 
 SHELLY_PLUS_RGBW_CHANNELS = 4
+
+VIRTUAL_COMPONENTS_MAP = {
+    "binary_sensor": {"type": "boolean", "mode": "label"},
+    "switch": {"type": "boolean", "mode": "toggle"},
+}

--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -551,7 +551,7 @@ class ShellyRpcCoordinator(ShellyCoordinatorBase[RpcDevice]):
             for event_callback in self._event_listeners:
                 event_callback(event)
 
-            if event_type == "config_changed":
+            if event_type in ("component_added", "component_removed", "config_changed"):
                 self.update_sleep_period()
                 LOGGER.info(
                     "Config for %s changed, reloading entry in %s seconds",

--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -739,6 +739,7 @@ class ShellyRpcPollingCoordinator(ShellyCoordinatorBase[RpcDevice]):
         LOGGER.debug("Polling Shelly RPC Device - %s", self.name)
         try:
             await self.device.update_status()
+            await self.device.get_dynamic_components()
         except (DeviceConnectionError, RpcCallError) as err:
             raise UpdateFailed(f"Device disconnected: {err!r}") from err
         except InvalidAuthError:

--- a/homeassistant/components/shelly/entity.py
+++ b/homeassistant/components/shelly/entity.py
@@ -505,6 +505,8 @@ class ShellyRpcAttributeEntity(ShellyRpcEntity, Entity):
         self._attr_unique_id = f"{super().unique_id}-{attribute}"
         self._attr_name = get_rpc_entity_name(coordinator.device, key, description.name)
         self._last_value = None
+        id_key = key.split(":")[-1]
+        self._id = int(id_key) if id_key.isnumeric() else None
 
     @property
     def sub_status(self) -> Any:

--- a/homeassistant/components/shelly/manifest.json
+++ b/homeassistant/components/shelly/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_push",
   "loggers": ["aioshelly"],
   "quality_scale": "platinum",
-  "requirements": ["aioshelly==11.0.0"],
+  "requirements": ["aioshelly==11.1.0"],
   "zeroconf": [
     {
       "type": "_http._tcp.local.",

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -138,7 +138,6 @@ def async_setup_rpc_entry(
     coordinator = config_entry.runtime_data.rpc
     assert coordinator
     switch_key_ids = get_rpc_key_ids(coordinator.device.status, "switch")
-    switches: list[ShellyRpcEntity] = []
 
     switch_ids = []
     for id_ in switch_key_ids:
@@ -173,10 +172,10 @@ def async_setup_rpc_entry(
         RpcVirtualSwitch,
     )
 
-    if not switches:
+    if not switch_ids:
         return
 
-    async_add_entities(switches)
+    async_add_entities(RpcRelaySwitch(coordinator, id_) for id_ in switch_ids)
 
 
 class BlockSleepingMotionSwitch(

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -8,7 +8,11 @@ from typing import Any, cast
 from aioshelly.block_device import Block
 from aioshelly.const import MODEL_2, MODEL_25, MODEL_WALL_DISPLAY, RPC_GENERATIONS
 
-from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.components.switch import (
+    DOMAIN as SWITCH_PLATFORM,
+    SwitchEntity,
+    SwitchEntityDescription,
+)
 from homeassistant.const import STATE_ON, EntityCategory
 from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -28,9 +32,11 @@ from .entity import (
     async_setup_rpc_attribute_entities,
 )
 from .utils import (
+    async_remove_orphaned_virtual_entities,
     async_remove_shelly_entity,
     get_device_entry_gen,
     get_rpc_key_ids,
+    get_virtual_component_ids,
     is_block_channel_type_light,
     is_rpc_channel_type_light,
     is_rpc_thermostat_internal_actuator,
@@ -170,6 +176,18 @@ def async_setup_rpc_entry(
         async_add_entities,
         {"boolean": RPC_VIRTUAL_SWITCH},
         RpcVirtualSwitch,
+    )
+
+    virtual_switch_ids = get_virtual_component_ids(
+        coordinator.device.config, SWITCH_PLATFORM
+    )
+    async_remove_orphaned_virtual_entities(
+        hass,
+        config_entry.entry_id,
+        coordinator.mac,
+        SWITCH_PLATFORM,
+        "boolean",
+        virtual_switch_ids,
     )
 
     if not switch_ids:

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -152,6 +152,7 @@ def async_setup_rpc_entry(
         component["key"].split(":")[-1]
         for component in coordinator.device.dynamic_components
         if "boolean" in component["key"]
+        and component["config"]["meta"]["ui"]["view"] == "toggle"
     )
     async_add_entities(RpcVirtualSwitch(coordinator, id_) for id_ in virtual_switches)
 

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -64,8 +64,6 @@ class RpcSwitchDescription(RpcEntityDescription, SwitchEntityDescription):
 RPC_VIRTUAL_SWITCH = RpcSwitchDescription(
     key="boolean",
     sub_key="value",
-    removal_condition=lambda config, _, key: config[key]["meta"]["ui"]["view"]
-    != "toggle",
 )
 
 

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -303,6 +303,7 @@ class RpcVirtualSwitch(ShellyRpcAttributeEntity, SwitchEntity):
     """Entity that controls a virtual boolean component on RPC based Shelly devices."""
 
     entity_description: RpcSwitchDescription
+    _attr_has_entity_name = True
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -178,6 +178,8 @@ def async_setup_rpc_entry(
         RpcVirtualSwitch,
     )
 
+    # the user can remove virtual components from the device configuration, so we need
+    # to remove orphaned entities
     virtual_switch_ids = get_virtual_component_ids(
         coordinator.device.config, SWITCH_PLATFORM
     )

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -153,7 +153,7 @@ def async_setup_rpc_entry(
     switches.extend(RpcRelaySwitch(coordinator, id_) for id_ in switch_ids)
 
     virtual_switch_key_ids = get_virtual_component_key_ids(
-        coordinator.device.dynamic_components, Platform.SWITCH
+        coordinator.device.config, Platform.SWITCH
     )
     switches.extend(
         RpcVirtualSwitch(coordinator, id_) for id_ in virtual_switch_key_ids

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -15,12 +15,8 @@ from homeassistant.components.switch import (
 )
 from homeassistant.const import STATE_ON, EntityCategory, Platform
 from homeassistant.core import HomeAssistant, State, callback
-from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.entity_registry import (
-    RegistryEntry,
-    async_entries_for_device,
-)
+from homeassistant.helpers.entity_registry import RegistryEntry
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import CONF_SLEEP_PERIOD, MOTION_MODELS
@@ -33,6 +29,7 @@ from .entity import (
     async_setup_entry_attribute_entities,
 )
 from .utils import (
+    async_get_orphaned_virtual_entities,
     async_remove_shelly_entity,
     async_remove_shelly_rpc_entities,
     get_device_entry_gen,
@@ -168,23 +165,11 @@ def async_setup_rpc_entry(
         RpcVirtualSwitch(coordinator, id_) for id_ in virtual_switch_key_ids
     )
 
-    device_registry = dr.async_get(hass)
-    entity_registry = er.async_get(hass)
-    if devices := device_registry.devices.get_devices_for_config_entry_id(
-        config_entry.entry_id
+    if orphaned_entities := async_get_orphaned_virtual_entities(
+        hass, config_entry.entry_id, SWITCH_PLATFORM, "boolean", virtual_switch_key_ids
     ):
-        entities_to_remove = []
-        device_id = devices[0].id
-        entities = async_entries_for_device(entity_registry, device_id, True)
-        for entity in entities:
-            if not entity.entity_id.startswith(SWITCH_PLATFORM):
-                continue
-            if "boolean" in entity.unique_id:
-                virtual_switch_id = int(entity.unique_id.split(":")[1])
-                if virtual_switch_id not in virtual_switch_key_ids:
-                    entities_to_remove.append(f"boolean:{virtual_switch_id}")
         async_remove_shelly_rpc_entities(
-            hass, SWITCH_PLATFORM, coordinator.mac, entities_to_remove
+            hass, SWITCH_PLATFORM, coordinator.mac, orphaned_entities
         )
 
     if not switches:

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -319,14 +319,13 @@ def get_rpc_channel_name(device: RpcDevice, key: str) -> str:
         entity_name = device.config[key].get("name", device_name)
 
     if entity_name is None:
-        if key.startswith(("boolean:", "input:", "light:", "switch:")):
+        if key.startswith(("input:", "light:", "switch:")):
             return f"{device_name} {key.replace(':', '_')}"
         if key.startswith("em1"):
             return f"{device_name} EM{key.split(':')[-1]}"
+        if key.startswith("boolean:"):
+            return key.replace(":", " ").title()
         return device_name
-
-    if key.startswith("boolean:"):
-        return f"{device_name} {entity_name}"
 
     return entity_name
 

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -321,7 +321,12 @@ def get_rpc_channel_name(device: RpcDevice, key: str) -> str:
             return f"{device_name} {key.replace(':', '_')}"
         if key.startswith("em1"):
             return f"{device_name} EM{key.split(':')[-1]}"
+        if key.startswith("boolean"):
+            return f"{device_name} Boolean {key.split(':')[-1]}"
         return device_name
+
+    if key.startswith("boolean"):
+        return f"{device_name} {entity_name}"
 
     return entity_name
 

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -508,14 +508,15 @@ def get_virtual_component_key_ids(
     config: dict[str, Any], platform: Platform
 ) -> list[int]:
     """Return a list of virtual component key IDs for a platform."""
+    ids: list[int] = []
     if platform is Platform.SWITCH:
-        return [
+        ids.extend(
             int(k.split(":")[1])
             for k, v in config.items()
             if k.startswith("boolean:") and v["meta"]["ui"]["view"] == "toggle"
-        ]
+        )
 
-    return []
+    return ids
 
 
 @callback

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -27,7 +27,7 @@ from aioshelly.rpc_device import RpcDevice, WsServer
 from homeassistant.components import network
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PORT, EVENT_HOMEASSISTANT_STOP, Platform
+from homeassistant.const import CONF_PORT, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import (
     device_registry as dr,
@@ -53,6 +53,7 @@ from .const import (
     SHBTN_MODELS,
     SHIX3_1_INPUTS_EVENTS_TYPES,
     UPTIME_DEVIATION,
+    VIRTUAL_COMPONENTS_MAP,
 )
 
 
@@ -505,21 +506,17 @@ def is_rpc_thermostat_mode(ident: int, status: dict[str, Any]) -> bool:
 
 def get_virtual_component_ids(config: dict[str, Any], platform: str) -> list[str]:
     """Return a list of virtual component IDs for a platform."""
-    ids: list[str] = []
-    if platform == Platform.SWITCH.value:
-        ids.extend(
-            k
-            for k, v in config.items()
-            if k.startswith("boolean") and v["meta"]["ui"]["view"] == "toggle"
-        )
-    if platform == Platform.BINARY_SENSOR.value:
-        ids.extend(
-            k
-            for k, v in config.items()
-            if k.startswith("boolean") and v["meta"]["ui"]["view"] == "label"
-        )
+    component = VIRTUAL_COMPONENTS_MAP.get(platform)
 
-    return ids
+    if not component:
+        return []
+
+    return [
+        k
+        for k, v in config.items()
+        if k.startswith(component["type"])
+        and v["meta"]["ui"]["view"] == component["mode"]
+    ]
 
 
 @callback

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -26,7 +26,7 @@ from aioshelly.rpc_device import RpcDevice, WsServer
 from homeassistant.components import network
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PORT, EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import CONF_PORT, EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import (
     device_registry as dr,
@@ -497,3 +497,18 @@ def async_remove_shelly_rpc_entities(
 def is_rpc_thermostat_mode(ident: int, status: dict[str, Any]) -> bool:
     """Return True if 'thermostat:<IDent>' is present in the status."""
     return f"thermostat:{ident}" in status
+
+
+def get_virtual_component_key_ids(
+    components: list[dict[str, Any]], platform: Platform
+) -> list[int]:
+    """Return a list of virtual component key IDs for a platform."""
+    if platform is Platform.SWITCH:
+        return [
+            int(component["key"].split(":")[-1])
+            for component in components
+            if "boolean" in component["key"]
+            and component["config"]["meta"]["ui"]["view"] == "toggle"
+        ]
+
+    return []

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -500,15 +500,14 @@ def is_rpc_thermostat_mode(ident: int, status: dict[str, Any]) -> bool:
 
 
 def get_virtual_component_key_ids(
-    components: list[dict[str, Any]], platform: Platform
+    config: dict[str, Any], platform: Platform
 ) -> list[int]:
     """Return a list of virtual component key IDs for a platform."""
     if platform is Platform.SWITCH:
         return [
-            int(component["key"].split(":")[-1])
-            for component in components
-            if "boolean" in component["key"]
-            and component["config"]["meta"]["ui"]["view"] == "toggle"
+            int(k.split(":")[1])
+            for k, v in config.items()
+            if k.startswith("boolean:") and v["meta"]["ui"]["view"] == "toggle"
         ]
 
     return []

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -323,7 +323,7 @@ def get_rpc_channel_name(device: RpcDevice, key: str) -> str:
             return f"{device_name} EM{key.split(':')[-1]}"
         return device_name
 
-    if key.startswith("boolean"):
+    if key.startswith("boolean:"):
         return f"{device_name} {entity_name}"
 
     return entity_name

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -317,12 +317,10 @@ def get_rpc_channel_name(device: RpcDevice, key: str) -> str:
         entity_name = device.config[key].get("name", device_name)
 
     if entity_name is None:
-        if key.startswith(("input:", "light:", "switch:")):
+        if key.startswith(("boolean:", "input:", "light:", "switch:")):
             return f"{device_name} {key.replace(':', '_')}"
         if key.startswith("em1"):
             return f"{device_name} EM{key.split(':')[-1]}"
-        if key.startswith("boolean"):
-            return f"{device_name} Boolean {key.split(':')[-1]}"
         return device_name
 
     if key.startswith("boolean"):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -362,7 +362,7 @@ aioruuvigateway==0.1.0
 aiosenz==1.0.0
 
 # homeassistant.components.shelly
-aioshelly==11.0.0
+aioshelly==11.1.0
 
 # homeassistant.components.skybell
 aioskybell==22.7.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -335,7 +335,7 @@ aioruuvigateway==0.1.0
 aiosenz==1.0.0
 
 # homeassistant.components.shelly
-aioshelly==11.0.0
+aioshelly==11.1.0
 
 # homeassistant.components.skybell
 aioskybell==22.7.0

--- a/tests/components/shelly/__init__.py
+++ b/tests/components/shelly/__init__.py
@@ -23,6 +23,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import (
     CONNECTION_NETWORK_MAC,
+    DeviceEntry,
     DeviceRegistry,
     format_mac,
 )
@@ -111,6 +112,7 @@ def register_entity(
     unique_id: str,
     config_entry: ConfigEntry | None = None,
     capabilities: Mapping[str, Any] | None = None,
+    device_id: str | None = None,
 ) -> str:
     """Register enabled entity, return entity_id."""
     entity_registry = er.async_get(hass)
@@ -122,6 +124,7 @@ def register_entity(
         disabled_by=None,
         config_entry=config_entry,
         capabilities=capabilities,
+        device_id=device_id,
     )
     return f"{domain}.{object_id}"
 
@@ -145,9 +148,11 @@ def get_entity_state(hass: HomeAssistant, entity_id: str) -> str:
     return entity.state
 
 
-def register_device(device_registry: DeviceRegistry, config_entry: ConfigEntry) -> None:
+def register_device(
+    device_registry: DeviceRegistry, config_entry: ConfigEntry
+) -> DeviceEntry:
     """Register Shelly device."""
-    device_registry.async_get_or_create(
+    return device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         connections={(CONNECTION_NETWORK_MAC, format_mac(MOCK_MAC))},
     )

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -186,6 +186,7 @@ MOCK_CONFIG = {
         "device": {"name": "Test name"},
     },
     "wifi": {"sta": {"enable": True}, "sta1": {"enable": False}},
+    "boolean:200": {"name": "Virtual Switch", "meta": {"ui": {"view": "toggle"}}},
 }
 
 MOCK_SHELLY_COAP = {
@@ -269,6 +270,7 @@ MOCK_STATUS_RPC = {
     },
     "voltmeter": {"voltage": 4.321},
     "wifi": {"rssi": -63},
+    "boolean:200": {"value": True},
 }
 
 

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -186,7 +186,6 @@ MOCK_CONFIG = {
         "device": {"name": "Test name"},
     },
     "wifi": {"sta": {"enable": True}, "sta1": {"enable": False}},
-    "boolean:200": {"name": "Virtual Switch", "meta": {"ui": {"view": "toggle"}}},
 }
 
 MOCK_SHELLY_COAP = {

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -269,7 +269,6 @@ MOCK_STATUS_RPC = {
     },
     "voltmeter": {"voltage": 4.321},
     "wifi": {"rssi": -63},
-    "boolean:200": {"value": True},
 }
 
 

--- a/tests/components/shelly/test_binary_sensor.py
+++ b/tests/components/shelly/test_binary_sensor.py
@@ -1,5 +1,6 @@
 """Tests for Shelly binary sensor platform."""
 
+from copy import deepcopy
 from unittest.mock import Mock
 
 from aioshelly.const import MODEL_MOTION
@@ -10,6 +11,7 @@ from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAI
 from homeassistant.components.shelly.const import UPDATE_PERIOD_MULTIPLIER
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceRegistry
 from homeassistant.helpers.entity_registry import EntityRegistry
 
@@ -353,3 +355,66 @@ async def test_rpc_restored_sleeping_binary_sensor_no_last_state(
     await hass.async_block_till_done()
 
     assert hass.states.get(entity_id).state == STATE_OFF
+
+
+async def test_rpc_device_virtual_binary_sensor_with_name(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_rpc_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test a virtual binary sensor for RPC device."""
+    config = deepcopy(mock_rpc_device.config)
+    config["boolean:203"] = {
+        "name": "Virtual binary sensor",
+        "meta": {"ui": {"view": "label"}},
+    }
+    monkeypatch.setattr(mock_rpc_device, "config", config)
+
+    status = deepcopy(mock_rpc_device.status)
+    status["boolean:203"] = {"value": True}
+    monkeypatch.setattr(mock_rpc_device, "status", status)
+
+    entity_id = "binary_sensor.test_name_virtual_binary_sensor"
+
+    await init_integration(hass, 3)
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_ON
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-boolean:203-boolean"
+
+    monkeypatch.setitem(mock_rpc_device.status["boolean:203"], "value", False)
+    mock_rpc_device.mock_update()
+    assert hass.states.get(entity_id).state == STATE_OFF
+
+
+async def test_rpc_device_virtual_binary_sensor_without_name(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_rpc_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test a virtual binary sensor for RPC device."""
+    config = deepcopy(mock_rpc_device.config)
+    config["boolean:203"] = {"name": None, "meta": {"ui": {"view": "label"}}}
+    monkeypatch.setattr(mock_rpc_device, "config", config)
+
+    status = deepcopy(mock_rpc_device.status)
+    status["boolean:203"] = {"value": True}
+    monkeypatch.setattr(mock_rpc_device, "status", status)
+
+    entity_id = "binary_sensor.test_name_boolean_203"
+
+    await init_integration(hass, 3)
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_ON
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-boolean:203-boolean"

--- a/tests/components/shelly/test_switch.py
+++ b/tests/components/shelly/test_switch.py
@@ -25,6 +25,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceRegistry
 from homeassistant.helpers.entity_registry import EntityRegistry
 
@@ -430,3 +431,23 @@ async def test_wall_display_relay_mode(
     entry = entity_registry.async_get(switch_entity_id)
     assert entry
     assert entry.unique_id == "123456789ABC-switch:0"
+
+
+async def test_rpc_device_virtual_switch(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_rpc_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test RPC device turn on/off services."""
+    entity_id = "switch.virtual_switch"
+
+    await init_integration(hass, 3)
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_ON
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-boolean:200"

--- a/tests/components/shelly/test_switch.py
+++ b/tests/components/shelly/test_switch.py
@@ -447,6 +447,10 @@ async def test_rpc_device_virtual_switch_with_name(
     }
     monkeypatch.setattr(mock_rpc_device, "config", config)
 
+    status = deepcopy(mock_rpc_device.status)
+    status["boolean:200"] = {"value": True}
+    monkeypatch.setattr(mock_rpc_device, "status", status)
+
     entity_id = "switch.test_name_virtual_switch"
 
     await init_integration(hass, 3)
@@ -457,7 +461,7 @@ async def test_rpc_device_virtual_switch_with_name(
 
     entry = entity_registry.async_get(entity_id)
     assert entry
-    assert entry.unique_id == "123456789ABC-boolean:200"
+    assert entry.unique_id == "123456789ABC-boolean:200-boolean"
 
     monkeypatch.setitem(mock_rpc_device.status["boolean:200"], "value", False)
     await hass.services.async_call(
@@ -491,6 +495,10 @@ async def test_rpc_device_virtual_switch_without_name(
     config["boolean:200"] = {"name": None, "meta": {"ui": {"view": "toggle"}}}
     monkeypatch.setattr(mock_rpc_device, "config", config)
 
+    status = deepcopy(mock_rpc_device.status)
+    status["boolean:200"] = {"value": True}
+    monkeypatch.setattr(mock_rpc_device, "status", status)
+
     entity_id = "switch.test_name_boolean_200"
 
     await init_integration(hass, 3)
@@ -514,6 +522,10 @@ async def test_rpc_device_virtual_binary_sensor(
     config["boolean:200"] = {"name": None, "meta": {"ui": {"view": "label"}}}
     monkeypatch.setattr(mock_rpc_device, "config", config)
 
+    status = deepcopy(mock_rpc_device.status)
+    status["boolean:200"] = {"value": True}
+    monkeypatch.setattr(mock_rpc_device, "status", status)
+
     entity_id = "switch.test_name_boolean_200"
 
     await init_integration(hass, 3)
@@ -533,6 +545,10 @@ async def test_rpc_device_remove_orphaned_virtual_component(
     config = deepcopy(mock_rpc_device.config)
     config["boolean:200"] = {"name": None, "meta": {"ui": {"view": "label"}}}
     monkeypatch.setattr(mock_rpc_device, "config", config)
+
+    status = deepcopy(mock_rpc_device.status)
+    status["boolean:200"] = {"value": True}
+    monkeypatch.setattr(mock_rpc_device, "status", status)
 
     config_entry = await init_integration(hass, 3, skip_setup=True)
     device_entry = register_device(device_registry, config_entry)

--- a/tests/components/shelly/test_switch.py
+++ b/tests/components/shelly/test_switch.py
@@ -520,3 +520,33 @@ async def test_rpc_device_virtual_binary_sensor(
 
     state = hass.states.get(entity_id)
     assert not state
+
+
+async def test_rpc_device_remove_orphaned_virtual_component(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: DeviceRegistry,
+    mock_rpc_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test whether the virtual switch entity will be removed if it is orphaned."""
+    config = deepcopy(mock_rpc_device.config)
+    config["boolean:200"] = {"name": None, "meta": {"ui": {"view": "label"}}}
+    monkeypatch.setattr(mock_rpc_device, "config", config)
+
+    config_entry = await init_integration(hass, 3, skip_setup=True)
+    device_entry = register_device(device_registry, config_entry)
+    entity_id = register_entity(
+        hass,
+        SWITCH_DOMAIN,
+        "test_name_boolean_200",
+        "boolean:200",
+        config_entry,
+        device_id=device_entry.id,
+    )
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entry = entity_registry.async_get(entity_id)
+    assert not entry

--- a/tests/components/shelly/test_switch.py
+++ b/tests/components/shelly/test_switch.py
@@ -501,7 +501,7 @@ async def test_rpc_device_virtual_switch_without_name(
 
     entry = entity_registry.async_get(entity_id)
     assert entry
-    assert entry.unique_id == "123456789ABC-boolean:200"
+    assert entry.unique_id == "123456789ABC-boolean:200-boolean"
 
 
 async def test_rpc_device_virtual_binary_sensor(
@@ -540,7 +540,7 @@ async def test_rpc_device_remove_orphaned_virtual_component(
         hass,
         SWITCH_DOMAIN,
         "test_name_boolean_200",
-        "boolean:200",
+        "boolean:200-boolean",
         config_entry,
         device_id=device_entry.id,
     )

--- a/tests/components/shelly/test_switch.py
+++ b/tests/components/shelly/test_switch.py
@@ -433,13 +433,13 @@ async def test_wall_display_relay_mode(
     assert entry.unique_id == "123456789ABC-switch:0"
 
 
-async def test_rpc_device_virtual_switch(
+async def test_rpc_device_virtual_switch_with_name(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_rpc_device: Mock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test virtual switch for RPC device."""
+    """Test a virtual switch for RPC device."""
     config = deepcopy(mock_rpc_device.config)
     config["boolean:200"] = {
         "name": "Virtual switch",
@@ -478,3 +478,45 @@ async def test_rpc_device_virtual_switch(
     )
     mock_rpc_device.mock_update()
     assert hass.states.get(entity_id).state == STATE_ON
+
+
+async def test_rpc_device_virtual_switch_without_name(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_rpc_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test a virtual switch for RPC device."""
+    config = deepcopy(mock_rpc_device.config)
+    config["boolean:200"] = {"name": None, "meta": {"ui": {"view": "toggle"}}}
+    monkeypatch.setattr(mock_rpc_device, "config", config)
+
+    entity_id = "switch.test_name_boolean_200"
+
+    await init_integration(hass, 3)
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_ON
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-boolean:200"
+
+
+async def test_rpc_device_virtual_binary_sensor(
+    hass: HomeAssistant,
+    mock_rpc_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that a switch entity has not been created for a virtual binary sensor."""
+    config = deepcopy(mock_rpc_device.config)
+    config["boolean:200"] = {"name": None, "meta": {"ui": {"view": "label"}}}
+    monkeypatch.setattr(mock_rpc_device, "config", config)
+
+    entity_id = "switch.test_name_boolean_200"
+
+    await init_integration(hass, 3)
+
+    state = hass.states.get(entity_id)
+    assert not state

--- a/tests/components/shelly/test_switch.py
+++ b/tests/components/shelly/test_switch.py
@@ -439,8 +439,15 @@ async def test_rpc_device_virtual_switch(
     mock_rpc_device: Mock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test RPC device turn on/off services."""
-    entity_id = "switch.virtual_switch"
+    """Test virtual switch for RPC device."""
+    config = deepcopy(mock_rpc_device.config)
+    config["boolean:200"] = {
+        "name": "Virtual switch",
+        "meta": {"ui": {"view": "toggle"}},
+    }
+    monkeypatch.setattr(mock_rpc_device, "config", config)
+
+    entity_id = "switch.test_name_virtual_switch"
 
     await init_integration(hass, 3)
 

--- a/tests/components/shelly/test_switch.py
+++ b/tests/components/shelly/test_switch.py
@@ -451,3 +451,23 @@ async def test_rpc_device_virtual_switch(
     entry = entity_registry.async_get(entity_id)
     assert entry
     assert entry.unique_id == "123456789ABC-boolean:200"
+
+    monkeypatch.setitem(mock_rpc_device.status["boolean:200"], "value", False)
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    mock_rpc_device.mock_update()
+    assert hass.states.get(entity_id).state == STATE_OFF
+
+    monkeypatch.setitem(mock_rpc_device.status["boolean:200"], "value", True)
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    mock_rpc_device.mock_update()
+    assert hass.states.get(entity_id).state == STATE_ON


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is the first step in adding support for Shelly virtual components.

Virtual components are supported on Gen3 devices and will be supported on Pro Gen2 devices in the future. Virtual components are elements that will connect the world of Home Assistant automation with the world of Shelly scripts. Additionally, virtual components will be used more often by Shelly X MOD1 boards.

This PR adds support for the `boolean` component. Such a component is mapped to:
- `switch` platform if component uses `toggle` mode
- `binary_sensor` platform if component uses `label` mode

`aioshelly` changelog: https://github.com/home-assistant-libs/aioshelly/compare/11.0.0...11.1.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33657

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
