### PR TITLE
Fix entry_id missing in mocked config entry

### DIFF
--- a/tests/components/pyload/conftest.py
+++ b/tests/components/pyload/conftest.py
@@ -109,6 +109,5 @@ def mock_config_entry() -> MockConfigEntry:
         domain=DOMAIN,
         title=DEFAULT_NAME,
         data=USER_INPUT,
-        unique_id="01J1306EB6MBEW6MK6S28W9WER",
-        entry_id="01J1306EB6MBEW6MK6S28W9WER",
+        entry_id="ENTRY_ID",
     )

--- a/tests/components/pyload/conftest.py
+++ b/tests/components/pyload/conftest.py
@@ -106,5 +106,9 @@ def mock_pyloadapi() -> Generator[AsyncMock, None, None]:
 def mock_config_entry() -> MockConfigEntry:
     """Mock pyLoad configuration entry."""
     return MockConfigEntry(
-        domain=DOMAIN, title=DEFAULT_NAME, data=USER_INPUT, entry_id="XXXXXXXXXXXXXX"
+        domain=DOMAIN,
+        title=DEFAULT_NAME,
+        data=USER_INPUT,
+        unique_id="01J1306EB6MBEW6MK6S28W9WER",
+        entry_id="01J1306EB6MBEW6MK6S28W9WER",
     )

--- a/tests/components/pyload/snapshots/test_sensor.ambr
+++ b/tests/components/pyload/snapshots/test_sensor.ambr
@@ -34,7 +34,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': <PyLoadSensorEntity.SPEED: 'speed'>,
-    'unique_id': 'XXXXXXXXXXXXXX_speed',
+    'unique_id': '01J1306EB6MBEW6MK6S28W9WER_speed',
     'unit_of_measurement': <UnitOfDataRate.MEGABYTES_PER_SECOND: 'MB/s'>,
   })
 # ---
@@ -88,7 +88,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': <PyLoadSensorEntity.SPEED: 'speed'>,
-    'unique_id': 'XXXXXXXXXXXXXX_speed',
+    'unique_id': '01J1306EB6MBEW6MK6S28W9WER_speed',
     'unit_of_measurement': <UnitOfDataRate.MEGABYTES_PER_SECOND: 'MB/s'>,
   })
 # ---
@@ -142,7 +142,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': <PyLoadSensorEntity.SPEED: 'speed'>,
-    'unique_id': 'XXXXXXXXXXXXXX_speed',
+    'unique_id': '01J1306EB6MBEW6MK6S28W9WER_speed',
     'unit_of_measurement': <UnitOfDataRate.MEGABYTES_PER_SECOND: 'MB/s'>,
   })
 # ---
@@ -159,183 +159,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
-  })
-# ---
-# name: test_sensors_unavailable[CannotConnect][sensor.pyload_speed-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.pyload_speed',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 1,
-      }),
-      'sensor.private': dict({
-        'suggested_unit_of_measurement': <UnitOfDataRate.MEGABYTES_PER_SECOND: 'MB/s'>,
-      }),
-    }),
-    'original_device_class': <SensorDeviceClass.DATA_RATE: 'data_rate'>,
-    'original_icon': None,
-    'original_name': 'Speed',
-    'platform': 'pyload',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': 'XXXXXXXXXXXXXX_speed',
-    'unit_of_measurement': <UnitOfDataRate.MEGABYTES_PER_SECOND: 'MB/s'>,
-  })
-# ---
-# name: test_sensors_unavailable[CannotConnect][sensor.pyload_speed-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'data_rate',
-      'friendly_name': 'pyLoad Speed',
-      'unit_of_measurement': <UnitOfDataRate.MEGABYTES_PER_SECOND: 'MB/s'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.pyload_speed',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_sensors_unavailable[InvalidAuth][sensor.pyload_speed-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.pyload_speed',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 1,
-      }),
-      'sensor.private': dict({
-        'suggested_unit_of_measurement': <UnitOfDataRate.MEGABYTES_PER_SECOND: 'MB/s'>,
-      }),
-    }),
-    'original_device_class': <SensorDeviceClass.DATA_RATE: 'data_rate'>,
-    'original_icon': None,
-    'original_name': 'Speed',
-    'platform': 'pyload',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': 'XXXXXXXXXXXXXX_speed',
-    'unit_of_measurement': <UnitOfDataRate.MEGABYTES_PER_SECOND: 'MB/s'>,
-  })
-# ---
-# name: test_sensors_unavailable[InvalidAuth][sensor.pyload_speed-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'data_rate',
-      'friendly_name': 'pyLoad Speed',
-      'unit_of_measurement': <UnitOfDataRate.MEGABYTES_PER_SECOND: 'MB/s'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.pyload_speed',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_sensors_unavailable[ParserError][sensor.pyload_speed-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.pyload_speed',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 1,
-      }),
-      'sensor.private': dict({
-        'suggested_unit_of_measurement': <UnitOfDataRate.MEGABYTES_PER_SECOND: 'MB/s'>,
-      }),
-    }),
-    'original_device_class': <SensorDeviceClass.DATA_RATE: 'data_rate'>,
-    'original_icon': None,
-    'original_name': 'Speed',
-    'platform': 'pyload',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': 'XXXXXXXXXXXXXX_speed',
-    'unit_of_measurement': <UnitOfDataRate.MEGABYTES_PER_SECOND: 'MB/s'>,
-  })
-# ---
-# name: test_sensors_unavailable[ParserError][sensor.pyload_speed-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'data_rate',
-      'friendly_name': 'pyLoad Speed',
-      'unit_of_measurement': <UnitOfDataRate.MEGABYTES_PER_SECOND: 'MB/s'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.pyload_speed',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_setup
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'data_rate',
-      'friendly_name': 'pyload Speed',
-      'unit_of_measurement': <UnitOfDataRate.MEGABYTES_PER_SECOND: 'MB/s'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.pyload_speed',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '5.405963',
   })
 # ---
 # name: test_setup[sensor.pyload_speed-entry]
@@ -373,7 +196,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': <PyLoadSensorEntity.SPEED: 'speed'>,
-    'unique_id': 'XXXXXXXXXXXXXX_speed',
+    'unique_id': '01J1306EB6MBEW6MK6S28W9WER_speed',
     'unit_of_measurement': <UnitOfDataRate.MEGABYTES_PER_SECOND: 'MB/s'>,
   })
 # ---

--- a/tests/components/pyload/snapshots/test_sensor.ambr
+++ b/tests/components/pyload/snapshots/test_sensor.ambr
@@ -34,7 +34,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': <PyLoadSensorEntity.SPEED: 'speed'>,
-    'unique_id': '01J1306EB6MBEW6MK6S28W9WER_speed',
+    'unique_id': 'ENTRY_ID_speed',
     'unit_of_measurement': <UnitOfDataRate.MEGABYTES_PER_SECOND: 'MB/s'>,
   })
 # ---
@@ -88,7 +88,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': <PyLoadSensorEntity.SPEED: 'speed'>,
-    'unique_id': '01J1306EB6MBEW6MK6S28W9WER_speed',
+    'unique_id': 'ENTRY_ID_speed',
     'unit_of_measurement': <UnitOfDataRate.MEGABYTES_PER_SECOND: 'MB/s'>,
   })
 # ---
@@ -142,7 +142,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': <PyLoadSensorEntity.SPEED: 'speed'>,
-    'unique_id': '01J1306EB6MBEW6MK6S28W9WER_speed',
+    'unique_id': 'ENTRY_ID_speed',
     'unit_of_measurement': <UnitOfDataRate.MEGABYTES_PER_SECOND: 'MB/s'>,
   })
 # ---
@@ -196,7 +196,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': <PyLoadSensorEntity.SPEED: 'speed'>,
-    'unique_id': '01J1306EB6MBEW6MK6S28W9WER_speed',
+    'unique_id': 'ENTRY_ID_speed',
     'unit_of_measurement': <UnitOfDataRate.MEGABYTES_PER_SECOND: 'MB/s'>,
   })
 # ---


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- The mocked config entry was missing the entry_id attribute, thefore translations in tests weren't working.
- Removes also some unused snapshots

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
