### PR TITLE
Remove dynamic feature creation from tplink integration

### DIFF
--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -332,7 +332,7 @@ class CoordinatedTPLinkFeatureEntity(CoordinatedTPLinkEntity, ABC):
             for feat in device.features.values()
             if feat.type == feature_type
             and (
-                feat.category != Feature.Category.Primary
+                feat.category is not Feature.Category.Primary
                 or device.device_type not in DEVICETYPES_WITH_SPECIALIZED_PLATFORMS
             )
             and (

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -19,11 +19,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import TPLinkConfigEntry
 from .coordinator import TPLinkDataUpdateCoordinator
-from .entity import (
-    CoordinatedTPLinkFeatureEntity,
-    TPLinkFeatureEntityDescription,
-    entities_for_device_and_its_children,
-)
+from .entity import CoordinatedTPLinkFeatureEntity, TPLinkFeatureEntityDescription
 
 UNIT_MAPPING = {
     "celsius": UnitOfTemperature.CELSIUS,
@@ -153,11 +149,12 @@ async def async_setup_entry(
     children_coordinators = data.children_coordinators
     device = parent_coordinator.device
 
-    entities = entities_for_device_and_its_children(
+    entities = CoordinatedTPLinkFeatureEntity.entities_for_device_and_its_children(
         device=device,
         coordinator=parent_coordinator,
         feature_type=Feature.Type.Sensor,
         entity_class=Sensor,
+        descriptions=SENSOR_DESCRIPTIONS_MAP,
         child_coordinators=children_coordinators,
     )
     async_add_entities(entities)
@@ -174,12 +171,10 @@ class Sensor(CoordinatedTPLinkFeatureEntity, SensorEntity):
         coordinator: TPLinkDataUpdateCoordinator,
         *,
         feature: Feature,
+        description: TPLinkSensorEntityDescription,
         parent: Device | None = None,
     ) -> None:
         """Initialize the sensor."""
-        description = self._description_for_feature(
-            TPLinkSensorEntityDescription, feature, SENSOR_DESCRIPTIONS_MAP
-        )
         super().__init__(
             device, coordinator, description=description, feature=feature, parent=parent
         )

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -18,7 +18,6 @@ from .entity import (
     CoordinatedTPLinkFeatureEntity,
     TPLinkFeatureEntityDescription,
     async_refresh_after,
-    entities_for_device_and_its_children,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -65,11 +64,12 @@ async def async_setup_entry(
     parent_coordinator = data.parent_coordinator
     device = parent_coordinator.device
 
-    entities = entities_for_device_and_its_children(
+    entities = CoordinatedTPLinkFeatureEntity.entities_for_device_and_its_children(
         device,
         coordinator=parent_coordinator,
         feature_type=Feature.Switch,
         entity_class=TPLinkSwitch,
+        descriptions=SWITCH_DESCRIPTIONS_MAP,
     )
 
     async_add_entities(entities)
@@ -86,15 +86,10 @@ class TPLinkSwitch(CoordinatedTPLinkFeatureEntity, SwitchEntity):
         coordinator: TPLinkDataUpdateCoordinator,
         *,
         feature: Feature,
+        description: TPLinkSwitchEntityDescription,
         parent: Device | None = None,
     ) -> None:
         """Initialize the switch."""
-        description = self._description_for_feature(
-            TPLinkSwitchEntityDescription,
-            feature,
-            SWITCH_DESCRIPTIONS_MAP,
-            child_alias=device.alias if parent else None,
-        )
         super().__init__(
             device, coordinator, description=description, feature=feature, parent=parent
         )

--- a/tests/components/tplink/test_sensor.py
+++ b/tests/components/tplink/test_sensor.py
@@ -155,34 +155,6 @@ async def test_sensor_unique_id(
         assert entity_registry.async_get(sensor_entity_id).unique_id == value
 
 
-async def test_new_sensor(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry
-) -> None:
-    """Test a sensor unique ids."""
-    already_migrated_config_entry = MockConfigEntry(
-        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
-    )
-    already_migrated_config_entry.add_to_hass(hass)
-    new_feature = _mocked_feature(
-        5.2,
-        "consumption_this_fortnight",
-        name="Consumption for fortnight",
-        type_=Feature.Type.Sensor,
-        category=Feature.Category.Primary,
-        unit="A",
-        precision_hint=2,
-    )
-    plug = _mocked_device(alias="my_plug", features=[new_feature])
-    with _patch_discovery(device=plug), _patch_connect(device=plug):
-        await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
-        await hass.async_block_till_done()
-
-    entity_id = "sensor.my_plug_consumption_for_fortnight"
-    entity = entity_registry.async_get(entity_id)
-    assert entity
-    assert entity.unique_id == f"{DEVICE_ID}_consumption_this_fortnight"
-
-
 async def test_sensor_children(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
@@ -193,10 +165,12 @@ async def test_sensor_children(
         domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
     )
     already_migrated_config_entry.add_to_hass(hass)
-    new_feature = _mocked_feature(
+    feature = _mocked_feature(
         5.2,
-        "consumption_this_fortnight",
-        name="Consumption for fortnight",
+        "consumption_this_month",
+        # integration should ignore name and use the value from strings.json:
+        # This month's consumption
+        name="Consumption for month",
         type_=Feature.Type.Sensor,
         category=Feature.Category.Primary,
         unit="A",
@@ -204,26 +178,23 @@ async def test_sensor_children(
     )
     plug = _mocked_device(
         alias="my_plug",
-        features=[new_feature],
-        children=_mocked_strip_children(features=[new_feature]),
+        features=[feature],
+        children=_mocked_strip_children(features=[feature]),
     )
     with _patch_discovery(device=plug), _patch_connect(device=plug):
         await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
         await hass.async_block_till_done()
 
-    entity_id = "sensor.my_plug_consumption_for_fortnight"
+    entity_id = "sensor.my_plug_this_month_s_consumption"
     entity = entity_registry.async_get(entity_id)
     assert entity
     device = device_registry.async_get(entity.device_id)
 
     for plug_id in range(2):
-        child_entity_id = f"sensor.my_plug_plug{plug_id}_consumption_for_fortnight"
+        child_entity_id = f"sensor.my_plug_plug{plug_id}_this_month_s_consumption"
         child_entity = entity_registry.async_get(child_entity_id)
         assert child_entity
-        assert (
-            child_entity.unique_id
-            == f"PLUG{plug_id}DEVICEID_consumption_this_fortnight"
-        )
+        assert child_entity.unique_id == f"PLUG{plug_id}DEVICEID_consumption_this_month"
         assert child_entity.device_id != entity.device_id
         child_device = device_registry.async_get(child_entity.device_id)
         assert child_device


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Remove the dynamic feature creation as per review feedback.

For some reason the diff looks larger than it should but essentially the changes are:

- Make `_entities_for_device_and_its_children` and `_entities_for_device` class methods
- Remove the description class as a parameter to `_description_for_feature`
- Call `_description_for_feature` as part of the entity creation condition in `_entities_for_device`
- Pass the descriptions as a parameter to `_entities_for_device_and_its_children` and `_entities_for_device` instead of creating them in the entity constructors.
  - This is required because if the descriptions are not in the map they will not be created so the constructor cannot call the method.  This approach retains the ability to log `info` on features undefined in HA and encourage updates to the integration to support new features.
  - It also gives mypy the description type to bind to retain proper typing after removing the description class parameter.

See https://github.com/home-assistant/core/pull/117785 for an explanation of the approach for merging into the tplink_rewrite branch

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
