### PR TITLE
Remove connection state handling from Idasen Desk

### DIFF
--- a/homeassistant/components/idasen_desk/__init__.py
+++ b/homeassistant/components/idasen_desk/__init__.py
@@ -68,7 +68,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     ) -> None:
         """Update from a Bluetooth callback to ensure that a new BLEDevice is fetched."""
         _LOGGER.debug("Bluetooth callback triggered")
-        hass.async_create_task(coordinator.async_ensure_connection_state())
+        hass.async_create_task(coordinator.async_connect_if_expected())
 
     entry.async_on_unload(
         bluetooth.async_register_callback(

--- a/homeassistant/components/idasen_desk/coordinator.py
+++ b/homeassistant/components/idasen_desk/coordinator.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 
 from idasen_ha import Desk
 
 from homeassistant.components import bluetooth
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -29,55 +28,29 @@ class IdasenDeskCoordinator(DataUpdateCoordinator[int | None]):
         super().__init__(hass, logger, name=name)
         self._address = address
         self._expected_connected = False
-        self._connection_lost = False
-        self._disconnect_lock = asyncio.Lock()
 
         self.desk = Desk(self.async_set_updated_data)
 
     async def async_connect(self) -> bool:
         """Connect to desk."""
         _LOGGER.debug("Trying to connect %s", self._address)
+        self._expected_connected = True
         ble_device = bluetooth.async_ble_device_from_address(
             self.hass, self._address, connectable=True
         )
         if ble_device is None:
             _LOGGER.debug("No BLEDevice for %s", self._address)
             return False
-        self._expected_connected = True
         await self.desk.connect(ble_device)
         return True
 
     async def async_disconnect(self) -> None:
         """Disconnect from desk."""
-        _LOGGER.debug("Disconnecting from %s", self._address)
         self._expected_connected = False
-        self._connection_lost = False
+        _LOGGER.debug("Disconnecting from %s", self._address)
         await self.desk.disconnect()
 
-    async def async_ensure_connection_state(self) -> None:
-        """Check if the expected connection state matches the current state.
-
-        If the expected and current state don't match, calls connect/disconnect
-        as needed.
-        """
+    async def async_connect_if_expected(self) -> None:
+        """Ensure that the desk is connected if that is the expected state."""
         if self._expected_connected:
-            if not self.desk.is_connected:
-                _LOGGER.debug("Desk disconnected. Reconnecting")
-                self._connection_lost = True
-                await self.async_connect()
-            elif self._connection_lost:
-                _LOGGER.info("Reconnected to desk")
-                self._connection_lost = False
-        elif self.desk.is_connected:
-            if self._disconnect_lock.locked():
-                _LOGGER.debug("Already disconnecting")
-                return
-            async with self._disconnect_lock:
-                _LOGGER.debug("Desk is connected but should not be. Disconnecting")
-                await self.desk.disconnect()
-
-    @callback
-    def async_set_updated_data(self, data: int | None) -> None:
-        """Handle data update."""
-        self.hass.async_create_task(self.async_ensure_connection_state())
-        return super().async_set_updated_data(data)
+            await self.async_connect()

--- a/homeassistant/components/idasen_desk/manifest.json
+++ b/homeassistant/components/idasen_desk/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://www.home-assistant.io/integrations/idasen_desk",
   "iot_class": "local_push",
   "quality_scale": "silver",
-  "requirements": ["idasen-ha==2.5.3"]
+  "requirements": ["idasen-ha==2.6.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1140,7 +1140,7 @@ ical==8.0.1
 icmplib==3.0
 
 # homeassistant.components.idasen_desk
-idasen-ha==2.5.3
+idasen-ha==2.6.1
 
 # homeassistant.components.network
 ifaddr==0.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -936,7 +936,7 @@ ical==8.0.1
 icmplib==3.0
 
 # homeassistant.components.idasen_desk
-idasen-ha==2.5.3
+idasen-ha==2.6.1
 
 # homeassistant.components.network
 ifaddr==0.2.0


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The connect/disconnect handling is now done by the idasen-ha lib 
and is no longer needed on HA anymore.
We still need to store the current "desired" state, so that if
the user presses the Connect button when the desk is missing (no
BLEDevice), then a connection is made as soon as the Bluetooth
callback is called.


- idasen-ha changelog: https://github.com/abmantis/idasen-ha/compare/2.5.3...2.6.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
