### PR TITLE
Reduce the amount of data fetched in individual Hydrawise API calls

### DIFF
--- a/homeassistant/components/hydrawise/config_flow.py
+++ b/homeassistant/components/hydrawise/config_flow.py
@@ -37,8 +37,8 @@ class HydrawiseConfigFlow(ConfigFlow, domain=DOMAIN):
         # Verify that the provided credentials work."""
         api = client.Hydrawise(auth.Auth(username, password))
         try:
-            # Skip fetching zones to save on metered API calls.
-            user = await api.get_user()
+            # Don't fetch zones because we don't need them yet.
+            user = await api.get_user(fetch_zones=False)
         except NotAuthorizedError:
             return on_failure("invalid_auth")
         except TimeoutError:

--- a/tests/components/hydrawise/conftest.py
+++ b/tests/components/hydrawise/conftest.py
@@ -1,6 +1,6 @@
 """Common fixtures for the Hydrawise tests."""
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Generator
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
@@ -20,7 +20,6 @@ from pydrawise.schema import (
     Zone,
 )
 import pytest
-from typing_extensions import Generator
 
 from homeassistant.components.hydrawise.const import DOMAIN
 from homeassistant.const import CONF_API_KEY, CONF_PASSWORD, CONF_USERNAME
@@ -67,9 +66,9 @@ def mock_pydrawise(
     """Mock Hydrawise."""
     with patch("pydrawise.client.Hydrawise", autospec=True) as mock_pydrawise:
         user.controllers = [controller]
-        controller.zones = zones
         controller.sensors = sensors
         mock_pydrawise.return_value.get_user.return_value = user
+        mock_pydrawise.return_value.get_zones.return_value = zones
         mock_pydrawise.return_value.get_water_use_summary.return_value = (
             controller_water_use_summary
         )
@@ -142,7 +141,7 @@ def sensors() -> list[Sensor]:
             ),
             status=SensorStatus(
                 water_flow=LocalizedValueType(value=577.0044752010709, unit="gal"),
-                active=None,
+                active=False,
             ),
         ),
     ]
@@ -154,7 +153,6 @@ def zones() -> list[Zone]:
     return [
         Zone(
             name="Zone One",
-            number=1,
             id=5965394,
             scheduled_runs=ScheduledZoneRuns(
                 summary="",
@@ -171,7 +169,6 @@ def zones() -> list[Zone]:
         ),
         Zone(
             name="Zone Two",
-            number=2,
             id=5965395,
             scheduled_runs=ScheduledZoneRuns(
                 current_run=ScheduledZoneRun(

--- a/tests/components/hydrawise/test_config_flow.py
+++ b/tests/components/hydrawise/test_config_flow.py
@@ -46,7 +46,7 @@ async def test_form(
         CONF_PASSWORD: "__password__",
     }
     assert len(mock_setup_entry.mock_calls) == 1
-    mock_pydrawise.get_user.assert_called_once_with()
+    mock_pydrawise.get_user.assert_called_once_with(fetch_zones=False)
 
 
 async def test_form_api_error(


### PR DESCRIPTION
## Proposed change
Fetch less data in Hydrawise API calls to prevent 502 errors in some cases.

Some users are reporting 502 errors when loading the Hydrawise integration, and this seems to be caused by the query either being too expensive to compute on the server or the reply simply returning too much data. https://www.google.com/search?q=graphql+502+bad+gateway shows this being a not-uncommon problem with GraphQL queries--particularly when the server is based on the Apollo framework.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #120128
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
