### PR TITLE
Fix songpal crash for soundbars without sound modes

### DIFF
--- a/homeassistant/components/songpal/media_player.py
+++ b/homeassistant/components/songpal/media_player.py
@@ -140,7 +140,12 @@ class SongpalEntity(MediaPlayerEntity):
 
     async def _get_sound_modes_info(self):
         """Get available sound modes and the active one."""
-        settings = await self._dev.get_sound_settings("soundField")
+        for settings in await self._dev.get_sound_settings():
+            if settings.target == "soundField":
+                break
+        else:
+            return None, {}
+
         if isinstance(settings, Setting):
             settings = [settings]
 

--- a/tests/components/songpal/__init__.py
+++ b/tests/components/songpal/__init__.py
@@ -23,7 +23,9 @@ CONF_DATA = {
 }
 
 
-def _create_mocked_device(throw_exception=False, wired_mac=MAC, wireless_mac=None):
+def _create_mocked_device(
+    throw_exception=False, wired_mac=MAC, wireless_mac=None, no_soundfield=False
+):
     mocked_device = MagicMock()
 
     type(mocked_device).get_supported_methods = AsyncMock(
@@ -106,7 +108,9 @@ def _create_mocked_device(throw_exception=False, wired_mac=MAC, wireless_mac=Non
     settings.target = "soundField"
     settings.__iter__.return_value = [soundField]
 
-    type(mocked_device).get_sound_settings = AsyncMock(return_value=[settings])
+    type(mocked_device).get_sound_settings = AsyncMock(
+        return_value=[] if no_soundfield else [settings]
+    )
 
     type(mocked_device).set_power = AsyncMock()
     type(mocked_device).set_sound_settings = AsyncMock()

--- a/tests/components/songpal/__init__.py
+++ b/tests/components/songpal/__init__.py
@@ -101,7 +101,12 @@ def _create_mocked_device(throw_exception=False, wired_mac=MAC, wireless_mac=Non
     soundField = MagicMock()
     soundField.currentValue = "sound_mode2"
     soundField.candidate = [sound_mode1, sound_mode2, sound_mode3]
-    type(mocked_device).get_sound_settings = AsyncMock(return_value=[soundField])
+
+    settings = MagicMock()
+    settings.target = "soundField"
+    settings.__iter__.return_value = [soundField]
+
+    type(mocked_device).get_sound_settings = AsyncMock(return_value=[settings])
 
     type(mocked_device).set_power = AsyncMock()
     type(mocked_device).set_sound_settings = AsyncMock()

--- a/tests/components/songpal/test_media_player.py
+++ b/tests/components/songpal/test_media_player.py
@@ -159,6 +159,43 @@ async def test_state(
     assert entity.unique_id == MAC
 
 
+async def test_state_nosoundmode(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test state of the entity with no soundField in sound settings."""
+    mocked_device = _create_mocked_device(no_soundfield=True)
+    entry = MockConfigEntry(domain=songpal.DOMAIN, data=CONF_DATA)
+    entry.add_to_hass(hass)
+
+    with _patch_media_player_device(mocked_device):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state.name == FRIENDLY_NAME
+    assert state.state == STATE_ON
+    attributes = state.as_dict()["attributes"]
+    assert attributes["volume_level"] == 0.5
+    assert attributes["is_volume_muted"] is False
+    assert attributes["source_list"] == ["title1", "title2"]
+    assert attributes["source"] == "title2"
+    assert "sound_mode_list" not in attributes
+    assert "sound_mode" not in attributes
+    assert attributes["supported_features"] == SUPPORT_SONGPAL
+
+    device = device_registry.async_get_device(identifiers={(songpal.DOMAIN, MAC)})
+    assert device.connections == {(dr.CONNECTION_NETWORK_MAC, MAC)}
+    assert device.manufacturer == "Sony Corporation"
+    assert device.name == FRIENDLY_NAME
+    assert device.sw_version == SW_VERSION
+    assert device.model == MODEL
+
+    entity = entity_registry.async_get(ENTITY_ID)
+    assert entity.unique_id == MAC
+
+
 async def test_state_wireless(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,


### PR DESCRIPTION
## Proposed change
Getting soundField on soundbar that doesn't support it crash raise an exception, so it make the whole components unavailable. As there is no simple way to know if soundField is supported, I just get all sound settings, and then pick soundField one if present. If not present, then return None to make it continue, it will just have to effect to display no sound mode and not able to select one (Exactly what we want).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #119626 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
