### PR TITLE
Fix race against is_smart_detected in unifiprotect

### DIFF
--- a/homeassistant/components/unifiprotect/binary_sensor.py
+++ b/homeassistant/components/unifiprotect/binary_sensor.py
@@ -750,13 +750,17 @@ class ProtectSmartEventBinarySensor(EventEntityMixin, BinarySensorEntity):
             event
             and not self._event_already_ended(prev_event, prev_event_end)
             and description.has_matching_smart(event)
+            and (
+                (is_end := event.end)
+                or (not prev_event and self.device.is_smart_detected)
+            )
         ):
             self._set_event_done()
             return
 
         self._attr_is_on = True
         self._set_event_attrs(event)
-        if event.end:
+        if is_end:
             self._async_event_with_immediate_end()
 
 

--- a/homeassistant/components/unifiprotect/binary_sensor.py
+++ b/homeassistant/components/unifiprotect/binary_sensor.py
@@ -742,21 +742,21 @@ class ProtectSmartEventBinarySensor(EventEntityMixin, BinarySensorEntity):
         prev_event = self._event
         prev_event_end = self._event_end
         super()._async_update_device_from_protect(device)
-        event = self._event = description.get_event_obj(device)
-        self._event_end = event.end if event else None
+        if event := description.get_event_obj(device):
+            self._event = event
+            self._event_end = event.end if event else None
 
         if not (
             event
             and not self._event_already_ended(prev_event, prev_event_end)
             and description.has_matching_smart(event)
-            and ((is_end := event.end) or self.device.is_smart_detected)
         ):
             self._set_event_done()
             return
 
         self._attr_is_on = True
         self._set_event_attrs(event)
-        if is_end:
+        if event.end:
             self._async_event_with_immediate_end()
 
 

--- a/homeassistant/components/unifiprotect/binary_sensor.py
+++ b/homeassistant/components/unifiprotect/binary_sensor.py
@@ -748,8 +748,8 @@ class ProtectSmartEventBinarySensor(EventEntityMixin, BinarySensorEntity):
 
         if not (
             event
-            and not self._event_already_ended(prev_event, prev_event_end)
             and description.has_matching_smart(event)
+            and not self._event_already_ended(prev_event, prev_event_end)
         ):
             self._set_event_done()
             return

--- a/homeassistant/components/unifiprotect/binary_sensor.py
+++ b/homeassistant/components/unifiprotect/binary_sensor.py
@@ -750,17 +750,13 @@ class ProtectSmartEventBinarySensor(EventEntityMixin, BinarySensorEntity):
             event
             and not self._event_already_ended(prev_event, prev_event_end)
             and description.has_matching_smart(event)
-            and (
-                (is_end := event.end)
-                or (not prev_event and self.device.is_smart_detected)
-            )
         ):
             self._set_event_done()
             return
 
         self._attr_is_on = True
         self._set_event_attrs(event)
-        if is_end:
+        if event.end:
             self._async_event_with_immediate_end()
 
 

--- a/homeassistant/components/unifiprotect/sensor.py
+++ b/homeassistant/components/unifiprotect/sensor.py
@@ -762,14 +762,14 @@ class ProtectLicensePlateEventSensor(ProtectEventSensor):
         prev_event = self._event
         prev_event_end = self._event_end
         super()._async_update_device_from_protect(device)
-        event = self._event = description.get_event_obj(device)
-        self._event_end = event.end if event else None
+        if event := description.get_event_obj(device):
+            self._event = event
+            self._event_end = event.end
 
         if not (
             event
             and not self._event_already_ended(prev_event, prev_event_end)
             and description.has_matching_smart(event)
-            and ((is_end := event.end) or self.device.is_smart_detected)
             and (metadata := event.metadata)
             and (license_plate := metadata.license_plate)
         ):
@@ -778,5 +778,5 @@ class ProtectLicensePlateEventSensor(ProtectEventSensor):
 
         self._attr_native_value = license_plate.name
         self._set_event_attrs(event)
-        if is_end:
+        if event.end:
             self._async_event_with_immediate_end()

--- a/homeassistant/components/unifiprotect/sensor.py
+++ b/homeassistant/components/unifiprotect/sensor.py
@@ -768,10 +768,10 @@ class ProtectLicensePlateEventSensor(ProtectEventSensor):
 
         if not (
             event
-            and not self._event_already_ended(prev_event, prev_event_end)
-            and description.has_matching_smart(event)
             and (metadata := event.metadata)
             and (license_plate := metadata.license_plate)
+            and description.has_matching_smart(event)
+            and not self._event_already_ended(prev_event, prev_event_end)
         ):
             self._set_event_done()
             return

--- a/homeassistant/components/unifiprotect/sensor.py
+++ b/homeassistant/components/unifiprotect/sensor.py
@@ -772,11 +772,15 @@ class ProtectLicensePlateEventSensor(ProtectEventSensor):
             and description.has_matching_smart(event)
             and (metadata := event.metadata)
             and (license_plate := metadata.license_plate)
+            and (
+                (is_end := event.end)
+                or (not prev_event and self.device.is_smart_detected)
+            )
         ):
             self._set_event_done()
             return
 
         self._attr_native_value = license_plate.name
         self._set_event_attrs(event)
-        if event.end:
+        if is_end:
             self._async_event_with_immediate_end()

--- a/homeassistant/components/unifiprotect/sensor.py
+++ b/homeassistant/components/unifiprotect/sensor.py
@@ -772,15 +772,11 @@ class ProtectLicensePlateEventSensor(ProtectEventSensor):
             and description.has_matching_smart(event)
             and (metadata := event.metadata)
             and (license_plate := metadata.license_plate)
-            and (
-                (is_end := event.end)
-                or (not prev_event and self.device.is_smart_detected)
-            )
         ):
             self._set_event_done()
             return
 
         self._attr_native_value = license_plate.name
         self._set_event_attrs(event)
-        if is_end:
+        if event.end:
             self._async_event_with_immediate_end()


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We cannot check `is_smart_detected` because the camera model updates after
the event model which means we would flip back and forth sometimes if
we loose the race.

We do not need to check `is_smart_detected` anyways because we already have the event.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
