### PR TITLE
Improve type hints in conversation tests

### DIFF
--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -1,6 +1,7 @@
 """Test for the default agent."""
 
 from collections import defaultdict
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 from hassil.recognize import Intent, IntentData, MatchEntity, RecognizeResult
@@ -34,7 +35,7 @@ from tests.common import MockConfigEntry, async_mock_service
 
 
 @pytest.fixture
-async def init_components(hass):
+async def init_components(hass: HomeAssistant) -> None:
     """Initialize relevant components with empty configs."""
     assert await async_setup_component(hass, "homeassistant", {})
     assert await async_setup_component(hass, "conversation", {})
@@ -50,8 +51,9 @@ async def init_components(hass):
         {"entity_category": entity.EntityCategory.DIAGNOSTIC},
     ],
 )
+@pytest.mark.usefixtures("init_components")
 async def test_hidden_entities_skipped(
-    hass: HomeAssistant, init_components, er_kwargs, entity_registry: er.EntityRegistry
+    hass: HomeAssistant, er_kwargs: dict[str, Any], entity_registry: er.EntityRegistry
 ) -> None:
     """Test we skip hidden entities."""
 
@@ -69,7 +71,8 @@ async def test_hidden_entities_skipped(
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
 
 
-async def test_exposed_domains(hass: HomeAssistant, init_components) -> None:
+@pytest.mark.usefixtures("init_components")
+async def test_exposed_domains(hass: HomeAssistant) -> None:
     """Test that we can't interact with entities that aren't exposed."""
     hass.states.async_set(
         "lock.front_door", "off", attributes={ATTR_FRIENDLY_NAME: "Front Door"}
@@ -93,9 +96,9 @@ async def test_exposed_domains(hass: HomeAssistant, init_components) -> None:
     assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
 
 
+@pytest.mark.usefixtures("init_components")
 async def test_exposed_areas(
     hass: HomeAssistant,
-    init_components,
     area_registry: ar.AreaRegistry,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
@@ -160,10 +163,8 @@ async def test_exposed_areas(
     assert result.response.response_type == intent.IntentResponseType.QUERY_ANSWER
 
 
-async def test_conversation_agent(
-    hass: HomeAssistant,
-    init_components,
-) -> None:
+@pytest.mark.usefixtures("init_components")
+async def test_conversation_agent(hass: HomeAssistant) -> None:
     """Test DefaultAgent."""
     agent = default_agent.async_get_default_agent(hass)
     with patch(
@@ -209,9 +210,9 @@ async def test_expose_flag_automatically_set(
     }
 
 
+@pytest.mark.usefixtures("init_components")
 async def test_unexposed_entities_skipped(
     hass: HomeAssistant,
-    init_components,
     area_registry: ar.AreaRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
@@ -262,7 +263,8 @@ async def test_unexposed_entities_skipped(
     assert result.response.matched_states[0].entity_id == exposed_light.entity_id
 
 
-async def test_trigger_sentences(hass: HomeAssistant, init_components) -> None:
+@pytest.mark.usefixtures("init_components")
+async def test_trigger_sentences(hass: HomeAssistant) -> None:
     """Test registering/unregistering/matching a few trigger sentences."""
     trigger_sentences = ["It's party time", "It is time to party"]
     trigger_response = "Cowabunga!"
@@ -303,9 +305,8 @@ async def test_trigger_sentences(hass: HomeAssistant, init_components) -> None:
     assert len(callback.mock_calls) == 0
 
 
-async def test_shopping_list_add_item(
-    hass: HomeAssistant, init_components, sl_setup
-) -> None:
+@pytest.mark.usefixtures("init_components", "sl_setup")
+async def test_shopping_list_add_item(hass: HomeAssistant) -> None:
     """Test adding an item to the shopping list through the default agent."""
     result = await conversation.async_converse(
         hass, "add apples to my shopping list", None, Context()
@@ -316,7 +317,8 @@ async def test_shopping_list_add_item(
     }
 
 
-async def test_nevermind_item(hass: HomeAssistant, init_components) -> None:
+@pytest.mark.usefixtures("init_components")
+async def test_nevermind_item(hass: HomeAssistant) -> None:
     """Test HassNevermind intent through the default agent."""
     result = await conversation.async_converse(hass, "nevermind", None, Context())
     assert result.response.intent is not None
@@ -326,9 +328,9 @@ async def test_nevermind_item(hass: HomeAssistant, init_components) -> None:
     assert not result.response.speech
 
 
+@pytest.mark.usefixtures("init_components")
 async def test_device_area_context(
     hass: HomeAssistant,
-    init_components,
     area_registry: ar.AreaRegistry,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
@@ -465,7 +467,8 @@ async def test_device_area_context(
         }
 
 
-async def test_error_no_device(hass: HomeAssistant, init_components) -> None:
+@pytest.mark.usefixtures("init_components")
+async def test_error_no_device(hass: HomeAssistant) -> None:
     """Test error message when device/entity is missing."""
     result = await conversation.async_converse(
         hass, "turn on missing entity", None, Context(), None
@@ -479,7 +482,8 @@ async def test_error_no_device(hass: HomeAssistant, init_components) -> None:
     )
 
 
-async def test_error_no_area(hass: HomeAssistant, init_components) -> None:
+@pytest.mark.usefixtures("init_components")
+async def test_error_no_area(hass: HomeAssistant) -> None:
     """Test error message when area is missing."""
     result = await conversation.async_converse(
         hass, "turn on the lights in missing area", None, Context(), None
@@ -493,7 +497,8 @@ async def test_error_no_area(hass: HomeAssistant, init_components) -> None:
     )
 
 
-async def test_error_no_floor(hass: HomeAssistant, init_components) -> None:
+@pytest.mark.usefixtures("init_components")
+async def test_error_no_floor(hass: HomeAssistant) -> None:
     """Test error message when floor is missing."""
     result = await conversation.async_converse(
         hass, "turn on all the lights on missing floor", None, Context(), None
@@ -507,8 +512,9 @@ async def test_error_no_floor(hass: HomeAssistant, init_components) -> None:
     )
 
 
+@pytest.mark.usefixtures("init_components")
 async def test_error_no_device_in_area(
-    hass: HomeAssistant, init_components, area_registry: ar.AreaRegistry
+    hass: HomeAssistant, area_registry: ar.AreaRegistry
 ) -> None:
     """Test error message when area is missing a device/entity."""
     area_kitchen = area_registry.async_get_or_create("kitchen_id")
@@ -525,9 +531,8 @@ async def test_error_no_device_in_area(
     )
 
 
-async def test_error_no_domain(
-    hass: HomeAssistant, init_components, area_registry: ar.AreaRegistry
-) -> None:
+@pytest.mark.usefixtures("init_components")
+async def test_error_no_domain(hass: HomeAssistant) -> None:
     """Test error message when no devices/entities exist for a domain."""
 
     # We don't have a sentence for turning on all fans
@@ -558,8 +563,9 @@ async def test_error_no_domain(
         )
 
 
+@pytest.mark.usefixtures("init_components")
 async def test_error_no_domain_in_area(
-    hass: HomeAssistant, init_components, area_registry: ar.AreaRegistry
+    hass: HomeAssistant, area_registry: ar.AreaRegistry
 ) -> None:
     """Test error message when no devices/entities for a domain exist in an area."""
     area_kitchen = area_registry.async_get_or_create("kitchen_id")
@@ -576,9 +582,9 @@ async def test_error_no_domain_in_area(
     )
 
 
+@pytest.mark.usefixtures("init_components")
 async def test_error_no_domain_in_floor(
     hass: HomeAssistant,
-    init_components,
     area_registry: ar.AreaRegistry,
     floor_registry: fr.FloorRegistry,
 ) -> None:
@@ -618,7 +624,8 @@ async def test_error_no_domain_in_floor(
     )
 
 
-async def test_error_no_device_class(hass: HomeAssistant, init_components) -> None:
+@pytest.mark.usefixtures("init_components")
+async def test_error_no_device_class(hass: HomeAssistant) -> None:
     """Test error message when no entities of a device class exist."""
     # Create a cover entity that is not a window.
     # This ensures that the filtering below won't exit early because there are
@@ -658,8 +665,9 @@ async def test_error_no_device_class(hass: HomeAssistant, init_components) -> No
         )
 
 
+@pytest.mark.usefixtures("init_components")
 async def test_error_no_device_class_in_area(
-    hass: HomeAssistant, init_components, area_registry: ar.AreaRegistry
+    hass: HomeAssistant, area_registry: ar.AreaRegistry
 ) -> None:
     """Test error message when no entities of a device class exist in an area."""
     area_bedroom = area_registry.async_get_or_create("bedroom_id")
@@ -676,7 +684,8 @@ async def test_error_no_device_class_in_area(
     )
 
 
-async def test_error_no_intent(hass: HomeAssistant, init_components) -> None:
+@pytest.mark.usefixtures("init_components")
+async def test_error_no_intent(hass: HomeAssistant) -> None:
     """Test response with an intent match failure."""
     with patch(
         "homeassistant.components.conversation.default_agent.recognize_all",
@@ -696,8 +705,9 @@ async def test_error_no_intent(hass: HomeAssistant, init_components) -> None:
         )
 
 
+@pytest.mark.usefixtures("init_components")
 async def test_error_duplicate_names(
-    hass: HomeAssistant, init_components, entity_registry: er.EntityRegistry
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test error message when multiple devices have the same name (or alias)."""
     kitchen_light_1 = entity_registry.async_get_or_create("light", "demo", "1234")
@@ -747,9 +757,9 @@ async def test_error_duplicate_names(
         )
 
 
+@pytest.mark.usefixtures("init_components")
 async def test_error_duplicate_names_in_area(
     hass: HomeAssistant,
-    init_components,
     area_registry: ar.AreaRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
@@ -805,7 +815,8 @@ async def test_error_duplicate_names_in_area(
         )
 
 
-async def test_error_wrong_state(hass: HomeAssistant, init_components) -> None:
+@pytest.mark.usefixtures("init_components")
+async def test_error_wrong_state(hass: HomeAssistant) -> None:
     """Test error message when no entities are in the correct state."""
     assert await async_setup_component(hass, media_player.DOMAIN, {})
 
@@ -824,9 +835,8 @@ async def test_error_wrong_state(hass: HomeAssistant, init_components) -> None:
     assert result.response.speech["plain"]["speech"] == "Sorry, no device is playing"
 
 
-async def test_error_feature_not_supported(
-    hass: HomeAssistant, init_components
-) -> None:
+@pytest.mark.usefixtures("init_components")
+async def test_error_feature_not_supported(hass: HomeAssistant) -> None:
     """Test error message when no devices support a required feature."""
     assert await async_setup_component(hass, media_player.DOMAIN, {})
 
@@ -849,7 +859,8 @@ async def test_error_feature_not_supported(
     )
 
 
-async def test_error_no_timer_support(hass: HomeAssistant, init_components) -> None:
+@pytest.mark.usefixtures("init_components")
+async def test_error_no_timer_support(hass: HomeAssistant) -> None:
     """Test error message when a device does not support timers (no handler is registered)."""
     device_id = "test_device"
 
@@ -866,7 +877,8 @@ async def test_error_no_timer_support(hass: HomeAssistant, init_components) -> N
     )
 
 
-async def test_error_timer_not_found(hass: HomeAssistant, init_components) -> None:
+@pytest.mark.usefixtures("init_components")
+async def test_error_timer_not_found(hass: HomeAssistant) -> None:
     """Test error message when a timer cannot be matched."""
     device_id = "test_device"
 
@@ -888,9 +900,9 @@ async def test_error_timer_not_found(hass: HomeAssistant, init_components) -> No
     )
 
 
+@pytest.mark.usefixtures("init_components")
 async def test_error_multiple_timers_matched(
     hass: HomeAssistant,
-    init_components,
     area_registry: ar.AreaRegistry,
     device_registry: dr.DeviceRegistry,
 ) -> None:
@@ -938,8 +950,9 @@ async def test_error_multiple_timers_matched(
     )
 
 
+@pytest.mark.usefixtures("init_components")
 async def test_no_states_matched_default_error(
-    hass: HomeAssistant, init_components, area_registry: ar.AreaRegistry
+    hass: HomeAssistant, area_registry: ar.AreaRegistry
 ) -> None:
     """Test default response when no states match and slots are missing."""
     area_kitchen = area_registry.async_get_or_create("kitchen_id")
@@ -966,9 +979,9 @@ async def test_no_states_matched_default_error(
         )
 
 
+@pytest.mark.usefixtures("init_components")
 async def test_empty_aliases(
     hass: HomeAssistant,
-    init_components,
     area_registry: ar.AreaRegistry,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
@@ -1031,7 +1044,8 @@ async def test_empty_aliases(
         assert floors.values[0].text_in.text == floor_1.name
 
 
-async def test_all_domains_loaded(hass: HomeAssistant, init_components) -> None:
+@pytest.mark.usefixtures("init_components")
+async def test_all_domains_loaded(hass: HomeAssistant) -> None:
     """Test that sentences for all domains are always loaded."""
 
     # light domain is not loaded
@@ -1050,9 +1064,9 @@ async def test_all_domains_loaded(hass: HomeAssistant, init_components) -> None:
     )
 
 
+@pytest.mark.usefixtures("init_components")
 async def test_same_named_entities_in_different_areas(
     hass: HomeAssistant,
-    init_components,
     area_registry: ar.AreaRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
@@ -1147,9 +1161,9 @@ async def test_same_named_entities_in_different_areas(
     assert result.response.response_type == intent.IntentResponseType.QUERY_ANSWER
 
 
+@pytest.mark.usefixtures("init_components")
 async def test_same_aliased_entities_in_different_areas(
     hass: HomeAssistant,
-    init_components,
     area_registry: ar.AreaRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
@@ -1238,7 +1252,8 @@ async def test_same_aliased_entities_in_different_areas(
     assert result.response.response_type == intent.IntentResponseType.QUERY_ANSWER
 
 
-async def test_device_id_in_handler(hass: HomeAssistant, init_components) -> None:
+@pytest.mark.usefixtures("init_components")
+async def test_device_id_in_handler(hass: HomeAssistant) -> None:
     """Test that the default agent passes device_id to intent handler."""
     device_id = "test_device"
 
@@ -1270,9 +1285,8 @@ async def test_device_id_in_handler(hass: HomeAssistant, init_components) -> Non
     assert handler.device_id == device_id
 
 
-async def test_name_wildcard_lower_priority(
-    hass: HomeAssistant, init_components
-) -> None:
+@pytest.mark.usefixtures("init_components")
+async def test_name_wildcard_lower_priority(hass: HomeAssistant) -> None:
     """Test that the default agent does not prioritize a {name} slot when it's a wildcard."""
 
     class OrderBeerIntentHandler(intent.IntentHandler):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302
https://github.com/home-assistant/core/actions/runs/9643593124/job/26593942586?pr=120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
