### PR TITLE
Improve Plugwise runtime-updating

### DIFF
--- a/homeassistant/components/plugwise/binary_sensor.py
+++ b/homeassistant/components/plugwise/binary_sensor.py
@@ -89,26 +89,20 @@ async def async_setup_entry(
         if not coordinator.new_devices:
             return
 
-        entities: list[PlugwiseBinarySensorEntity] = []
-        for device_id, device in coordinator.data.devices.items():
-            if not (binary_sensors := device.get("binary_sensors")):
-                continue
-            for description in BINARY_SENSORS:
-                if description.key not in binary_sensors:
-                    continue
-
-                entities.append(
-                    PlugwiseBinarySensorEntity(
-                        coordinator,
-                        device_id,
-                        description,
-                    )
+        async_add_entities(
+            PlugwiseBinarySensorEntity(coordinator, device_id, description)
+            for device_id in coordinator.new_devices
+            if (
+                binary_sensors := coordinator.data.devices[device_id].get(
+                    "binary_sensors"
                 )
-        async_add_entities(entities)
-
-    entry.async_on_unload(coordinator.async_add_listener(_add_entities))
+            )
+            for description in BINARY_SENSORS
+            if description.key in binary_sensors
+        )
 
     _add_entities()
+    entry.async_on_unload(coordinator.async_add_listener(_add_entities))
 
 
 class PlugwiseBinarySensorEntity(PlugwiseEntity, BinarySensorEntity):

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -45,7 +45,7 @@ async def async_setup_entry(
             if coordinator.data.devices[device_id]["dev_class"] in MASTER_THERMOSTATS
         )
 
-    _add_entities(PlugwiseClimateEntity)
+    _add_entities()
     entry.async_on_unload(coordinator.async_add_listener(_add_entities))
 
 

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -41,13 +41,12 @@ async def async_setup_entry(
 
         async_add_entities(
             PlugwiseClimateEntity(coordinator, device_id)
-            for device_id, device in coordinator.data.devices.items()
-            if device["dev_class"] in MASTER_THERMOSTATS
+            for device_id in coordinator.new_devices
+            if coordinator.data.devices[device_id]["dev_class"] in MASTER_THERMOSTATS
         )
 
+    _add_entities(PlugwiseClimateEntity)
     entry.async_on_unload(coordinator.async_add_listener(_add_entities))
-
-    _add_entities()
 
 
 class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):

--- a/homeassistant/components/plugwise/number.py
+++ b/homeassistant/components/plugwise/number.py
@@ -81,14 +81,13 @@ async def async_setup_entry(
 
         async_add_entities(
             PlugwiseNumberEntity(coordinator, device_id, description)
-            for device_id, device in coordinator.data.devices.items()
+            for device_id in coordinator.new_devices
             for description in NUMBER_TYPES
-            if description.key in device
+            if description.key in coordinator.data.devices[device_id]
         )
 
-    entry.async_on_unload(coordinator.async_add_listener(_add_entities))
-
     _add_entities()
+    entry.async_on_unload(coordinator.async_add_listener(_add_entities))
 
 
 class PlugwiseNumberEntity(PlugwiseEntity, NumberEntity):

--- a/homeassistant/components/plugwise/select.py
+++ b/homeassistant/components/plugwise/select.py
@@ -74,14 +74,13 @@ async def async_setup_entry(
 
         async_add_entities(
             PlugwiseSelectEntity(coordinator, device_id, description)
-            for device_id, device in coordinator.data.devices.items()
+            for device_id in coordinator.new_devices
             for description in SELECT_TYPES
-            if description.options_key in device
+            if description.options_key in coordinator.data.devices[device_id]
         )
 
-    entry.async_on_unload(coordinator.async_add_listener(_add_entities))
-
     _add_entities()
+    entry.async_on_unload(coordinator.async_add_listener(_add_entities))
 
 
 class PlugwiseSelectEntity(PlugwiseEntity, SelectEntity):

--- a/homeassistant/components/plugwise/sensor.py
+++ b/homeassistant/components/plugwise/sensor.py
@@ -414,27 +414,16 @@ async def async_setup_entry(
         if not coordinator.new_devices:
             return
 
-        entities: list[PlugwiseSensorEntity] = []
-        for device_id, device in coordinator.data.devices.items():
-            if not (sensors := device.get("sensors")):
-                continue
-            for description in SENSORS:
-                if description.key not in sensors:
-                    continue
-
-                entities.append(
-                    PlugwiseSensorEntity(
-                        coordinator,
-                        device_id,
-                        description,
-                    )
-                )
-
-        async_add_entities(entities)
-
-    entry.async_on_unload(coordinator.async_add_listener(_add_entities))
+        async_add_entities(
+            PlugwiseSensorEntity(coordinator, device_id, description)
+            for device_id in coordinator.new_devices
+            if (sensors := coordinator.data.devices[device_id].get("sensors"))
+            for description in SENSORS
+            if description.key in sensors
+        )
 
     _add_entities()
+    entry.async_on_unload(coordinator.async_add_listener(_add_entities))
 
 
 class PlugwiseSensorEntity(PlugwiseEntity, SensorEntity):

--- a/homeassistant/components/plugwise/switch.py
+++ b/homeassistant/components/plugwise/switch.py
@@ -68,22 +68,16 @@ async def async_setup_entry(
         if not coordinator.new_devices:
             return
 
-        entities: list[PlugwiseSwitchEntity] = []
-        for device_id, device in coordinator.data.devices.items():
-            if not (switches := device.get("switches")):
-                continue
-            for description in SWITCHES:
-                if description.key not in switches:
-                    continue
-                entities.append(
-                    PlugwiseSwitchEntity(coordinator, device_id, description)
-                )
-
-        async_add_entities(entities)
-
-    entry.async_on_unload(coordinator.async_add_listener(_add_entities))
+        async_add_entities(
+            PlugwiseSwitchEntity(coordinator, device_id, description)
+            for device_id in coordinator.new_devices
+            if (switches := coordinator.data.devices[device_id].get("switches"))
+            for description in SWITCHES
+            if description.key in switches
+        )
 
     _add_entities()
+    entry.async_on_unload(coordinator.async_add_listener(_add_entities))
 
 
 class PlugwiseSwitchEntity(PlugwiseEntity, SwitchEntity):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This update improves the recently introduced automatic runtime-updating:
- Use set() in `coordinator.py` as discussed with @joostlek 
- More DRY-ed code
- Only add the new device(s), don't try to add all devices when a new device is detected

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
