### PR TITLE
Set up mqtt tests from client fixture of mqtt entry setup fixture, not both

### DIFF
--- a/tests/components/mqtt/conftest.py
+++ b/tests/components/mqtt/conftest.py
@@ -1,12 +1,20 @@
 """Test fixtures for mqtt component."""
 
+import asyncio
 from random import getrandbits
+from typing import Any
 from unittest.mock import patch
 
 import pytest
-from typing_extensions import Generator
+from typing_extensions import AsyncGenerator, Generator
 
 from homeassistant.components import mqtt
+from homeassistant.components.mqtt.models import ReceiveMessage
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
+from homeassistant.core import HomeAssistant, callback
+
+from tests.common import MockConfigEntry
+from tests.typing import MqttMockPahoClient
 
 ENTRY_DEFAULT_BIRTH_MESSAGE = {
     mqtt.CONF_BROKER: "mock-broker",
@@ -39,3 +47,35 @@ def mock_temp_dir(temp_dir_prefix: str) -> Generator[str]:
         f"home-assistant-mqtt-{temp_dir_prefix}-{getrandbits(10):03x}",
     ) as mocked_temp_dir:
         yield mocked_temp_dir
+
+
+@pytest.fixture
+async def setup_with_birth_msg_client_mock(
+    hass: HomeAssistant,
+    mqtt_config_entry_data: dict[str, Any] | None,
+    mqtt_client_mock: MqttMockPahoClient,
+) -> AsyncGenerator[MqttMockPahoClient]:
+    """Test sending birth message."""
+    birth = asyncio.Event()
+    with (
+        patch("homeassistant.components.mqtt.client.INITIAL_SUBSCRIBE_COOLDOWN", 0.0),
+        patch("homeassistant.components.mqtt.client.DISCOVERY_COOLDOWN", 0.0),
+        patch("homeassistant.components.mqtt.client.SUBSCRIBE_COOLDOWN", 0.1),
+    ):
+        entry = MockConfigEntry(
+            domain=mqtt.DOMAIN, data={mqtt.CONF_BROKER: "test-broker"}
+        )
+        entry.add_to_hass(hass)
+        hass.config.components.add(mqtt.DOMAIN)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+
+        @callback
+        def wait_birth(msg: ReceiveMessage) -> None:
+            """Handle birth message."""
+            birth.set()
+
+        await mqtt.async_subscribe(hass, "homeassistant/status", wait_birth)
+        await hass.async_block_till_done()
+        await birth.wait()
+        yield mqtt_client_mock

--- a/tests/components/mqtt/conftest.py
+++ b/tests/components/mqtt/conftest.py
@@ -60,7 +60,7 @@ async def setup_with_birth_msg_client_mock(
     with (
         patch("homeassistant.components.mqtt.client.INITIAL_SUBSCRIBE_COOLDOWN", 0.0),
         patch("homeassistant.components.mqtt.client.DISCOVERY_COOLDOWN", 0.0),
-        patch("homeassistant.components.mqtt.client.SUBSCRIBE_COOLDOWN", 0.1),
+        patch("homeassistant.components.mqtt.client.SUBSCRIBE_COOLDOWN", 0.0),
     ):
         entry = MockConfigEntry(
             domain=mqtt.DOMAIN, data={mqtt.CONF_BROKER: "test-broker"}

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -1531,7 +1531,7 @@ async def test_mqtt_discovery_unsubscribe_once(
 
         async def async_step_mqtt(self, discovery_info: MqttServiceInfo) -> FlowResult:
             """Test mqtt step."""
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(0)
             return self.async_abort(reason="already_configured")
 
     mock_platform(hass, "comp.config_flow", None)
@@ -1573,7 +1573,7 @@ async def test_mqtt_discovery_unsubscribe_once(
         async_fire_mqtt_message(hass, "comp/discovery/bla/config", "")
         async_fire_mqtt_message(hass, "comp/discovery/bla/config", "")
         await wait_unsub.wait()
-        await asyncio.sleep(0.2)
+        await asyncio.sleep(0)
         await hass.async_block_till_done(wait_background_tasks=True)
         mqtt_client_mock.unsubscribe.assert_called_once_with(["comp/discovery/#"])
         await hass.async_block_till_done(wait_background_tasks=True)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In mqtt tests where we used the `mqtt_mock_entry` and also need to assert on the paho client we now only use the paho client fixture as a base. This avoid issues with multiple instances of mqtt clients interfearing in tests.

A helper fixture `mock_setup_with_birth_message` was added to `test_init.py` to help set up MQTT including birth message, to be able to on assert subscriptions  on the Paho client. This fixture sets up the MQTT entry, awaits the birth message and returns client mock like `mqtt_client_mock` does that allows to assert on client subscriptions.

Already completed
- [x] https://github.com/home-assistant/core/pull/120329
- [x] https://github.com/home-assistant/core/pull/120333

So the main goals for this PR are:
- avoid `CanceledError`'s during the tear down of the tests caused by not processed ACK's.
- ensure the MQTT entry has been set up including the initial subscriptions in tests.
- Avoid mixing up `mqtt_mock_entry` and `mqtt_client_mock`, offering `mock_setup_with_birth_message` as a helper.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
