### PR TITLE
Bump gcal_sync to 6.1.3

### DIFF
--- a/homeassistant/components/google/manifest.json
+++ b/homeassistant/components/google/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/calendar.google",
   "iot_class": "cloud_polling",
   "loggers": ["googleapiclient"],
-  "requirements": ["gcal-sync==6.1.2", "oauth2client==4.1.3", "ical==8.0.1"]
+  "requirements": ["gcal-sync==6.1.3", "oauth2client==4.1.3", "ical==8.0.1"]
 }

--- a/homeassistant/components/google/manifest.json
+++ b/homeassistant/components/google/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/calendar.google",
   "iot_class": "cloud_polling",
   "loggers": ["googleapiclient"],
-  "requirements": ["gcal-sync==6.1.1", "oauth2client==4.1.3", "ical==8.0.1"]
+  "requirements": ["gcal-sync==6.1.2", "oauth2client==4.1.3", "ical==8.0.1"]
 }

--- a/homeassistant/components/google/manifest.json
+++ b/homeassistant/components/google/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/calendar.google",
   "iot_class": "cloud_polling",
   "loggers": ["googleapiclient"],
-  "requirements": ["gcal-sync==6.0.4", "oauth2client==4.1.3", "ical==8.0.1"]
+  "requirements": ["gcal-sync==6.1.1", "oauth2client==4.1.3", "ical==8.0.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -924,7 +924,7 @@ gardena-bluetooth==1.4.2
 gassist-text==0.0.11
 
 # homeassistant.components.google
-gcal-sync==6.1.2
+gcal-sync==6.1.3
 
 # homeassistant.components.aladdin_connect
 genie-partner-sdk==1.0.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -924,7 +924,7 @@ gardena-bluetooth==1.4.2
 gassist-text==0.0.11
 
 # homeassistant.components.google
-gcal-sync==6.1.1
+gcal-sync==6.1.2
 
 # homeassistant.components.aladdin_connect
 genie-partner-sdk==1.0.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -924,7 +924,7 @@ gardena-bluetooth==1.4.2
 gassist-text==0.0.11
 
 # homeassistant.components.google
-gcal-sync==6.0.4
+gcal-sync==6.1.1
 
 # homeassistant.components.aladdin_connect
 genie-partner-sdk==1.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -762,7 +762,7 @@ gardena-bluetooth==1.4.2
 gassist-text==0.0.11
 
 # homeassistant.components.google
-gcal-sync==6.1.1
+gcal-sync==6.1.2
 
 # homeassistant.components.aladdin_connect
 genie-partner-sdk==1.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -762,7 +762,7 @@ gardena-bluetooth==1.4.2
 gassist-text==0.0.11
 
 # homeassistant.components.google
-gcal-sync==6.1.2
+gcal-sync==6.1.3
 
 # homeassistant.components.aladdin_connect
 genie-partner-sdk==1.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -762,7 +762,7 @@ gardena-bluetooth==1.4.2
 gassist-text==0.0.11
 
 # homeassistant.components.google
-gcal-sync==6.0.4
+gcal-sync==6.1.1
 
 # homeassistant.components.aladdin_connect
 genie-partner-sdk==1.0.2

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -651,6 +651,7 @@ async def test_future_event_offset_update_behavior(
     await hass.async_block_till_done()
     # Ensure coordinator update completes
     await hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     # Event has not started, but the offset was reached
     state = hass.states.get(TEST_ENTITY)

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -387,6 +387,7 @@ async def test_update_error(
         await hass.async_block_till_done()
         # Ensure coordinator update completes
         await hass.async_block_till_done()
+        await hass.async_block_till_done()
 
     # Entity is marked uanvailable due to API failure
     state = hass.states.get(TEST_ENTITY)
@@ -417,6 +418,7 @@ async def test_update_error(
         async_fire_time_changed(hass, now)
         await hass.async_block_till_done()
         # Ensure coordinator update completes
+        await hass.async_block_till_done()
         await hass.async_block_till_done()
 
     # State updated with new API response
@@ -611,6 +613,7 @@ async def test_future_event_update_behavior(
     async_fire_time_changed(hass, now)
     await hass.async_block_till_done()
     # Ensure coordinator update completes
+    await hass.async_block_till_done()
     await hass.async_block_till_done()
 
     # Event has started

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -385,6 +385,8 @@ async def test_update_error(
     with patch("homeassistant.util.utcnow", return_value=now):
         async_fire_time_changed(hass, now)
         await hass.async_block_till_done()
+        # Ensure coordinator update completes
+        await hass.async_block_till_done()
 
     # Entity is marked uanvailable due to API failure
     state = hass.states.get(TEST_ENTITY)
@@ -413,6 +415,8 @@ async def test_update_error(
 
     with patch("homeassistant.util.utcnow", return_value=now):
         async_fire_time_changed(hass, now)
+        await hass.async_block_till_done()
+        # Ensure coordinator update completes
         await hass.async_block_till_done()
 
     # State updated with new API response
@@ -606,6 +610,8 @@ async def test_future_event_update_behavior(
     freezer.move_to(now)
     async_fire_time_changed(hass, now)
     await hass.async_block_till_done()
+    # Ensure coordinator update completes
+    await hass.async_block_till_done()
 
     # Event has started
     state = hass.states.get(TEST_ENTITY)
@@ -642,6 +648,8 @@ async def test_future_event_offset_update_behavior(
     now += datetime.timedelta(minutes=45)
     freezer.move_to(now)
     async_fire_time_changed(hass, now)
+    await hass.async_block_till_done()
+    # Ensure coordinator update completes
     await hass.async_block_till_done()
 
     # Event has not started, but the offset was reached


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump gcal_sync to 6.1.3. Fixes include adding more asyncio hand-offs when loading timezones (which internally read the timezone file from disk the first time they are loaded) which requires additional workarounds in home assistant tests. 

Changes: https://github.com/allenporter/gcal_sync/compare/6.0.4...6.1.3
Release notes: https://github.com/allenporter/gcal_sync/releases

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #118627 fixes #120712
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
