### PR TITLE
Extend component root imports in tests (2)

### DIFF
--- a/tests/components/demo/test_media_player.py
+++ b/tests/components/demo/test_media_player.py
@@ -6,11 +6,46 @@ from unittest.mock import patch
 import pytest
 import voluptuous as vol
 
-import homeassistant.components.media_player as mp
+from homeassistant.components.media_player import (
+    ATTR_GROUP_MEMBERS,
+    ATTR_INPUT_SOURCE,
+    ATTR_MEDIA_CONTENT_ID,
+    ATTR_MEDIA_CONTENT_TYPE,
+    ATTR_MEDIA_EPISODE,
+    ATTR_MEDIA_REPEAT,
+    ATTR_MEDIA_SEEK_POSITION,
+    ATTR_MEDIA_TRACK,
+    ATTR_MEDIA_VOLUME_LEVEL,
+    ATTR_MEDIA_VOLUME_MUTED,
+    DOMAIN as MP_DOMAIN,
+    SERVICE_CLEAR_PLAYLIST,
+    SERVICE_JOIN,
+    SERVICE_PLAY_MEDIA,
+    SERVICE_SELECT_SOURCE,
+    SERVICE_UNJOIN,
+    MediaPlayerEntityFeature,
+    RepeatMode,
+    is_on,
+)
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_ENTITY_PICTURE,
     ATTR_SUPPORTED_FEATURES,
+    SERVICE_MEDIA_NEXT_TRACK,
+    SERVICE_MEDIA_PAUSE,
+    SERVICE_MEDIA_PLAY,
+    SERVICE_MEDIA_PLAY_PAUSE,
+    SERVICE_MEDIA_PREVIOUS_TRACK,
+    SERVICE_MEDIA_SEEK,
+    SERVICE_MEDIA_STOP,
+    SERVICE_REPEAT_SET,
+    SERVICE_TOGGLE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    SERVICE_VOLUME_DOWN,
+    SERVICE_VOLUME_MUTE,
+    SERVICE_VOLUME_SET,
+    SERVICE_VOLUME_UP,
     STATE_OFF,
     STATE_PAUSED,
     STATE_PLAYING,
@@ -50,30 +85,30 @@ async def test_source_select(hass: HomeAssistant) -> None:
     entity_id = "media_player.lounge_room"
 
     assert await async_setup_component(
-        hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
+        hass, MP_DOMAIN, {"media_player": {"platform": "demo"}}
     )
     await hass.async_block_till_done()
     state = hass.states.get(entity_id)
-    assert state.attributes.get(mp.ATTR_INPUT_SOURCE) == "dvd"
+    assert state.attributes.get(ATTR_INPUT_SOURCE) == "dvd"
 
     with pytest.raises(vol.Invalid):
         await hass.services.async_call(
-            mp.DOMAIN,
-            mp.SERVICE_SELECT_SOURCE,
-            {ATTR_ENTITY_ID: entity_id, mp.ATTR_INPUT_SOURCE: None},
+            MP_DOMAIN,
+            SERVICE_SELECT_SOURCE,
+            {ATTR_ENTITY_ID: entity_id, ATTR_INPUT_SOURCE: None},
             blocking=True,
         )
     state = hass.states.get(entity_id)
-    assert state.attributes.get(mp.ATTR_INPUT_SOURCE) == "dvd"
+    assert state.attributes.get(ATTR_INPUT_SOURCE) == "dvd"
 
     await hass.services.async_call(
-        mp.DOMAIN,
-        mp.SERVICE_SELECT_SOURCE,
-        {ATTR_ENTITY_ID: entity_id, mp.ATTR_INPUT_SOURCE: "xbox"},
+        MP_DOMAIN,
+        SERVICE_SELECT_SOURCE,
+        {ATTR_ENTITY_ID: entity_id, ATTR_INPUT_SOURCE: "xbox"},
         blocking=True,
     )
     state = hass.states.get(entity_id)
-    assert state.attributes.get(mp.ATTR_INPUT_SOURCE) == "xbox"
+    assert state.attributes.get(ATTR_INPUT_SOURCE) == "xbox"
 
 
 async def test_repeat_set(hass: HomeAssistant) -> None:
@@ -81,26 +116,26 @@ async def test_repeat_set(hass: HomeAssistant) -> None:
     entity_id = "media_player.walkman"
 
     assert await async_setup_component(
-        hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
+        hass, MP_DOMAIN, {"media_player": {"platform": "demo"}}
     )
     await hass.async_block_till_done()
     state = hass.states.get(entity_id)
-    assert state.attributes.get(mp.ATTR_MEDIA_REPEAT) == mp.const.REPEAT_MODE_OFF
+    assert state.attributes.get(ATTR_MEDIA_REPEAT) == RepeatMode.OFF
 
     await hass.services.async_call(
-        mp.DOMAIN,
-        mp.SERVICE_REPEAT_SET,
-        {ATTR_ENTITY_ID: entity_id, mp.ATTR_MEDIA_REPEAT: mp.const.REPEAT_MODE_ALL},
+        MP_DOMAIN,
+        SERVICE_REPEAT_SET,
+        {ATTR_ENTITY_ID: entity_id, ATTR_MEDIA_REPEAT: RepeatMode.ALL},
         blocking=True,
     )
     state = hass.states.get(entity_id)
-    assert state.attributes.get(mp.ATTR_MEDIA_REPEAT) == mp.const.REPEAT_MODE_ALL
+    assert state.attributes.get(ATTR_MEDIA_REPEAT) == RepeatMode.ALL
 
 
 async def test_clear_playlist(hass: HomeAssistant) -> None:
     """Test clear playlist."""
     assert await async_setup_component(
-        hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
+        hass, MP_DOMAIN, {"media_player": {"platform": "demo"}}
     )
     await hass.async_block_till_done()
 
@@ -108,8 +143,8 @@ async def test_clear_playlist(hass: HomeAssistant) -> None:
     assert state.state == STATE_PLAYING
 
     await hass.services.async_call(
-        mp.DOMAIN,
-        mp.SERVICE_CLEAR_PLAYLIST,
+        MP_DOMAIN,
+        SERVICE_CLEAR_PLAYLIST,
         {ATTR_ENTITY_ID: TEST_ENTITY_ID},
         blocking=True,
     )
@@ -120,79 +155,79 @@ async def test_clear_playlist(hass: HomeAssistant) -> None:
 async def test_volume_services(hass: HomeAssistant) -> None:
     """Test the volume service."""
     assert await async_setup_component(
-        hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
+        hass, MP_DOMAIN, {"media_player": {"platform": "demo"}}
     )
     await hass.async_block_till_done()
 
     state = hass.states.get(TEST_ENTITY_ID)
-    assert state.attributes.get(mp.ATTR_MEDIA_VOLUME_LEVEL) == 1.0
+    assert state.attributes.get(ATTR_MEDIA_VOLUME_LEVEL) == 1.0
 
     with pytest.raises(vol.Invalid):
         await hass.services.async_call(
-            mp.DOMAIN,
-            mp.SERVICE_VOLUME_SET,
-            {ATTR_ENTITY_ID: TEST_ENTITY_ID, mp.ATTR_MEDIA_VOLUME_LEVEL: None},
+            MP_DOMAIN,
+            SERVICE_VOLUME_SET,
+            {ATTR_ENTITY_ID: TEST_ENTITY_ID, ATTR_MEDIA_VOLUME_LEVEL: None},
             blocking=True,
         )
 
     state = hass.states.get(TEST_ENTITY_ID)
-    assert state.attributes.get(mp.ATTR_MEDIA_VOLUME_LEVEL) == 1.0
+    assert state.attributes.get(ATTR_MEDIA_VOLUME_LEVEL) == 1.0
 
     await hass.services.async_call(
-        mp.DOMAIN,
-        mp.SERVICE_VOLUME_SET,
-        {ATTR_ENTITY_ID: TEST_ENTITY_ID, mp.ATTR_MEDIA_VOLUME_LEVEL: 0.5},
+        MP_DOMAIN,
+        SERVICE_VOLUME_SET,
+        {ATTR_ENTITY_ID: TEST_ENTITY_ID, ATTR_MEDIA_VOLUME_LEVEL: 0.5},
         blocking=True,
     )
     state = hass.states.get(TEST_ENTITY_ID)
-    assert state.attributes.get(mp.ATTR_MEDIA_VOLUME_LEVEL) == 0.5
+    assert state.attributes.get(ATTR_MEDIA_VOLUME_LEVEL) == 0.5
 
     await hass.services.async_call(
-        mp.DOMAIN,
-        mp.SERVICE_VOLUME_DOWN,
+        MP_DOMAIN,
+        SERVICE_VOLUME_DOWN,
         {ATTR_ENTITY_ID: TEST_ENTITY_ID},
         blocking=True,
     )
     state = hass.states.get(TEST_ENTITY_ID)
-    assert state.attributes.get(mp.ATTR_MEDIA_VOLUME_LEVEL) == 0.4
+    assert state.attributes.get(ATTR_MEDIA_VOLUME_LEVEL) == 0.4
 
     await hass.services.async_call(
-        mp.DOMAIN,
-        mp.SERVICE_VOLUME_UP,
+        MP_DOMAIN,
+        SERVICE_VOLUME_UP,
         {ATTR_ENTITY_ID: TEST_ENTITY_ID},
         blocking=True,
     )
     state = hass.states.get(TEST_ENTITY_ID)
-    assert state.attributes.get(mp.ATTR_MEDIA_VOLUME_LEVEL) == 0.5
+    assert state.attributes.get(ATTR_MEDIA_VOLUME_LEVEL) == 0.5
 
-    assert state.attributes.get(mp.ATTR_MEDIA_VOLUME_MUTED) is False
+    assert state.attributes.get(ATTR_MEDIA_VOLUME_MUTED) is False
 
     with pytest.raises(vol.Invalid):
         await hass.services.async_call(
-            mp.DOMAIN,
-            mp.SERVICE_VOLUME_MUTE,
-            {ATTR_ENTITY_ID: TEST_ENTITY_ID, mp.ATTR_MEDIA_VOLUME_MUTED: None},
+            MP_DOMAIN,
+            SERVICE_VOLUME_MUTE,
+            {ATTR_ENTITY_ID: TEST_ENTITY_ID, ATTR_MEDIA_VOLUME_MUTED: None},
             blocking=True,
         )
 
     state = hass.states.get(TEST_ENTITY_ID)
-    assert state.attributes.get(mp.ATTR_MEDIA_VOLUME_MUTED) is False
+    assert state.attributes.get(ATTR_MEDIA_VOLUME_MUTED) is False
 
     await hass.services.async_call(
-        mp.DOMAIN,
-        mp.SERVICE_VOLUME_MUTE,
-        {ATTR_ENTITY_ID: TEST_ENTITY_ID, mp.ATTR_MEDIA_VOLUME_MUTED: True},
+        MP_DOMAIN,
+        SERVICE_VOLUME_MUTE,
+        {ATTR_ENTITY_ID: TEST_ENTITY_ID, ATTR_MEDIA_VOLUME_MUTED: True},
         blocking=True,
     )
 
     state = hass.states.get(TEST_ENTITY_ID)
-    assert state.attributes.get(mp.ATTR_MEDIA_VOLUME_MUTED) is True
+    assert state.attributes.get(ATTR_MEDIA_VOLUME_MUTED) is True
 
 
 async def test_turning_off_and_on(hass: HomeAssistant) -> None:
     """Test turn_on and turn_off."""
     assert await async_setup_component(
-        hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
+        hass, MP_DOMAIN, {"media_player": {"platform": "demo"}}
     )
     await hass.async_block_till_done()
 
@@ -200,40 +235,40 @@ async def test_turning_off_and_on(hass: HomeAssistant) -> None:
     assert state.state == STATE_PLAYING
 
     await hass.services.async_call(
-        mp.DOMAIN,
-        mp.SERVICE_TURN_OFF,
+        MP_DOMAIN,
+        SERVICE_TURN_OFF,
         {ATTR_ENTITY_ID: TEST_ENTITY_ID},
         blocking=True,
     )
     state = hass.states.get(TEST_ENTITY_ID)
     assert state.state == STATE_OFF
-    assert not mp.is_on(hass, TEST_ENTITY_ID)
+    assert not is_on(hass, TEST_ENTITY_ID)
 
     await hass.services.async_call(
-        mp.DOMAIN,
-        mp.SERVICE_TURN_ON,
+        MP_DOMAIN,
+        SERVICE_TURN_ON,
         {ATTR_ENTITY_ID: TEST_ENTITY_ID},
         blocking=True,
     )
     state = hass.states.get(TEST_ENTITY_ID)
     assert state.state == STATE_PLAYING
-    assert mp.is_on(hass, TEST_ENTITY_ID)
+    assert is_on(hass, TEST_ENTITY_ID)
 
     await hass.services.async_call(
-        mp.DOMAIN,
-        mp.SERVICE_TOGGLE,
+        MP_DOMAIN,
+        SERVICE_TOGGLE,
         {ATTR_ENTITY_ID: TEST_ENTITY_ID},
         blocking=True,
     )
     state = hass.states.get(TEST_ENTITY_ID)
     assert state.state == STATE_OFF
-    assert not mp.is_on(hass, TEST_ENTITY_ID)
+    assert not is_on(hass, TEST_ENTITY_ID)
 
 
 async def test_playing_pausing(hass: HomeAssistant) -> None:
     """Test media_pause."""
     assert await async_setup_component(
-        hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
+        hass, MP_DOMAIN, {"media_player": {"platform": "demo"}}
     )
     await hass.async_block_till_done()
 
@@ -241,8 +276,8 @@ async def test_playing_pausing(hass: HomeAssistant) -> None:
     assert state.state == STATE_PLAYING
 
     await hass.services.async_call(
-        mp.DOMAIN,
-        mp.SERVICE_MEDIA_PAUSE,
+        MP_DOMAIN,
+        SERVICE_MEDIA_PAUSE,
         {ATTR_ENTITY_ID: TEST_ENTITY_ID},
         blocking=True,
     )
@@ -250,8 +285,8 @@ async def test_playing_pausing(hass: HomeAssistant) -> None:
     assert state.state == STATE_PAUSED
 
     await hass.services.async_call(
-        mp.DOMAIN,
-        mp.SERVICE_MEDIA_PLAY_PAUSE,
+        MP_DOMAIN,
+        SERVICE_MEDIA_PLAY_PAUSE,
         {ATTR_ENTITY_ID: TEST_ENTITY_ID},
         blocking=True,
     )
@@ -259,8 +294,8 @@ async def test_playing_pausing(hass: HomeAssistant) -> None:
     assert state.state == STATE_PLAYING
 
     await hass.services.async_call(
-        mp.DOMAIN,
-        mp.SERVICE_MEDIA_PLAY_PAUSE,
+        MP_DOMAIN,
+        SERVICE_MEDIA_PLAY_PAUSE,
         {ATTR_ENTITY_ID: TEST_ENTITY_ID},
         blocking=True,
     )
@@ -268,8 +303,8 @@ async def test_playing_pausing(hass: HomeAssistant) -> None:
     assert state.state == STATE_PAUSED
 
     await hass.services.async_call(
-        mp.DOMAIN,
-        mp.SERVICE_MEDIA_PLAY,
+        MP_DOMAIN,
+        SERVICE_MEDIA_PLAY,
         {ATTR_ENTITY_ID: TEST_ENTITY_ID},
         blocking=True,
     )
@@ -280,148 +315,148 @@ async def test_playing_pausing(hass: HomeAssistant) -> None:
 async def test_prev_next_track(hass: HomeAssistant) -> None:
     """Test media_next_track and media_previous_track ."""
     assert await async_setup_component(
-        hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
+        hass, MP_DOMAIN, {"media_player": {"platform": "demo"}}
     )
     await hass.async_block_till_done()
 
     state = hass.states.get(TEST_ENTITY_ID)
-    assert state.attributes.get(mp.ATTR_MEDIA_TRACK) == 1
+    assert state.attributes.get(ATTR_MEDIA_TRACK) == 1
 
     await hass.services.async_call(
-        mp.DOMAIN,
-        mp.SERVICE_MEDIA_NEXT_TRACK,
+        MP_DOMAIN,
+        SERVICE_MEDIA_NEXT_TRACK,
         {ATTR_ENTITY_ID: TEST_ENTITY_ID},
         blocking=True,
     )
     state = hass.states.get(TEST_ENTITY_ID)
-    assert state.attributes.get(mp.ATTR_MEDIA_TRACK) == 2
+    assert state.attributes.get(ATTR_MEDIA_TRACK) == 2
 
     await hass.services.async_call(
-        mp.DOMAIN,
-        mp.SERVICE_MEDIA_NEXT_TRACK,
+        MP_DOMAIN,
+        SERVICE_MEDIA_NEXT_TRACK,
         {ATTR_ENTITY_ID: TEST_ENTITY_ID},
         blocking=True,
     )
     state = hass.states.get(TEST_ENTITY_ID)
-    assert state.attributes.get(mp.ATTR_MEDIA_TRACK) == 3
+    assert state.attributes.get(ATTR_MEDIA_TRACK) == 3
 
     await hass.services.async_call(
-        mp.DOMAIN,
-        mp.SERVICE_MEDIA_PREVIOUS_TRACK,
+        MP_DOMAIN,
+        SERVICE_MEDIA_PREVIOUS_TRACK,
         {ATTR_ENTITY_ID: TEST_ENTITY_ID},
         blocking=True,
     )
     state = hass.states.get(TEST_ENTITY_ID)
-    assert state.attributes.get(mp.ATTR_MEDIA_TRACK) == 2
+    assert state.attributes.get(ATTR_MEDIA_TRACK) == 2
 
     assert await async_setup_component(
-        hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
+        hass, MP_DOMAIN, {"media_player": {"platform": "demo"}}
     )
     await hass.async_block_till_done()
 
     ent_id = "media_player.lounge_room"
     state = hass.states.get(ent_id)
-    assert state.attributes.get(mp.ATTR_MEDIA_EPISODE) == "1"
+    assert state.attributes.get(ATTR_MEDIA_EPISODE) == "1"
 
     await hass.services.async_call(
-        mp.DOMAIN,
-        mp.SERVICE_MEDIA_NEXT_TRACK,
+        MP_DOMAIN,
+        SERVICE_MEDIA_NEXT_TRACK,
         {ATTR_ENTITY_ID: ent_id},
         blocking=True,
     )
     state = hass.states.get(ent_id)
-    assert state.attributes.get(mp.ATTR_MEDIA_EPISODE) == "2"
+    assert state.attributes.get(ATTR_MEDIA_EPISODE) == "2"
 
     await hass.services.async_call(
-        mp.DOMAIN,
-        mp.SERVICE_MEDIA_PREVIOUS_TRACK,
+        MP_DOMAIN,
+        SERVICE_MEDIA_PREVIOUS_TRACK,
         {ATTR_ENTITY_ID: ent_id},
         blocking=True,
     )
     state = hass.states.get(ent_id)
-    assert state.attributes.get(mp.ATTR_MEDIA_EPISODE) == "1"
+    assert state.attributes.get(ATTR_MEDIA_EPISODE) == "1"
 
 
 async def test_play_media(hass: HomeAssistant) -> None:
     """Test play_media ."""
     assert await async_setup_component(
-        hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
+        hass, MP_DOMAIN, {"media_player": {"platform": "demo"}}
     )
     await hass.async_block_till_done()
 
     ent_id = "media_player.living_room"
     state = hass.states.get(ent_id)
     assert (
-        mp.MediaPlayerEntityFeature.PLAY_MEDIA
+        MediaPlayerEntityFeature.PLAY_MEDIA
         & state.attributes.get(ATTR_SUPPORTED_FEATURES)
         > 0
     )
-    assert state.attributes.get(mp.ATTR_MEDIA_CONTENT_ID) is not None
+    assert state.attributes.get(ATTR_MEDIA_CONTENT_ID) is not None
 
     with pytest.raises(vol.Invalid):
         await hass.services.async_call(
-            mp.DOMAIN,
-            mp.SERVICE_PLAY_MEDIA,
-            {ATTR_ENTITY_ID: ent_id, mp.ATTR_MEDIA_CONTENT_ID: "some_id"},
+            MP_DOMAIN,
+            SERVICE_PLAY_MEDIA,
+            {ATTR_ENTITY_ID: ent_id, ATTR_MEDIA_CONTENT_ID: "some_id"},
             blocking=True,
         )
     state = hass.states.get(ent_id)
     assert (
-        mp.MediaPlayerEntityFeature.PLAY_MEDIA
+        MediaPlayerEntityFeature.PLAY_MEDIA
         & state.attributes.get(ATTR_SUPPORTED_FEATURES)
         > 0
     )
-    assert state.attributes.get(mp.ATTR_MEDIA_CONTENT_ID) != "some_id"
+    assert state.attributes.get(ATTR_MEDIA_CONTENT_ID) != "some_id"
 
     await hass.services.async_call(
-        mp.DOMAIN,
-        mp.SERVICE_PLAY_MEDIA,
+        MP_DOMAIN,
+        SERVICE_PLAY_MEDIA,
         {
             ATTR_ENTITY_ID: ent_id,
-            mp.ATTR_MEDIA_CONTENT_TYPE: "youtube",
-            mp.ATTR_MEDIA_CONTENT_ID: "some_id",
+            ATTR_MEDIA_CONTENT_TYPE: "youtube",
+            ATTR_MEDIA_CONTENT_ID: "some_id",
         },
         blocking=True,
     )
     state = hass.states.get(ent_id)
     assert (
-        mp.MediaPlayerEntityFeature.PLAY_MEDIA
+        MediaPlayerEntityFeature.PLAY_MEDIA
         & state.attributes.get(ATTR_SUPPORTED_FEATURES)
         > 0
     )
-    assert state.attributes.get(mp.ATTR_MEDIA_CONTENT_ID) == "some_id"
+    assert state.attributes.get(ATTR_MEDIA_CONTENT_ID) == "some_id"
 
 
 async def test_seek(hass: HomeAssistant, mock_media_seek) -> None:
     """Test seek."""
     assert await async_setup_component(
-        hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
+        hass, MP_DOMAIN, {"media_player": {"platform": "demo"}}
     )
     await hass.async_block_till_done()
 
     ent_id = "media_player.living_room"
     state = hass.states.get(ent_id)
-    assert state.attributes[ATTR_SUPPORTED_FEATURES] & mp.MediaPlayerEntityFeature.SEEK
+    assert state.attributes[ATTR_SUPPORTED_FEATURES] & MediaPlayerEntityFeature.SEEK
     assert not mock_media_seek.called
 
     with pytest.raises(vol.Invalid):
         await hass.services.async_call(
-            mp.DOMAIN,
-            mp.SERVICE_MEDIA_SEEK,
+            MP_DOMAIN,
+            SERVICE_MEDIA_SEEK,
             {
                 ATTR_ENTITY_ID: ent_id,
-                mp.ATTR_MEDIA_SEEK_POSITION: None,
+                ATTR_MEDIA_SEEK_POSITION: None,
             },
             blocking=True,
         )
     assert not mock_media_seek.called
 
     await hass.services.async_call(
-        mp.DOMAIN,
-        mp.SERVICE_MEDIA_SEEK,
+        MP_DOMAIN,
+        SERVICE_MEDIA_SEEK,
         {
             ATTR_ENTITY_ID: ent_id,
-            mp.ATTR_MEDIA_SEEK_POSITION: 100,
+            ATTR_MEDIA_SEEK_POSITION: 100,
         },
         blocking=True,
     )
@@ -431,7 +466,7 @@ async def test_seek(hass: HomeAssistant, mock_media_seek) -> None:
 async def test_stop(hass: HomeAssistant) -> None:
     """Test stop."""
     assert await async_setup_component(
-        hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
+        hass, MP_DOMAIN, {"media_player": {"platform": "demo"}}
     )
     await hass.async_block_till_done()
 
@@ -439,8 +474,8 @@ async def test_stop(hass: HomeAssistant) -> None:
     assert state.state == STATE_PLAYING
 
     await hass.services.async_call(
-        mp.DOMAIN,
-        mp.SERVICE_MEDIA_STOP,
+        MP_DOMAIN,
+        SERVICE_MEDIA_STOP,
         {ATTR_ENTITY_ID: TEST_ENTITY_ID},
         blocking=True,
     )
@@ -453,7 +488,7 @@ async def test_media_image_proxy(
 ) -> None:
     """Test the media server image proxy server ."""
     assert await async_setup_component(
-        hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
+        hass, MP_DOMAIN, {"media_player": {"platform": "demo"}}
     )
     await hass.async_block_till_done()
 
@@ -500,31 +535,31 @@ async def test_grouping(hass: HomeAssistant) -> None:
     kitchen = "media_player.kitchen"
 
     assert await async_setup_component(
-        hass, mp.DOMAIN, {"media_player": {"platform": "demo"}}
+        hass, MP_DOMAIN, {"media_player": {"platform": "demo"}}
     )
     await hass.async_block_till_done()
     state = hass.states.get(walkman)
-    assert state.attributes.get(mp.ATTR_GROUP_MEMBERS) == []
+    assert state.attributes.get(ATTR_GROUP_MEMBERS) == []
 
     await hass.services.async_call(
-        mp.DOMAIN,
-        mp.SERVICE_JOIN,
+        MP_DOMAIN,
+        SERVICE_JOIN,
         {
             ATTR_ENTITY_ID: walkman,
-            mp.ATTR_GROUP_MEMBERS: [
+            ATTR_GROUP_MEMBERS: [
                 kitchen,
             ],
         },
         blocking=True,
     )
     state = hass.states.get(walkman)
-    assert state.attributes.get(mp.ATTR_GROUP_MEMBERS) == [walkman, kitchen]
+    assert state.attributes.get(ATTR_GROUP_MEMBERS) == [walkman, kitchen]
 
     await hass.services.async_call(
-        mp.DOMAIN,
-        mp.SERVICE_UNJOIN,
+        MP_DOMAIN,
+        SERVICE_UNJOIN,
         {ATTR_ENTITY_ID: walkman},
         blocking=True,
     )
     state = hass.states.get(walkman)
-    assert state.attributes.get(mp.ATTR_GROUP_MEMBERS) == []
+    assert state.attributes.get(ATTR_GROUP_MEMBERS) == []


### PR DESCRIPTION
## Proposed change
Replace a few more import aliases with root imports.
_These are not yet caught by our `hass-component-root-import` pylint check._

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
