### PR TITLE
Improve type hints in cloudflare tests

### DIFF
--- a/tests/components/cloudflare/__init__.py
+++ b/tests/components/cloudflare/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pycfdns
 
@@ -80,25 +80,20 @@ async def init_integration(
     return entry
 
 
-def _get_mock_client(
-    zone: pycfdns.ZoneModel | UndefinedType = UNDEFINED,
-    records: list[pycfdns.RecordModel] | UndefinedType = UNDEFINED,
-):
-    client: pycfdns.Client = AsyncMock()
+def get_mock_client() -> Mock:
+    """Return of Mock of pycfdns.Client."""
+    client = Mock()
 
-    client.list_zones = AsyncMock(
-        return_value=[MOCK_ZONE if zone is UNDEFINED else zone]
-    )
-    client.list_dns_records = AsyncMock(
-        return_value=MOCK_ZONE_RECORDS if records is UNDEFINED else records
-    )
+    client.list_zones = AsyncMock(return_value=[MOCK_ZONE])
+    client.list_dns_records = AsyncMock(return_value=MOCK_ZONE_RECORDS)
     client.update_dns_record = AsyncMock(return_value=None)
 
     return client
 
 
-def _patch_async_setup_entry(return_value=True):
+def patch_async_setup_entry() -> AsyncMock:
+    """Patch the async_setup_entry method and return a mock."""
     return patch(
         "homeassistant.components.cloudflare.async_setup_entry",
-        return_value=return_value,
+        return_value=True,
     )

--- a/tests/components/cloudflare/conftest.py
+++ b/tests/components/cloudflare/conftest.py
@@ -1,16 +1,17 @@
 """Define fixtures available for all tests."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+from typing_extensions import Generator
 
-from . import _get_mock_client
+from . import get_mock_client
 
 
 @pytest.fixture
-def cfupdate(hass):
+def cfupdate() -> Generator[MagicMock]:
     """Mock the CloudflareUpdater for easier testing."""
-    mock_cfupdate = _get_mock_client()
+    mock_cfupdate = get_mock_client()
     with patch(
         "homeassistant.components.cloudflare.pycfdns.Client",
         return_value=mock_cfupdate,
@@ -19,11 +20,11 @@ def cfupdate(hass):
 
 
 @pytest.fixture
-def cfupdate_flow(hass):
+def cfupdate_flow() -> Generator[MagicMock]:
     """Mock the CloudflareUpdater for easier config flow testing."""
-    mock_cfupdate = _get_mock_client()
+    mock_cfupdate = get_mock_client()
     with patch(
-        "homeassistant.components.cloudflare.pycfdns.Client",
+        "homeassistant.components.cloudflare.config_flow.pycfdns.Client",
         return_value=mock_cfupdate,
     ) as mock_api:
         yield mock_api

--- a/tests/components/cloudflare/test_config_flow.py
+++ b/tests/components/cloudflare/test_config_flow.py
@@ -1,5 +1,7 @@
 """Test the Cloudflare config flow."""
 
+from unittest.mock import MagicMock
+
 import pycfdns
 
 from homeassistant.components.cloudflare.const import CONF_RECORDS, DOMAIN
@@ -13,13 +15,13 @@ from . import (
     USER_INPUT,
     USER_INPUT_RECORDS,
     USER_INPUT_ZONE,
-    _patch_async_setup_entry,
+    patch_async_setup_entry,
 )
 
 from tests.common import MockConfigEntry
 
 
-async def test_user_form(hass: HomeAssistant, cfupdate_flow) -> None:
+async def test_user_form(hass: HomeAssistant, cfupdate_flow: MagicMock) -> None:
     """Test we get the user initiated form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -49,7 +51,7 @@ async def test_user_form(hass: HomeAssistant, cfupdate_flow) -> None:
     assert result["step_id"] == "records"
     assert result["errors"] is None
 
-    with _patch_async_setup_entry() as mock_setup_entry:
+    with patch_async_setup_entry() as mock_setup_entry:
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             USER_INPUT_RECORDS,
@@ -70,7 +72,9 @@ async def test_user_form(hass: HomeAssistant, cfupdate_flow) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_user_form_cannot_connect(hass: HomeAssistant, cfupdate_flow) -> None:
+async def test_user_form_cannot_connect(
+    hass: HomeAssistant, cfupdate_flow: MagicMock
+) -> None:
     """Test we handle cannot connect error."""
     instance = cfupdate_flow.return_value
 
@@ -88,7 +92,9 @@ async def test_user_form_cannot_connect(hass: HomeAssistant, cfupdate_flow) -> N
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_user_form_invalid_auth(hass: HomeAssistant, cfupdate_flow) -> None:
+async def test_user_form_invalid_auth(
+    hass: HomeAssistant, cfupdate_flow: MagicMock
+) -> None:
     """Test we handle invalid auth error."""
     instance = cfupdate_flow.return_value
 
@@ -107,7 +113,7 @@ async def test_user_form_invalid_auth(hass: HomeAssistant, cfupdate_flow) -> Non
 
 
 async def test_user_form_unexpected_exception(
-    hass: HomeAssistant, cfupdate_flow
+    hass: HomeAssistant, cfupdate_flow: MagicMock
 ) -> None:
     """Test we handle unexpected exception."""
     instance = cfupdate_flow.return_value
@@ -140,7 +146,7 @@ async def test_user_form_single_instance_allowed(hass: HomeAssistant) -> None:
     assert result["reason"] == "single_instance_allowed"
 
 
-async def test_reauth_flow(hass: HomeAssistant, cfupdate_flow) -> None:
+async def test_reauth_flow(hass: HomeAssistant, cfupdate_flow: MagicMock) -> None:
     """Test the reauthentication configuration flow."""
     entry = MockConfigEntry(domain=DOMAIN, data=ENTRY_CONFIG)
     entry.add_to_hass(hass)
@@ -157,7 +163,7 @@ async def test_reauth_flow(hass: HomeAssistant, cfupdate_flow) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
-    with _patch_async_setup_entry() as mock_setup_entry:
+    with patch_async_setup_entry() as mock_setup_entry:
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {CONF_API_TOKEN: "other_token"},

--- a/tests/components/cloudflare/test_init.py
+++ b/tests/components/cloudflare/test_init.py
@@ -1,7 +1,7 @@
 """Test the Cloudflare integration."""
 
 from datetime import timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pycfdns
 import pytest
@@ -23,7 +23,7 @@ from . import ENTRY_CONFIG, init_integration
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-async def test_unload_entry(hass: HomeAssistant, cfupdate) -> None:
+async def test_unload_entry(hass: HomeAssistant, cfupdate: MagicMock) -> None:
     """Test successful unload of entry."""
     entry = await init_integration(hass)
 
@@ -42,7 +42,7 @@ async def test_unload_entry(hass: HomeAssistant, cfupdate) -> None:
     [pycfdns.ComunicationException()],
 )
 async def test_async_setup_raises_entry_not_ready(
-    hass: HomeAssistant, cfupdate, side_effect
+    hass: HomeAssistant, cfupdate: MagicMock, side_effect: Exception
 ) -> None:
     """Test that it throws ConfigEntryNotReady when exception occurs during setup."""
     instance = cfupdate.return_value
@@ -57,7 +57,7 @@ async def test_async_setup_raises_entry_not_ready(
 
 
 async def test_async_setup_raises_entry_auth_failed(
-    hass: HomeAssistant, cfupdate
+    hass: HomeAssistant, cfupdate: MagicMock
 ) -> None:
     """Test that it throws ConfigEntryAuthFailed when exception occurs during setup."""
     instance = cfupdate.return_value
@@ -84,7 +84,7 @@ async def test_async_setup_raises_entry_auth_failed(
 
 
 async def test_integration_services(
-    hass: HomeAssistant, cfupdate, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant, cfupdate: MagicMock, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test integration services."""
     instance = cfupdate.return_value
@@ -120,7 +120,9 @@ async def test_integration_services(
     assert "All target records are up to date" not in caplog.text
 
 
-async def test_integration_services_with_issue(hass: HomeAssistant, cfupdate) -> None:
+async def test_integration_services_with_issue(
+    hass: HomeAssistant, cfupdate: MagicMock
+) -> None:
     """Test integration services with issue."""
     instance = cfupdate.return_value
 
@@ -145,7 +147,7 @@ async def test_integration_services_with_issue(hass: HomeAssistant, cfupdate) ->
 
 
 async def test_integration_services_with_nonexisting_record(
-    hass: HomeAssistant, cfupdate, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant, cfupdate: MagicMock, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test integration services."""
     instance = cfupdate.return_value
@@ -185,7 +187,7 @@ async def test_integration_services_with_nonexisting_record(
 
 async def test_integration_update_interval(
     hass: HomeAssistant,
-    cfupdate,
+    cfupdate: MagicMock,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test integration update interval."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302
https://github.com/home-assistant/core/actions/runs/9643593124/job/26593942586?pr=120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
