### PR TITLE
Reload Risco on connection reset

### DIFF
--- a/homeassistant/components/risco/__init__.py
+++ b/homeassistant/components/risco/__init__.py
@@ -90,6 +90,9 @@ async def _async_setup_local_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
 
     async def _error(error: Exception) -> None:
         _LOGGER.error("Error in Risco library", exc_info=error)
+        if isinstance(error, ConnectionResetError) and not hass.is_stopping:
+            _LOGGER.debug("Disconnected from panel. Reloading integration")
+            hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))
 
     entry.async_on_unload(risco.add_error_handler(_error))
 

--- a/homeassistant/components/risco/manifest.json
+++ b/homeassistant/components/risco/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_push",
   "loggers": ["pyrisco"],
   "quality_scale": "platinum",
-  "requirements": ["pyrisco==0.6.2"]
+  "requirements": ["pyrisco==0.6.4"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2126,7 +2126,7 @@ pyrecswitch==1.0.2
 pyrepetierng==0.1.0
 
 # homeassistant.components.risco
-pyrisco==0.6.2
+pyrisco==0.6.4
 
 # homeassistant.components.rituals_perfume_genie
 pyrituals==0.0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1671,7 +1671,7 @@ pyqwikswitch==0.93
 pyrainbird==6.0.1
 
 # homeassistant.components.risco
-pyrisco==0.6.2
+pyrisco==0.6.4
 
 # homeassistant.components.rituals_perfume_genie
 pyrituals==0.0.6

--- a/tests/components/risco/test_init.py
+++ b/tests/components/risco/test_init.py
@@ -1,0 +1,30 @@
+"""Tests for the Risco integration."""
+
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+
+
+@pytest.fixture
+def mock_error_handler():
+    """Create a mock for add_error_handler."""
+    with patch("homeassistant.components.risco.RiscoLocal.add_error_handler") as mock:
+        yield mock
+
+
+async def test_connection_reset(
+    hass: HomeAssistant, two_zone_local, mock_error_handler, setup_risco_local
+) -> None:
+    """Test config entry reload on connection reset."""
+
+    callback = mock_error_handler.call_args.args[0]
+    assert callback is not None
+
+    with patch.object(hass.config_entries, "async_reload") as reload_mock:
+        await callback(Exception())
+        reload_mock.assert_not_awaited()
+
+        await callback(ConnectionResetError())
+        reload_mock.assert_awaited_once()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When the Risco integration encounters a connection reset error after it's already connected there's a memory leak and the system quickly becomes unusable. This PR handles it by closing the connection and reloading the integration.
Changes in the underlying library:
https://github.com/OnFreund/pyrisco/compare/v0.6.2...v0.6.4

Please note, I wasn't able to reproduce this so can't test locally. @IlPicasso confirmed that the library update fixed the memory leak.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #119138
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
