### PR TITLE
Adjust base entities in Husqvarna Automower

### DIFF
--- a/homeassistant/components/husqvarna_automower/button.py
+++ b/homeassistant/components/husqvarna_automower/button.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import AutomowerConfigEntry
 from .const import DOMAIN
 from .coordinator import AutomowerDataUpdateCoordinator
-from .entity import AutomowerControlEntity
+from .entity import AutomowerAvailableEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,7 +29,7 @@ async def async_setup_entry(
     )
 
 
-class AutomowerButtonEntity(AutomowerControlEntity, ButtonEntity):
+class AutomowerButtonEntity(AutomowerAvailableEntity, ButtonEntity):
     """Defining the AutomowerButtonEntity."""
 
     _attr_translation_key = "confirm_error"

--- a/homeassistant/components/husqvarna_automower/entity.py
+++ b/homeassistant/components/husqvarna_automower/entity.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from aioautomower.model import MowerAttributes
+from aioautomower.model import MowerActivities, MowerAttributes, MowerStates
 
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -11,6 +11,21 @@ from . import AutomowerDataUpdateCoordinator
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+ERROR_ACTIVITIES = (
+    MowerActivities.STOPPED_IN_GARDEN,
+    MowerActivities.UNKNOWN,
+    MowerActivities.NOT_APPLICABLE,
+)
+ERROR_STATES = [
+    MowerStates.FATAL_ERROR,
+    MowerStates.ERROR,
+    MowerStates.ERROR_AT_POWER_UP,
+    MowerStates.NOT_APPLICABLE,
+    MowerStates.UNKNOWN,
+    MowerStates.STOPPED,
+    MowerStates.OFF,
+]
 
 
 class AutomowerBaseEntity(CoordinatorEntity[AutomowerDataUpdateCoordinator]):
@@ -41,10 +56,22 @@ class AutomowerBaseEntity(CoordinatorEntity[AutomowerDataUpdateCoordinator]):
         return self.coordinator.data[self.mower_id]
 
 
-class AutomowerControlEntity(AutomowerBaseEntity):
+class AutomowerAvailableEntity(AutomowerBaseEntity):
     """AutomowerControlEntity, for dynamic availability."""
 
     @property
     def available(self) -> bool:
         """Return True if the device is available."""
         return super().available and self.mower_attributes.metadata.connected
+
+
+class AutomowerControlEntity(AutomowerAvailableEntity):
+    """AutomowerControlEntity, for dynamic availability."""
+
+    @property
+    def available(self) -> bool:
+        """Return True if the device is available."""
+        return super().available and (
+            self.mower_attributes.mower.state not in ERROR_STATES
+            or self.mower_attributes.mower.activity not in ERROR_ACTIVITIES
+        )

--- a/homeassistant/components/husqvarna_automower/entity.py
+++ b/homeassistant/components/husqvarna_automower/entity.py
@@ -57,7 +57,7 @@ class AutomowerBaseEntity(CoordinatorEntity[AutomowerDataUpdateCoordinator]):
 
 
 class AutomowerAvailableEntity(AutomowerBaseEntity):
-    """AutomowerControlEntity, for dynamic availability."""
+    """Replies available when the mower is connected."""
 
     @property
     def available(self) -> bool:
@@ -66,7 +66,7 @@ class AutomowerAvailableEntity(AutomowerBaseEntity):
 
 
 class AutomowerControlEntity(AutomowerAvailableEntity):
-    """AutomowerControlEntity, for dynamic availability."""
+    """Replies available when the mower is connected and not in error state."""
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/husqvarna_automower/lawn_mower.py
+++ b/homeassistant/components/husqvarna_automower/lawn_mower.py
@@ -23,7 +23,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import AutomowerConfigEntry
 from .const import DOMAIN
 from .coordinator import AutomowerDataUpdateCoordinator
-from .entity import AutomowerControlEntity
+from .entity import AutomowerAvailableEntity
 
 DOCKED_ACTIVITIES = (MowerActivities.PARKED_IN_CS, MowerActivities.CHARGING)
 MOWING_ACTIVITIES = (
@@ -94,7 +94,7 @@ async def async_setup_entry(
     )
 
 
-class AutomowerLawnMowerEntity(AutomowerControlEntity, LawnMowerEntity):
+class AutomowerLawnMowerEntity(AutomowerAvailableEntity, LawnMowerEntity):
     """Defining each mower Entity."""
 
     _attr_name = None

--- a/homeassistant/components/husqvarna_automower/switch.py
+++ b/homeassistant/components/husqvarna_automower/switch.py
@@ -5,13 +5,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from aioautomower.exceptions import ApiException
-from aioautomower.model import (
-    MowerActivities,
-    MowerModes,
-    MowerStates,
-    StayOutZones,
-    Zone,
-)
+from aioautomower.model import MowerModes, StayOutZones, Zone
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.const import Platform
@@ -26,21 +20,6 @@ from .coordinator import AutomowerDataUpdateCoordinator
 from .entity import AutomowerControlEntity
 
 _LOGGER = logging.getLogger(__name__)
-
-ERROR_ACTIVITIES = (
-    MowerActivities.STOPPED_IN_GARDEN,
-    MowerActivities.UNKNOWN,
-    MowerActivities.NOT_APPLICABLE,
-)
-ERROR_STATES = [
-    MowerStates.FATAL_ERROR,
-    MowerStates.ERROR,
-    MowerStates.ERROR_AT_POWER_UP,
-    MowerStates.NOT_APPLICABLE,
-    MowerStates.UNKNOWN,
-    MowerStates.STOPPED,
-    MowerStates.OFF,
-]
 
 
 async def async_setup_entry(
@@ -87,14 +66,6 @@ class AutomowerScheduleSwitchEntity(AutomowerControlEntity, SwitchEntity):
     def is_on(self) -> bool:
         """Return the state of the switch."""
         return self.mower_attributes.mower.mode != MowerModes.HOME
-
-    @property
-    def available(self) -> bool:
-        """Return True if the device is available."""
-        return super().available and (
-            self.mower_attributes.mower.state not in ERROR_STATES
-            or self.mower_attributes.mower.activity not in ERROR_ACTIVITIES
-        )
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adjusts the base entities of the integration.
The behavior of the `AutomowerControlEntity` changed, so that it's not possible to send a command, when the mower is in error state. This is like it was for the schedule switch already.
So this also applies no to this platforms:
- number
- select
- switch

Button and lawn_mower platform are now using the `AutomowerAvailabeEntity`, which has the same behaviour like the `AutomowerControlEntity`. So there are no changes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
