### PR TITLE
Handle availability in Idasen Desk height sensor

### DIFF
--- a/homeassistant/components/idasen_desk/cover.py
+++ b/homeassistant/components/idasen_desk/cover.py
@@ -66,7 +66,7 @@ class IdasenDeskCover(CoordinatorEntity[IdasenDeskCoordinator], CoverEntity):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        return self._desk.is_connected is True
+        return super().available and self._desk.is_connected is True
 
     @property
     def is_closed(self) -> bool:

--- a/homeassistant/components/idasen_desk/sensor.py
+++ b/homeassistant/components/idasen_desk/sensor.py
@@ -79,11 +79,17 @@ class IdasenDeskSensor(CoordinatorEntity[IdasenDeskCoordinator], SensorEntity):
         self._attr_unique_id = f"{description.key}-{address}"
         self._attr_device_info = device_info
         self._address = address
+        self._desk = coordinator.desk
 
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
         self._update_native_value()
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self._desk.is_connected is True
 
     @callback
     def _handle_coordinator_update(self, *args: Any) -> None:

--- a/homeassistant/components/idasen_desk/sensor.py
+++ b/homeassistant/components/idasen_desk/sensor.py
@@ -89,7 +89,7 @@ class IdasenDeskSensor(CoordinatorEntity[IdasenDeskCoordinator], SensorEntity):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        return self._desk.is_connected is True
+        return super().available and self._desk.is_connected is True
 
     @callback
     def _handle_coordinator_update(self, *args: Any) -> None:

--- a/tests/components/idasen_desk/test_sensors.py
+++ b/tests/components/idasen_desk/test_sensors.py
@@ -4,9 +4,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 
 from . import init_integration
+
+EXPECTED_INITIAL_HEIGHT = "1"
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -17,7 +20,7 @@ async def test_height_sensor(hass: HomeAssistant, mock_desk_api: MagicMock) -> N
     entity_id = "sensor.test_height"
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == "1"
+    assert state.state == EXPECTED_INITIAL_HEIGHT
 
     mock_desk_api.height = 1.2
     mock_desk_api.trigger_update_callback(None)
@@ -25,3 +28,24 @@ async def test_height_sensor(hass: HomeAssistant, mock_desk_api: MagicMock) -> N
     state = hass.states.get(entity_id)
     assert state
     assert state.state == "1.2"
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_sensor_available(
+    hass: HomeAssistant,
+    mock_desk_api: MagicMock,
+) -> None:
+    """Test sensor available property."""
+    await init_integration(hass)
+
+    entity_id = "sensor.test_height"
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == EXPECTED_INITIAL_HEIGHT
+
+    mock_desk_api.is_connected = False
+    mock_desk_api.trigger_update_callback(None)
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The sensor will now become `unavailable` when the desk is not connected, just like the cover entity.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
