### PR TITLE
Sonos add tests for media_player.play_media share link

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,7 +38,6 @@
       "request": "attach",
       "port": 5678,
       "host": "localhost",
-      "justMyCode": false,
       "pathMappings": [
         {
           "localRoot": "${workspaceFolder}",
@@ -54,22 +53,12 @@
       "request": "attach",
       "port": 5678,
       "host": "homeassistant.local",
-      "justMyCode": false,
       "pathMappings": [
         {
           "localRoot": "${workspaceFolder}",
           "remoteRoot": "/usr/src/homeassistant"
         }
       ]
-    },
-    {
-      "name": "Python: Debug Tests",
-      "type": "python",
-      "request": "launch",
-      "program": "${file}",
-      "purpose": ["debug-test"],
-      "console": "integratedTerminal",
-      "justMyCode": false
-    }    
+    }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,6 +38,7 @@
       "request": "attach",
       "port": 5678,
       "host": "localhost",
+      "justMyCode": false,
       "pathMappings": [
         {
           "localRoot": "${workspaceFolder}",
@@ -53,12 +54,22 @@
       "request": "attach",
       "port": 5678,
       "host": "homeassistant.local",
+      "justMyCode": false,
       "pathMappings": [
         {
           "localRoot": "${workspaceFolder}",
           "remoteRoot": "/usr/src/homeassistant"
         }
       ]
-    }
+    },
+    {
+      "name": "Python: Debug Tests",
+      "type": "python",
+      "request": "launch",
+      "program": "${file}",
+      "purpose": ["debug-test"],
+      "console": "integratedTerminal",
+      "justMyCode": false
+    }    
   ]
 }

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -237,6 +237,17 @@ def patch_gethostbyname(host: str) -> str:
     return host
 
 
+@pytest.fixture(name="soco_sharelink")
+def soco_sharelink():
+    """Fixture to mock soco.plugins.sharelink.ShareLinkPlugin."""
+    with patch("homeassistant.components.sonos.speaker.ShareLinkPlugin") as mock_share:
+        mock_instance = MagicMock()
+        mock_instance.is_share_link.return_value = True
+        mock_instance.add_share_link_to_queue.return_value = 10
+        mock_share.return_value = mock_instance
+        yield mock_instance
+
+
 @pytest.fixture(name="soco_factory")
 def soco_factory(
     music_library, speaker_info, current_track_info_empty, battery_info, alarm_clock

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -302,6 +302,134 @@ async def test_play_media_lib_track_add(
     assert soco_mock.play_from_queue.call_count == 0
 
 
+_share_link: str = "spotify:playlist:abcdefghij0123456789XY"
+
+
+async def test_play_media_share_link_add(
+    hass: HomeAssistant,
+    soco_factory: SoCoMockFactory,
+    async_autosetup_sonos,
+    soco_sharelink,
+) -> None:
+    """Tests playing a shared link."""
+    await hass.services.async_call(
+        MP_DOMAIN,
+        SERVICE_PLAY_MEDIA,
+        {
+            "entity_id": "media_player.zone_a",
+            "media_content_type": "playlist",
+            "media_content_id": _share_link,
+            ATTR_MEDIA_ENQUEUE: MediaPlayerEnqueue.ADD,
+        },
+        blocking=True,
+    )
+    assert soco_sharelink.add_share_link_to_queue.call_count == 1
+    assert (
+        soco_sharelink.add_share_link_to_queue.call_args_list[0].args[0] == _share_link
+    )
+    assert (
+        soco_sharelink.add_share_link_to_queue.call_args_list[0].kwargs["timeout"]
+        == LONG_SERVICE_TIMEOUT
+    )
+
+
+async def test_play_media_share_link_next(
+    hass: HomeAssistant,
+    soco_factory: SoCoMockFactory,
+    async_autosetup_sonos,
+    soco_sharelink,
+) -> None:
+    """Tests playing a shared link."""
+    await hass.services.async_call(
+        MP_DOMAIN,
+        SERVICE_PLAY_MEDIA,
+        {
+            "entity_id": "media_player.zone_a",
+            "media_content_type": "playlist",
+            "media_content_id": _share_link,
+            ATTR_MEDIA_ENQUEUE: MediaPlayerEnqueue.NEXT,
+        },
+        blocking=True,
+    )
+    assert soco_sharelink.add_share_link_to_queue.call_count == 1
+    assert (
+        soco_sharelink.add_share_link_to_queue.call_args_list[0].args[0] == _share_link
+    )
+    assert (
+        soco_sharelink.add_share_link_to_queue.call_args_list[0].kwargs["timeout"]
+        == LONG_SERVICE_TIMEOUT
+    )
+    assert (
+        soco_sharelink.add_share_link_to_queue.call_args_list[0].kwargs["position"] == 1
+    )
+
+
+async def test_play_media_share_link_play(
+    hass: HomeAssistant,
+    soco_factory: SoCoMockFactory,
+    async_autosetup_sonos,
+    soco_sharelink,
+) -> None:
+    """Tests playing a shared link."""
+    soco_mock = soco_factory.mock_list.get("192.168.42.2")
+    await hass.services.async_call(
+        MP_DOMAIN,
+        SERVICE_PLAY_MEDIA,
+        {
+            "entity_id": "media_player.zone_a",
+            "media_content_type": "playlist",
+            "media_content_id": _share_link,
+            ATTR_MEDIA_ENQUEUE: MediaPlayerEnqueue.PLAY,
+        },
+        blocking=True,
+    )
+    assert soco_sharelink.add_share_link_to_queue.call_count == 1
+    assert (
+        soco_sharelink.add_share_link_to_queue.call_args_list[0].args[0] == _share_link
+    )
+    assert (
+        soco_sharelink.add_share_link_to_queue.call_args_list[0].kwargs["timeout"]
+        == LONG_SERVICE_TIMEOUT
+    )
+    assert (
+        soco_sharelink.add_share_link_to_queue.call_args_list[0].kwargs["position"] == 1
+    )
+    assert soco_mock.play_from_queue.call_count == 1
+    soco_mock.play_from_queue.assert_called_with(9)
+
+
+async def test_play_media_share_link_replace(
+    hass: HomeAssistant,
+    soco_factory: SoCoMockFactory,
+    async_autosetup_sonos,
+    soco_sharelink,
+) -> None:
+    """Tests playing a shared link."""
+    soco_mock = soco_factory.mock_list.get("192.168.42.2")
+    await hass.services.async_call(
+        MP_DOMAIN,
+        SERVICE_PLAY_MEDIA,
+        {
+            "entity_id": "media_player.zone_a",
+            "media_content_type": "playlist",
+            "media_content_id": _share_link,
+            ATTR_MEDIA_ENQUEUE: MediaPlayerEnqueue.REPLACE,
+        },
+        blocking=True,
+    )
+    assert soco_mock.clear_queue.call_count == 1
+    assert soco_sharelink.add_share_link_to_queue.call_count == 1
+    assert (
+        soco_sharelink.add_share_link_to_queue.call_args_list[0].args[0] == _share_link
+    )
+    assert (
+        soco_sharelink.add_share_link_to_queue.call_args_list[0].kwargs["timeout"]
+        == LONG_SERVICE_TIMEOUT
+    )
+    assert soco_mock.play_from_queue.call_count == 1
+    soco_mock.play_from_queue.assert_called_with(0)
+
+
 _mock_playlists = [
     MockMusicServiceItem(
         "playlist1",

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -311,7 +311,7 @@ async def test_play_media_share_link_add(
     async_autosetup_sonos,
     soco_sharelink,
 ) -> None:
-    """Tests playing a shared link."""
+    """Tests playing a shared link with enqueue option add."""
     await hass.services.async_call(
         MP_DOMAIN,
         SERVICE_PLAY_MEDIA,
@@ -339,7 +339,7 @@ async def test_play_media_share_link_next(
     async_autosetup_sonos,
     soco_sharelink,
 ) -> None:
-    """Tests playing a shared link."""
+    """Tests playing a shared link with enqueue option next."""
     await hass.services.async_call(
         MP_DOMAIN,
         SERVICE_PLAY_MEDIA,
@@ -370,7 +370,7 @@ async def test_play_media_share_link_play(
     async_autosetup_sonos,
     soco_sharelink,
 ) -> None:
-    """Tests playing a shared link."""
+    """Tests playing a shared link with enqueue option play."""
     soco_mock = soco_factory.mock_list.get("192.168.42.2")
     await hass.services.async_call(
         MP_DOMAIN,
@@ -404,7 +404,7 @@ async def test_play_media_share_link_replace(
     async_autosetup_sonos,
     soco_sharelink,
 ) -> None:
-    """Tests playing a shared link."""
+    """Tests playing a shared link with enqueue option replace."""
     soco_mock = soco_factory.mock_list.get("192.168.42.2")
     await hass.services.async_call(
         MP_DOMAIN,

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -311,7 +311,7 @@ async def test_play_media_share_link_add(
     async_autosetup_sonos,
     soco_sharelink,
 ) -> None:
-    """Tests playing a shared link with enqueue option add."""
+    """Tests playing a share link with enqueue option add."""
     await hass.services.async_call(
         MP_DOMAIN,
         SERVICE_PLAY_MEDIA,
@@ -339,7 +339,7 @@ async def test_play_media_share_link_next(
     async_autosetup_sonos,
     soco_sharelink,
 ) -> None:
-    """Tests playing a shared link with enqueue option next."""
+    """Tests playing a share link with enqueue option next."""
     await hass.services.async_call(
         MP_DOMAIN,
         SERVICE_PLAY_MEDIA,
@@ -370,7 +370,7 @@ async def test_play_media_share_link_play(
     async_autosetup_sonos,
     soco_sharelink,
 ) -> None:
-    """Tests playing a shared link with enqueue option play."""
+    """Tests playing a share link with enqueue option play."""
     soco_mock = soco_factory.mock_list.get("192.168.42.2")
     await hass.services.async_call(
         MP_DOMAIN,
@@ -404,7 +404,7 @@ async def test_play_media_share_link_replace(
     async_autosetup_sonos,
     soco_sharelink,
 ) -> None:
-    """Tests playing a shared link with enqueue option replace."""
+    """Tests playing a share link with enqueue option replace."""
     soco_mock = soco_factory.mock_list.get("192.168.42.2")
     await hass.services.async_call(
         MP_DOMAIN,


### PR DESCRIPTION
## Proposed change

Add tests for Sonos media_player.play_media when playing a share link (for example a spotify playlist link)

Specifically targeting this section of code.

https://github.com/home-assistant/core/blob/8e93116ed3fdc5c0639b21de8a78479e4390d9e2/homeassistant/components/sonos/media_player.py#L595-L616

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
