### PR TITLE
Address outstanding tplink review suggestions

### DIFF
--- a/homeassistant/components/tplink/README.md
+++ b/homeassistant/components/tplink/README.md
@@ -30,5 +30,6 @@ is not yet added it will be created manually and a warning will be logged.
 For features to use translation keys they should be added to `strings.json` and `icons.json`
 with the feature.id as key.
 
-**All described features must have corresponding entries in `strings.json` and `icons.json`**
+**All described features must have corresponding entries in `strings.json` and `icons.json`
+unless the base platform provides it's own via the device_class**
 

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Final, cast
+from typing import cast
 
 from kasa import Device, Feature
 
@@ -22,8 +22,7 @@ from .coordinator import TPLinkDataUpdateCoordinator
 from .entity import (
     CoordinatedTPLinkFeatureEntity,
     TPLinkFeatureEntityDescription,
-    _description_for_feature,
-    _entities_for_device_and_its_children,
+    entities_for_device_and_its_children,
 )
 
 UNIT_MAPPING = {
@@ -39,7 +38,7 @@ class TPLinkSensorEntityDescription(
     """Base class for a TPLink feature based sensor entity description."""
 
 
-SENSOR_DESCRIPTIONS: Final = [
+SENSOR_DESCRIPTIONS: tuple[TPLinkSensorEntityDescription, ...] = (
     TPLinkSensorEntityDescription(
         key="current_consumption",
         device_class=SensorDeviceClass.POWER,
@@ -70,7 +69,7 @@ SENSOR_DESCRIPTIONS: Final = [
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-]
+)
 
 SENSOR_DESCRIPTIONS_MAP = {desc.key: desc for desc in SENSOR_DESCRIPTIONS}
 
@@ -86,7 +85,7 @@ async def async_setup_entry(
     children_coordinators = data.children_coordinators
     device = parent_coordinator.device
 
-    entities = _entities_for_device_and_its_children(
+    entities = entities_for_device_and_its_children(
         device=device,
         coordinator=parent_coordinator,
         feature_type=Feature.Type.Sensor,
@@ -110,7 +109,7 @@ class Sensor(CoordinatedTPLinkFeatureEntity, SensorEntity):
         parent: Device | None = None,
     ) -> None:
         """Initialize the sensor."""
-        description = _description_for_feature(
+        description = self._description_for_feature(
             TPLinkSensorEntityDescription, feature, SENSOR_DESCRIPTIONS_MAP
         )
         super().__init__(

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
-from typing import Any, Final
+from typing import Any
 
 from kasa import Device, Feature
 
@@ -17,9 +17,8 @@ from .coordinator import TPLinkDataUpdateCoordinator
 from .entity import (
     CoordinatedTPLinkFeatureEntity,
     TPLinkFeatureEntityDescription,
-    _description_for_feature,
-    _entities_for_device_and_its_children,
     async_refresh_after,
+    entities_for_device_and_its_children,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -32,7 +31,7 @@ class TPLinkSwitchEntityDescription(
     """Base class for a TPLink feature based sensor entity description."""
 
 
-SWITCH_DESCRIPTIONS: Final = [
+SWITCH_DESCRIPTIONS: tuple[TPLinkSwitchEntityDescription, ...] = (
     TPLinkSwitchEntityDescription(
         key="state",
     ),
@@ -45,7 +44,7 @@ SWITCH_DESCRIPTIONS: Final = [
     TPLinkSwitchEntityDescription(
         key="auto_off_enabled",
     ),
-]
+)
 
 SWITCH_DESCRIPTIONS_MAP = {desc.key: desc for desc in SWITCH_DESCRIPTIONS}
 
@@ -60,7 +59,7 @@ async def async_setup_entry(
     parent_coordinator = data.parent_coordinator
     device = parent_coordinator.device
 
-    entities = _entities_for_device_and_its_children(
+    entities = entities_for_device_and_its_children(
         device,
         coordinator=parent_coordinator,
         feature_type=Feature.Switch,
@@ -84,7 +83,7 @@ class TPLinkSwitch(CoordinatedTPLinkFeatureEntity, SwitchEntity):
         parent: Device | None = None,
     ) -> None:
         """Initialize the switch."""
-        description = _description_for_feature(
+        description = self._description_for_feature(
             TPLinkSwitchEntityDescription,
             feature,
             SWITCH_DESCRIPTIONS_MAP,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Address minor tweaks resulting from reviews for https://github.com/home-assistant/core/pull/120025, https://github.com/home-assistant/core/pull/120060 and https://github.com/home-assistant/core/pull/117760.
- Moves `_description_for_feature` and `_category_for_feature` to class methods on `CoordinatedTPLinkFeatureEntity` (with no changes to method bodies except to call `_category_for_feature` with `self`)
- Renames `entities_for_device_and_its_children` to be non-protected
- Converts entity descriptions to be a tuple
- Adds/modifies some code comments
- Updates readme

See https://github.com/home-assistant/core/pull/117785 for an explanation of the approach for merging into the tplink_rewrite branch.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
