### PR TITLE
Add snapshot tests and feature exclusions to tplink integration

### DIFF
--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -54,6 +54,19 @@ DEVICETYPES_WITH_SPECIALIZED_PLATFORMS = {
     DeviceType.Dimmer,
 }
 
+# Features excluded due to future platform additions
+EXCLUDED_FEATURES = {
+    # climate
+    "target_temperature",
+    "thermostat_mode",
+    # update
+    "current_firmware_version",
+    "available_firmware_version",
+    "frost_protection_enabled",
+    # fan
+    "fan_speed_level",
+}
+
 LEGACY_KEY_MAPPING = {
     "current": ATTR_CURRENT_A,
     "current_consumption": ATTR_CURRENT_POWER_W,
@@ -336,6 +349,7 @@ class CoordinatedTPLinkFeatureEntity(CoordinatedTPLinkEntity, ABC):
             )
             for feat in device.features.values()
             if feat.type == feature_type
+            and feat.id not in EXCLUDED_FEATURES
             and (
                 feat.category is not Feature.Category.Primary
                 or device.device_type not in DEVICETYPES_WITH_SPECIALIZED_PLATFORMS

--- a/homeassistant/components/tplink/number.py
+++ b/homeassistant/components/tplink/number.py
@@ -49,10 +49,6 @@ NUMBER_DESCRIPTIONS: Final = (
         key="temperature_offset",
         mode=NumberMode.BOX,
     ),
-    TPLinkNumberEntityDescription(
-        key="target_temperature",
-        mode=NumberMode.BOX,
-    ),
 )
 
 NUMBER_DESCRIPTIONS_MAP = {desc.key: desc for desc in NUMBER_DESCRIPTIONS}

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -117,22 +117,6 @@ SENSOR_DESCRIPTIONS: tuple[TPLinkSensorEntityDescription, ...] = (
         key="temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
     ),
-    # Firmware based features are all disabled by default pending
-    # the update platform
-    TPLinkSensorEntityDescription(
-        entity_registry_enabled_default=False,
-        key="current_firmware_version",
-    ),
-    TPLinkSensorEntityDescription(
-        entity_registry_enabled_default=False,
-        key="available_firmware_version",
-    ),
-    # Thermostat based features are all disabled by default pending
-    # the climate platform
-    TPLinkSensorEntityDescription(
-        key="thermostat_mode",
-        entity_registry_enabled_default=False,
-    ),
 )
 
 SENSOR_DESCRIPTIONS_MAP = {desc.key: desc for desc in SENSOR_DESCRIPTIONS}

--- a/homeassistant/components/tplink/strings.json
+++ b/homeassistant/components/tplink/strings.json
@@ -68,6 +68,19 @@
       },
       "overheated": {
         "name": "Overheated"
+      },
+      "battery_low": {
+        "name": "Battery low"
+      },
+      "cloud_connection": {
+        "name": "Cloud connection"
+      },
+      "update_available": {
+        "name": "[%key:component::binary_sensor::entity_component::update::name%]",
+        "state": {
+          "off": "[%key:component::binary_sensor::entity_component::update::state::off%]",
+          "on": "[%key:component::binary_sensor::entity_component::update::state::on%]"
+        }
       }
     },
     "button": {
@@ -110,6 +123,36 @@
       },
       "available_firmware_version": {
         "name": "Available firmware version"
+      },
+      "battery_level": {
+        "name": "Battery level"
+      },
+      "temperature": {
+        "name": "[%key:component::sensor::entity_component::temperature::name%]"
+      },
+      "voltage": {
+        "name": "[%key:component::sensor::entity_component::voltage::name%]"
+      },
+      "current": {
+        "name": "[%key:component::sensor::entity_component::current::name%]"
+      },
+      "humidity": {
+        "name": "[%key:component::sensor::entity_component::humidity::name%]"
+      },
+      "device_time": {
+        "name": "Device time"
+      },
+      "auto_off_at": {
+        "name": "Auto off at"
+      },
+      "report_interval": {
+        "name": "Report interval"
+      },
+      "alarm_source": {
+        "name": "Alarm source"
+      },
+      "rssi": {
+        "name": "[%key:component::sensor::entity_component::signal_strength::name%]"
       }
     },
     "switch": {

--- a/homeassistant/components/tplink/strings.json
+++ b/homeassistant/components/tplink/strings.json
@@ -81,6 +81,20 @@
           "off": "[%key:component::binary_sensor::entity_component::update::state::off%]",
           "on": "[%key:component::binary_sensor::entity_component::update::state::on%]"
         }
+      },
+      "is_open": {
+        "name": "[%key:component::binary_sensor::entity_component::door::name%]",
+        "state": {
+          "off": "[%key:common::state::closed%]",
+          "on": "[%key:common::state::open%]"
+        }
+      },
+      "water_alert": {
+        "name": "[%key:component::binary_sensor::entity_component::moisture::name%]",
+        "state": {
+          "off": "[%key:component::binary_sensor::entity_component::moisture::state::off%]",
+          "on": "[%key:component::binary_sensor::entity_component::moisture::state::on%]"
+        }
       }
     },
     "button": {

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -46,9 +46,6 @@ SWITCH_DESCRIPTIONS: tuple[TPLinkSwitchEntityDescription, ...] = (
     TPLinkSwitchEntityDescription(
         key="smooth_transitions",
     ),
-    TPLinkSwitchEntityDescription(
-        key="frost_protection_enabled",
-    ),
 )
 
 SWITCH_DESCRIPTIONS_MAP = {desc.key: desc for desc in SWITCH_DESCRIPTIONS}

--- a/tests/components/tplink/__init__.py
+++ b/tests/components/tplink/__init__.py
@@ -267,11 +267,16 @@ def _mocked_feature(
     feature.type = type_ or Feature.Type[fixture["type"]]
     feature.category = category or Feature.Category[fixture["category"]]
 
+    # sensor
     feature.precision_hint = precision_hint or fixture.get("precision_hint")
     feature.unit = unit or fixture.get("unit")
+    
+
+    # number
     feature.minimum_value = minimum_value or fixture.get("minimum_value")
     feature.maximum_value = maximum_value or fixture.get("maximum_value")
 
+    # select
     feature.choices = choices or fixture.get("choices")
     return feature
 

--- a/tests/components/tplink/__init__.py
+++ b/tests/components/tplink/__init__.py
@@ -340,11 +340,6 @@ def _mocked_energy_features(
             _mocked_feature(
                 "current_consumption",
                 value=power,
-                name="Current consumption",
-                type_=Feature.Type.Sensor,
-                category=Feature.Category.Primary,
-                unit="W",
-                precision_hint=1,
             )
         )
     if total is not None:
@@ -352,11 +347,6 @@ def _mocked_energy_features(
             _mocked_feature(
                 "consumption_total",
                 value=total,
-                name="Total consumption",
-                type_=Feature.Type.Sensor,
-                category=Feature.Category.Info,
-                unit="kWh",
-                precision_hint=3,
             )
         )
     if voltage is not None:
@@ -364,11 +354,6 @@ def _mocked_energy_features(
             _mocked_feature(
                 "voltage",
                 value=voltage,
-                name="Voltage",
-                type_=Feature.Type.Sensor,
-                category=Feature.Category.Primary,
-                unit="V",
-                precision_hint=1,
             )
         )
     if current is not None:
@@ -376,11 +361,6 @@ def _mocked_energy_features(
             _mocked_feature(
                 "current",
                 value=current,
-                name="Current",
-                type_=Feature.Type.Sensor,
-                category=Feature.Category.Primary,
-                unit="A",
-                precision_hint=2,
             )
         )
     # Today is always reported as 0 by the library rather than none
@@ -388,11 +368,6 @@ def _mocked_energy_features(
         _mocked_feature(
             "consumption_today",
             value=today if today is not None else 0.0,
-            name="Today's consumption",
-            type_=Feature.Type.Sensor,
-            category=Feature.Category.Info,
-            unit="kWh",
-            precision_hint=3,
         )
     )
     return feats

--- a/tests/components/tplink/__init__.py
+++ b/tests/components/tplink/__init__.py
@@ -270,7 +270,6 @@ def _mocked_feature(
     # sensor
     feature.precision_hint = precision_hint or fixture.get("precision_hint")
     feature.unit = unit or fixture.get("unit")
-    
 
     # number
     feature.minimum_value = minimum_value or fixture.get("minimum_value")

--- a/tests/components/tplink/fixtures/features.json
+++ b/tests/components/tplink/fixtures/features.json
@@ -180,6 +180,16 @@
     "type": "BinarySensor",
     "category": "Debug"
   },
+  "water_alert": {
+    "value": false,
+    "type": "BinarySensor",
+    "category": "Primary"
+  },
+  "is_open": {
+    "value": false,
+    "type": "BinarySensor",
+    "category": "Primary"
+  },
   "test_alarm": {
     "value": "<Action>",
     "type": "Action",
@@ -236,5 +246,37 @@
     "type": "Choice",
     "category": "Config",
     "choices": ["Off", "Preset 1", "Preset 2"]
+  },
+  "alarm_sound": {
+    "value": "Phone Ring",
+    "type": "Choice",
+    "category": "Config",
+    "choices": [
+      "Doorbell Ring 1",
+      "Doorbell Ring 2",
+      "Doorbell Ring 3",
+      "Doorbell Ring 4",
+      "Doorbell Ring 5",
+      "Doorbell Ring 6",
+      "Doorbell Ring 7",
+      "Doorbell Ring 8",
+      "Doorbell Ring 9",
+      "Doorbell Ring 10",
+      "Phone Ring",
+      "Alarm 1",
+      "Alarm 2",
+      "Alarm 3",
+      "Alarm 4",
+      "Dripping Tap",
+      "Alarm 5",
+      "Connection 1",
+      "Connection 2"
+    ]
+  },
+  "alarm_volume": {
+    "value": "normal",
+    "type": "Choice",
+    "category": "Config",
+    "choices": ["low", "normal", "high"]
   }
 }

--- a/tests/components/tplink/fixtures/features.json
+++ b/tests/components/tplink/fixtures/features.json
@@ -34,7 +34,7 @@
     "type": "Sensor",
     "category": "Primary",
     "unit": "W",
-    "precision_hint": 3
+    "precision_hint": 1
   },
   "consumption_today": {
     "value": 5.23,
@@ -62,14 +62,14 @@
     "type": "Sensor",
     "category": "Primary",
     "unit": "A",
-    "precision_hint": 1
+    "precision_hint": 2
   },
   "voltage": {
     "value": 121.1,
     "type": "Sensor",
     "category": "Primary",
     "unit": "v",
-    "precision_hint": 2
+    "precision_hint": 1
   },
   "device_id": {
     "value": "94hd2dn298812je12u0931828",

--- a/tests/components/tplink/fixtures/features.json
+++ b/tests/components/tplink/fixtures/features.json
@@ -1,0 +1,240 @@
+{
+  "state": {
+    "value": true,
+    "type": "Switch",
+    "category": "Primary"
+  },
+  "led": {
+    "value": true,
+    "type": "Switch",
+    "category": "Config"
+  },
+  "auto_update_enabled": {
+    "value": true,
+    "type": "Switch",
+    "category": "Config"
+  },
+  "auto_off_enabled": {
+    "value": true,
+    "type": "Switch",
+    "category": "Config"
+  },
+  "smooth_transitions": {
+    "value": true,
+    "type": "Switch",
+    "category": "Config"
+  },
+  "frost_protection_enabled": {
+    "value": true,
+    "type": "Switch",
+    "category": "Config"
+  },
+  "current_consumption": {
+    "value": 5.23,
+    "type": "Sensor",
+    "category": "Primary",
+    "unit": "W",
+    "precision_hint": 3
+  },
+  "consumption_today": {
+    "value": 5.23,
+    "type": "Sensor",
+    "category": "Info",
+    "unit": "kWh",
+    "precision_hint": 3
+  },
+  "consumption_this_month": {
+    "value": 15.345,
+    "type": "Sensor",
+    "category": "Info",
+    "unit": "kWh",
+    "precision_hint": 3
+  },
+  "consumption_total": {
+    "value": 30.0049,
+    "type": "Sensor",
+    "category": "Info",
+    "unit": "kWh",
+    "precision_hint": 3
+  },
+  "current": {
+    "value": 5.035,
+    "type": "Sensor",
+    "category": "Primary",
+    "unit": "A",
+    "precision_hint": 1
+  },
+  "voltage": {
+    "value": 121.1,
+    "type": "Sensor",
+    "category": "Primary",
+    "unit": "v",
+    "precision_hint": 2
+  },
+  "device_id": {
+    "value": "94hd2dn298812je12u0931828",
+    "type": "Sensor",
+    "category": "Debug"
+  },
+  "signal_level": {
+    "value": 2,
+    "type": "Sensor",
+    "category": "Info"
+  },
+  "rssi": {
+    "value": -62,
+    "type": "Sensor",
+    "category": "Debug"
+  },
+  "ssid": {
+    "value": "HOMEWIFI",
+    "type": "Sensor",
+    "category": "Debug"
+  },
+  "on_since": {
+    "value": "2024-06-24 10:03:11.046643+01:00",
+    "type": "Sensor",
+    "category": "Debug"
+  },
+  "battery_level": {
+    "value": 85,
+    "type": "Sensor",
+    "category": "Info",
+    "unit": "%"
+  },
+  "auto_off_at": {
+    "value": "2024-06-24 10:03:11.046643+01:00",
+    "type": "Sensor",
+    "category": "Info"
+  },
+  "humidity": {
+    "value": 12,
+    "type": "Sensor",
+    "category": "Primary",
+    "unit": "%"
+  },
+  "report_interval": {
+    "value": 16,
+    "type": "Sensor",
+    "category": "Debug",
+    "unit": "%"
+  },
+  "alarm_source": {
+    "value": "",
+    "type": "Sensor",
+    "category": "Debug"
+  },
+  "device_time": {
+    "value": "2024-06-24 10:03:11.046643+01:00",
+    "type": "Sensor",
+    "category": "Debug"
+  },
+  "temperature": {
+    "value": 19.2,
+    "type": "Sensor",
+    "category": "Debug",
+    "unit": "celsius"
+  },
+  "current_firmware_version": {
+    "value": "1.1.2",
+    "type": "Sensor",
+    "category": "Debug"
+  },
+  "available_firmware_version": {
+    "value": "1.1.3",
+    "type": "Sensor",
+    "category": "Debug"
+  },
+  "thermostat_mode": {
+    "value": "off",
+    "type": "Sensor",
+    "category": "Primary"
+  },
+  "overheated": {
+    "value": false,
+    "type": "BinarySensor",
+    "category": "Info"
+  },
+  "battery_low": {
+    "value": false,
+    "type": "BinarySensor",
+    "category": "Debug"
+  },
+  "update_available": {
+    "value": false,
+    "type": "BinarySensor",
+    "category": "Info"
+  },
+  "cloud_connection": {
+    "value": false,
+    "type": "BinarySensor",
+    "category": "Info"
+  },
+  "temperature_warning": {
+    "value": false,
+    "type": "BinarySensor",
+    "category": "Debug"
+  },
+  "humidity_warning": {
+    "value": false,
+    "type": "BinarySensor",
+    "category": "Debug"
+  },
+  "test_alarm": {
+    "value": "<Action>",
+    "type": "Action",
+    "category": "Config"
+  },
+  "stop_alarm": {
+    "value": "<Action>",
+    "type": "Action",
+    "category": "Config"
+  },
+  "smooth_transition_on": {
+    "value": false,
+    "type": "Number",
+    "category": "Config",
+    "minimum_value": 0,
+    "maximum_value": 60
+  },
+  "smooth_transition_off": {
+    "value": false,
+    "type": "Number",
+    "category": "Config",
+    "minimum_value": 0,
+    "maximum_value": 60
+  },
+  "auto_off_minutes": {
+    "value": false,
+    "type": "Number",
+    "category": "Config",
+    "unit": "min",
+    "minimum_value": 0,
+    "maximum_value": 60
+  },
+  "temperature_offset": {
+    "value": false,
+    "type": "Number",
+    "category": "Config",
+    "minimum_value": -10,
+    "maximum_value": 10
+  },
+  "target_temperature": {
+    "value": false,
+    "type": "Number",
+    "category": "Primary"
+  },
+  "fan_speed_level": {
+    "value": 2,
+    "type": "Number",
+    "category": "Primary",
+    "minimum_value": 0,
+    "maximum_value": 4
+  },
+  "light_preset": {
+    "value": "Off",
+    "type": "Choice",
+    "category": "Config",
+    "choices": ["Off", "Preset 1", "Preset 2"]
+  }
+}

--- a/tests/components/tplink/snapshots/test_binary_sensor.ambr
+++ b/tests/components/tplink/snapshots/test_binary_sensor.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_states[binary_sensor.my_device_battery-entry]
+# name: test_states[binary_sensor.my_device_battery_low-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -11,7 +11,7 @@
     'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
     'domain': 'binary_sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.my_device_battery',
+    'entity_id': 'binary_sensor.my_device_battery_low',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -23,7 +23,7 @@
     }),
     'original_device_class': <BinarySensorDeviceClass.BATTERY: 'battery'>,
     'original_icon': None,
-    'original_name': 'Battery',
+    'original_name': 'Battery low',
     'platform': 'tplink',
     'previous_unique_id': None,
     'supported_features': 0,
@@ -32,7 +32,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_states[binary_sensor.my_device_connectivity-entry]
+# name: test_states[binary_sensor.my_device_cloud_connection-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -44,7 +44,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.my_device_connectivity',
+    'entity_id': 'binary_sensor.my_device_cloud_connection',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -56,7 +56,7 @@
     }),
     'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
     'original_icon': None,
-    'original_name': 'Connectivity',
+    'original_name': 'Cloud connection',
     'platform': 'tplink',
     'previous_unique_id': None,
     'supported_features': 0,
@@ -65,14 +65,14 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_states[binary_sensor.my_device_connectivity-state]
+# name: test_states[binary_sensor.my_device_cloud_connection-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'connectivity',
-      'friendly_name': 'my_device Connectivity',
+      'friendly_name': 'my_device Cloud connection',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.my_device_connectivity',
+    'entity_id': 'binary_sensor.my_device_cloud_connection',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/tplink/snapshots/test_binary_sensor.ambr
+++ b/tests/components/tplink/snapshots/test_binary_sensor.ambr
@@ -79,6 +79,53 @@
     'state': 'off',
   })
 # ---
+# name: test_states[binary_sensor.my_device_door-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.my_device_door',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.DOOR: 'door'>,
+    'original_icon': None,
+    'original_name': 'Door',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_open',
+    'unique_id': '123456789ABCDEFGH_is_open',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[binary_sensor.my_device_door-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'my_device Door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.my_device_door',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_states[binary_sensor.my_device_humidity_warning-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -110,6 +157,53 @@
     'translation_key': 'humidity_warning',
     'unique_id': '123456789ABCDEFGH_humidity_warning',
     'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[binary_sensor.my_device_moisture-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.my_device_moisture',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.MOISTURE: 'moisture'>,
+    'original_icon': None,
+    'original_name': 'Moisture',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'water_alert',
+    'unique_id': '123456789ABCDEFGH_water_alert',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[binary_sensor.my_device_moisture-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'moisture',
+      'friendly_name': 'my_device Moisture',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.my_device_moisture',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
   })
 # ---
 # name: test_states[binary_sensor.my_device_overheated-entry]

--- a/tests/components/tplink/snapshots/test_binary_sensor.ambr
+++ b/tests/components/tplink/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,275 @@
+# serializer version: 1
+# name: test_states[binary_sensor.my_device_battery-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.my_device_battery',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.BATTERY: 'battery'>,
+    'original_icon': None,
+    'original_name': 'Battery',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'battery_low',
+    'unique_id': '123456789ABCDEFGH_battery_low',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[binary_sensor.my_device_connectivity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.my_device_connectivity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': 'Connectivity',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'cloud_connection',
+    'unique_id': '123456789ABCDEFGH_cloud_connection',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[binary_sensor.my_device_connectivity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'connectivity',
+      'friendly_name': 'my_device Connectivity',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.my_device_connectivity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_states[binary_sensor.my_device_humidity_warning-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.my_device_humidity_warning',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Humidity warning',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'humidity_warning',
+    'unique_id': '123456789ABCDEFGH_humidity_warning',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[binary_sensor.my_device_overheated-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.my_device_overheated',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Overheated',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'overheated',
+    'unique_id': '123456789ABCDEFGH_overheated',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[binary_sensor.my_device_overheated-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'my_device Overheated',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.my_device_overheated',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_states[binary_sensor.my_device_temperature_warning-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.my_device_temperature_warning',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Temperature warning',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'temperature_warning',
+    'unique_id': '123456789ABCDEFGH_temperature_warning',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[binary_sensor.my_device_update-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.my_device_update',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.UPDATE: 'update'>,
+    'original_icon': None,
+    'original_name': 'Update',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'update_available',
+    'unique_id': '123456789ABCDEFGH_update_available',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[binary_sensor.my_device_update-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'update',
+      'friendly_name': 'my_device Update',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.my_device_update',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_states[my_device-entry]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        'aa:bb:cc:dd:ee:ff',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': '1.0.0',
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'tplink',
+        '123456789ABCDEFGH',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'TP-Link',
+    'model': 'HS100',
+    'name': 'my_device',
+    'name_by_user': None,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': '1.0.0',
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/tplink/snapshots/test_button.ambr
+++ b/tests/components/tplink/snapshots/test_button.ambr
@@ -1,0 +1,127 @@
+# serializer version: 1
+# name: test_states[button.my_device_stop_alarm-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.my_device_stop_alarm',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Stop alarm',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'stop_alarm',
+    'unique_id': '123456789ABCDEFGH_stop_alarm',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[button.my_device_stop_alarm-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'my_device Stop alarm',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.my_device_stop_alarm',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_states[button.my_device_test_alarm-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.my_device_test_alarm',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Test alarm',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'test_alarm',
+    'unique_id': '123456789ABCDEFGH_test_alarm',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[button.my_device_test_alarm-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'my_device Test alarm',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.my_device_test_alarm',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_states[my_device-entry]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        'aa:bb:cc:dd:ee:ff',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': '1.0.0',
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'tplink',
+        '123456789ABCDEFGH',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'TP-Link',
+    'model': 'HS100',
+    'name': 'my_device',
+    'name_by_user': None,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': '1.0.0',
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/tplink/snapshots/test_number.ambr
+++ b/tests/components/tplink/snapshots/test_number.ambr
@@ -1,0 +1,255 @@
+# serializer version: 1
+# name: test_states[my_device-entry]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        'aa:bb:cc:dd:ee:ff',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': '1.0.0',
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'tplink',
+        '123456789ABCDEFGH',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'TP-Link',
+    'model': 'HS100',
+    'name': 'my_device',
+    'name_by_user': None,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': '1.0.0',
+    'via_device_id': None,
+  })
+# ---
+# name: test_states[number.my_device_smooth_off-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 65536,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.my_device_smooth_off',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Smooth off',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'smooth_transition_off',
+    'unique_id': '123456789ABCDEFGH_smooth_transition_off',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[number.my_device_smooth_off-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'my_device Smooth off',
+      'max': 65536,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.my_device_smooth_off',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'False',
+  })
+# ---
+# name: test_states[number.my_device_smooth_on-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 65536,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.my_device_smooth_on',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Smooth on',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'smooth_transition_on',
+    'unique_id': '123456789ABCDEFGH_smooth_transition_on',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[number.my_device_smooth_on-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'my_device Smooth on',
+      'max': 65536,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.my_device_smooth_on',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'False',
+  })
+# ---
+# name: test_states[number.my_device_temperature_offset-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 65536,
+      'min': -10,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.my_device_temperature_offset',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Temperature offset',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'temperature_offset',
+    'unique_id': '123456789ABCDEFGH_temperature_offset',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[number.my_device_temperature_offset-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'my_device Temperature offset',
+      'max': 65536,
+      'min': -10,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.my_device_temperature_offset',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'False',
+  })
+# ---
+# name: test_states[number.my_device_turn_off_in-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 65536,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.my_device_turn_off_in',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Turn off in',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'auto_off_minutes',
+    'unique_id': '123456789ABCDEFGH_auto_off_minutes',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[number.my_device_turn_off_in-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'my_device Turn off in',
+      'max': 65536,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.my_device_turn_off_in',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'False',
+  })
+# ---

--- a/tests/components/tplink/snapshots/test_select.ambr
+++ b/tests/components/tplink/snapshots/test_select.ambr
@@ -33,6 +33,152 @@
     'via_device_id': None,
   })
 # ---
+# name: test_states[select.my_device_alarm_sound-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'Doorbell Ring 1',
+        'Doorbell Ring 2',
+        'Doorbell Ring 3',
+        'Doorbell Ring 4',
+        'Doorbell Ring 5',
+        'Doorbell Ring 6',
+        'Doorbell Ring 7',
+        'Doorbell Ring 8',
+        'Doorbell Ring 9',
+        'Doorbell Ring 10',
+        'Phone Ring',
+        'Alarm 1',
+        'Alarm 2',
+        'Alarm 3',
+        'Alarm 4',
+        'Dripping Tap',
+        'Alarm 5',
+        'Connection 1',
+        'Connection 2',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'select.my_device_alarm_sound',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Alarm sound',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'alarm_sound',
+    'unique_id': '123456789ABCDEFGH_alarm_sound',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[select.my_device_alarm_sound-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'my_device Alarm sound',
+      'options': list([
+        'Doorbell Ring 1',
+        'Doorbell Ring 2',
+        'Doorbell Ring 3',
+        'Doorbell Ring 4',
+        'Doorbell Ring 5',
+        'Doorbell Ring 6',
+        'Doorbell Ring 7',
+        'Doorbell Ring 8',
+        'Doorbell Ring 9',
+        'Doorbell Ring 10',
+        'Phone Ring',
+        'Alarm 1',
+        'Alarm 2',
+        'Alarm 3',
+        'Alarm 4',
+        'Dripping Tap',
+        'Alarm 5',
+        'Connection 1',
+        'Connection 2',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.my_device_alarm_sound',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Phone Ring',
+  })
+# ---
+# name: test_states[select.my_device_alarm_volume-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'low',
+        'normal',
+        'high',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'select.my_device_alarm_volume',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Alarm volume',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'alarm_volume',
+    'unique_id': '123456789ABCDEFGH_alarm_volume',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[select.my_device_alarm_volume-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'my_device Alarm volume',
+      'options': list([
+        'low',
+        'normal',
+        'high',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.my_device_alarm_volume',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'normal',
+  })
+# ---
 # name: test_states[select.my_device_light_preset-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/tplink/snapshots/test_select.ambr
+++ b/tests/components/tplink/snapshots/test_select.ambr
@@ -1,0 +1,92 @@
+# serializer version: 1
+# name: test_states[my_device-entry]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        'aa:bb:cc:dd:ee:ff',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': '1.0.0',
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'tplink',
+        '123456789ABCDEFGH',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'TP-Link',
+    'model': 'HS100',
+    'name': 'my_device',
+    'name_by_user': None,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': '1.0.0',
+    'via_device_id': None,
+  })
+# ---
+# name: test_states[select.my_device_light_preset-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'Off',
+        'Preset 1',
+        'Preset 2',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'select.my_device_light_preset',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Light preset',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'light_preset',
+    'unique_id': '123456789ABCDEFGH_light_preset',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[select.my_device_light_preset-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'my_device Light preset',
+      'options': list([
+        'Off',
+        'Preset 1',
+        'Preset 2',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.my_device_light_preset',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Off',
+  })
+# ---

--- a/tests/components/tplink/snapshots/test_sensor.ambr
+++ b/tests/components/tplink/snapshots/test_sensor.ambr
@@ -188,7 +188,7 @@
     'name': None,
     'options': dict({
       'sensor': dict({
-        'suggested_display_precision': 1,
+        'suggested_display_precision': 2,
       }),
     }),
     'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
@@ -215,7 +215,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '5.0',
+    'state': '5.04',
   })
 # ---
 # name: test_states[sensor.my_device_current_consumption-entry]
@@ -242,7 +242,7 @@
     'name': None,
     'options': dict({
       'sensor': dict({
-        'suggested_display_precision': 3,
+        'suggested_display_precision': 1,
       }),
     }),
     'original_device_class': <SensorDeviceClass.POWER: 'power'>,
@@ -269,7 +269,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '5.23',
+    'state': '5.2',
   })
 # ---
 # name: test_states[sensor.my_device_device_time-entry]
@@ -758,7 +758,7 @@
     'name': None,
     'options': dict({
       'sensor': dict({
-        'suggested_display_precision': 2,
+        'suggested_display_precision': 1,
       }),
     }),
     'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,

--- a/tests/components/tplink/snapshots/test_sensor.ambr
+++ b/tests/components/tplink/snapshots/test_sensor.ambr
@@ -145,7 +145,7 @@
     'supported_features': 0,
     'translation_key': 'battery_level',
     'unique_id': '123456789ABCDEFGH_battery_level',
-    'unit_of_measurement': None,
+    'unit_of_measurement': '%',
   })
 # ---
 # name: test_states[sensor.my_device_battery_level-state]
@@ -154,6 +154,7 @@
       'device_class': 'battery',
       'friendly_name': 'my_device Battery level',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.my_device_battery_level',
@@ -198,7 +199,7 @@
     'supported_features': 0,
     'translation_key': 'current',
     'unique_id': '123456789ABCDEFGH_current_a',
-    'unit_of_measurement': 1,
+    'unit_of_measurement': 'A',
   })
 # ---
 # name: test_states[sensor.my_device_current-state]
@@ -207,7 +208,7 @@
       'device_class': 'current',
       'friendly_name': 'my_device Current',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 1,
+      'unit_of_measurement': 'A',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.my_device_current',
@@ -252,7 +253,7 @@
     'supported_features': 0,
     'translation_key': 'current_consumption',
     'unique_id': '123456789ABCDEFGH_current_power_w',
-    'unit_of_measurement': 3,
+    'unit_of_measurement': 'W',
   })
 # ---
 # name: test_states[sensor.my_device_current_consumption-state]
@@ -261,7 +262,7 @@
       'device_class': 'power',
       'friendly_name': 'my_device Current consumption',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 3,
+      'unit_of_measurement': 'W',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.my_device_current_consumption',
@@ -336,7 +337,7 @@
     'supported_features': 0,
     'translation_key': 'humidity',
     'unique_id': '123456789ABCDEFGH_humidity',
-    'unit_of_measurement': None,
+    'unit_of_measurement': '%',
   })
 # ---
 # name: test_states[sensor.my_device_humidity-state]
@@ -345,6 +346,7 @@
       'device_class': 'humidity',
       'friendly_name': 'my_device Humidity',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.my_device_humidity',
@@ -417,7 +419,7 @@
     'supported_features': 0,
     'translation_key': 'report_interval',
     'unique_id': '123456789ABCDEFGH_report_interval',
-    'unit_of_measurement': None,
+    'unit_of_measurement': '%',
   })
 # ---
 # name: test_states[sensor.my_device_signal_level-entry]
@@ -567,7 +569,7 @@
     'supported_features': 0,
     'translation_key': 'temperature',
     'unique_id': '123456789ABCDEFGH_temperature',
-    'unit_of_measurement': None,
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
 # name: test_states[sensor.my_device_this_month_s_consumption-entry]
@@ -605,7 +607,7 @@
     'supported_features': 0,
     'translation_key': 'consumption_this_month',
     'unique_id': '123456789ABCDEFGH_consumption_this_month',
-    'unit_of_measurement': 3,
+    'unit_of_measurement': 'kWh',
   })
 # ---
 # name: test_states[sensor.my_device_this_month_s_consumption-state]
@@ -614,7 +616,7 @@
       'device_class': 'energy',
       'friendly_name': "my_device This month's consumption",
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': 3,
+      'unit_of_measurement': 'kWh',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.my_device_this_month_s_consumption',
@@ -659,7 +661,7 @@
     'supported_features': 0,
     'translation_key': 'consumption_today',
     'unique_id': '123456789ABCDEFGH_today_energy_kwh',
-    'unit_of_measurement': 3,
+    'unit_of_measurement': 'kWh',
   })
 # ---
 # name: test_states[sensor.my_device_today_s_consumption-state]
@@ -668,7 +670,7 @@
       'device_class': 'energy',
       'friendly_name': "my_device Today's consumption",
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': 3,
+      'unit_of_measurement': 'kWh',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.my_device_today_s_consumption',
@@ -713,7 +715,7 @@
     'supported_features': 0,
     'translation_key': 'consumption_total',
     'unique_id': '123456789ABCDEFGH_total_energy_kwh',
-    'unit_of_measurement': 3,
+    'unit_of_measurement': 'kWh',
   })
 # ---
 # name: test_states[sensor.my_device_total_consumption-state]
@@ -722,7 +724,7 @@
       'device_class': 'energy',
       'friendly_name': 'my_device Total consumption',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': 3,
+      'unit_of_measurement': 'kWh',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.my_device_total_consumption',
@@ -767,7 +769,7 @@
     'supported_features': 0,
     'translation_key': 'voltage',
     'unique_id': '123456789ABCDEFGH_voltage',
-    'unit_of_measurement': 2,
+    'unit_of_measurement': 'v',
   })
 # ---
 # name: test_states[sensor.my_device_voltage-state]
@@ -776,7 +778,7 @@
       'device_class': 'voltage',
       'friendly_name': 'my_device Voltage',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 2,
+      'unit_of_measurement': 'v',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.my_device_voltage',

--- a/tests/components/tplink/snapshots/test_sensor.ambr
+++ b/tests/components/tplink/snapshots/test_sensor.ambr
@@ -33,7 +33,87 @@
     'via_device_id': None,
   })
 # ---
-# name: test_states[sensor.my_device_battery-entry]
+# name: test_states[sensor.my_device_alarm_source-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.my_device_alarm_source',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Alarm source',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'alarm_source',
+    'unique_id': '123456789ABCDEFGH_alarm_source',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[sensor.my_device_auto_off_at-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.my_device_auto_off_at',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Auto off at',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'auto_off_at',
+    'unique_id': '123456789ABCDEFGH_auto_off_at',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[sensor.my_device_auto_off_at-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'my_device Auto off at',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.my_device_auto_off_at',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-06-24T09:03:11+00:00',
+  })
+# ---
+# name: test_states[sensor.my_device_battery_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -47,7 +127,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.my_device_battery',
+    'entity_id': 'sensor.my_device_battery_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -59,7 +139,7 @@
     }),
     'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
     'original_icon': None,
-    'original_name': 'Battery',
+    'original_name': 'Battery level',
     'platform': 'tplink',
     'previous_unique_id': None,
     'supported_features': 0,
@@ -68,15 +148,15 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_states[sensor.my_device_battery-state]
+# name: test_states[sensor.my_device_battery_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'battery',
-      'friendly_name': 'my_device Battery',
+      'friendly_name': 'my_device Battery level',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.my_device_battery',
+    'entity_id': 'sensor.my_device_battery_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -191,7 +271,7 @@
     'state': '5.23',
   })
 # ---
-# name: test_states[sensor.my_device_duration-entry]
+# name: test_states[sensor.my_device_device_time-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -203,7 +283,7 @@
     'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.my_device_duration',
+    'entity_id': 'sensor.my_device_device_time',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -213,14 +293,14 @@
     'name': None,
     'options': dict({
     }),
-    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
     'original_icon': None,
-    'original_name': 'Duration',
+    'original_name': 'Device time',
     'platform': 'tplink',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': 'report_interval',
-    'unique_id': '123456789ABCDEFGH_report_interval',
+    'translation_key': 'device_time',
+    'unique_id': '123456789ABCDEFGH_device_time',
     'unit_of_measurement': None,
   })
 # ---
@@ -274,39 +354,6 @@
     'state': '12',
   })
 # ---
-# name: test_states[sensor.my_device_none-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.my_device_none',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'tplink',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': 'alarm_source',
-    'unique_id': '123456789ABCDEFGH_alarm_source',
-    'unit_of_measurement': None,
-  })
-# ---
 # name: test_states[sensor.my_device_on_since-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -337,6 +384,39 @@
     'supported_features': 0,
     'translation_key': 'on_since',
     'unique_id': '123456789ABCDEFGH_on_since',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[sensor.my_device_report_interval-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.my_device_report_interval',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Report interval',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'report_interval',
+    'unique_id': '123456789ABCDEFGH_report_interval',
     'unit_of_measurement': None,
   })
 # ---
@@ -542,86 +622,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '15.345',
-  })
-# ---
-# name: test_states[sensor.my_device_timestamp-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.my_device_timestamp',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
-    'original_icon': None,
-    'original_name': 'Timestamp',
-    'platform': 'tplink',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': 'auto_off_at',
-    'unique_id': '123456789ABCDEFGH_auto_off_at',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_states[sensor.my_device_timestamp-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'my_device Timestamp',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.my_device_timestamp',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2024-06-24T09:03:11+00:00',
-  })
-# ---
-# name: test_states[sensor.my_device_timestamp_2-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.my_device_timestamp_2',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
-    'original_icon': None,
-    'original_name': 'Timestamp',
-    'platform': 'tplink',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': 'device_time',
-    'unique_id': '123456789ABCDEFGH_device_time',
-    'unit_of_measurement': None,
   })
 # ---
 # name: test_states[sensor.my_device_today_s_consumption-entry]

--- a/tests/components/tplink/snapshots/test_sensor.ambr
+++ b/tests/components/tplink/snapshots/test_sensor.ambr
@@ -1,0 +1,788 @@
+# serializer version: 1
+# name: test_states[my_device-entry]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        'aa:bb:cc:dd:ee:ff',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': '1.0.0',
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'tplink',
+        '123456789ABCDEFGH',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'TP-Link',
+    'model': 'HS100',
+    'name': 'my_device',
+    'name_by_user': None,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': '1.0.0',
+    'via_device_id': None,
+  })
+# ---
+# name: test_states[sensor.my_device_battery-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.my_device_battery',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+    'original_icon': None,
+    'original_name': 'Battery',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'battery_level',
+    'unique_id': '123456789ABCDEFGH_battery_level',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[sensor.my_device_battery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'my_device Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.my_device_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '85',
+  })
+# ---
+# name: test_states[sensor.my_device_current-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.my_device_current',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
+    'original_icon': None,
+    'original_name': 'Current',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'current',
+    'unique_id': '123456789ABCDEFGH_current_a',
+    'unit_of_measurement': 1,
+  })
+# ---
+# name: test_states[sensor.my_device_current-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'my_device Current',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.my_device_current',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '5.0',
+  })
+# ---
+# name: test_states[sensor.my_device_current_consumption-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.my_device_current_consumption',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Current consumption',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'current_consumption',
+    'unique_id': '123456789ABCDEFGH_current_power_w',
+    'unit_of_measurement': 3,
+  })
+# ---
+# name: test_states[sensor.my_device_current_consumption-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'my_device Current consumption',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 3,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.my_device_current_consumption',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '5.23',
+  })
+# ---
+# name: test_states[sensor.my_device_duration-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.my_device_duration',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Duration',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'report_interval',
+    'unique_id': '123456789ABCDEFGH_report_interval',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[sensor.my_device_humidity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.my_device_humidity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+    'original_icon': None,
+    'original_name': 'Humidity',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'humidity',
+    'unique_id': '123456789ABCDEFGH_humidity',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[sensor.my_device_humidity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'humidity',
+      'friendly_name': 'my_device Humidity',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.my_device_humidity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '12',
+  })
+# ---
+# name: test_states[sensor.my_device_none-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.my_device_none',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'alarm_source',
+    'unique_id': '123456789ABCDEFGH_alarm_source',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[sensor.my_device_on_since-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.my_device_on_since',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'On since',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'on_since',
+    'unique_id': '123456789ABCDEFGH_on_since',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[sensor.my_device_signal_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.my_device_signal_level',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Signal level',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'signal_level',
+    'unique_id': '123456789ABCDEFGH_signal_level',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[sensor.my_device_signal_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'my_device Signal level',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.my_device_signal_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2',
+  })
+# ---
+# name: test_states[sensor.my_device_signal_strength-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.my_device_signal_strength',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
+    'original_icon': None,
+    'original_name': 'Signal strength',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'rssi',
+    'unique_id': '123456789ABCDEFGH_rssi',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[sensor.my_device_ssid-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.my_device_ssid',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'SSID',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'ssid',
+    'unique_id': '123456789ABCDEFGH_ssid',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[sensor.my_device_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.my_device_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Temperature',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'temperature',
+    'unique_id': '123456789ABCDEFGH_temperature',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[sensor.my_device_this_month_s_consumption-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.my_device_this_month_s_consumption',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': None,
+    'original_name': "This month's consumption",
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'consumption_this_month',
+    'unique_id': '123456789ABCDEFGH_consumption_this_month',
+    'unit_of_measurement': 3,
+  })
+# ---
+# name: test_states[sensor.my_device_this_month_s_consumption-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': "my_device This month's consumption",
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': 3,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.my_device_this_month_s_consumption',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '15.345',
+  })
+# ---
+# name: test_states[sensor.my_device_timestamp-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.my_device_timestamp',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Timestamp',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'auto_off_at',
+    'unique_id': '123456789ABCDEFGH_auto_off_at',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[sensor.my_device_timestamp-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'my_device Timestamp',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.my_device_timestamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-06-24T09:03:11+00:00',
+  })
+# ---
+# name: test_states[sensor.my_device_timestamp_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.my_device_timestamp_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Timestamp',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'device_time',
+    'unique_id': '123456789ABCDEFGH_device_time',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[sensor.my_device_today_s_consumption-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.my_device_today_s_consumption',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': None,
+    'original_name': "Today's consumption",
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'consumption_today',
+    'unique_id': '123456789ABCDEFGH_today_energy_kwh',
+    'unit_of_measurement': 3,
+  })
+# ---
+# name: test_states[sensor.my_device_today_s_consumption-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': "my_device Today's consumption",
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': 3,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.my_device_today_s_consumption',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '5.23',
+  })
+# ---
+# name: test_states[sensor.my_device_total_consumption-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.my_device_total_consumption',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': None,
+    'original_name': 'Total consumption',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'consumption_total',
+    'unique_id': '123456789ABCDEFGH_total_energy_kwh',
+    'unit_of_measurement': 3,
+  })
+# ---
+# name: test_states[sensor.my_device_total_consumption-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'my_device Total consumption',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': 3,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.my_device_total_consumption',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '30.005',
+  })
+# ---
+# name: test_states[sensor.my_device_voltage-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.my_device_voltage',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': None,
+    'original_name': 'Voltage',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'voltage',
+    'unique_id': '123456789ABCDEFGH_voltage',
+    'unit_of_measurement': 2,
+  })
+# ---
+# name: test_states[sensor.my_device_voltage-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'my_device Voltage',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 2,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.my_device_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '121.1',
+  })
+# ---

--- a/tests/components/tplink/snapshots/test_switch.ambr
+++ b/tests/components/tplink/snapshots/test_switch.ambr
@@ -1,0 +1,265 @@
+# serializer version: 1
+# name: test_states[my_device-entry]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        'aa:bb:cc:dd:ee:ff',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': '1.0.0',
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'tplink',
+        '123456789ABCDEFGH',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'TP-Link',
+    'model': 'HS100',
+    'name': 'my_device',
+    'name_by_user': None,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': '1.0.0',
+    'via_device_id': None,
+  })
+# ---
+# name: test_states[switch.my_device-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.my_device',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '123456789ABCDEFGH',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[switch.my_device-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'my_device',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.my_device',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_states[switch.my_device_auto_off_enabled-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.my_device_auto_off_enabled',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Auto off enabled',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'auto_off_enabled',
+    'unique_id': '123456789ABCDEFGH_auto_off_enabled',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[switch.my_device_auto_off_enabled-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'my_device Auto off enabled',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.my_device_auto_off_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_states[switch.my_device_auto_update_enabled-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.my_device_auto_update_enabled',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Auto update enabled',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'auto_update_enabled',
+    'unique_id': '123456789ABCDEFGH_auto_update_enabled',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[switch.my_device_auto_update_enabled-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'my_device Auto update enabled',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.my_device_auto_update_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_states[switch.my_device_led-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.my_device_led',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'LED',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'led',
+    'unique_id': '123456789ABCDEFGH_led',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[switch.my_device_led-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'my_device LED',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.my_device_led',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_states[switch.my_device_smooth_transitions-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.my_device_smooth_transitions',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Smooth transitions',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'smooth_transitions',
+    'unique_id': '123456789ABCDEFGH_smooth_transitions',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[switch.my_device_smooth_transitions-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'my_device Smooth transitions',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.my_device_smooth_transitions',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/tplink/test_binary_sensor.py
+++ b/tests/components/tplink/test_binary_sensor.py
@@ -2,10 +2,13 @@
 
 from kasa import Feature
 import pytest
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components import tplink
+from homeassistant.components.tplink.binary_sensor import BINARYSENSOR_DESCRIPTIONS
 from homeassistant.components.tplink.const import DOMAIN
-from homeassistant.const import CONF_HOST
+from homeassistant.components.tplink.entity import EXCLUDED_FEATURES
+from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
@@ -18,6 +21,8 @@ from . import (
     _mocked_strip_children,
     _patch_connect,
     _patch_discovery,
+    setup_platform_for_device,
+    snapshot_platform,
 )
 
 from tests.common import MockConfigEntry
@@ -27,12 +32,35 @@ from tests.common import MockConfigEntry
 def mocked_feature_binary_sensor() -> Feature:
     """Return mocked tplink binary sensor feature."""
     return _mocked_feature(
-        False,
         "overheated",
+        value=False,
         name="Overheated",
         type_=Feature.Type.BinarySensor,
         category=Feature.Category.Primary,
     )
+
+
+async def test_states(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test a sensor unique ids."""
+    features = {description.key for description in BINARYSENSOR_DESCRIPTIONS}
+    features.update(EXCLUDED_FEATURES)
+    device = _mocked_device(alias="my_device", features=features)
+
+    await setup_platform_for_device(
+        hass, mock_config_entry, Platform.BINARY_SENSOR, device
+    )
+    await snapshot_platform(
+        hass, entity_registry, device_registry, snapshot, mock_config_entry.entry_id
+    )
+
+    for excluded in EXCLUDED_FEATURES:
+        assert hass.states.get(f"sensor.my_device_{excluded}") is None
 
 
 async def test_binary_sensor(

--- a/tests/components/tplink/test_button.py
+++ b/tests/components/tplink/test_button.py
@@ -2,11 +2,14 @@
 
 from kasa import Feature
 import pytest
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components import tplink
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.components.tplink.button import BUTTON_DESCRIPTIONS
 from homeassistant.components.tplink.const import DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST
+from homeassistant.components.tplink.entity import EXCLUDED_FEATURES
+from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
@@ -19,6 +22,8 @@ from . import (
     _mocked_strip_children,
     _patch_connect,
     _patch_discovery,
+    setup_platform_for_device,
+    snapshot_platform,
 )
 
 from tests.common import MockConfigEntry
@@ -28,12 +33,33 @@ from tests.common import MockConfigEntry
 def mocked_feature_button() -> Feature:
     """Return mocked tplink binary sensor feature."""
     return _mocked_feature(
-        False,
         "test_alarm",
+        value=False,
         name="Test alarm",
         type_=Feature.Type.Action,
         category=Feature.Category.Primary,
     )
+
+
+async def test_states(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test a sensor unique ids."""
+    features = {description.key for description in BUTTON_DESCRIPTIONS}
+    features.update(EXCLUDED_FEATURES)
+    device = _mocked_device(alias="my_device", features=features)
+
+    await setup_platform_for_device(hass, mock_config_entry, Platform.BUTTON, device)
+    await snapshot_platform(
+        hass, entity_registry, device_registry, snapshot, mock_config_entry.entry_id
+    )
+
+    for excluded in EXCLUDED_FEATURES:
+        assert hass.states.get(f"sensor.my_device_{excluded}") is None
 
 
 async def test_button(

--- a/tests/components/tplink/test_button.py
+++ b/tests/components/tplink/test_button.py
@@ -34,7 +34,7 @@ def mocked_feature_button() -> Feature:
     """Return mocked tplink binary sensor feature."""
     return _mocked_feature(
         "test_alarm",
-        value=False,
+        value="<Action>",
         name="Test alarm",
         type_=Feature.Type.Action,
         category=Feature.Category.Primary,

--- a/tests/components/tplink/test_select.py
+++ b/tests/components/tplink/test_select.py
@@ -2,6 +2,7 @@
 
 from kasa import Feature
 import pytest
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components import tplink
 from homeassistant.components.select import (
@@ -10,7 +11,9 @@ from homeassistant.components.select import (
     SERVICE_SELECT_OPTION,
 )
 from homeassistant.components.tplink.const import DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST
+from homeassistant.components.tplink.entity import EXCLUDED_FEATURES
+from homeassistant.components.tplink.select import SELECT_DESCRIPTIONS
+from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
@@ -23,6 +26,8 @@ from . import (
     _mocked_strip_children,
     _patch_connect,
     _patch_discovery,
+    setup_platform_for_device,
+    snapshot_platform,
 )
 
 from tests.common import MockConfigEntry
@@ -32,13 +37,34 @@ from tests.common import MockConfigEntry
 def mocked_feature_select() -> Feature:
     """Return mocked tplink binary sensor feature."""
     return _mocked_feature(
-        "First choice",
         "light_preset",
+        value="First choice",
         name="light_preset",
         choices=["First choice", "Second choice"],
         type_=Feature.Type.Choice,
         category=Feature.Category.Config,
     )
+
+
+async def test_states(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test a sensor unique ids."""
+    features = {description.key for description in SELECT_DESCRIPTIONS}
+    features.update(EXCLUDED_FEATURES)
+    device = _mocked_device(alias="my_device", features=features)
+
+    await setup_platform_for_device(hass, mock_config_entry, Platform.SELECT, device)
+    await snapshot_platform(
+        hass, entity_registry, device_registry, snapshot, mock_config_entry.entry_id
+    )
+
+    for excluded in EXCLUDED_FEATURES:
+        assert hass.states.get(f"sensor.my_device_{excluded}") is None
 
 
 async def test_select(

--- a/tests/components/tplink/test_switch.py
+++ b/tests/components/tplink/test_switch.py
@@ -6,10 +6,13 @@ from unittest.mock import AsyncMock
 from kasa import AuthenticationError, Device, KasaException, Module, TimeoutError
 from kasa.iot import IotStrip
 import pytest
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components import tplink
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.tplink.const import DOMAIN
+from homeassistant.components.tplink.entity import EXCLUDED_FEATURES
+from homeassistant.components.tplink.switch import SWITCH_DESCRIPTIONS
 from homeassistant.config_entries import SOURCE_REAUTH
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -17,10 +20,11 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
+    Platform,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util, slugify
 
@@ -31,9 +35,32 @@ from . import (
     _mocked_strip_children,
     _patch_connect,
     _patch_discovery,
+    setup_platform_for_device,
+    snapshot_platform,
 )
 
 from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+async def test_states(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test a sensor unique ids."""
+    features = {description.key for description in SWITCH_DESCRIPTIONS}
+    features.update(EXCLUDED_FEATURES)
+    device = _mocked_device(alias="my_device", features=features)
+
+    await setup_platform_for_device(hass, mock_config_entry, Platform.SWITCH, device)
+    await snapshot_platform(
+        hass, entity_registry, device_registry, snapshot, mock_config_entry.entry_id
+    )
+
+    for excluded in EXCLUDED_FEATURES:
+        assert hass.states.get(f"sensor.my_device_{excluded}") is None
 
 
 async def test_plug(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## This PR is part of the tplink rewrite series, to be merged into tplink_rewrite branch (see https://github.com/home-assistant/core/pull/120060).


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds snapshot tests for device entries, entity entries and entity state. Introduces feature fixtures to get meaningful state snapshots for different features.

Add `EXCLUDED_FEATURES` set to entity creation logic to allow features to be completely excluded pending future platforms. Will prevent orphaned entities in homeassistant when new platforms are implemented.

N.B. Simply omitting the feature from the descriptions will result in the log info message that the feature needs to be added to HA.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
