### PR TITLE
Adjust blocking I/O messages to provide developer help

### DIFF
--- a/homeassistant/util/loop.py
+++ b/homeassistant/util/loop.py
@@ -51,7 +51,7 @@ def raise_for_blocking_call(
             _LOGGER.warning(
                 "Detected blocking call to %s with args %s in %s, "
                 "line %s: %s inside the event loop; "
-                "This is causing stability issues."
+                "This is causing stability issues. "
                 "Please create a bug report at "
                 "https://github.com/home-assistant/core/issues?q=is%%3Aopen+is%%3Aissue\n"
                 "%s\n"

--- a/homeassistant/util/loop.py
+++ b/homeassistant/util/loop.py
@@ -20,12 +20,6 @@ from homeassistant.loader import async_suggest_report_issue
 
 _LOGGER = logging.getLogger(__name__)
 
-_STABILITY_REPORT_TEXT = (
-    "This is causing stability issues. "
-    "Please create a bug report at "
-    "https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue"
-)
-
 
 def _get_line_from_cache(filename: str, lineno: int) -> str:
     """Get line from cache or read from file."""

--- a/homeassistant/util/loop.py
+++ b/homeassistant/util/loop.py
@@ -84,11 +84,13 @@ def raise_for_blocking_call(
     )
 
     _LOGGER.warning(
-        "Detected blocking call to %s inside the event loop by %sintegration '%s' "
+        "Detected blocking call to %s with args %s "
+        "inside the event loop by %sintegration '%s' "
         "at %s, line %s: %s (offender: %s, line %s: %s), please %s\n"
         "%s\n"
         "Traceback (most recent call last):\n%s",
         func.__name__,
+        mapped_args.get("args"),
         "custom " if integration_frame.custom_integration else "",
         integration_frame.integration,
         integration_frame.relative_filename,
@@ -104,7 +106,8 @@ def raise_for_blocking_call(
 
     if strict:
         raise RuntimeError(
-            "Caught blocking call to {func.__name__} inside the event loop by"
+            "Caught blocking call to {func.__name__} with args "
+            f"{mapped_args.get('args')} inside the event loop by"
             f"{'custom ' if integration_frame.custom_integration else ''}"
             "integration '{integration_frame.integration}' at "
             f"{integration_frame.relative_filename}, line {integration_frame.line_number}:"

--- a/homeassistant/util/loop.py
+++ b/homeassistant/util/loop.py
@@ -20,6 +20,12 @@ from homeassistant.loader import async_suggest_report_issue
 
 _LOGGER = logging.getLogger(__name__)
 
+_STABILITY_REPORT_TEXT = (
+    "This is causing stability issues. "
+    "Please create a bug report at "
+    "https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue"
+)
+
 
 def _get_line_from_cache(filename: str, lineno: int) -> str:
     """Get line from cache or read from file."""
@@ -31,14 +37,9 @@ def raise_for_blocking_call(
     check_allowed: Callable[[dict[str, Any]], bool] | None = None,
     strict: bool = True,
     strict_core: bool = True,
-    advise_msg: str | None = None,
     **mapped_args: Any,
 ) -> None:
-    """Warn if called inside the event loop. Raise if `strict` is True.
-
-    The default advisory message is 'Use `await hass.async_add_executor_job()'
-    Set `advise_msg` to an alternate message if the solution differs.
-    """
+    """Warn if called inside the event loop. Raise if `strict` is True."""
     if check_allowed is not None and check_allowed(mapped_args):
         return
 
@@ -55,24 +56,31 @@ def raise_for_blocking_call(
         if not strict_core:
             _LOGGER.warning(
                 "Detected blocking call to %s with args %s in %s, "
-                "line %s: %s inside the event loop\n"
+                "line %s: %s inside the event loop; "
+                "This is causing stability issues."
+                "Please create a bug report at "
+                "https://github.com/home-assistant/core/issues?q=is%%3Aopen+is%%3Aissue\n"
+                "%s\n"
                 "Traceback (most recent call last):\n%s",
                 func.__name__,
                 mapped_args.get("args"),
                 offender_filename,
                 offender_lineno,
                 offender_line,
+                _dev_help_message(func.__name__),
                 "".join(traceback.format_stack(f=offender_frame)),
             )
             return
 
         if found_frame is None:
             raise RuntimeError(  # noqa: TRY200
-                f"Detected blocking call to {func.__name__} inside the event loop "
-                f"in {offender_filename}, line {offender_lineno}: {offender_line}. "
-                f"{advise_msg or 'Use `await hass.async_add_executor_job()`'}; "
-                "This is causing stability issues. Please create a bug report at "
-                f"https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue"
+                f"Caught blocking call to {func.__name__} with args {mapped_args.get("args")} "
+                f"in {offender_filename}, line {offender_lineno}: {offender_line} "
+                "inside the event loop; "
+                "This is causing stability issues. "
+                "Please create a bug report at "
+                "https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue\n"
+                f"{_dev_help_message(func.__name__)}"
             )
 
     report_issue = async_suggest_report_issue(
@@ -84,6 +92,7 @@ def raise_for_blocking_call(
     _LOGGER.warning(
         "Detected blocking call to %s inside the event loop by %sintegration '%s' "
         "at %s, line %s: %s (offender: %s, line %s: %s), please %s\n"
+        "%s\n"
         "Traceback (most recent call last):\n%s",
         func.__name__,
         "custom " if integration_frame.custom_integration else "",
@@ -95,17 +104,29 @@ def raise_for_blocking_call(
         offender_lineno,
         offender_line,
         report_issue,
+        _dev_help_message(func.__name__),
         "".join(traceback.format_stack(f=integration_frame.frame)),
     )
 
     if strict:
         raise RuntimeError(
-            "Blocking calls must be done in the executor or a separate thread;"
-            f" {advise_msg or 'Use `await hass.async_add_executor_job()`'}; at"
-            f" {integration_frame.relative_filename}, line {integration_frame.line_number}:"
-            f" {integration_frame.line} "
-            f"(offender: {offender_filename}, line {offender_lineno}: {offender_line})"
+            "Caught blocking call to {func.__name__} inside the event loop by"
+            f"{'custom ' if integration_frame.custom_integration else ''}"
+            "integration '{integration_frame.integration}' at "
+            f"{integration_frame.relative_filename}, line {integration_frame.line_number}:"
+            f" {integration_frame.line}. (offender: {offender_filename}, line "
+            f"{offender_lineno}: {offender_line}), please {report_issue}\n"
+            f"{_dev_help_message(func.__name__)}"
         )
+
+
+def _dev_help_message(what: str) -> str:
+    """Generate help message to guide developers."""
+    return (
+        "For developers, please see "
+        "https://developers.home-assistant.io/docs/asyncio_blocking_operations/"
+        f"#{what.replace('.', '')}"
+    )
 
 
 def protect_loop[**_P, _R](

--- a/tests/test_block_async_io.py
+++ b/tests/test_block_async_io.py
@@ -61,9 +61,7 @@ async def test_protect_loop_sleep() -> None:
         ]
     )
     with (
-        pytest.raises(
-            RuntimeError, match="Detected blocking call to sleep inside the event loop"
-        ),
+        pytest.raises(RuntimeError, match="Caught blocking call to sleep with args"),
         patch(
             "homeassistant.block_async_io.get_current_frame",
             return_value=frames,
@@ -89,9 +87,7 @@ async def test_protect_loop_sleep_get_current_frame_raises() -> None:
         ]
     )
     with (
-        pytest.raises(
-            RuntimeError, match="Detected blocking call to sleep inside the event loop"
-        ),
+        pytest.raises(RuntimeError, match="Caught blocking call to sleep with args"),
         patch(
             "homeassistant.block_async_io.get_current_frame",
             side_effect=ValueError,
@@ -204,7 +200,8 @@ async def test_protect_loop_importlib_import_module_in_integration(
             importlib.import_module("not_loaded_module")
 
     assert (
-        "Detected blocking call to import_module inside the event loop by "
+        "Detected blocking call to import_module with args ('not_loaded_module',) "
+        "inside the event loop by "
         "integration 'hue' at homeassistant/components/hue/light.py, line 23"
     ) in caplog.text
 

--- a/tests/util/test_loop.py
+++ b/tests/util/test_loop.py
@@ -28,6 +28,10 @@ async def test_raise_for_blocking_call_async_non_strict_core(
     haloop.raise_for_blocking_call(banned_function, strict_core=False)
     assert "Detected blocking call to banned_function" in caplog.text
     assert "Traceback (most recent call last)" in caplog.text
+    assert (
+        "For developers, please see "
+        "https://developers.home-assistant.io/docs/asyncio_blocking_operations/#banned_function"
+    ) in caplog.text
 
 
 async def test_raise_for_blocking_call_async_integration(
@@ -80,6 +84,10 @@ async def test_raise_for_blocking_call_async_integration(
         "a bug report at https://github.com/home-assistant/core/issues?"
         "q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+hue%22" in caplog.text
     )
+    assert (
+        "For developers, please see "
+        "https://developers.home-assistant.io/docs/asyncio_blocking_operations/#banned_function"
+    ) in caplog.text
 
 
 async def test_raise_for_blocking_call_async_integration_non_strict(
@@ -136,6 +144,10 @@ async def test_raise_for_blocking_call_async_integration_non_strict(
         'File "/home/paulus/homeassistant/components/hue/light.py", line 23'
         in caplog.text
     )
+    assert (
+        "For developers, please see "
+        "https://developers.home-assistant.io/docs/asyncio_blocking_operations/#banned_function"
+    ) in caplog.text
 
 
 async def test_raise_for_blocking_call_async_custom(
@@ -193,6 +205,10 @@ async def test_raise_for_blocking_call_async_custom(
         'File "/home/paulus/config/custom_components/hue/light.py", line 23'
         in caplog.text
     )
+    assert (
+        "For developers, please see "
+        "https://developers.home-assistant.io/docs/asyncio_blocking_operations/#banned_function"
+    ) in caplog.text
 
 
 async def test_raise_for_blocking_call_sync(

--- a/tests/util/test_loop.py
+++ b/tests/util/test_loop.py
@@ -82,7 +82,8 @@ async def test_raise_for_blocking_call_async_integration(
     ):
         haloop.raise_for_blocking_call(banned_function)
     assert (
-        "Detected blocking call to banned_function inside the event loop by integration"
+        "Detected blocking call to banned_function with args None"
+        " inside the event loop by integration"
         " 'hue' at homeassistant/components/hue/light.py, line 23: self.light.is_on "
         "(offender: /home/paulus/aiohue/lights.py, line 2: mock_line), please create "
         "a bug report at https://github.com/home-assistant/core/issues?"
@@ -137,7 +138,8 @@ async def test_raise_for_blocking_call_async_integration_non_strict(
     ):
         haloop.raise_for_blocking_call(banned_function, strict=False)
     assert (
-        "Detected blocking call to banned_function inside the event loop by integration"
+        "Detected blocking call to banned_function with args None"
+        " inside the event loop by integration"
         " 'hue' at homeassistant/components/hue/light.py, line 23: self.light.is_on "
         "(offender: /home/paulus/aiohue/lights.py, line 2: mock_line), "
         "please create a bug report at https://github.com/home-assistant/core/issues?"
@@ -202,7 +204,8 @@ async def test_raise_for_blocking_call_async_custom(
     ):
         haloop.raise_for_blocking_call(banned_function)
     assert (
-        "Detected blocking call to banned_function inside the event loop by custom "
+        "Detected blocking call to banned_function with args None"
+        " inside the event loop by custom "
         "integration 'hue' at custom_components/hue/light.py, line 23: self.light.is_on"
         " (offender: /home/paulus/aiohue/lights.py, line 2: mock_line), "
         "please create a bug report at https://github.com/home-assistant/core/issues?"

--- a/tests/util/test_loop.py
+++ b/tests/util/test_loop.py
@@ -29,6 +29,10 @@ async def test_raise_for_blocking_call_async_non_strict_core(
     assert "Detected blocking call to banned_function" in caplog.text
     assert "Traceback (most recent call last)" in caplog.text
     assert (
+        "Please create a bug report at https://github.com/home-assistant/core/issues"
+        in caplog.text
+    )
+    assert (
         "For developers, please see "
         "https://developers.home-assistant.io/docs/asyncio_blocking_operations/#banned_function"
     ) in caplog.text
@@ -142,6 +146,10 @@ async def test_raise_for_blocking_call_async_integration_non_strict(
     assert "Traceback (most recent call last)" in caplog.text
     assert (
         'File "/home/paulus/homeassistant/components/hue/light.py", line 23'
+        in caplog.text
+    )
+    assert (
+        "please create a bug report at https://github.com/home-assistant/core/issues"
         in caplog.text
     )
     assert (


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Since we keep seeing blocking I/O calls being partially fixed because we cannot detect blocking read/write calls and only warn on the open call, we need to help devs understand how to solve these problem. Include a link to the dev docs in the blocking I/O error/warning message.

Removed `advise_msg` since it was never passed and always advised `hass.async_add_executor_job` which is frequently only part of the solution.

The `args` are now always logged as well now since the open/state/walk/listdir calls are hard to find without knowing which file is being accessed. It now looks like `2024-06-21 11:35:47.516 WARNING (MainThread) [homeassistant.util.loop] Detected blocking call to stat with args ('/usr/local/lib/python3.12/site-packages/pysmi/parser/smi.py',) inside the event loop by integration 'snmp' at homeassistant/components/snmp/sensor.py, line 156: get_result = await getCmd(*request_args) (offender: <frozen genericpath>, line 19: ?), please create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+snmp%22
For developers, please see https://developers.home-assistant.io/docs/asyncio_blocking_operations/#stat`

ex: https://deploy-preview-2225--developers-home-assistant.netlify.app/docs/asyncio_blocking_operations/#open

https://github.com/home-assistant/developers.home-assistant/pull/2225
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
