### PR TITLE
mystrom: Add MAC and Config URL to devices

### DIFF
--- a/homeassistant/components/mystrom/switch.py
+++ b/homeassistant/components/mystrom/switch.py
@@ -10,7 +10,7 @@ from pymystrom.exceptions import MyStromConnectionError
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceInfo, format_mac
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN, MANUFACTURER
@@ -43,6 +43,7 @@ class MyStromSwitch(SwitchEntity):
             name=name,
             manufacturer=MANUFACTURER,
             sw_version=self.plug.firmware,
+            connections={("mac", format_mac(self.plug.mac))},
         )
 
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/homeassistant/components/mystrom/switch.py
+++ b/homeassistant/components/mystrom/switch.py
@@ -44,6 +44,7 @@ class MyStromSwitch(SwitchEntity):
             manufacturer=MANUFACTURER,
             sw_version=self.plug.firmware,
             connections={("mac", format_mac(self.plug.mac))},
+            configuration_url=self.plug.uri,
         )
 
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/tests/components/mystrom/__init__.py
+++ b/tests/components/mystrom/__init__.py
@@ -173,3 +173,10 @@ class MyStromSwitchMock(MyStromDeviceMock):
         if not self._requested_state:
             return None
         return self._state["temperature"]
+
+    @property
+    def uri(self) -> str | None:
+        """Return the URI."""
+        if not self._requested_state:
+            return None
+        return f"http://{self._state["ip"]}"


### PR DESCRIPTION
Hi, first HomeAssistant PR 🙂 Thanks for the awesome software. Now that I seem to have a working dev setup, I might be able to contribute more in the future.

## Proposed change

A myStrom switch can be identified physically by its MAC address, which is printed on the label. Similarly, the MAC address is often used to set up static DHCP rules. Thus, it is helpful to list it in the `connections` attribute.

Additionally, it makes sense to set the `configuration_url` as well, since that's where the configuration can be changed and the firmware can be updated.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

n/a

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
