### PR TITLE
Fix issue in mqtt fixture calling disconnect handler

### DIFF
--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -1111,9 +1111,7 @@ async def test_subscribe_and_resubscribe(
     record_calls: MessageCallbackType,
 ) -> None:
     """Test resubscribing within the debounce time."""
-    mqtt_mock = await mqtt_mock_entry()
-    # Fake that the client is connected
-    mqtt_mock().connected = True
+    await mqtt_mock_entry()
 
     unsub = await mqtt.async_subscribe(hass, "test-topic", record_calls)
     # This unsub will be un-done with the following subscribe
@@ -1452,10 +1450,7 @@ async def test_subscribe_same_topic(
     When subscribing to the same topic again, SUBSCRIBE must be sent to the broker again
     for it to resend any retained messages.
     """
-    mqtt_mock = await mqtt_mock_entry()
-
-    # Fake that the client is connected
-    mqtt_mock().connected = True
+    await mqtt_mock_entry()
 
     calls_a: list[ReceiveMessage] = []
     calls_b: list[ReceiveMessage] = []
@@ -1506,10 +1501,7 @@ async def test_replaying_payload_same_topic(
     Retained messages must only be replayed for new subscriptions, except
     when the MQTT client is reconnecting.
     """
-    mqtt_mock = await mqtt_mock_entry()
-
-    # Fake that the client is connected
-    mqtt_mock().connected = True
+    await mqtt_mock_entry()
 
     calls_a: list[ReceiveMessage] = []
     calls_b: list[ReceiveMessage] = []
@@ -1613,10 +1605,7 @@ async def test_replaying_payload_after_resubscribing(
     Retained messages must only be replayed for new subscriptions, except
     when the MQTT client is reconnection.
     """
-    mqtt_mock = await mqtt_mock_entry()
-
-    # Fake that the client is connected
-    mqtt_mock().connected = True
+    await mqtt_mock_entry()
 
     calls_a: list[ReceiveMessage] = []
 
@@ -1677,10 +1666,7 @@ async def test_replaying_payload_wildcard_topic(
     Retained messages should only be replayed for new subscriptions, except
     when the MQTT client is reconnection.
     """
-    mqtt_mock = await mqtt_mock_entry()
-
-    # Fake that the client is connected
-    mqtt_mock().connected = True
+    await mqtt_mock_entry()
 
     calls_a: list[ReceiveMessage] = []
     calls_b: list[ReceiveMessage] = []
@@ -1759,10 +1745,7 @@ async def test_not_calling_unsubscribe_with_active_subscribers(
     record_calls: MessageCallbackType,
 ) -> None:
     """Test not calling unsubscribe() when other subscribers are active."""
-    mqtt_mock = await mqtt_mock_entry()
-    # Fake that the client is connected
-    mqtt_mock().connected = True
-
+    await mqtt_mock_entry()
     unsub = await mqtt.async_subscribe(hass, "test/state", record_calls, 2)
     await mqtt.async_subscribe(hass, "test/state", record_calls, 1)
     await hass.async_block_till_done()
@@ -1787,10 +1770,8 @@ async def test_not_calling_subscribe_when_unsubscribed_within_cooldown(
     Make sure subscriptions are cleared if unsubscribed before
     the subscribe cool down period has ended.
     """
-    mqtt_mock = await mqtt_mock_entry()
+    await mqtt_mock_entry()
     mqtt_client_mock.subscribe.reset_mock()
-    # Fake that the client is connected
-    mqtt_mock().connected = True
 
     unsub = await mqtt.async_subscribe(hass, "test/state", record_calls)
     unsub()
@@ -1808,9 +1789,7 @@ async def test_unsubscribe_race(
     mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test not calling unsubscribe() when other subscribers are active."""
-    mqtt_mock = await mqtt_mock_entry()
-    # Fake that the client is connected
-    mqtt_mock().connected = True
+    await mqtt_mock_entry()
     await hass.async_block_till_done()
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=3))  # cooldown
     await hass.async_block_till_done()
@@ -1871,9 +1850,7 @@ async def test_restore_subscriptions_on_reconnect(
     record_calls: MessageCallbackType,
 ) -> None:
     """Test subscriptions are restored on reconnect."""
-    mqtt_mock = await mqtt_mock_entry()
-    # Fake that the client is connected
-    mqtt_mock().connected = True
+    await mqtt_mock_entry()
     await hass.async_block_till_done()
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=3))  # cooldown
     await hass.async_block_till_done()
@@ -1909,9 +1886,7 @@ async def test_restore_all_active_subscriptions_on_reconnect(
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test active subscriptions are restored correctly on reconnect."""
-    mqtt_mock = await mqtt_mock_entry()
-    # Fake that the client is connected
-    mqtt_mock().connected = True
+    await mqtt_mock_entry()
 
     unsub = await mqtt.async_subscribe(hass, "test/state", record_calls, qos=2)
     await mqtt.async_subscribe(hass, "test/state", record_calls, qos=1)
@@ -1964,9 +1939,7 @@ async def test_subscribed_at_highest_qos(
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test the highest qos as assigned when subscribing to the same topic."""
-    mqtt_mock = await mqtt_mock_entry()
-    # Fake that the client is connected
-    mqtt_mock().connected = True
+    await mqtt_mock_entry()
 
     await mqtt.async_subscribe(hass, "test/state", record_calls, qos=0)
     await hass.async_block_till_done()
@@ -2064,11 +2037,8 @@ async def test_canceling_debouncer_on_shutdown(
 ) -> None:
     """Test canceling the debouncer when HA shuts down."""
 
-    mqtt_mock = await mqtt_mock_entry()
+    await mqtt_mock_entry()
     mqtt_client_mock.subscribe.reset_mock()
-
-    # Fake that the client is connected
-    mqtt_mock().connected = True
 
     await mqtt.async_subscribe(hass, "test/state1", record_calls)
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=0.2))
@@ -2879,9 +2849,7 @@ async def test_mqtt_subscribes_in_single_call(
     record_calls: MessageCallbackType,
 ) -> None:
     """Test bundled client subscription to topic."""
-    mqtt_mock = await mqtt_mock_entry()
-    # Fake that the client is connected
-    mqtt_mock().connected = True
+    await mqtt_mock_entry()
 
     mqtt_client_mock.subscribe.reset_mock()
     await mqtt.async_subscribe(hass, "topic/test", record_calls)
@@ -2919,9 +2887,7 @@ async def test_mqtt_subscribes_and_unsubscribes_in_chunks(
     record_calls: MessageCallbackType,
 ) -> None:
     """Test chunked client subscriptions."""
-    mqtt_mock = await mqtt_mock_entry()
-    # Fake that the client is connected
-    mqtt_mock().connected = True
+    await mqtt_mock_entry()
 
     mqtt_client_mock.subscribe.reset_mock()
     unsub_tasks: list[CALLBACK_TYPE] = []
@@ -4177,9 +4143,6 @@ async def test_reload_config_entry(
         assert await hass.config_entries.async_reload(entry.entry_id)
         assert entry.state is ConfigEntryState.LOADED
         await hass.async_block_till_done()
-    # Assert the MQTT client was connected gracefully
-    with caplog.at_level(logging.INFO):
-        assert "Disconnected from MQTT server mock-broker:1883" in caplog.text
 
     assert (state := hass.states.get("sensor.test_manual1")) is not None
     assert state.attributes["friendly_name"] == "test_manual1_updated"
@@ -4609,8 +4572,6 @@ async def test_client_sock_failure_after_connect(
 ) -> None:
     """Test handling the socket connected and disconnected."""
     mqtt_mock = await mqtt_mock_entry()
-    # Fake that the client is connected
-    mqtt_mock().connected = True
     await hass.async_block_till_done()
     assert mqtt_mock.connected is True
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -960,6 +960,7 @@ def mqtt_client_mock(hass: HomeAssistant) -> Generator[MqttMockPahoClient]:
         mock_client.subscribe.side_effect = _subscribe
         mock_client.unsubscribe.side_effect = _unsubscribe
         mock_client.publish.side_effect = _async_fire_mqtt_message
+        mock_client.loop_read.return_value = 0
         yield mock_client
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix the mqtt client fixture to return 0 for loop `client.loop_read`. During mqtt entry set up the `on_connect` hook is called by the fixture by default. So we do not need to fake the client is connected.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
