### PR TITLE
Update aioairzone-cloud to v0.5.3

### DIFF
--- a/homeassistant/components/airzone_cloud/manifest.json
+++ b/homeassistant/components/airzone_cloud/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/airzone_cloud",
   "iot_class": "cloud_push",
   "loggers": ["aioairzone_cloud"],
-  "requirements": ["aioairzone-cloud==0.5.2"]
+  "requirements": ["aioairzone-cloud==0.5.3"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -182,7 +182,7 @@ aio-georss-gdacs==0.9
 aioairq==0.3.2
 
 # homeassistant.components.airzone_cloud
-aioairzone-cloud==0.5.2
+aioairzone-cloud==0.5.3
 
 # homeassistant.components.airzone
 aioairzone==0.7.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -161,7 +161,7 @@ aio-georss-gdacs==0.9
 aioairq==0.3.2
 
 # homeassistant.components.airzone_cloud
-aioairzone-cloud==0.5.2
+aioairzone-cloud==0.5.3
 
 # homeassistant.components.airzone
 aioairzone==0.7.6

--- a/tests/components/airzone_cloud/snapshots/test_diagnostics.ambr
+++ b/tests/components/airzone_cloud/snapshots/test_diagnostics.ambr
@@ -438,6 +438,7 @@
         'zone1': dict({
           'action': 1,
           'active': True,
+          'air-demand': True,
           'aq-active': False,
           'aq-index': 1,
           'aq-mode-conf': 'auto',
@@ -453,6 +454,7 @@
           'aq-status': 'good',
           'available': True,
           'double-set-point': False,
+          'floor-demand': False,
           'humidity': 30,
           'id': 'zone1',
           'installation': 'installation1',
@@ -499,6 +501,7 @@
         'zone2': dict({
           'action': 6,
           'active': False,
+          'air-demand': False,
           'aq-active': False,
           'aq-index': 1,
           'aq-mode-conf': 'auto',
@@ -514,6 +517,7 @@
           'aq-status': 'good',
           'available': True,
           'double-set-point': False,
+          'floor-demand': False,
           'humidity': 24,
           'id': 'zone2',
           'installation': 'installation1',

--- a/tests/components/airzone_cloud/util.py
+++ b/tests/components/airzone_cloud/util.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from aioairzone_cloud.common import OperationMode
 from aioairzone_cloud.const import (
     API_ACTIVE,
+    API_AIR_ACTIVE,
     API_AQ_ACTIVE,
     API_AQ_MODE_CONF,
     API_AQ_MODE_VALUES,
@@ -42,6 +43,7 @@ from aioairzone_cloud.const import (
     API_OLD_ID,
     API_POWER,
     API_POWERFUL_MODE,
+    API_RAD_ACTIVE,
     API_RANGE_MAX_AIR,
     API_RANGE_MIN_AIR,
     API_RANGE_SP_MAX_ACS,
@@ -353,6 +355,7 @@ def mock_get_device_status(device: Device) -> dict[str, Any]:
     if device.get_id() == "zone1":
         return {
             API_ACTIVE: True,
+            API_AIR_ACTIVE: True,
             API_AQ_ACTIVE: False,
             API_AQ_MODE_CONF: "auto",
             API_AQ_MODE_VALUES: ["off", "on", "auto"],
@@ -370,6 +373,7 @@ def mock_get_device_status(device: Device) -> dict[str, Any]:
                 OperationMode.VENTILATION.value,
                 OperationMode.DRY.value,
             ],
+            API_RAD_ACTIVE: False,
             API_RANGE_MAX_AIR: {API_CELSIUS: 30, API_FAH: 86},
             API_RANGE_SP_MAX_COOL_AIR: {API_FAH: 86, API_CELSIUS: 30},
             API_RANGE_SP_MAX_DRY_AIR: {API_FAH: 86, API_CELSIUS: 30},
@@ -398,6 +402,7 @@ def mock_get_device_status(device: Device) -> dict[str, Any]:
     if device.get_id() == "zone2":
         return {
             API_ACTIVE: False,
+            API_AIR_ACTIVE: False,
             API_AQ_ACTIVE: False,
             API_AQ_MODE_CONF: "auto",
             API_AQ_MODE_VALUES: ["off", "on", "auto"],
@@ -410,6 +415,7 @@ def mock_get_device_status(device: Device) -> dict[str, Any]:
             API_HUMIDITY: 24,
             API_MODE: OperationMode.COOLING.value,
             API_MODE_AVAIL: [],
+            API_RAD_ACTIVE: False,
             API_RANGE_MAX_AIR: {API_CELSIUS: 30, API_FAH: 86},
             API_RANGE_SP_MAX_COOL_AIR: {API_FAH: 86, API_CELSIUS: 30},
             API_RANGE_SP_MAX_DRY_AIR: {API_FAH: 86, API_CELSIUS: 30},


### PR DESCRIPTION
## Proposed change
Update aioairzone-cloud to [v0.5.3](https://github.com/Noltari/aioairzone-cloud/compare/0.5.2...0.5.3).

Releases:
- https://github.com/Noltari/aioairzone-cloud/releases/tag/0.5.3

Git compare: https://github.com/Noltari/aioairzone-cloud/compare/0.5.2...0.5.3

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
