### PR TITLE
Huisbaasje rebranded to EnergyFlip

### DIFF
--- a/homeassistant/components/huisbaasje/__init__.py
+++ b/homeassistant/components/huisbaasje/__init__.py
@@ -1,4 +1,4 @@
-"""The Huisbaasje integration."""
+"""The EnergyFlip integration."""
 
 import asyncio
 from datetime import timedelta
@@ -31,8 +31,8 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up Huisbaasje from a config entry."""
-    # Create the Huisbaasje client
+    """Set up EnergyFlip from a config entry."""
+    # Create the EnergyFlip client
     energyflip = EnergyFlip(
         username=entry.data[CONF_USERNAME],
         password=entry.data[CONF_PASSWORD],
@@ -48,7 +48,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         return False
 
     async def async_update_data() -> dict[str, dict[str, Any]]:
-        return await async_update_huisbaasje(energyflip)
+        return await async_update_energyflip(energyflip)
 
     # Create a coordinator for polling updates
     coordinator = DataUpdateCoordinator(
@@ -75,21 +75,21 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Forward the unloading of the entry to the platform
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
-    # If successful, unload the Huisbaasje client
+    # If successful, unload the EnergyFlip client
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
 
 
-async def async_update_huisbaasje(energyflip: EnergyFlip) -> dict[str, dict[str, Any]]:
-    """Update the data by performing a request to Huisbaasje."""
+async def async_update_energyflip(energyflip: EnergyFlip) -> dict[str, dict[str, Any]]:
+    """Update the data by performing a request to EnergyFlip."""
     try:
         # Note: TimeoutError and aiohttp.ClientError are already
         # handled by the data update coordinator.
         async with asyncio.timeout(FETCH_TIMEOUT):
             if not energyflip.is_authenticated():
-                _LOGGER.warning("Huisbaasje is unauthenticated. Reauthenticating")
+                _LOGGER.warning("EnergyFlip is unauthenticated. Reauthenticating")
                 await energyflip.authenticate()
 
             current_measurements = await energyflip.current_measurements()
@@ -125,7 +125,7 @@ def _get_cumulative_value(
 ):
     """Get the cumulative energy consumption for a certain period.
 
-    :param current_measurements: The result from the Huisbaasje client
+    :param current_measurements: The result from the EnergyFlip client
     :param source_type: The source of energy (electricity or gas)
     :param period_type: The period for which cumulative value should be given.
     """

--- a/homeassistant/components/huisbaasje/config_flow.py
+++ b/homeassistant/components/huisbaasje/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow for Huisbaasje integration."""
+"""Config flow for EnergyFlip integration."""
 
 import logging
 
@@ -18,8 +18,8 @@ DATA_SCHEMA = vol.Schema(
 )
 
 
-class HuisbaasjeConfigFlow(ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for Huisbaasje."""
+class EnergyFlipConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for EnergyFlip."""
 
     VERSION = 1
 

--- a/homeassistant/components/huisbaasje/const.py
+++ b/homeassistant/components/huisbaasje/const.py
@@ -1,4 +1,4 @@
-"""Constants for the Huisbaasje integration."""
+"""Constants for the EnergyFlip integration."""
 
 from energyflip.const import (
     SOURCE_TYPE_ELECTRICITY,
@@ -13,7 +13,7 @@ DATA_COORDINATOR = "coordinator"
 
 DOMAIN = "huisbaasje"
 
-"""Interval in seconds between polls to huisbaasje."""
+"""Interval in seconds between polls to EnergyFlip."""
 POLLING_INTERVAL = 20
 
 """Timeout for fetching sensor data"""

--- a/homeassistant/components/huisbaasje/manifest.json
+++ b/homeassistant/components/huisbaasje/manifest.json
@@ -1,10 +1,10 @@
 {
   "domain": "huisbaasje",
-  "name": "Huisbaasje",
+  "name": "EnergyFlip",
   "codeowners": ["@dennisschroer"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/huisbaasje",
   "iot_class": "cloud_polling",
-  "loggers": ["huisbaasje"],
+  "loggers": ["energyflip"],
   "requirements": ["energyflip-client==0.2.2"]
 }

--- a/homeassistant/components/huisbaasje/sensor.py
+++ b/homeassistant/components/huisbaasje/sensor.py
@@ -50,14 +50,14 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class HuisbaasjeSensorEntityDescription(SensorEntityDescription):
+class EnergyFlipSensorEntityDescription(SensorEntityDescription):
     """Class describing Airly sensor entities."""
 
     sensor_type: str = SENSOR_TYPE_RATE
 
 
 SENSORS_INFO = [
-    HuisbaasjeSensorEntityDescription(
+    EnergyFlipSensorEntityDescription(
         translation_key="current_power",
         sensor_type=SENSOR_TYPE_RATE,
         device_class=SensorDeviceClass.POWER,
@@ -65,7 +65,7 @@ SENSORS_INFO = [
         key=SOURCE_TYPE_ELECTRICITY,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    HuisbaasjeSensorEntityDescription(
+    EnergyFlipSensorEntityDescription(
         translation_key="current_power_peak",
         sensor_type=SENSOR_TYPE_RATE,
         device_class=SensorDeviceClass.POWER,
@@ -73,7 +73,7 @@ SENSORS_INFO = [
         key=SOURCE_TYPE_ELECTRICITY_IN,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    HuisbaasjeSensorEntityDescription(
+    EnergyFlipSensorEntityDescription(
         translation_key="current_power_off_peak",
         sensor_type=SENSOR_TYPE_RATE,
         device_class=SensorDeviceClass.POWER,
@@ -81,7 +81,7 @@ SENSORS_INFO = [
         key=SOURCE_TYPE_ELECTRICITY_IN_LOW,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    HuisbaasjeSensorEntityDescription(
+    EnergyFlipSensorEntityDescription(
         translation_key="current_power_out_peak",
         sensor_type=SENSOR_TYPE_RATE,
         device_class=SensorDeviceClass.POWER,
@@ -89,7 +89,7 @@ SENSORS_INFO = [
         key=SOURCE_TYPE_ELECTRICITY_OUT,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    HuisbaasjeSensorEntityDescription(
+    EnergyFlipSensorEntityDescription(
         translation_key="current_power_out_off_peak",
         sensor_type=SENSOR_TYPE_RATE,
         device_class=SensorDeviceClass.POWER,
@@ -97,7 +97,7 @@ SENSORS_INFO = [
         key=SOURCE_TYPE_ELECTRICITY_OUT_LOW,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    HuisbaasjeSensorEntityDescription(
+    EnergyFlipSensorEntityDescription(
         translation_key="energy_consumption_peak_today",
         device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
@@ -106,7 +106,7 @@ SENSORS_INFO = [
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=3,
     ),
-    HuisbaasjeSensorEntityDescription(
+    EnergyFlipSensorEntityDescription(
         translation_key="energy_consumption_off_peak_today",
         device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
@@ -115,7 +115,7 @@ SENSORS_INFO = [
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=3,
     ),
-    HuisbaasjeSensorEntityDescription(
+    EnergyFlipSensorEntityDescription(
         translation_key="energy_production_peak_today",
         device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
@@ -124,7 +124,7 @@ SENSORS_INFO = [
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=3,
     ),
-    HuisbaasjeSensorEntityDescription(
+    EnergyFlipSensorEntityDescription(
         translation_key="energy_production_off_peak_today",
         device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
@@ -133,7 +133,7 @@ SENSORS_INFO = [
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=3,
     ),
-    HuisbaasjeSensorEntityDescription(
+    EnergyFlipSensorEntityDescription(
         translation_key="energy_today",
         device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
@@ -142,7 +142,7 @@ SENSORS_INFO = [
         sensor_type=SENSOR_TYPE_THIS_DAY,
         suggested_display_precision=1,
     ),
-    HuisbaasjeSensorEntityDescription(
+    EnergyFlipSensorEntityDescription(
         translation_key="energy_week",
         device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
@@ -151,7 +151,7 @@ SENSORS_INFO = [
         sensor_type=SENSOR_TYPE_THIS_WEEK,
         suggested_display_precision=1,
     ),
-    HuisbaasjeSensorEntityDescription(
+    EnergyFlipSensorEntityDescription(
         translation_key="energy_month",
         device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
@@ -160,7 +160,7 @@ SENSORS_INFO = [
         sensor_type=SENSOR_TYPE_THIS_MONTH,
         suggested_display_precision=1,
     ),
-    HuisbaasjeSensorEntityDescription(
+    EnergyFlipSensorEntityDescription(
         translation_key="energy_year",
         device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
@@ -169,7 +169,7 @@ SENSORS_INFO = [
         sensor_type=SENSOR_TYPE_THIS_YEAR,
         suggested_display_precision=1,
     ),
-    HuisbaasjeSensorEntityDescription(
+    EnergyFlipSensorEntityDescription(
         translation_key="current_gas",
         native_unit_of_measurement=UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         sensor_type=SENSOR_TYPE_RATE,
@@ -177,7 +177,7 @@ SENSORS_INFO = [
         key=SOURCE_TYPE_GAS,
         suggested_display_precision=2,
     ),
-    HuisbaasjeSensorEntityDescription(
+    EnergyFlipSensorEntityDescription(
         translation_key="gas_today",
         device_class=SensorDeviceClass.GAS,
         native_unit_of_measurement=UnitOfVolume.CUBIC_METERS,
@@ -186,7 +186,7 @@ SENSORS_INFO = [
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
     ),
-    HuisbaasjeSensorEntityDescription(
+    EnergyFlipSensorEntityDescription(
         translation_key="gas_week",
         device_class=SensorDeviceClass.GAS,
         native_unit_of_measurement=UnitOfVolume.CUBIC_METERS,
@@ -195,7 +195,7 @@ SENSORS_INFO = [
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
     ),
-    HuisbaasjeSensorEntityDescription(
+    EnergyFlipSensorEntityDescription(
         translation_key="gas_month",
         device_class=SensorDeviceClass.GAS,
         native_unit_of_measurement=UnitOfVolume.CUBIC_METERS,
@@ -204,7 +204,7 @@ SENSORS_INFO = [
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
     ),
-    HuisbaasjeSensorEntityDescription(
+    EnergyFlipSensorEntityDescription(
         translation_key="gas_year",
         device_class=SensorDeviceClass.GAS,
         native_unit_of_measurement=UnitOfVolume.CUBIC_METERS,
@@ -228,24 +228,24 @@ async def async_setup_entry(
     user_id = config_entry.data[CONF_ID]
 
     async_add_entities(
-        HuisbaasjeSensor(coordinator, user_id, description)
+        EnergyFlipSensor(coordinator, user_id, description)
         for description in SENSORS_INFO
     )
 
 
-class HuisbaasjeSensor(
+class EnergyFlipSensor(
     CoordinatorEntity[DataUpdateCoordinator[dict[str, dict[str, Any]]]], SensorEntity
 ):
-    """Defines a Huisbaasje sensor."""
+    """Defines a EnergyFlip sensor."""
 
-    entity_description: HuisbaasjeSensorEntityDescription
+    entity_description: EnergyFlipSensorEntityDescription
     _attr_has_entity_name = True
 
     def __init__(
         self,
         coordinator: DataUpdateCoordinator[dict[str, dict[str, Any]]],
         user_id: str,
-        description: HuisbaasjeSensorEntityDescription,
+        description: EnergyFlipSensorEntityDescription,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -2659,7 +2659,7 @@
       "iot_class": "local_polling"
     },
     "huisbaasje": {
-      "name": "Huisbaasje",
+      "name": "EnergyFlip",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "cloud_polling"


### PR DESCRIPTION
## Proposed change

Back in 2021 Huisbaasje rebranded to EnergyFlip:

> EnergyFlip was created in 2017 in collaboration with the Consumentenbond. Back then, it was called Huisbaasje. In 2021, we changed the name to EnergyFlip. Our heart is here, but our ambitions are truly borderless!

See: https://www.energyflip.com.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/120138#discussion_r1649602706
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33362
- Link to brands pull request: <https://github.com/home-assistant/brands/pull/5605>

- I couldn't find where this image is defined:  <img width="302" alt="image" src="https://github.com/home-assistant/core/assets/235882/1ad51c5a-3415-4d09-aa3b-ce559f1abde5">

- Should the module name also be renamed?
- Keeping the domain defined as `huisbaasje` to not break existing setups.


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
