### PR TITLE
Extend component root imports in tests (1)

### DIFF
--- a/tests/components/homematic/test_notify.py
+++ b/tests/components/homematic/test_notify.py
@@ -1,6 +1,6 @@
 """The tests for the Homematic notification platform."""
 
-import homeassistant.components.notify as notify_comp
+from homeassistant.components.notify import DOMAIN as NOTIFY_DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -30,7 +30,7 @@ async def test_setup_full(hass: HomeAssistant) -> None:
                 }
             },
         )
-    assert handle_config[notify_comp.DOMAIN]
+    assert handle_config[NOTIFY_DOMAIN]
 
 
 async def test_setup_without_optional(hass: HomeAssistant) -> None:
@@ -55,12 +55,12 @@ async def test_setup_without_optional(hass: HomeAssistant) -> None:
                 }
             },
         )
-    assert handle_config[notify_comp.DOMAIN]
+    assert handle_config[NOTIFY_DOMAIN]
 
 
 async def test_bad_config(hass: HomeAssistant) -> None:
     """Test invalid configuration."""
-    config = {notify_comp.DOMAIN: {"name": "test", "platform": "homematic"}}
+    config = {NOTIFY_DOMAIN: {"name": "test", "platform": "homematic"}}
     with assert_setup_component(0, domain="notify") as handle_config:
-        assert await async_setup_component(hass, notify_comp.DOMAIN, config)
-    assert not handle_config[notify_comp.DOMAIN]
+        assert await async_setup_component(hass, NOTIFY_DOMAIN, config)
+    assert not handle_config[NOTIFY_DOMAIN]

--- a/tests/components/microsoft_face_detect/test_image_processing.py
+++ b/tests/components/microsoft_face_detect/test_image_processing.py
@@ -4,8 +4,8 @@ from unittest.mock import PropertyMock, patch
 
 import pytest
 
-import homeassistant.components.image_processing as ip
-import homeassistant.components.microsoft_face as mf
+from homeassistant.components.image_processing import DOMAIN as IP_DOMAIN
+from homeassistant.components.microsoft_face import DOMAIN as MF_DOMAIN, FACE_API_URL
 from homeassistant.const import ATTR_ENTITY_PICTURE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.setup import async_setup_component
@@ -15,16 +15,16 @@ from tests.components.image_processing import common
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 CONFIG = {
-    ip.DOMAIN: {
+    IP_DOMAIN: {
         "platform": "microsoft_face_detect",
         "source": {"entity_id": "camera.demo_camera", "name": "test local"},
         "attributes": ["age", "gender"],
     },
     "camera": {"platform": "demo"},
-    mf.DOMAIN: {"api_key": "12345678abcdef6"},
+    MF_DOMAIN: {"api_key": "12345678abcdef6"},
 }
 
-ENDPOINT_URL = f"https://westus.{mf.FACE_API_URL}"
+ENDPOINT_URL = f"https://westus.{FACE_API_URL}"
 
 
 @pytest.fixture(autouse=True)
@@ -57,17 +57,17 @@ def poll_mock():
 async def test_setup_platform(hass: HomeAssistant, store_mock) -> None:
     """Set up platform with one entity."""
     config = {
-        ip.DOMAIN: {
+        IP_DOMAIN: {
             "platform": "microsoft_face_detect",
             "source": {"entity_id": "camera.demo_camera"},
             "attributes": ["age", "gender"],
         },
         "camera": {"platform": "demo"},
-        mf.DOMAIN: {"api_key": "12345678abcdef6"},
+        MF_DOMAIN: {"api_key": "12345678abcdef6"},
     }
 
-    with assert_setup_component(1, ip.DOMAIN):
-        await async_setup_component(hass, ip.DOMAIN, config)
+    with assert_setup_component(1, IP_DOMAIN):
+        await async_setup_component(hass, IP_DOMAIN, config)
         await hass.async_block_till_done()
 
     assert hass.states.get("image_processing.microsoftface_demo_camera")
@@ -76,16 +76,16 @@ async def test_setup_platform(hass: HomeAssistant, store_mock) -> None:
 async def test_setup_platform_name(hass: HomeAssistant, store_mock) -> None:
     """Set up platform with one entity and set name."""
     config = {
-        ip.DOMAIN: {
+        IP_DOMAIN: {
             "platform": "microsoft_face_detect",
             "source": {"entity_id": "camera.demo_camera", "name": "test local"},
         },
         "camera": {"platform": "demo"},
-        mf.DOMAIN: {"api_key": "12345678abcdef6"},
+        MF_DOMAIN: {"api_key": "12345678abcdef6"},
     }
 
-    with assert_setup_component(1, ip.DOMAIN):
-        await async_setup_component(hass, ip.DOMAIN, config)
+    with assert_setup_component(1, IP_DOMAIN):
+        await async_setup_component(hass, IP_DOMAIN, config)
         await hass.async_block_till_done()
 
     assert hass.states.get("image_processing.test_local")
@@ -108,7 +108,7 @@ async def test_ms_detect_process_image(
         text=load_fixture("persons.json", "microsoft_face_detect"),
     )
 
-    await async_setup_component(hass, ip.DOMAIN, CONFIG)
+    await async_setup_component(hass, IP_DOMAIN, CONFIG)
     await hass.async_block_till_done()
 
     state = hass.states.get("camera.demo_camera")

--- a/tests/components/microsoft_face_identify/test_image_processing.py
+++ b/tests/components/microsoft_face_identify/test_image_processing.py
@@ -4,8 +4,8 @@ from unittest.mock import PropertyMock, patch
 
 import pytest
 
-import homeassistant.components.image_processing as ip
-import homeassistant.components.microsoft_face as mf
+from homeassistant.components.image_processing import DOMAIN as IP_DOMAIN
+from homeassistant.components.microsoft_face import DOMAIN as MF_DOMAIN, FACE_API_URL
 from homeassistant.const import ATTR_ENTITY_PICTURE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.setup import async_setup_component
@@ -43,32 +43,32 @@ def poll_mock():
 
 
 CONFIG = {
-    ip.DOMAIN: {
+    IP_DOMAIN: {
         "platform": "microsoft_face_identify",
         "source": {"entity_id": "camera.demo_camera", "name": "test local"},
         "group": "Test Group1",
     },
     "camera": {"platform": "demo"},
-    mf.DOMAIN: {"api_key": "12345678abcdef6"},
+    MF_DOMAIN: {"api_key": "12345678abcdef6"},
 }
 
-ENDPOINT_URL = f"https://westus.{mf.FACE_API_URL}"
+ENDPOINT_URL = f"https://westus.{FACE_API_URL}"
 
 
 async def test_setup_platform(hass: HomeAssistant, store_mock) -> None:
     """Set up platform with one entity."""
     config = {
-        ip.DOMAIN: {
+        IP_DOMAIN: {
             "platform": "microsoft_face_identify",
             "source": {"entity_id": "camera.demo_camera"},
             "group": "Test Group1",
         },
         "camera": {"platform": "demo"},
-        mf.DOMAIN: {"api_key": "12345678abcdef6"},
+        MF_DOMAIN: {"api_key": "12345678abcdef6"},
     }
 
-    with assert_setup_component(1, ip.DOMAIN):
-        await async_setup_component(hass, ip.DOMAIN, config)
+    with assert_setup_component(1, IP_DOMAIN):
+        await async_setup_component(hass, IP_DOMAIN, config)
         await hass.async_block_till_done()
 
     assert hass.states.get("image_processing.microsoftface_demo_camera")
@@ -77,17 +77,17 @@ async def test_setup_platform(hass: HomeAssistant, store_mock) -> None:
 async def test_setup_platform_name(hass: HomeAssistant, store_mock) -> None:
     """Set up platform with one entity and set name."""
     config = {
-        ip.DOMAIN: {
+        IP_DOMAIN: {
             "platform": "microsoft_face_identify",
             "source": {"entity_id": "camera.demo_camera", "name": "test local"},
             "group": "Test Group1",
         },
         "camera": {"platform": "demo"},
-        mf.DOMAIN: {"api_key": "12345678abcdef6"},
+        MF_DOMAIN: {"api_key": "12345678abcdef6"},
     }
 
-    with assert_setup_component(1, ip.DOMAIN):
-        await async_setup_component(hass, ip.DOMAIN, config)
+    with assert_setup_component(1, IP_DOMAIN):
+        await async_setup_component(hass, IP_DOMAIN, config)
         await hass.async_block_till_done()
 
     assert hass.states.get("image_processing.test_local")
@@ -110,7 +110,7 @@ async def test_ms_identify_process_image(
         text=load_fixture("persons.json", "microsoft_face_identify"),
     )
 
-    await async_setup_component(hass, ip.DOMAIN, CONFIG)
+    await async_setup_component(hass, IP_DOMAIN, CONFIG)
     await hass.async_block_till_done()
 
     state = hass.states.get("camera.demo_camera")

--- a/tests/components/notify/test_persistent_notification.py
+++ b/tests/components/notify/test_persistent_notification.py
@@ -1,7 +1,7 @@
 """The tests for the notify.persistent_notification service."""
 
 from homeassistant.components import notify
-import homeassistant.components.persistent_notification as pn
+from homeassistant.components.persistent_notification import DOMAIN as PN_DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -10,7 +10,7 @@ from tests.common import async_get_persistent_notifications
 
 async def test_async_send_message(hass: HomeAssistant) -> None:
     """Test sending a message to notify.persistent_notification service."""
-    await async_setup_component(hass, pn.DOMAIN, {"core": {}})
+    await async_setup_component(hass, PN_DOMAIN, {"core": {}})
     await async_setup_component(hass, notify.DOMAIN, {})
     await hass.async_block_till_done()
 
@@ -30,7 +30,7 @@ async def test_async_send_message(hass: HomeAssistant) -> None:
 
 async def test_async_supports_notification_id(hass: HomeAssistant) -> None:
     """Test that notify.persistent_notification supports notification_id."""
-    await async_setup_component(hass, pn.DOMAIN, {"core": {}})
+    await async_setup_component(hass, PN_DOMAIN, {"core": {}})
     await async_setup_component(hass, notify.DOMAIN, {})
     await hass.async_block_till_done()
 

--- a/tests/components/sighthound/test_image_processing.py
+++ b/tests/components/sighthound/test_image_processing.py
@@ -10,19 +10,24 @@ from PIL import UnidentifiedImageError
 import pytest
 import simplehound.core as hound
 
-import homeassistant.components.image_processing as ip
+from homeassistant.components.image_processing import DOMAIN as IP_DOMAIN, SERVICE_SCAN
 import homeassistant.components.sighthound.image_processing as sh
-from homeassistant.const import ATTR_ENTITY_ID, CONF_API_KEY
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_API_KEY,
+    CONF_ENTITY_ID,
+    CONF_SOURCE,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.setup import async_setup_component
 
 TEST_DIR = os.path.dirname(__file__)
 
 VALID_CONFIG = {
-    ip.DOMAIN: {
+    IP_DOMAIN: {
         "platform": "sighthound",
         CONF_API_KEY: "abc123",
-        ip.CONF_SOURCE: {ip.CONF_ENTITY_ID: "camera.demo_camera"},
+        CONF_SOURCE: {CONF_ENTITY_ID: "camera.demo_camera"},
     },
     "camera": {"platform": "demo"},
 }
@@ -96,7 +101,7 @@ async def test_bad_api_key(
     with mock.patch(
         "simplehound.core.cloud.detect", side_effect=hound.SimplehoundException
     ):
-        await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
+        await async_setup_component(hass, IP_DOMAIN, VALID_CONFIG)
         await hass.async_block_till_done()
         assert "Sighthound error" in caplog.text
         assert not hass.states.get(VALID_ENTITY_ID)
@@ -104,14 +109,14 @@ async def test_bad_api_key(
 
 async def test_setup_platform(hass: HomeAssistant, mock_detections) -> None:
     """Set up platform with one entity."""
-    await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
+    await async_setup_component(hass, IP_DOMAIN, VALID_CONFIG)
     await hass.async_block_till_done()
     assert hass.states.get(VALID_ENTITY_ID)
 
 
 async def test_process_image(hass: HomeAssistant, mock_image, mock_detections) -> None:
     """Process an image."""
-    await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
+    await async_setup_component(hass, IP_DOMAIN, VALID_CONFIG)
     await hass.async_block_till_done()
     assert hass.states.get(VALID_ENTITY_ID)
 
@@ -125,7 +130,7 @@ async def test_process_image(hass: HomeAssistant, mock_image, mock_detections) -
     hass.bus.async_listen(sh.EVENT_PERSON_DETECTED, capture_person_event)
 
     data = {ATTR_ENTITY_ID: VALID_ENTITY_ID}
-    await hass.services.async_call(ip.DOMAIN, ip.SERVICE_SCAN, service_data=data)
+    await hass.services.async_call(IP_DOMAIN, SERVICE_SCAN, service_data=data)
     await hass.async_block_till_done()
 
     state = hass.states.get(VALID_ENTITY_ID)
@@ -142,13 +147,13 @@ async def test_catch_bad_image(
 ) -> None:
     """Process an image."""
     valid_config_save_file = deepcopy(VALID_CONFIG)
-    valid_config_save_file[ip.DOMAIN].update({sh.CONF_SAVE_FILE_FOLDER: TEST_DIR})
-    await async_setup_component(hass, ip.DOMAIN, valid_config_save_file)
+    valid_config_save_file[IP_DOMAIN].update({sh.CONF_SAVE_FILE_FOLDER: TEST_DIR})
+    await async_setup_component(hass, IP_DOMAIN, valid_config_save_file)
     await hass.async_block_till_done()
     assert hass.states.get(VALID_ENTITY_ID)
 
     data = {ATTR_ENTITY_ID: VALID_ENTITY_ID}
-    await hass.services.async_call(ip.DOMAIN, ip.SERVICE_SCAN, service_data=data)
+    await hass.services.async_call(IP_DOMAIN, SERVICE_SCAN, service_data=data)
     await hass.async_block_till_done()
     assert "Sighthound unable to process image" in caplog.text
 
@@ -156,8 +161,8 @@ async def test_catch_bad_image(
 async def test_save_image(hass: HomeAssistant, mock_image, mock_detections) -> None:
     """Save a processed image."""
     valid_config_save_file = deepcopy(VALID_CONFIG)
-    valid_config_save_file[ip.DOMAIN].update({sh.CONF_SAVE_FILE_FOLDER: TEST_DIR})
-    await async_setup_component(hass, ip.DOMAIN, valid_config_save_file)
+    valid_config_save_file[IP_DOMAIN].update({sh.CONF_SAVE_FILE_FOLDER: TEST_DIR})
+    await async_setup_component(hass, IP_DOMAIN, valid_config_save_file)
     await hass.async_block_till_done()
     assert hass.states.get(VALID_ENTITY_ID)
 
@@ -167,7 +172,7 @@ async def test_save_image(hass: HomeAssistant, mock_image, mock_detections) -> N
         pil_img = pil_img_open.return_value
         pil_img = pil_img.convert.return_value
         data = {ATTR_ENTITY_ID: VALID_ENTITY_ID}
-        await hass.services.async_call(ip.DOMAIN, ip.SERVICE_SCAN, service_data=data)
+        await hass.services.async_call(IP_DOMAIN, SERVICE_SCAN, service_data=data)
         await hass.async_block_till_done()
         state = hass.states.get(VALID_ENTITY_ID)
         assert state.state == "2"
@@ -183,9 +188,9 @@ async def test_save_timestamped_image(
 ) -> None:
     """Save a processed image."""
     valid_config_save_ts_file = deepcopy(VALID_CONFIG)
-    valid_config_save_ts_file[ip.DOMAIN].update({sh.CONF_SAVE_FILE_FOLDER: TEST_DIR})
-    valid_config_save_ts_file[ip.DOMAIN].update({sh.CONF_SAVE_TIMESTAMPTED_FILE: True})
-    await async_setup_component(hass, ip.DOMAIN, valid_config_save_ts_file)
+    valid_config_save_ts_file[IP_DOMAIN].update({sh.CONF_SAVE_FILE_FOLDER: TEST_DIR})
+    valid_config_save_ts_file[IP_DOMAIN].update({sh.CONF_SAVE_TIMESTAMPTED_FILE: True})
+    await async_setup_component(hass, IP_DOMAIN, valid_config_save_ts_file)
     await hass.async_block_till_done()
     assert hass.states.get(VALID_ENTITY_ID)
 
@@ -195,7 +200,7 @@ async def test_save_timestamped_image(
         pil_img = pil_img_open.return_value
         pil_img = pil_img.convert.return_value
         data = {ATTR_ENTITY_ID: VALID_ENTITY_ID}
-        await hass.services.async_call(ip.DOMAIN, ip.SERVICE_SCAN, service_data=data)
+        await hass.services.async_call(IP_DOMAIN, SERVICE_SCAN, service_data=data)
         await hass.async_block_till_done()
         state = hass.states.get(VALID_ENTITY_ID)
         assert state.state == "2"

--- a/tests/components/yamaha/test_media_player.py
+++ b/tests/components/yamaha/test_media_player.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, PropertyMock, call, patch
 
 import pytest
 
-import homeassistant.components.media_player as mp
+from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.components.yamaha import media_player as yamaha
 from homeassistant.components.yamaha.const import DOMAIN
 from homeassistant.core import HomeAssistant
@@ -52,7 +52,7 @@ def device_fixture(main_zone):
 
 async def test_setup_host(hass: HomeAssistant, device, main_zone) -> None:
     """Test set up integration with host."""
-    assert await async_setup_component(hass, mp.DOMAIN, CONFIG)
+    assert await async_setup_component(hass, MP_DOMAIN, CONFIG)
     await hass.async_block_till_done()
 
     state = hass.states.get("media_player.yamaha_receiver_main_zone")
@@ -65,7 +65,7 @@ async def test_setup_no_host(hass: HomeAssistant, device, main_zone) -> None:
     """Test set up integration without host."""
     with patch("rxv.find", return_value=[device]):
         assert await async_setup_component(
-            hass, mp.DOMAIN, {"media_player": {"platform": "yamaha"}}
+            hass, MP_DOMAIN, {"media_player": {"platform": "yamaha"}}
         )
         await hass.async_block_till_done()
 
@@ -84,7 +84,7 @@ async def test_setup_discovery(hass: HomeAssistant, device, main_zone) -> None:
         "description_url": "http://receiver/description",
     }
     await async_load_platform(
-        hass, mp.DOMAIN, "yamaha", discovery_info, {mp.DOMAIN: {}}
+        hass, MP_DOMAIN, "yamaha", discovery_info, {MP_DOMAIN: {}}
     )
     await hass.async_block_till_done()
 
@@ -98,7 +98,7 @@ async def test_setup_zone_ignore(hass: HomeAssistant, device, main_zone) -> None
     """Test set up integration without host."""
     assert await async_setup_component(
         hass,
-        mp.DOMAIN,
+        MP_DOMAIN,
         {
             "media_player": {
                 "platform": "yamaha",
@@ -116,7 +116,7 @@ async def test_setup_zone_ignore(hass: HomeAssistant, device, main_zone) -> None
 
 async def test_enable_output(hass: HomeAssistant, device, main_zone) -> None:
     """Test enable output service."""
-    assert await async_setup_component(hass, mp.DOMAIN, CONFIG)
+    assert await async_setup_component(hass, MP_DOMAIN, CONFIG)
     await hass.async_block_till_done()
 
     port = "hdmi1"
@@ -147,7 +147,7 @@ async def test_enable_output(hass: HomeAssistant, device, main_zone) -> None:
 @pytest.mark.usefixtures("device")
 async def test_menu_cursor(hass: HomeAssistant, main_zone, cursor, method) -> None:
     """Verify that the correct menu method is called for the menu_cursor service."""
-    assert await async_setup_component(hass, mp.DOMAIN, CONFIG)
+    assert await async_setup_component(hass, MP_DOMAIN, CONFIG)
     await hass.async_block_till_done()
 
     data = {
@@ -166,7 +166,7 @@ async def test_select_scene(
     scene_prop = PropertyMock(return_value=None)
     type(main_zone).scene = scene_prop
 
-    assert await async_setup_component(hass, mp.DOMAIN, CONFIG)
+    assert await async_setup_component(hass, MP_DOMAIN, CONFIG)
     await hass.async_block_till_done()
 
     scene = "TV Viewing"


### PR DESCRIPTION
## Proposed change
Replace a few more import aliases with root imports.
_These are not yet caught by our `hass-component-root-import` pylint check._

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
