### PR TITLE
Fix dlna_dms test RuntimeWarning

### DIFF
--- a/tests/components/dlna_dms/conftest.py
+++ b/tests/components/dlna_dms/conftest.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterable, Iterable
 from typing import Final, cast
-from unittest.mock import Mock, create_autospec, patch, seal
+from unittest.mock import AsyncMock, MagicMock, Mock, create_autospec, patch, seal
 
 from async_upnp_client.client import UpnpDevice, UpnpService
 from async_upnp_client.utils import absolute_url
@@ -87,6 +87,8 @@ def aiohttp_session_requester_mock() -> Iterable[Mock]:
     with patch(
         "homeassistant.components.dlna_dms.dms.AiohttpSessionRequester", autospec=True
     ) as requester_mock:
+        requester_mock.return_value = mock = AsyncMock()
+        mock.async_http_request.return_value.body = MagicMock()
         yield requester_mock
 
 


### PR DESCRIPTION
## Proposed change
Fixes
```py
tests/components/dlna_dms/test_init.py::test_migrate_entry
tests/components/dlna_dms/test_init.py::test_migrate_entry_collision
  /home/runner/work/ha-core/ha-core/venv/lib/python3.12/site-packages/_pytest/stash.py:108: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
  Coroutine created at (most recent call last)
    File "/home/runner/work/ha-core/ha-core/homeassistant/config_entries.py", line 586, in async_setup
      result = await component.async_setup_entry(hass, self)
    File "/home/runner/work/ha-core/ha-core/homeassistant/components/dlna_dms/__init__.py", line 29, in async_setup_entry
      return await get_domain_data(hass).async_setup_entry(entry)
    File "/home/runner/work/ha-core/ha-core/homeassistant/components/dlna_dms/dms.py", line 77, in async_setup_entry
      await device.async_added_to_hass()
    File "/home/runner/work/ha-core/ha-core/homeassistant/components/dlna_dms/dms.py", line 192, in async_added_to_hass
      await self.device_connect()
    File "/home/runner/work/ha-core/ha-core/homeassistant/components/dlna_dms/dms.py", line 298, in device_connect
      upnp_device = await domain_data.upnp_factory.async_create_device(
    File "/home/runner/work/ha-core/ha-core/venv/lib/python3.12/site-packages/async_upnp_client/client_factory.py", line 100, in async_create_device
      root_el = await self._async_get_device_spec(description_url)
    File "/home/runner/work/ha-core/ha-core/venv/lib/python3.12/site-packages/async_upnp_client/client_factory.py", line 434, in _async_get_device_spec
      response = self._on_post_receive_device_spec(bare_response)
    File "/home/runner/work/ha-core/ha-core/venv/lib/python3.12/site-packages/async_upnp_client/client.py", line 68, in default_on_post_receive_device_spec
      fixed_body = (response.body or "").rstrip(" \t\r\n\0")
    File "/opt/hostedtoolcache/Python/3.12.4/x64/lib/python3.12/unittest/mock.py", line 1134, in __call__
      return self._mock_call(*args, **kwargs)
    File "/opt/hostedtoolcache/Python/3.12.4/x64/lib/python3.12/unittest/mock.py", line 1138, in _mock_call
      return self._execute_mock_call(*args, **kwargs)
    del self._storage[key]
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
