### PR TITLE
Revert "UniFi temp fix to handle runtime data"

### DIFF
--- a/homeassistant/components/unifi/config_flow.py
+++ b/homeassistant/components/unifi/config_flow.py
@@ -164,14 +164,10 @@ class UnifiFlowHandler(ConfigFlow, domain=UNIFI_DOMAIN):
                 abort_reason = "reauth_successful"
 
             if config_entry:
-                try:
-                    hub = config_entry.runtime_data
+                hub = config_entry.runtime_data
 
-                    if hub and hub.available:
-                        return self.async_abort(reason="already_configured")
-
-                except AttributeError:
-                    pass
+                if hub and hub.available:
+                    return self.async_abort(reason="already_configured")
 
                 return self.async_update_reload_and_abort(
                     config_entry, data=self.config, reason=abort_reason


### PR DESCRIPTION
Reverts home-assistant/core#120031

It causes error in the release PR

See: <https://github.com/home-assistant/core/pull/120114>

![image](https://github.com/home-assistant/core/assets/195327/454b158f-71e8-4197-87d8-a1e6fef1af5e)

But after fixing those, tests will fail. I've discussed with @Kane610 on Discord to revert this one for now. As this PR was targeted at the `rc` branch, this PR goes into the `rc` branch as well.

The `dev` branch isn't affected.

../Frenck