### PR TITLE
Fix Hydrawise volume unit bug

### DIFF
--- a/homeassistant/components/hydrawise/sensor.py
+++ b/homeassistant/components/hydrawise/sensor.py
@@ -71,7 +71,6 @@ FLOW_CONTROLLER_SENSORS: tuple[HydrawiseSensorEntityDescription, ...] = (
         key="daily_total_water_use",
         translation_key="daily_total_water_use",
         device_class=SensorDeviceClass.VOLUME,
-        native_unit_of_measurement=UnitOfVolume.GALLONS,
         suggested_display_precision=1,
         value_fn=_get_controller_daily_total_water_use,
     ),
@@ -79,7 +78,6 @@ FLOW_CONTROLLER_SENSORS: tuple[HydrawiseSensorEntityDescription, ...] = (
         key="daily_active_water_use",
         translation_key="daily_active_water_use",
         device_class=SensorDeviceClass.VOLUME,
-        native_unit_of_measurement=UnitOfVolume.GALLONS,
         suggested_display_precision=1,
         value_fn=_get_controller_daily_active_water_use,
     ),
@@ -87,7 +85,6 @@ FLOW_CONTROLLER_SENSORS: tuple[HydrawiseSensorEntityDescription, ...] = (
         key="daily_inactive_water_use",
         translation_key="daily_inactive_water_use",
         device_class=SensorDeviceClass.VOLUME,
-        native_unit_of_measurement=UnitOfVolume.GALLONS,
         suggested_display_precision=1,
         value_fn=_get_controller_daily_inactive_water_use,
     ),
@@ -98,7 +95,6 @@ FLOW_ZONE_SENSORS: tuple[SensorEntityDescription, ...] = (
         key="daily_active_water_use",
         translation_key="daily_active_water_use",
         device_class=SensorDeviceClass.VOLUME,
-        native_unit_of_measurement=UnitOfVolume.GALLONS,
         suggested_display_precision=1,
         value_fn=_get_zone_daily_active_water_use,
     ),
@@ -164,6 +160,17 @@ class HydrawiseSensor(HydrawiseEntity, SensorEntity):
     """A sensor implementation for Hydrawise device."""
 
     entity_description: HydrawiseSensorEntityDescription
+
+    @property
+    def native_unit_of_measurement(self) -> str | None:
+        """Return the unit_of_measurement of the sensor."""
+        if self.entity_description.device_class != SensorDeviceClass.VOLUME:
+            return self.entity_description.native_unit_of_measurement
+        return (
+            UnitOfVolume.GALLONS
+            if self.coordinator.data.user.units.units_name == "imperial"
+            else UnitOfVolume.LITERS
+        )
 
     @property
     def icon(self) -> str | None:

--- a/tests/components/hydrawise/conftest.py
+++ b/tests/components/hydrawise/conftest.py
@@ -1,6 +1,6 @@
 """Common fixtures for the Hydrawise tests."""
 
-from collections.abc import Awaitable, Callable, Generator
+from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
@@ -20,6 +20,7 @@ from pydrawise.schema import (
     Zone,
 )
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.hydrawise.const import DOMAIN
 from homeassistant.const import CONF_API_KEY, CONF_PASSWORD, CONF_USERNAME

--- a/tests/components/hydrawise/conftest.py
+++ b/tests/components/hydrawise/conftest.py
@@ -1,6 +1,6 @@
 """Common fixtures for the Hydrawise tests."""
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Generator
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
@@ -15,11 +15,11 @@ from pydrawise.schema import (
     Sensor,
     SensorModel,
     SensorStatus,
+    UnitsSummary,
     User,
     Zone,
 )
 import pytest
-from typing_extensions import Generator
 
 from homeassistant.components.hydrawise.const import DOMAIN
 from homeassistant.const import CONF_API_KEY, CONF_PASSWORD, CONF_USERNAME
@@ -85,7 +85,11 @@ def mock_auth() -> Generator[AsyncMock]:
 @pytest.fixture
 def user() -> User:
     """Hydrawise User fixture."""
-    return User(customer_id=12345, email="asdf@asdf.com")
+    return User(
+        customer_id=12345,
+        email="asdf@asdf.com",
+        units=UnitsSummary(units_name="imperial"),
+    )
 
 
 @pytest.fixture

--- a/tests/components/hydrawise/test_sensor.py
+++ b/tests/components/hydrawise/test_sensor.py
@@ -10,7 +10,11 @@ from syrupy.assertion import SnapshotAssertion
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM, UnitSystem
+from homeassistant.util.unit_system import (
+    METRIC_SYSTEM,
+    US_CUSTOMARY_SYSTEM,
+    UnitSystem,
+)
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -70,9 +74,9 @@ async def test_no_sensor_and_water_state(
     ("hydrawise_unit_system", "unit_system", "expected_state"),
     [
         ("imperial", METRIC_SYSTEM, "454.6279552584"),
-        ("imperial", IMPERIAL_SYSTEM, "120.1"),
+        ("imperial", US_CUSTOMARY_SYSTEM, "120.1"),
         ("metric", METRIC_SYSTEM, "120.1"),
-        ("metric", IMPERIAL_SYSTEM, "31.7270634882136"),
+        ("metric", US_CUSTOMARY_SYSTEM, "31.7270634882136"),
     ],
 )
 async def test_volume_unit_conversion(

--- a/tests/components/hydrawise/test_sensor.py
+++ b/tests/components/hydrawise/test_sensor.py
@@ -3,13 +3,14 @@
 from collections.abc import Awaitable, Callable
 from unittest.mock import patch
 
-from pydrawise.schema import Controller, Zone
+from pydrawise.schema import Controller, User, Zone
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM, UnitSystem
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -45,7 +46,7 @@ async def test_suspended_state(
     assert next_cycle.state == "unknown"
 
 
-async def test_no_sensor_and_water_state2(
+async def test_no_sensor_and_water_state(
     hass: HomeAssistant,
     controller: Controller,
     mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
@@ -63,3 +64,30 @@ async def test_no_sensor_and_water_state2(
     sensor = hass.states.get("binary_sensor.home_controller_connectivity")
     assert sensor is not None
     assert sensor.state == "on"
+
+
+@pytest.mark.parametrize(
+    ("hydrawise_unit_system", "unit_system", "expected_state"),
+    [
+        ("imperial", METRIC_SYSTEM, "454.6279552584"),
+        ("imperial", IMPERIAL_SYSTEM, "120.1"),
+        ("metric", METRIC_SYSTEM, "120.1"),
+        ("metric", IMPERIAL_SYSTEM, "31.7270634882136"),
+    ],
+)
+async def test_volume_unit_conversion(
+    hass: HomeAssistant,
+    unit_system: UnitSystem,
+    hydrawise_unit_system: str,
+    expected_state: str,
+    user: User,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+) -> None:
+    """Test volume unit conversion."""
+    hass.config.units = unit_system
+    user.units.units_name = hydrawise_unit_system
+    await mock_add_config_entry()
+
+    daily_active_water_use = hass.states.get("sensor.zone_one_daily_active_water_use")
+    assert daily_active_water_use is not None
+    assert daily_active_water_use.state == expected_state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix Hydrawise volume unit bug. Consider the Hydrawise user's native unit system (either `imperial` or `metric`) for volume sensors (i.e., water use).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #119819
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
