### PR TITLE
Allow excluding of specific features from HA

### DIFF
--- a/homeassistant/components/tplink/binary_sensor.py
+++ b/homeassistant/components/tplink/binary_sensor.py
@@ -39,8 +39,9 @@ BINARYSENSOR_DESCRIPTIONS: Final = (
         key="cloud_connection",
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
     ),
-    # To be replaced & disabled per default by the upcoming update platform.
+    # To be replaced by the upcoming update platform.
     TPLinkBinarySensorEntityDescription(
+        exclude=True,
         key="update_available",
         device_class=BinarySensorDeviceClass.UPDATE,
     ),

--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -66,6 +66,8 @@ LEGACY_KEY_MAPPING = {
 class TPLinkFeatureEntityDescription(EntityDescription):
     """Base class for a TPLink feature based entity description."""
 
+    exclude: bool = False
+
 
 def async_refresh_after[_T: CoordinatedTPLinkEntity, **_P](
     func: Callable[Concatenate[_T, _P], Awaitable[None]],
@@ -263,7 +265,7 @@ class CoordinatedTPLinkFeatureEntity(CoordinatedTPLinkEntity, ABC):
         return entity_category
 
     @classmethod
-    def _description_for_feature[_D: EntityDescription](
+    def _description_for_feature[_D: TPLinkFeatureEntityDescription](
         cls,
         feature: Feature,
         descriptions: Mapping[str, _D],
@@ -277,6 +279,13 @@ class CoordinatedTPLinkFeatureEntity(CoordinatedTPLinkEntity, ABC):
         """
 
         if descriptions and (desc := descriptions.get(feature.id)):
+            if desc.exclude:
+                _LOGGER.debug(
+                    "Device feature: %s (%s) excluded by description",
+                    feature.name,
+                    feature.id,
+                )
+                return None
             translation_key: str | None = feature.id
             # HA logic is to name entities based on the following logic:
             # _attr_name > translation.name > description.name

--- a/homeassistant/components/tplink/number.py
+++ b/homeassistant/components/tplink/number.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import logging
 from typing import Final
 
@@ -26,6 +27,7 @@ from .entity import (
 _LOGGER = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True, kw_only=True)
 class TPLinkNumberEntityDescription(
     NumberEntityDescription, TPLinkFeatureEntityDescription
 ):
@@ -49,7 +51,9 @@ NUMBER_DESCRIPTIONS: Final = (
         key="temperature_offset",
         mode=NumberMode.BOX,
     ),
+    # To be included as part of new climate platform
     TPLinkNumberEntityDescription(
+        exclude=True,
         key="target_temperature",
         mode=NumberMode.BOX,
     ),

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -120,18 +120,18 @@ SENSOR_DESCRIPTIONS: tuple[TPLinkSensorEntityDescription, ...] = (
     # Firmware based features are all disabled by default pending
     # the update platform
     TPLinkSensorEntityDescription(
-        entity_registry_enabled_default=False,
+        exclude=True,
         key="current_firmware_version",
     ),
     TPLinkSensorEntityDescription(
-        entity_registry_enabled_default=False,
+        exclude=True,
         key="available_firmware_version",
     ),
     # Thermostat based features are all disabled by default pending
     # the climate platform
     TPLinkSensorEntityDescription(
+        exclude=True,
         key="thermostat_mode",
-        entity_registry_enabled_default=False,
     ),
 )
 

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -46,7 +46,9 @@ SWITCH_DESCRIPTIONS: tuple[TPLinkSwitchEntityDescription, ...] = (
     TPLinkSwitchEntityDescription(
         key="smooth_transitions",
     ),
+    # To be included as part of new climate platform
     TPLinkSwitchEntityDescription(
+        exclude=True,
         key="frost_protection_enabled",
     ),
 )


### PR DESCRIPTION
## This PR is part of the tplink rewrite series, to be merged into tplink_rewrite branch (see https://github.com/home-assistant/core/pull/120060).


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add `exclude` parameter to `TPLinkFeatureEntityDescription` to allow features to be completely excluded pending future platforms. Will prevent orphaned entities in homeassistant when new platforms are implemented.

Simply omitting the feature from the descriptions will result in the log info message that the feature needs to be added to HA.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
