### PR TITLE
Unifi break out switch availability test to separate test

### DIFF
--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -1544,6 +1544,10 @@ async def test_updating_unique_id(
     assert hass.states.get("switch.switch_port_1_poe")
 
 
+@pytest.mark.parametrize(
+    "config_entry_options", [{CONF_BLOCK_CLIENT: [UNBLOCKED["mac"]]}]
+)
+@pytest.mark.parametrize("client_payload", [[UNBLOCKED]])
 @pytest.mark.parametrize("device_payload", [[DEVICE_1, OUTLET_UP1]])
 @pytest.mark.parametrize("dpi_app_payload", [DPI_APPS])
 @pytest.mark.parametrize("dpi_group_payload", [DPI_GROUPS])
@@ -1553,6 +1557,7 @@ async def test_updating_unique_id(
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_hub_state_change(hass: HomeAssistant, mock_websocket_state) -> None:
     """Verify entities state reflect on hub connection becoming unavailable."""
+    assert hass.states.get("switch.block_client_2").state == STATE_ON
     assert hass.states.get("switch.mock_name_port_1_poe").state == STATE_ON
     assert hass.states.get("switch.plug_outlet_1").state == STATE_ON
     assert hass.states.get("switch.block_media_streaming").state == STATE_ON
@@ -1561,6 +1566,7 @@ async def test_hub_state_change(hass: HomeAssistant, mock_websocket_state) -> No
 
     # Controller disconnects
     await mock_websocket_state.disconnect()
+    assert hass.states.get("switch.block_client_2").state == STATE_UNAVAILABLE
     assert hass.states.get("switch.mock_name_port_1_poe").state == STATE_UNAVAILABLE
     assert hass.states.get("switch.plug_outlet_1").state == STATE_UNAVAILABLE
     assert hass.states.get("switch.block_media_streaming").state == STATE_UNAVAILABLE
@@ -1569,6 +1575,7 @@ async def test_hub_state_change(hass: HomeAssistant, mock_websocket_state) -> No
 
     # Controller reconnects
     await mock_websocket_state.reconnect()
+    assert hass.states.get("switch.block_client_2").state == STATE_ON
     assert hass.states.get("switch.mock_name_port_1_poe").state == STATE_ON
     assert hass.states.get("switch.plug_outlet_1").state == STATE_ON
     assert hass.states.get("switch.block_media_streaming").state == STATE_ON

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -1557,27 +1557,23 @@ async def test_updating_unique_id(
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_hub_state_change(hass: HomeAssistant, mock_websocket_state) -> None:
     """Verify entities state reflect on hub connection becoming unavailable."""
-    assert hass.states.get("switch.block_client_2").state == STATE_ON
-    assert hass.states.get("switch.mock_name_port_1_poe").state == STATE_ON
-    assert hass.states.get("switch.plug_outlet_1").state == STATE_ON
-    assert hass.states.get("switch.block_media_streaming").state == STATE_ON
-    assert hass.states.get("switch.unifi_network_plex").state == STATE_ON
-    assert hass.states.get("switch.ssid_1").state == STATE_ON
+    entity_ids = (
+        "switch.block_client_2",
+        "switch.mock_name_port_1_poe",
+        "switch.plug_outlet_1",
+        "switch.block_media_streaming",
+        "switch.unifi_network_plex",
+        "switch.ssid_1",
+    )
+    for entity_id in entity_ids:
+        assert hass.states.get(entity_id).state == STATE_ON
 
     # Controller disconnects
     await mock_websocket_state.disconnect()
-    assert hass.states.get("switch.block_client_2").state == STATE_UNAVAILABLE
-    assert hass.states.get("switch.mock_name_port_1_poe").state == STATE_UNAVAILABLE
-    assert hass.states.get("switch.plug_outlet_1").state == STATE_UNAVAILABLE
-    assert hass.states.get("switch.block_media_streaming").state == STATE_UNAVAILABLE
-    assert hass.states.get("switch.unifi_network_plex").state == STATE_UNAVAILABLE
-    assert hass.states.get("switch.ssid_1").state == STATE_UNAVAILABLE
+    for entity_id in entity_ids:
+        assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
     # Controller reconnects
     await mock_websocket_state.reconnect()
-    assert hass.states.get("switch.block_client_2").state == STATE_ON
-    assert hass.states.get("switch.mock_name_port_1_poe").state == STATE_ON
-    assert hass.states.get("switch.plug_outlet_1").state == STATE_ON
-    assert hass.states.get("switch.block_media_streaming").state == STATE_ON
-    assert hass.states.get("switch.unifi_network_plex").state == STATE_ON
-    assert hass.states.get("switch.ssid_1").state == STATE_ON
+    for entity_id in entity_ids:
+        assert hass.states.get(entity_id).state == STATE_ON

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -996,9 +996,7 @@ async def test_block_switches(
 @pytest.mark.parametrize("dpi_app_payload", [DPI_APPS])
 @pytest.mark.parametrize("dpi_group_payload", [DPI_GROUPS])
 @pytest.mark.usefixtures("config_entry_setup")
-async def test_dpi_switches(
-    hass: HomeAssistant, mock_websocket_message, mock_websocket_state
-) -> None:
+async def test_dpi_switches(hass: HomeAssistant, mock_websocket_message) -> None:
     """Test the update_items function with some clients."""
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 1
 
@@ -1010,16 +1008,6 @@ async def test_dpi_switches(
     mock_websocket_message(data=DPI_APP_DISABLED_EVENT)
     await hass.async_block_till_done()
 
-    assert hass.states.get("switch.block_media_streaming").state == STATE_OFF
-
-    # Availability signalling
-
-    # Controller disconnects
-    await mock_websocket_state.disconnect()
-    assert hass.states.get("switch.block_media_streaming").state == STATE_UNAVAILABLE
-
-    # Controller reconnects
-    await mock_websocket_state.reconnect()
     assert hass.states.get("switch.block_media_streaming").state == STATE_OFF
 
     # Remove app
@@ -1557,6 +1545,8 @@ async def test_updating_unique_id(
 
 
 @pytest.mark.parametrize("device_payload", [[DEVICE_1, OUTLET_UP1]])
+@pytest.mark.parametrize("dpi_app_payload", [DPI_APPS])
+@pytest.mark.parametrize("dpi_group_payload", [DPI_GROUPS])
 @pytest.mark.parametrize("port_forward_payload", [[PORT_FORWARD_PLEX]])
 @pytest.mark.parametrize("wlan_payload", [[WLAN]])
 @pytest.mark.usefixtures("config_entry_setup")
@@ -1565,6 +1555,7 @@ async def test_hub_state_change(hass: HomeAssistant, mock_websocket_state) -> No
     """Verify entities state reflect on hub connection becoming unavailable."""
     assert hass.states.get("switch.mock_name_port_1_poe").state == STATE_ON
     assert hass.states.get("switch.plug_outlet_1").state == STATE_ON
+    assert hass.states.get("switch.block_media_streaming").state == STATE_ON
     assert hass.states.get("switch.unifi_network_plex").state == STATE_ON
     assert hass.states.get("switch.ssid_1").state == STATE_ON
 
@@ -1572,6 +1563,7 @@ async def test_hub_state_change(hass: HomeAssistant, mock_websocket_state) -> No
     await mock_websocket_state.disconnect()
     assert hass.states.get("switch.mock_name_port_1_poe").state == STATE_UNAVAILABLE
     assert hass.states.get("switch.plug_outlet_1").state == STATE_UNAVAILABLE
+    assert hass.states.get("switch.block_media_streaming").state == STATE_UNAVAILABLE
     assert hass.states.get("switch.unifi_network_plex").state == STATE_UNAVAILABLE
     assert hass.states.get("switch.ssid_1").state == STATE_UNAVAILABLE
 
@@ -1579,5 +1571,6 @@ async def test_hub_state_change(hass: HomeAssistant, mock_websocket_state) -> No
     await mock_websocket_state.reconnect()
     assert hass.states.get("switch.mock_name_port_1_poe").state == STATE_ON
     assert hass.states.get("switch.plug_outlet_1").state == STATE_ON
+    assert hass.states.get("switch.block_media_streaming").state == STATE_ON
     assert hass.states.get("switch.unifi_network_plex").state == STATE_ON
     assert hass.states.get("switch.ssid_1").state == STATE_ON


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Combine all UniFi switch availability tests into one test

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
