### PR TITLE
Only raise Reolink re-auth flow when login fails 3 consecutive times

### DIFF
--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -38,6 +38,7 @@ PLATFORMS = [
 ]
 DEVICE_UPDATE_INTERVAL = timedelta(seconds=60)
 FIRMWARE_UPDATE_INTERVAL = timedelta(hours=12)
+NUM_CRED_ERRORS = 3
 
 
 @dataclass
@@ -75,7 +76,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     )
 
     starting = True
-    credential_errors = 0
 
     async def async_device_config_update() -> None:
         """Update the host state cache and renew the ONVIF-subscription."""
@@ -83,16 +83,16 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             try:
                 await host.update_states()
             except CredentialsInvalidError as err:
-                credential_errors += 1
-                if credential_errors >= 3:
+                host.credential_errors += 1
+                if host.credential_errors >= NUM_CRED_ERRORS:
                     await host.stop()
                     raise ConfigEntryAuthFailed(err) from err
                 raise UpdateFailed(str(err)) from err
             except ReolinkError as err:
-                credential_errors = 0
+                host.credential_errors = 0
                 raise UpdateFailed(str(err)) from err
 
-        credential_errors = 0
+        host.credential_errors = 0
 
         async with asyncio.timeout(host.api.timeout * (RETRY_ATTEMPTS + 2)):
             await host.renew()

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -79,6 +79,8 @@ class ReolinkHost:
         )
         self.firmware_ch_list: list[int | None] = []
 
+        self.credential_errors: int = 0
+
         self.webhook_id: str | None = None
         self._onvif_push_supported: bool = True
         self._onvif_long_poll_supported: bool = True

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -7,11 +7,16 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 import pytest
 from reolink_aio.exceptions import CredentialsInvalidError, ReolinkError
 
-from homeassistant.components.reolink import FIRMWARE_UPDATE_INTERVAL, const
+from homeassistant.components.reolink import (
+    DEVICE_UPDATE_INTERVAL,
+    FIRMWARE_UPDATE_INTERVAL,
+    NUM_CRED_ERRORS,
+    const,
+)
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_OFF, STATE_UNAVAILABLE, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import DOMAIN as HA_DOMAIN, HomeAssistant
 from homeassistant.helpers import (
     device_registry as dr,
     entity_registry as er,
@@ -58,7 +63,7 @@ pytestmark = pytest.mark.usefixtures("reolink_connect", "reolink_platforms")
             ConfigEntryState.SETUP_RETRY,
         ),
         (
-            "get_states",
+            "get_host_data",
             AsyncMock(side_effect=CredentialsInvalidError("Test error")),
             ConfigEntryState.SETUP_ERROR,
         ),
@@ -111,6 +116,33 @@ async def test_firmware_error_twice(
     await hass.async_block_till_done()
 
     assert hass.states.is_state(entity_id, STATE_UNAVAILABLE)
+
+
+async def test_credential_error_three(
+    hass: HomeAssistant,
+    reolink_connect: MagicMock,
+    config_entry: MockConfigEntry,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test when the update gives credential error 3 times."""
+    with patch("homeassistant.components.reolink.PLATFORMS", [Platform.SWITCH]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id) is True
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    reolink_connect.get_states = AsyncMock(
+        side_effect=CredentialsInvalidError("Test error")
+    )
+
+    issue_id = f"config_entry_reauth_{const.DOMAIN}_{config_entry.entry_id}"
+    for _ in range(NUM_CRED_ERRORS):
+        assert (HA_DOMAIN, issue_id) not in issue_registry.issues
+        async_fire_time_changed(
+            hass, utcnow() + DEVICE_UPDATE_INTERVAL + timedelta(seconds=30)
+        )
+        await hass.async_block_till_done()
+
+    assert (HA_DOMAIN, issue_id) in issue_registry.issues
 
 
 async def test_entry_reloading(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Only raise Reolink re-auth flow when login fails 3 consecutive times.

Some camera's (especially WiFi camera's with a very bad signal) sometimes wrongfully respond with a "wrong password" messages, see https://github.com/home-assistant/core/issues/113379.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/113379
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
