### PR TITLE
Add MockToggleEntity type hints in tests

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -17,7 +17,7 @@ import pathlib
 import threading
 import time
 from types import FrameType, ModuleType
-from typing import Any, NoReturn
+from typing import Any, Literal, NoReturn
 from unittest.mock import AsyncMock, Mock, patch
 
 from aiohttp.test_utils import unused_port as get_test_instance_port  # noqa: F401
@@ -959,41 +959,41 @@ class MockEntityPlatform(entity_platform.EntityPlatform):
 class MockToggleEntity(entity.ToggleEntity):
     """Provide a mock toggle device."""
 
-    def __init__(self, name, state, unique_id=None):
+    def __init__(self, name: str | None, state: Literal["on", "off"] | None) -> None:
         """Initialize the mock entity."""
         self._name = name or DEVICE_DEFAULT_NAME
         self._state = state
-        self.calls = []
+        self.calls: list[tuple[str, dict[str, Any]]] = []
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the name of the entity if any."""
         self.calls.append(("name", {}))
         return self._name
 
     @property
-    def state(self):
+    def state(self) -> Literal["on", "off"] | None:
         """Return the state of the entity if any."""
         self.calls.append(("state", {}))
         return self._state
 
     @property
-    def is_on(self):
+    def is_on(self) -> bool:
         """Return true if entity is on."""
         self.calls.append(("is_on", {}))
         return self._state == STATE_ON
 
-    def turn_on(self, **kwargs):
+    def turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         self.calls.append(("turn_on", kwargs))
         self._state = STATE_ON
 
-    def turn_off(self, **kwargs):
+    def turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         self.calls.append(("turn_off", kwargs))
         self._state = STATE_OFF
 
-    def last_call(self, method=None):
+    def last_call(self, method: str | None = None) -> tuple[str, dict[str, Any]]:
         """Return the last call."""
         if not self.calls:
             return None

--- a/tests/components/conversation/test_init.py
+++ b/tests/components/conversation/test_init.py
@@ -13,7 +13,7 @@ from homeassistant.components.conversation import default_agent
 from homeassistant.components.conversation.models import ConversationInput
 from homeassistant.components.cover import SERVICE_OPEN_COVER
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
-from homeassistant.const import ATTR_FRIENDLY_NAME
+from homeassistant.const import ATTR_FRIENDLY_NAME, STATE_ON
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import (
@@ -269,7 +269,7 @@ async def test_http_processing_intent_entity_renamed(
     We want to ensure that renaming an entity later busts the cache
     so that the new name is used.
     """
-    entity = MockLight("kitchen light", "on")
+    entity = MockLight("kitchen light", STATE_ON)
     entity._attr_unique_id = "1234"
     entity.entity_id = "light.kitchen"
     setup_test_component_platform(hass, LIGHT_DOMAIN, [entity])
@@ -357,7 +357,7 @@ async def test_http_processing_intent_entity_exposed(
     We want to ensure that manually exposing an entity later busts the cache
     so that the new setting is used.
     """
-    entity = MockLight("kitchen light", "on")
+    entity = MockLight("kitchen light", STATE_ON)
     entity._attr_unique_id = "1234"
     entity.entity_id = "light.kitchen"
     setup_test_component_platform(hass, LIGHT_DOMAIN, [entity])
@@ -458,7 +458,7 @@ async def test_http_processing_intent_conversion_not_expose_new(
     # Disable exposing new entities to the default agent
     expose_new(hass, False)
 
-    entity = MockLight("kitchen light", "on")
+    entity = MockLight("kitchen light", STATE_ON)
     entity._attr_unique_id = "1234"
     entity.entity_id = "light.kitchen"
     setup_test_component_platform(hass, LIGHT_DOMAIN, [entity])

--- a/tests/components/light/common.py
+++ b/tests/components/light/common.py
@@ -4,6 +4,8 @@ All containing methods are legacy helpers that should not be used by new
 components. Instead call the service directly.
 """
 
+from typing import Any, Literal
+
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_BRIGHTNESS_PCT,
@@ -250,13 +252,12 @@ class MockLight(MockToggleEntity, LightEntity):
 
     def __init__(
         self,
-        name,
-        state,
-        unique_id=None,
+        name: str | None,
+        state: Literal["on", "off"] | None,
         supported_color_modes: set[ColorMode] | None = None,
     ) -> None:
         """Initialize the mock light."""
-        super().__init__(name, state, unique_id)
+        super().__init__(name, state)
         if supported_color_modes is None:
             supported_color_modes = {ColorMode.ONOFF}
         self._attr_supported_color_modes = supported_color_modes
@@ -265,7 +266,7 @@ class MockLight(MockToggleEntity, LightEntity):
             color_mode = next(iter(supported_color_modes))
         self._attr_color_mode = color_mode
 
-    def turn_on(self, **kwargs):
+    def turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         super().turn_on(**kwargs)
         for key, value in kwargs.items():

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -1,5 +1,6 @@
 """The tests for the Light component."""
 
+from typing import Literal
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
@@ -1144,7 +1145,7 @@ invalid_no_brightness_no_color_no_transition,,,
 
 @pytest.mark.parametrize("light_state", [STATE_ON, STATE_OFF])
 async def test_light_backwards_compatibility_supported_color_modes(
-    hass: HomeAssistant, light_state
+    hass: HomeAssistant, light_state: Literal["on", "off"]
 ) -> None:
     """Test supported_color_modes if not implemented by the entity."""
     entities = [

--- a/tests/testing_config/custom_components/test/light.py
+++ b/tests/testing_config/custom_components/test/light.py
@@ -3,6 +3,8 @@
 Call init before using it in your tests to ensure clean test data.
 """
 
+from typing import Any, Literal
+
 from homeassistant.components.light import ColorMode, LightEntity
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
@@ -67,13 +69,12 @@ class MockLight(MockToggleEntity, LightEntity):
 
     def __init__(
         self,
-        name,
-        state,
-        unique_id=None,
+        name: str | None,
+        state: Literal["on", "off"] | None,
         supported_color_modes: set[ColorMode] | None = None,
     ) -> None:
         """Initialize the mock light."""
-        super().__init__(name, state, unique_id)
+        super().__init__(name, state)
         if supported_color_modes is None:
             supported_color_modes = {ColorMode.ONOFF}
         self._attr_supported_color_modes = supported_color_modes
@@ -82,7 +83,7 @@ class MockLight(MockToggleEntity, LightEntity):
             color_mode = next(iter(supported_color_modes))
         self._attr_color_mode = color_mode
 
-    def turn_on(self, **kwargs):
+    def turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         super().turn_on(**kwargs)
         for key, value in kwargs.items():


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, from pylint:
```console
$ pylint tests/*.py                                                                      
************* Module tests.common
tests/common.py:962:4: W7432: Return type should be None in __init__ (hass-return-type)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
