### PR TITLE
Remove "no API" prompt

### DIFF
--- a/homeassistant/components/google_generative_ai_conversation/conversation.py
+++ b/homeassistant/components/google_generative_ai_conversation/conversation.py
@@ -349,27 +349,22 @@ class GoogleGenerativeAIConversationEntity(
         ):
             user_name = user.name
 
-        if llm_api:
-            api_prompt = llm_api.api_prompt
-        else:
-            api_prompt = llm.async_render_no_api_prompt(self.hass)
-
-        return "\n".join(
-            (
-                template.Template(
-                    llm.BASE_PROMPT
-                    + self.entry.options.get(
-                        CONF_PROMPT, llm.DEFAULT_INSTRUCTIONS_PROMPT
-                    ),
-                    self.hass,
-                ).async_render(
-                    {
-                        "ha_name": self.hass.config.location_name,
-                        "user_name": user_name,
-                        "llm_context": llm_context,
-                    },
-                    parse_result=False,
-                ),
-                api_prompt,
+        parts = [
+            template.Template(
+                llm.BASE_PROMPT
+                + self.entry.options.get(CONF_PROMPT, llm.DEFAULT_INSTRUCTIONS_PROMPT),
+                self.hass,
+            ).async_render(
+                {
+                    "ha_name": self.hass.config.location_name,
+                    "user_name": user_name,
+                    "llm_context": llm_context,
+                },
+                parse_result=False,
             )
-        )
+        ]
+
+        if llm_api:
+            parts.append(llm_api.api_prompt)
+
+        return "\n".join(parts)

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -51,11 +51,11 @@ Answer in plain text. Keep it simple and to the point.
 
 @callback
 def async_render_no_api_prompt(hass: HomeAssistant) -> str:
-    """Return the prompt to be used when no API is configured."""
-    return (
-        "Only if the user wants to control a device, tell them to edit the AI configuration "
-        "and allow access to Home Assistant."
-    )
+    """Return the prompt to be used when no API is configured.
+
+    No longer used since Home Assistant 2024.7.
+    """
+    return ""
 
 
 @singleton("llm")

--- a/tests/components/google_generative_ai_conversation/snapshots/test_conversation.ambr
+++ b/tests/components/google_generative_ai_conversation/snapshots/test_conversation.ambr
@@ -35,7 +35,6 @@
               You are a voice assistant for Home Assistant.
               Answer questions about the world truthfully.
               Answer in plain text. Keep it simple and to the point.
-              Only if the user wants to control a device, tell them to edit the AI configuration and allow access to Home Assistant.
             ''',
             'role': 'user',
           }),
@@ -88,7 +87,6 @@
               You are a voice assistant for Home Assistant.
               Answer questions about the world truthfully.
               Answer in plain text. Keep it simple and to the point.
-              Only if the user wants to control a device, tell them to edit the AI configuration and allow access to Home Assistant.
             ''',
             'role': 'user',
           }),
@@ -142,7 +140,6 @@
           You are a voice assistant for Home Assistant.
           Answer questions about the world truthfully.
           Answer in plain text. Keep it simple and to the point.
-          Only if the user wants to control a device, tell them to edit the AI configuration and allow access to Home Assistant.
         ''',
         'tools': None,
       }),
@@ -187,7 +184,6 @@
           You are a voice assistant for Home Assistant.
           Answer questions about the world truthfully.
           Answer in plain text. Keep it simple and to the point.
-          Only if the user wants to control a device, tell them to edit the AI configuration and allow access to Home Assistant.
         ''',
         'tools': None,
       }),
@@ -244,7 +240,6 @@
           You are a voice assistant for Home Assistant.
           Answer questions about the world truthfully.
           Answer in plain text. Keep it simple and to the point.
-          <no_api_prompt>
         ''',
         'tools': None,
       }),
@@ -293,7 +288,6 @@
           You are a voice assistant for Home Assistant.
           Answer questions about the world truthfully.
           Answer in plain text. Keep it simple and to the point.
-          <no_api_prompt>
         ''',
         'tools': None,
       }),

--- a/tests/components/google_generative_ai_conversation/test_conversation.py
+++ b/tests/components/google_generative_ai_conversation/test_conversation.py
@@ -75,10 +75,6 @@ async def test_default_prompt(
             "homeassistant.components.google_generative_ai_conversation.conversation.llm.AssistAPI._async_get_api_prompt",
             return_value="<api_prompt>",
         ),
-        patch(
-            "homeassistant.components.google_generative_ai_conversation.conversation.llm.async_render_no_api_prompt",
-            return_value="<no_api_prompt>",
-        ),
     ):
         mock_chat = AsyncMock()
         mock_model.return_value.start_chat.return_value = mock_chat


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When an LLM had no API configured, we inject a "no api" text to the prompt to educate the user how to configure the LLM if they try to control a device.

We noticed that this extra instruction, even if crafted carefully, can leak into the output of unrelated outputs. Especially on weaker models.

This PR removes the injection of a no api text. Instead, we're going to show a message when talking to an LLM without API access using a new proposed [`API_ACCESS` supported feature](https://github.com/home-assistant/architecture/discussions/1102)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
