### PR TITLE
Add MockPlatform type hints in tests

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Coroutine, Mapping, Sequence
 from contextlib import asynccontextmanager, contextmanager
 from datetime import UTC, datetime, timedelta
 from enum import Enum
@@ -858,13 +858,25 @@ class MockPlatform:
 
     def __init__(
         self,
-        setup_platform=None,
-        dependencies=None,
-        platform_schema=None,
-        async_setup_platform=None,
-        async_setup_entry=None,
-        scan_interval=None,
-    ):
+        *,
+        setup_platform: Callable[
+            [HomeAssistant, ConfigType, AddEntitiesCallback, DiscoveryInfoType | None],
+            None,
+        ]
+        | None = None,
+        dependencies: list[str] | None = None,
+        platform_schema: vol.Schema | None = None,
+        async_setup_platform: Callable[
+            [HomeAssistant, ConfigType, AddEntitiesCallback, DiscoveryInfoType | None],
+            Coroutine[Any, Any, None],
+        ]
+        | None = None,
+        async_setup_entry: Callable[
+            [HomeAssistant, ConfigEntry, AddEntitiesCallback], Coroutine[Any, Any, None]
+        ]
+        | None = None,
+        scan_interval: timedelta | None = None,
+    ) -> None:
         """Initialize the platform."""
         self.DEPENDENCIES = dependencies or []
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -850,7 +850,7 @@ class MockModule:
         }
 
 
-class MockPlatform:
+class MockPlatform(entity_platform.EntityPlatformModule):
     """Provide a fake platform."""
 
     __name__ = "homeassistant.components.light.bla"

--- a/tests/common.py
+++ b/tests/common.py
@@ -850,7 +850,7 @@ class MockModule:
         }
 
 
-class MockPlatform(entity_platform.EntityPlatformModule):
+class MockPlatform:
     """Provide a fake platform."""
 
     __name__ = "homeassistant.components.light.bla"

--- a/tests/components/alarm_control_panel/conftest.py
+++ b/tests/components/alarm_control_panel/conftest.py
@@ -160,7 +160,6 @@ async def setup_lock_platform_test_entity(
         )
         return True
 
-    MockPlatform()
     mock_integration(
         hass,
         MockModule(

--- a/tests/components/alarm_control_panel/conftest.py
+++ b/tests/components/alarm_control_panel/conftest.py
@@ -160,7 +160,7 @@ async def setup_lock_platform_test_entity(
         )
         return True
 
-    MockPlatform(hass, f"{TEST_DOMAIN}.config_flow")
+    MockPlatform()
     mock_integration(
         hass,
         MockModule(

--- a/tests/components/lock/conftest.py
+++ b/tests/components/lock/conftest.py
@@ -103,7 +103,6 @@ async def setup_lock_platform_test_entity(
         )
         return True
 
-    MockPlatform()
     mock_integration(
         hass,
         MockModule(

--- a/tests/components/lock/conftest.py
+++ b/tests/components/lock/conftest.py
@@ -103,7 +103,7 @@ async def setup_lock_platform_test_entity(
         )
         return True
 
-    MockPlatform(hass, f"{TEST_DOMAIN}.config_flow")
+    MockPlatform()
     mock_integration(
         hass,
         MockModule(

--- a/tests/helpers/test_discovery.py
+++ b/tests/helpers/test_discovery.py
@@ -132,7 +132,9 @@ async def test_circular_import(hass: HomeAssistant) -> None:
     # dependencies are only set in component level
     # since we are using manifest to hold them
     mock_integration(hass, MockModule("test_circular", dependencies=["test_component"]))
-    mock_platform(hass, "test_circular.switch", MockPlatform(setup_platform))
+    mock_platform(
+        hass, "test_circular.switch", MockPlatform(setup_platform=setup_platform)
+    )
 
     await setup.async_setup_component(
         hass,

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -52,7 +52,7 @@ async def test_setup_loads_platforms(hass: HomeAssistant) -> None:
     mock_integration(hass, MockModule("test_component", setup=component_setup))
     # mock the dependencies
     mock_integration(hass, MockModule("mod2", dependencies=["test_component"]))
-    mock_platform(hass, "mod2.test_domain", MockPlatform(platform_setup))
+    mock_platform(hass, "mod2.test_domain", MockPlatform(setup_platform=platform_setup))
 
     component = EntityComponent(_LOGGER, DOMAIN, hass)
 
@@ -71,8 +71,12 @@ async def test_setup_recovers_when_setup_raises(hass: HomeAssistant) -> None:
     platform1_setup = Mock(side_effect=Exception("Broken"))
     platform2_setup = Mock(return_value=None)
 
-    mock_platform(hass, "mod1.test_domain", MockPlatform(platform1_setup))
-    mock_platform(hass, "mod2.test_domain", MockPlatform(platform2_setup))
+    mock_platform(
+        hass, "mod1.test_domain", MockPlatform(setup_platform=platform1_setup)
+    )
+    mock_platform(
+        hass, "mod2.test_domain", MockPlatform(setup_platform=platform2_setup)
+    )
 
     component = EntityComponent(_LOGGER, DOMAIN, hass)
 
@@ -128,7 +132,9 @@ async def test_set_scan_interval_via_config(hass: HomeAssistant) -> None:
         """Test the platform setup."""
         add_entities([MockEntity(should_poll=True)])
 
-    mock_platform(hass, "platform.test_domain", MockPlatform(platform_setup))
+    mock_platform(
+        hass, "platform.test_domain", MockPlatform(setup_platform=platform_setup)
+    )
 
     component = EntityComponent(_LOGGER, DOMAIN, hass)
 
@@ -154,7 +160,7 @@ async def test_set_entity_namespace_via_config(hass: HomeAssistant) -> None:
         """Test the platform setup."""
         add_entities([MockEntity(name="beer"), MockEntity(name=None)])
 
-    platform = MockPlatform(platform_setup)
+    platform = MockPlatform(setup_platform=platform_setup)
 
     mock_platform(hass, "platform.test_domain", platform)
 
@@ -204,7 +210,9 @@ async def test_platform_not_ready(hass: HomeAssistant) -> None:
     """Test that we retry when platform not ready."""
     platform1_setup = Mock(side_effect=[PlatformNotReady, PlatformNotReady, None])
     mock_integration(hass, MockModule("mod1"))
-    mock_platform(hass, "mod1.test_domain", MockPlatform(platform1_setup))
+    mock_platform(
+        hass, "mod1.test_domain", MockPlatform(setup_platform=platform1_setup)
+    )
 
     component = EntityComponent(_LOGGER, DOMAIN, hass)
 
@@ -678,7 +686,9 @@ async def test_platforms_shutdown_on_stop(hass: HomeAssistant) -> None:
     """Test that we shutdown platforms on stop."""
     platform1_setup = Mock(side_effect=[PlatformNotReady, PlatformNotReady, None])
     mock_integration(hass, MockModule("mod1"))
-    mock_platform(hass, "mod1.test_domain", MockPlatform(platform1_setup))
+    mock_platform(
+        hass, "mod1.test_domain", MockPlatform(setup_platform=platform1_setup)
+    )
 
     component = EntityComponent(_LOGGER, DOMAIN, hass)
 

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -228,7 +228,7 @@ async def test_set_scan_interval_via_platform(hass: HomeAssistant) -> None:
         """Test the platform setup."""
         add_entities([MockEntity(should_poll=True)])
 
-    platform = MockPlatform(platform_setup)
+    platform = MockPlatform(setup_platform=platform_setup)
     platform.SCAN_INTERVAL = timedelta(seconds=30)
 
     mock_platform(hass, "platform.test_domain", platform)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -163,7 +163,7 @@ async def test_validate_platform_config_2(
     mock_platform(
         hass,
         "whatever.platform_conf",
-        MockPlatform("whatever", platform_schema=platform_schema),
+        MockPlatform(platform_schema=platform_schema),
     )
 
     with assert_setup_component(1):
@@ -192,7 +192,7 @@ async def test_validate_platform_config_3(
     mock_platform(
         hass,
         "whatever.platform_conf",
-        MockPlatform("whatever", platform_schema=platform_schema),
+        MockPlatform(platform_schema=platform_schema),
     )
 
     with assert_setup_component(1):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
