### PR TITLE
Tuya's light POS actually means "opposite state"

### DIFF
--- a/homeassistant/components/tuya/strings.json
+++ b/homeassistant/components/tuya/strings.json
@@ -275,7 +275,7 @@
         "name": "Indicator light mode",
         "state": {
           "none": "[%key:common::state::off%]",
-          "pos": "Indicate switch location",
+          "pos": "Indicate inverted switch state",
           "relay": "Indicate switch on/off state"
         }
       },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
That's described in the commit text, as follows:
> It made no sense for a color-less LED to "indicate the location", and HA was the only place with that exact sentence (found no posts explaining it). Googling more generically, I found the [Tuya docs](https://developer.tuya.com/en/docs/iot/smart-switch-product-function-definition?id=K9r7gh4lbe886#title-6-5.%20Indicator%20status%20setting%20(optional)%3A%20DP%20ID%2015.) that explain in a very weird way that this option is to "find the device in the dark when it is off", being technically just "light is on when it's disabled and off when it's enabled". It is much easier to say exactly that instead of what they _intended_ with calling it "position".

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

I would even go ahead and remove the "indicate" from both strings, as it's kind of redundant given the field is named "indicator light mode" (an indicator light will indicate stuff, right? haha)

I'm also not sure if I must change this in other places as well, but thought it would be silly to open a full issue just to point to a string change.

- ~This PR fixes or closes issue: fixes #~
- ~This PR is related to issue:~
- ~Link to documentation pull request:~

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->
> I scratched the options that doesn't apply, given this is just a string change.

- [ ] ~The code change is tested and works locally.~
- [ ] ~Local tests pass. **Your PR cannot be merged unless tests pass**~
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] ~The code has been formatted using Ruff (`ruff format homeassistant tests`)~
- [ ] ~Tests have been added to verify that the new code works.~

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.
>I have mostly no Python knowledge and can't help much, as I never coded anything inside HA.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
