### PR TITLE
Add MockModule type hints in tests

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -778,7 +778,7 @@ def ensure_auth_manager_loaded(auth_mgr: auth.AuthManager) -> None:
         store._set_defaults()
 
 
-class MockModule(loader.ComponentProtocol):
+class MockModule:
     """Representation of a fake module."""
 
     def __init__(

--- a/tests/common.py
+++ b/tests/common.py
@@ -783,7 +783,8 @@ class MockModule:
 
     def __init__(
         self,
-        domain=None,
+        domain: str,
+        *,
         dependencies=None,
         setup=None,
         requirements=None,
@@ -797,7 +798,7 @@ class MockModule:
         async_remove_entry=None,
         partial_manifest=None,
         async_remove_config_entry_device=None,
-    ):
+    ) -> None:
         """Initialize the mock module."""
         self.__name__ = f"homeassistant.components.{domain}"
         self.__file__ = f"homeassistant/components/{domain}"

--- a/tests/common.py
+++ b/tests/common.py
@@ -778,7 +778,7 @@ def ensure_auth_manager_loaded(auth_mgr: auth.AuthManager) -> None:
         store._set_defaults()
 
 
-class MockModule:
+class MockModule(loader.ComponentProtocol):
     """Representation of a fake module."""
 
     def __init__(

--- a/tests/common.py
+++ b/tests/common.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Coroutine, Mapping, Sequence
 from contextlib import asynccontextmanager, contextmanager
 from datetime import UTC, datetime, timedelta
 from enum import Enum
@@ -783,21 +783,37 @@ class MockModule:
 
     def __init__(
         self,
-        domain: str,
+        domain: str | None = None,
         *,
-        dependencies=None,
-        setup=None,
-        requirements=None,
-        config_schema=None,
-        platform_schema=None,
-        platform_schema_base=None,
-        async_setup=None,
-        async_setup_entry=None,
-        async_unload_entry=None,
-        async_migrate_entry=None,
-        async_remove_entry=None,
-        partial_manifest=None,
-        async_remove_config_entry_device=None,
+        dependencies: list[str] | None = None,
+        setup: Callable[[HomeAssistant, ConfigType], bool] | None = None,
+        requirements: list[str] | None = None,
+        config_schema: vol.Schema | None = None,
+        platform_schema: vol.Schema | None = None,
+        platform_schema_base: vol.Schema | None = None,
+        async_setup: Callable[[HomeAssistant, ConfigType], Coroutine[Any, Any, bool]]
+        | None = None,
+        async_setup_entry: Callable[
+            [HomeAssistant, ConfigEntry], Coroutine[Any, Any, bool]
+        ]
+        | None = None,
+        async_unload_entry: Callable[
+            [HomeAssistant, ConfigEntry], Coroutine[Any, Any, bool]
+        ]
+        | None = None,
+        async_migrate_entry: Callable[
+            [HomeAssistant, ConfigEntry], Coroutine[Any, Any, bool]
+        ]
+        | None = None,
+        async_remove_entry: Callable[
+            [HomeAssistant, ConfigEntry], Coroutine[Any, Any, None]
+        ]
+        | None = None,
+        partial_manifest: dict[str, Any] | None = None,
+        async_remove_config_entry_device: Callable[
+            [HomeAssistant, ConfigEntry, dr.DeviceEntry], Coroutine[Any, Any, bool]
+        ]
+        | None = None,
     ) -> None:
         """Initialize the mock module."""
         self.__name__ = f"homeassistant.components.{domain}"

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -25,20 +25,20 @@ from .common import MockModule, async_get_persistent_notifications, mock_integra
 async def test_circular_component_dependencies(hass: HomeAssistant) -> None:
     """Test if we can detect circular dependencies of components."""
     mock_integration(hass, MockModule("mod1"))
-    mock_integration(hass, MockModule("mod2", ["mod1"]))
-    mock_integration(hass, MockModule("mod3", ["mod1"]))
-    mod_4 = mock_integration(hass, MockModule("mod4", ["mod2", "mod3"]))
+    mock_integration(hass, MockModule("mod2", dependencies=["mod1"]))
+    mock_integration(hass, MockModule("mod3", dependencies=["mod1"]))
+    mod_4 = mock_integration(hass, MockModule("mod4", dependencies=["mod2", "mod3"]))
 
     deps = await loader._async_component_dependencies(hass, mod_4)
     assert deps == {"mod1", "mod2", "mod3", "mod4"}
 
     # Create a circular dependency
-    mock_integration(hass, MockModule("mod1", ["mod4"]))
+    mock_integration(hass, MockModule("mod1", dependencies=["mod4"]))
     with pytest.raises(loader.CircularDependency):
         await loader._async_component_dependencies(hass, mod_4)
 
     # Create a different circular dependency
-    mock_integration(hass, MockModule("mod1", ["mod3"]))
+    mock_integration(hass, MockModule("mod1", dependencies=["mod3"]))
     with pytest.raises(loader.CircularDependency):
         await loader._async_component_dependencies(hass, mod_4)
 
@@ -59,7 +59,7 @@ async def test_circular_component_dependencies(hass: HomeAssistant) -> None:
 
 async def test_nonexistent_component_dependencies(hass: HomeAssistant) -> None:
     """Test if we can detect nonexistent dependencies of components."""
-    mod_1 = mock_integration(hass, MockModule("mod1", ["nonexistent"]))
+    mod_1 = mock_integration(hass, MockModule("mod1", dependencies=["nonexistent"]))
     with pytest.raises(loader.IntegrationNotFound):
         await loader._async_component_dependencies(hass, mod_1)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
