### PR TITLE
Sonos add tests for media_player.play_media favorite_item_id

### DIFF
--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -456,6 +456,7 @@ async def test_play_media_favorite_item_id(
     )
     assert soco_mock.play_uri.call_args_list[0].kwargs["title"] == "66 - Watercolors"
 
+    # Test exception handling with an invalid id.
     with pytest.raises(ValueError) as sve:
         await hass.services.async_call(
             MP_DOMAIN,

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -427,3 +427,44 @@ async def test_select_source_error(
         )
     assert "invalid_source" in str(sve.value)
     assert "Could not find a Sonos favorite" in str(sve.value)
+
+
+async def test_play_media_favorite_item_id(
+    hass: HomeAssistant,
+    soco_factory: SoCoMockFactory,
+    async_autosetup_sonos,
+) -> None:
+    """Test playing media with a favorite item id."""
+    soco_mock = soco_factory.mock_list.get("192.168.42.2")
+    await hass.services.async_call(
+        MP_DOMAIN,
+        SERVICE_PLAY_MEDIA,
+        {
+            "entity_id": "media_player.zone_a",
+            "media_content_type": "favorite_item_id",
+            "media_content_id": "FV:2/4",
+        },
+        blocking=True,
+    )
+    assert soco_mock.play_uri.call_count == 1
+    assert (
+        soco_mock.play_uri.call_args_list[0].args[0]
+        == "x-sonosapi-hls:Api%3atune%3aliveAudio%3ajazzcafe%3aetc"
+    )
+    assert (
+        soco_mock.play_uri.call_args_list[0].kwargs["timeout"] == LONG_SERVICE_TIMEOUT
+    )
+    assert soco_mock.play_uri.call_args_list[0].kwargs["title"] == "66 - Watercolors"
+
+    with pytest.raises(ValueError) as sve:
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_PLAY_MEDIA,
+            {
+                "entity_id": "media_player.zone_a",
+                "media_content_type": "favorite_item_id",
+                "media_content_id": "UNKNOWN_ID",
+            },
+            blocking=True,
+        )
+    assert "UNKNOWN_ID" in str(sve.value)


### PR DESCRIPTION
## Proposed change
Add tests for Sonos media_player.play_media when playing a favorite item id.

Specifically targeting these two sections of code:

https://github.com/home-assistant/core/blob/c13efa36647410d2531937f026a59ae6ba734c72/homeassistant/components/sonos/media_player.py#L562-L567

and

https://github.com/home-assistant/core/blob/c13efa36647410d2531937f026a59ae6ba734c72/homeassistant/components/sonos/media_player.py#L450-L454

The other branch in the function above already has coverage.,

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
