### PR TITLE
Get zwave_js statistics data from model

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -331,8 +331,8 @@ class DriverEvents:
         """Set up platform if needed."""
         if platform not in self.platform_setup_tasks:
             self.platform_setup_tasks[platform] = self.hass.async_create_task(
-                self.hass.config_entries.async_forward_entry_setup(
-                    self.config_entry, platform
+                self.hass.config_entries.async_forward_entry_setups(
+                    self.config_entry, [platform]
                 )
             )
         await self.platform_setup_tasks[platform]

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -331,8 +331,8 @@ class DriverEvents:
         """Set up platform if needed."""
         if platform not in self.platform_setup_tasks:
             self.platform_setup_tasks[platform] = self.hass.async_create_task(
-                self.hass.config_entries.async_forward_entry_setups(
-                    self.config_entry, [platform]
+                self.hass.config_entries.async_forward_entry_setup(
+                    self.config_entry, platform
                 )
             )
         await self.platform_setup_tasks[platform]
@@ -353,7 +353,7 @@ class ControllerEvents:
         self.discovered_value_ids: dict[str, set[str]] = defaultdict(set)
         self.driver_events = driver_events
         self.dev_reg = driver_events.dev_reg
-        self.registered_unique_ids: dict[str, dict[str, set[str]]] = defaultdict(
+        self.registered_unique_ids: dict[str, dict[Platform, set[str]]] = defaultdict(
             lambda: defaultdict(set)
         )
         self.node_events = NodeEvents(hass, self)

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from datetime import datetime
 from typing import Any
 
 import voluptuous as vol
@@ -16,10 +15,10 @@ from zwave_js_server.const.command_class.meter import (
 )
 from zwave_js_server.exceptions import BaseZwaveJSServerError
 from zwave_js_server.model.controller import Controller
-from zwave_js_server.model.controller.statistics import ControllerStatisticsDataType
+from zwave_js_server.model.controller.statistics import ControllerStatistics
 from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.node import Node as ZwaveNode
-from zwave_js_server.model.node.statistics import NodeStatisticsDataType
+from zwave_js_server.model.node.statistics import NodeStatistics
 from zwave_js_server.util.command_class.meter import get_meter_type
 
 from homeassistant.components.sensor import (
@@ -328,152 +327,154 @@ ENTITY_DESCRIPTION_KEY_MAP = {
 }
 
 
-def convert_dict_of_dicts(
-    statistics: ControllerStatisticsDataType | NodeStatisticsDataType, key: str
+def convert_nested_attr(
+    statistics: ControllerStatistics | NodeStatistics, key: str
 ) -> Any:
-    """Convert a dictionary of dictionaries to a value."""
-    keys = key.split(".")
-    return statistics.get(keys[0], {}).get(keys[1], {}).get(keys[2])  # type: ignore[attr-defined]
+    """Convert a string that represents a nested attr to a value."""
+    data = statistics
+    for _key in key.split("."):
+        if data is None:
+            return None  # type: ignore[unreachable]
+        data = getattr(data, _key)
+    return data
 
 
 @dataclass(frozen=True, kw_only=True)
 class ZWaveJSStatisticsSensorEntityDescription(SensorEntityDescription):
     """Class to represent a Z-Wave JS statistics sensor entity description."""
 
-    convert: Callable[
-        [ControllerStatisticsDataType | NodeStatisticsDataType, str], Any
-    ] = lambda statistics, key: statistics.get(key)
+    convert: Callable[[ControllerStatistics | NodeStatistics, str], Any] = getattr
     entity_registry_enabled_default: bool = False
 
 
 # Controller statistics descriptions
 ENTITY_DESCRIPTION_CONTROLLER_STATISTICS_LIST = [
     ZWaveJSStatisticsSensorEntityDescription(
-        key="messagesTX",
+        key="messages_tx",
         translation_key="successful_messages",
         translation_placeholders={"direction": "TX"},
         state_class=SensorStateClass.TOTAL,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
-        key="messagesRX",
+        key="messages_rx",
         translation_key="successful_messages",
         translation_placeholders={"direction": "RX"},
         state_class=SensorStateClass.TOTAL,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
-        key="messagesDroppedTX",
+        key="messages_dropped_tx",
         translation_key="messages_dropped",
         translation_placeholders={"direction": "TX"},
         state_class=SensorStateClass.TOTAL,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
-        key="messagesDroppedRX",
+        key="messages_dropped_rx",
         translation_key="messages_dropped",
         translation_placeholders={"direction": "RX"},
         state_class=SensorStateClass.TOTAL,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
-        key="NAK", translation_key="nak", state_class=SensorStateClass.TOTAL
+        key="nak", translation_key="nak", state_class=SensorStateClass.TOTAL
     ),
     ZWaveJSStatisticsSensorEntityDescription(
-        key="CAN", translation_key="can", state_class=SensorStateClass.TOTAL
+        key="can", translation_key="can", state_class=SensorStateClass.TOTAL
     ),
     ZWaveJSStatisticsSensorEntityDescription(
-        key="timeoutACK",
+        key="timeout_ack",
         translation_key="timeout_ack",
         state_class=SensorStateClass.TOTAL,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
-        key="timeoutResponse",
+        key="timeout_response",
         translation_key="timeout_response",
         state_class=SensorStateClass.TOTAL,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
-        key="timeoutCallback",
+        key="timeout_callback",
         translation_key="timeout_callback",
         state_class=SensorStateClass.TOTAL,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
-        key="backgroundRSSI.channel0.average",
+        key="background_rssi.channel_0.average",
         translation_key="average_background_rssi",
         translation_placeholders={"channel": "0"},
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
-        convert=convert_dict_of_dicts,
+        convert=convert_nested_attr,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
-        key="backgroundRSSI.channel0.current",
+        key="background_rssi.channel_0.current",
         translation_key="current_background_rssi",
         translation_placeholders={"channel": "0"},
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         state_class=SensorStateClass.MEASUREMENT,
-        convert=convert_dict_of_dicts,
+        convert=convert_nested_attr,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
-        key="backgroundRSSI.channel1.average",
+        key="background_rssi.channel_1.average",
         translation_key="average_background_rssi",
         translation_placeholders={"channel": "1"},
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
-        convert=convert_dict_of_dicts,
+        convert=convert_nested_attr,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
-        key="backgroundRSSI.channel1.current",
+        key="background_rssi.channel_1.current",
         translation_key="current_background_rssi",
         translation_placeholders={"channel": "1"},
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         state_class=SensorStateClass.MEASUREMENT,
-        convert=convert_dict_of_dicts,
+        convert=convert_nested_attr,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
-        key="backgroundRSSI.channel2.average",
+        key="background_rssi.channel_2.average",
         translation_key="average_background_rssi",
         translation_placeholders={"channel": "2"},
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
-        convert=convert_dict_of_dicts,
+        convert=convert_nested_attr,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
-        key="backgroundRSSI.channel2.current",
+        key="background_rssi.channel_2.current",
         translation_key="current_background_rssi",
         translation_placeholders={"channel": "2"},
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         state_class=SensorStateClass.MEASUREMENT,
-        convert=convert_dict_of_dicts,
+        convert=convert_nested_attr,
     ),
 ]
 
 # Node statistics descriptions
 ENTITY_DESCRIPTION_NODE_STATISTICS_LIST = [
     ZWaveJSStatisticsSensorEntityDescription(
-        key="commandsRX",
+        key="commands_rx",
         translation_key="successful_commands",
         translation_placeholders={"direction": "RX"},
         state_class=SensorStateClass.TOTAL,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
-        key="commandsTX",
+        key="commands_tx",
         translation_key="successful_commands",
         translation_placeholders={"direction": "TX"},
         state_class=SensorStateClass.TOTAL,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
-        key="commandsDroppedRX",
+        key="commands_dropped_rx",
         translation_key="commands_dropped",
         translation_placeholders={"direction": "RX"},
         state_class=SensorStateClass.TOTAL,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
-        key="commandsDroppedTX",
+        key="commands_dropped_tx",
         translation_key="commands_dropped",
         translation_placeholders={"direction": "TX"},
         state_class=SensorStateClass.TOTAL,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
-        key="timeoutResponse",
+        key="timeout_response",
         translation_key="timeout_response",
         state_class=SensorStateClass.TOTAL,
     ),
@@ -492,16 +493,9 @@ ENTITY_DESCRIPTION_NODE_STATISTICS_LIST = [
         state_class=SensorStateClass.MEASUREMENT,
     ),
     ZWaveJSStatisticsSensorEntityDescription(
-        key="lastSeen",
+        key="last_seen",
         translation_key="last_seen",
         device_class=SensorDeviceClass.TIMESTAMP,
-        convert=(
-            lambda statistics, key: (
-                datetime.fromisoformat(dt)  # type: ignore[arg-type]
-                if (dt := statistics.get(key))
-                else None
-            )
-        ),
         entity_registry_enabled_default=True,
     ),
 ]
@@ -1001,7 +995,7 @@ class ZWaveStatisticsSensor(SensorEntity):
     def statistics_updated(self, event_data: dict) -> None:
         """Call when statistics updated event is received."""
         self._attr_native_value = self.entity_description.convert(
-            event_data["statistics"], self.entity_description.key
+            event_data["statistics_updated"], self.entity_description.key
         )
         self.async_write_ha_state()
 
@@ -1027,5 +1021,5 @@ class ZWaveStatisticsSensor(SensorEntity):
 
         # Set initial state
         self._attr_native_value = self.entity_description.convert(
-            self.statistics_src.statistics.data, self.entity_description.key
+            self.statistics_src.statistics, self.entity_description.key
         )

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -23,6 +23,10 @@ from homeassistant.components.zwave_js.const import (
     SERVICE_RESET_METER,
 )
 from homeassistant.components.zwave_js.helpers import get_valueless_base_unique_id
+from homeassistant.components.zwave_js.sensor import (
+    CONTROLLER_STATISTICS_KEY_MAP,
+    NODE_STATISTICS_KEY_MAP,
+)
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_ENTITY_ID,
@@ -54,6 +58,8 @@ from .common import (
     POWER_SENSOR,
     VOLTAGE_SENSOR,
 )
+
+from tests.common import MockConfigEntry
 
 
 async def test_numeric_sensor(
@@ -754,6 +760,54 @@ NODE_STATISTICS_SUFFIXES_UNKNOWN = {
     "round_trip_time": 6,
     "rssi": 7,
 }
+
+
+async def test_statistics_sensors_migration(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    zp3111_state,
+    client,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test statistics migration sensor."""
+    node = Node(client, copy.deepcopy(zp3111_state))
+    client.driver.controller.nodes[node.node_id] = node
+
+    entry = MockConfigEntry(domain="zwave_js", data={"url": "ws://test.org"})
+    entry.add_to_hass(hass)
+
+    controller_base_unique_id = f"{client.driver.controller.home_id}.1.statistics"
+    node_base_unique_id = f"{client.driver.controller.home_id}.22.statistics"
+
+    # Create entity registry records for the old statistics keys
+    for base_unique_id, key_map in (
+        (controller_base_unique_id, CONTROLLER_STATISTICS_KEY_MAP),
+        (node_base_unique_id, NODE_STATISTICS_KEY_MAP),
+    ):
+        # old key
+        for key in key_map.values():
+            entity_registry.async_get_or_create(
+                "sensor", DOMAIN, f"{base_unique_id}_{key}"
+            )
+
+    # Set up integration
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Validate that entity unique ID's have changed
+    for base_unique_id, key_map in (
+        (controller_base_unique_id, CONTROLLER_STATISTICS_KEY_MAP),
+        (node_base_unique_id, NODE_STATISTICS_KEY_MAP),
+    ):
+        for new_key, old_key in key_map.items():
+            # If there was nothing to migrate there was nothing removed
+            if new_key != old_key:
+                assert not entity_registry.async_get_entity_id(
+                    "sensor", DOMAIN, f"{base_unique_id}_{old_key}"
+                )
+            assert entity_registry.async_get_entity_id(
+                "sensor", DOMAIN, f"{base_unique_id}_{new_key}"
+            )
 
 
 async def test_statistics_sensors_no_last_seen(

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -800,7 +800,7 @@ async def test_statistics_sensors_migration(
         (node_base_unique_id, NODE_STATISTICS_KEY_MAP),
     ):
         for new_key, old_key in key_map.items():
-            # If there was nothing to migrate there was nothing removed
+            # If the key has changed, the old entity should not exist
             if new_key != old_key:
                 assert not entity_registry.async_get_entity_id(
                     "sensor", DOMAIN, f"{base_unique_id}_{old_key}"


### PR DESCRIPTION
## Proposed change
In the `zwave_js` library, we model zwave-js, and behind the scenes we also store the raw data from zwave-js. The statisitics sensors previously accessed the raw data but we'd prefer if the data was accessed via the model instead. This PR addresses that 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
