### PR TITLE
Fix setup and tear down issues for mqtt discovery and config flow tests

### DIFF
--- a/tests/components/mqtt/conftest.py
+++ b/tests/components/mqtt/conftest.py
@@ -6,7 +6,17 @@ from unittest.mock import patch
 import pytest
 from typing_extensions import Generator
 
-from tests.components.light.conftest import mock_light_profiles  # noqa: F401
+from homeassistant.components import mqtt
+
+ENTRY_DEFAULT_BIRTH_MESSAGE = {
+    mqtt.CONF_BROKER: "mock-broker",
+    mqtt.CONF_BIRTH_MESSAGE: {
+        mqtt.ATTR_TOPIC: "homeassistant/status",
+        mqtt.ATTR_PAYLOAD: "online",
+        mqtt.ATTR_QOS: 0,
+        mqtt.ATTR_RETAIN: False,
+    },
+}
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/mqtt/test_config_flow.py
+++ b/tests/components/mqtt/test_config_flow.py
@@ -1104,7 +1104,6 @@ async def test_skipping_advanced_options(
 )
 async def test_step_reauth(
     hass: HomeAssistant,
-    mqtt_mock_entry: MqttMockHAClientGenerator,
     mqtt_client_mock: MqttMockPahoClient,
     mock_try_connection: MagicMock,
     mock_reload_after_entry_update: MagicMock,
@@ -1115,12 +1114,9 @@ async def test_step_reauth(
     """Test that the reauth step works."""
 
     # Prepare the config entry
-    config_entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
-    hass.config_entries.async_update_entry(
-        config_entry,
-        data=test_input,
-    )
-    await mqtt_mock_entry()
+    config_entry = MockConfigEntry(domain=mqtt.DOMAIN, data=test_input)
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
 
     # Start reauth flow
     config_entry.async_start_reauth(hass)

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -22,7 +22,9 @@ from homeassistant.components.mqtt.discovery import (
     MQTTDiscoveryPayload,
     async_start,
 )
+from homeassistant.components.mqtt.models import ReceiveMessage
 from homeassistant.const import (
+    EVENT_HOMEASSISTANT_STARTED,
     EVENT_STATE_CHANGED,
     STATE_ON,
     STATE_UNAVAILABLE,
@@ -40,6 +42,7 @@ from homeassistant.helpers.service_info.mqtt import MqttServiceInfo
 from homeassistant.setup import async_setup_component
 from homeassistant.util.signal_type import SignalTypeFormat
 
+from .conftest import ENTRY_DEFAULT_BIRTH_MESSAGE
 from .test_common import help_all_subscribe_calls, help_test_unload_config_entry
 
 from tests.common import (
@@ -1454,32 +1457,15 @@ async def test_complex_discovery_topic_prefix(
     ].discovery_already_discovered
 
 
+@patch("homeassistant.components.mqtt.client.DISCOVERY_COOLDOWN", 0.0)
 @patch("homeassistant.components.mqtt.client.INITIAL_SUBSCRIBE_COOLDOWN", 0.0)
 @patch("homeassistant.components.mqtt.client.SUBSCRIBE_COOLDOWN", 0.0)
 @patch("homeassistant.components.mqtt.client.UNSUBSCRIBE_COOLDOWN", 0.0)
 async def test_mqtt_integration_discovery_subscribe_unsubscribe(
     hass: HomeAssistant,
     mqtt_client_mock: MqttMockPahoClient,
-    mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Check MQTT integration discovery subscribe and unsubscribe."""
-    mqtt_mock = await mqtt_mock_entry()
-    mock_platform(hass, "comp.config_flow", None)
-
-    entry = hass.config_entries.async_entries("mqtt")[0]
-    mqtt_mock().connected = True
-
-    with patch(
-        "homeassistant.components.mqtt.discovery.async_get_mqtt",
-        return_value={"comp": ["comp/discovery/#"]},
-    ):
-        await async_start(hass, "homeassistant", entry)
-        await hass.async_block_till_done()
-        await hass.async_block_till_done()
-        await hass.async_block_till_done()
-
-    assert ("comp/discovery/#", 0) in help_all_subscribe_calls(mqtt_client_mock)
-    assert not mqtt_client_mock.unsubscribe.called
 
     class TestFlow(config_entries.ConfigFlow):
         """Test flow."""
@@ -1488,7 +1474,13 @@ async def test_mqtt_integration_discovery_subscribe_unsubscribe(
             """Test mqtt step."""
             return self.async_abort(reason="already_configured")
 
-    assert not mqtt_client_mock.unsubscribe.called
+    mock_platform(hass, "comp.config_flow", None)
+
+    birth = asyncio.Event()
+
+    async def wait_birth(msg: ReceiveMessage) -> None:
+        """Handle birth message."""
+        birth.set()
 
     wait_unsub = asyncio.Event()
 
@@ -1496,41 +1488,41 @@ async def test_mqtt_integration_discovery_subscribe_unsubscribe(
         wait_unsub.set()
         return (0, 0)
 
+    entry = MockConfigEntry(domain=mqtt.DOMAIN, data=ENTRY_DEFAULT_BIRTH_MESSAGE)
+    entry.add_to_hass(hass)
     with (
+        patch(
+            "homeassistant.components.mqtt.discovery.async_get_mqtt",
+            return_value={"comp": ["comp/discovery/#"]},
+        ),
         mock_config_flow("comp", TestFlow),
         patch.object(mqtt_client_mock, "unsubscribe", side_effect=_mock_unsubscribe),
     ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await mqtt.async_subscribe(hass, "homeassistant/status", wait_birth)
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await birth.wait()
+
+        assert ("comp/discovery/#", 0) in help_all_subscribe_calls(mqtt_client_mock)
+        assert not mqtt_client_mock.unsubscribe.called
+        mqtt_client_mock.reset_mock()
+
+        await hass.async_block_till_done(wait_background_tasks=True)
         async_fire_mqtt_message(hass, "comp/discovery/bla/config", "")
         await wait_unsub.wait()
         mqtt_client_mock.unsubscribe.assert_called_once_with(["comp/discovery/#"])
+        await hass.async_block_till_done(wait_background_tasks=True)
 
 
+@patch("homeassistant.components.mqtt.client.DISCOVERY_COOLDOWN", 0.0)
 @patch("homeassistant.components.mqtt.client.INITIAL_SUBSCRIBE_COOLDOWN", 0.0)
 @patch("homeassistant.components.mqtt.client.SUBSCRIBE_COOLDOWN", 0.0)
 @patch("homeassistant.components.mqtt.client.UNSUBSCRIBE_COOLDOWN", 0.0)
 async def test_mqtt_discovery_unsubscribe_once(
     hass: HomeAssistant,
     mqtt_client_mock: MqttMockPahoClient,
-    mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Check MQTT integration discovery unsubscribe once."""
-    mqtt_mock = await mqtt_mock_entry()
-    mock_platform(hass, "comp.config_flow", None)
-
-    entry = hass.config_entries.async_entries("mqtt")[0]
-    mqtt_mock().connected = True
-
-    with patch(
-        "homeassistant.components.mqtt.discovery.async_get_mqtt",
-        return_value={"comp": ["comp/discovery/#"]},
-    ):
-        await async_start(hass, "homeassistant", entry)
-        await hass.async_block_till_done()
-        await hass.async_block_till_done()
-        await hass.async_block_till_done()
-
-    assert ("comp/discovery/#", 0) in help_all_subscribe_calls(mqtt_client_mock)
-    assert not mqtt_client_mock.unsubscribe.called
 
     class TestFlow(config_entries.ConfigFlow):
         """Test flow."""
@@ -1540,13 +1532,47 @@ async def test_mqtt_discovery_unsubscribe_once(
             await asyncio.sleep(0.1)
             return self.async_abort(reason="already_configured")
 
-    with mock_config_flow("comp", TestFlow):
+    mock_platform(hass, "comp.config_flow", None)
+
+    birth = asyncio.Event()
+
+    async def wait_birth(msg: ReceiveMessage) -> None:
+        """Handle birth message."""
+        birth.set()
+
+    wait_unsub = asyncio.Event()
+
+    def _mock_unsubscribe(topics: list[str]) -> tuple[int, int]:
+        wait_unsub.set()
+        return (0, 0)
+
+    entry = MockConfigEntry(domain=mqtt.DOMAIN, data=ENTRY_DEFAULT_BIRTH_MESSAGE)
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.mqtt.discovery.async_get_mqtt",
+            return_value={"comp": ["comp/discovery/#"]},
+        ),
+        mock_config_flow("comp", TestFlow),
+        patch.object(mqtt_client_mock, "unsubscribe", side_effect=_mock_unsubscribe),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await mqtt.async_subscribe(hass, "homeassistant/status", wait_birth)
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await birth.wait()
+
+        assert ("comp/discovery/#", 0) in help_all_subscribe_calls(mqtt_client_mock)
+        assert not mqtt_client_mock.unsubscribe.called
+
+        await hass.async_block_till_done(wait_background_tasks=True)
         async_fire_mqtt_message(hass, "comp/discovery/bla/config", "")
         async_fire_mqtt_message(hass, "comp/discovery/bla/config", "")
-        await asyncio.sleep(0.1)
-        await hass.async_block_till_done()
-        await hass.async_block_till_done()
+        await wait_unsub.wait()
+        await asyncio.sleep(0.2)
+        await hass.async_block_till_done(wait_background_tasks=True)
         mqtt_client_mock.unsubscribe.assert_called_once_with(["comp/discovery/#"])
+        await hass.async_block_till_done(wait_background_tasks=True)
 
 
 async def test_clear_config_topic_disabled_entity(

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -1478,12 +1478,14 @@ async def test_mqtt_integration_discovery_subscribe_unsubscribe(
 
     birth = asyncio.Event()
 
-    async def wait_birth(msg: ReceiveMessage) -> None:
+    @callback
+    def wait_birth(msg: ReceiveMessage) -> None:
         """Handle birth message."""
         birth.set()
 
     wait_unsub = asyncio.Event()
 
+    @callback
     def _mock_unsubscribe(topics: list[str]) -> tuple[int, int]:
         wait_unsub.set()
         return (0, 0)
@@ -1536,12 +1538,14 @@ async def test_mqtt_discovery_unsubscribe_once(
 
     birth = asyncio.Event()
 
-    async def wait_birth(msg: ReceiveMessage) -> None:
+    @callback
+    def wait_birth(msg: ReceiveMessage) -> None:
         """Handle birth message."""
         birth.set()
 
     wait_unsub = asyncio.Event()
 
+    @callback
     def _mock_unsubscribe(topics: list[str]) -> tuple[int, int]:
         wait_unsub.set()
         return (0, 0)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix setup and tear down issues for mqtt discovery and config flow tests. The tests use the birth message to synchronize the assertions on the client subscription.
This is part of https://github.com/home-assistant/core/pull/120274

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
