### PR TITLE
Add Airzone Cloud air/floor demand binary sensors

### DIFF
--- a/homeassistant/components/airzone_cloud/binary_sensor.py
+++ b/homeassistant/components/airzone_cloud/binary_sensor.py
@@ -8,8 +8,10 @@ from typing import Any, Final
 from aioairzone_cloud.const import (
     AZD_ACTIVE,
     AZD_AIDOOS,
+    AZD_AIR_DEMAND,
     AZD_AQ_ACTIVE,
     AZD_ERRORS,
+    AZD_FLOOR_DEMAND,
     AZD_PROBLEMS,
     AZD_SYSTEMS,
     AZD_WARNINGS,
@@ -78,8 +80,18 @@ ZONE_BINARY_SENSOR_TYPES: Final[tuple[AirzoneBinarySensorEntityDescription, ...]
         key=AZD_ACTIVE,
     ),
     AirzoneBinarySensorEntityDescription(
+        device_class=BinarySensorDeviceClass.RUNNING,
+        key=AZD_AIR_DEMAND,
+        translation_key="air_demand",
+    ),
+    AirzoneBinarySensorEntityDescription(
         key=AZD_AQ_ACTIVE,
         translation_key="air_quality_active",
+    ),
+    AirzoneBinarySensorEntityDescription(
+        device_class=BinarySensorDeviceClass.RUNNING,
+        key=AZD_FLOOR_DEMAND,
+        translation_key="floor_demand",
     ),
     AirzoneBinarySensorEntityDescription(
         attributes={

--- a/homeassistant/components/airzone_cloud/strings.json
+++ b/homeassistant/components/airzone_cloud/strings.json
@@ -18,8 +18,14 @@
   },
   "entity": {
     "binary_sensor": {
+      "air_demand": {
+        "name": "Air demand"
+      },
       "air_quality_active": {
         "name": "Air Quality active"
+      },
+      "floor_demand": {
+        "name": "Floor demand"
       }
     },
     "select": {

--- a/tests/components/airzone_cloud/test_binary_sensor.py
+++ b/tests/components/airzone_cloud/test_binary_sensor.py
@@ -41,7 +41,13 @@ async def test_airzone_create_binary_sensors(hass: HomeAssistant) -> None:
     assert state.attributes.get("warnings") is None
 
     # Zones
+    state = hass.states.get("binary_sensor.dormitorio_air_demand")
+    assert state.state == STATE_OFF
+
     state = hass.states.get("binary_sensor.dormitorio_air_quality_active")
+    assert state.state == STATE_OFF
+
+    state = hass.states.get("binary_sensor.dormitorio_floor_demand")
     assert state.state == STATE_OFF
 
     state = hass.states.get("binary_sensor.dormitorio_problem")
@@ -51,7 +57,13 @@ async def test_airzone_create_binary_sensors(hass: HomeAssistant) -> None:
     state = hass.states.get("binary_sensor.dormitorio_running")
     assert state.state == STATE_OFF
 
+    state = hass.states.get("binary_sensor.salon_air_demand")
+    assert state.state == STATE_ON
+
     state = hass.states.get("binary_sensor.salon_air_quality_active")
+    assert state.state == STATE_OFF
+
+    state = hass.states.get("binary_sensor.salon_floor_demand")
     assert state.state == STATE_OFF
 
     state = hass.states.get("binary_sensor.salon_problem")


### PR DESCRIPTION
## Proposed change
Add Airzone Cloud air/floor demand binary sensors.
These binary sensors prorvide the current running status of Air Conditioning and Radiant Floor (if installed).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
