### PR TITLE
Add created_seconds to timer info and pass to ESPHome devices

### DIFF
--- a/homeassistant/components/esphome/voice_assistant.py
+++ b/homeassistant/components/esphome/voice_assistant.py
@@ -467,7 +467,7 @@ def handle_timer_event(
         native_event_type,
         timer_info.id,
         timer_info.name,
-        timer_info.seconds,
+        timer_info.created_seconds,
         timer_info.seconds_left,
         timer_info.is_active,
     )

--- a/homeassistant/components/intent/timers.py
+++ b/homeassistant/components/intent/timers.py
@@ -93,6 +93,13 @@ class TimerInfo:
     This agent will be used to execute the conversation command.
     """
 
+    _created_seconds: int = 0
+    """Number of seconds on the timer when it was created."""
+
+    def __post_init__(self) -> None:
+        """Post initialization."""
+        self._created_seconds = self.seconds
+
     @property
     def seconds_left(self) -> int:
         """Return number of seconds left on the timer."""
@@ -102,6 +109,15 @@ class TimerInfo:
         now = time.monotonic_ns()
         seconds_running = int((now - self.updated_at) / 1e9)
         return max(0, self.seconds - seconds_running)
+
+    @property
+    def created_seconds(self) -> int:
+        """Return number of seconds on the timer when it was created.
+
+        This value is increased if time is added to the timer, exceeding its
+        original created_seconds.
+        """
+        return self._created_seconds
 
     @cached_property
     def name_normalized(self) -> str:
@@ -131,6 +147,7 @@ class TimerInfo:
         Seconds may be negative to remove time instead.
         """
         self.seconds = max(0, self.seconds_left + seconds)
+        self._created_seconds = max(self._created_seconds, self.seconds)
         self.updated_at = time.monotonic_ns()
 
     def finish(self) -> None:

--- a/tests/components/esphome/test_voice_assistant.py
+++ b/tests/components/esphome/test_voice_assistant.py
@@ -836,6 +836,7 @@ async def test_timer_events(
         connections={(dr.CONNECTION_NETWORK_MAC, mock_device.entry.unique_id)}
     )
 
+    total_seconds = (1 * 60 * 60) + (2 * 60) + 3
     await intent_helper.async_handle(
         hass,
         "test",
@@ -853,8 +854,32 @@ async def test_timer_events(
         VoiceAssistantTimerEventType.VOICE_ASSISTANT_TIMER_STARTED,
         ANY,
         "test timer",
-        3723,
-        3723,
+        total_seconds,
+        total_seconds,
+        True,
+    )
+
+    # Increase timer beyond original time and check total_seconds has increased
+    mock_client.send_voice_assistant_timer_event.reset_mock()
+
+    total_seconds += 5 * 60
+    await intent_helper.async_handle(
+        hass,
+        "test",
+        intent_helper.INTENT_INCREASE_TIMER,
+        {
+            "name": {"value": "test timer"},
+            "minutes": {"value": 5},
+        },
+        device_id=dev.id,
+    )
+
+    mock_client.send_voice_assistant_timer_event.assert_called_with(
+        VoiceAssistantTimerEventType.VOICE_ASSISTANT_TIMER_UPDATED,
+        ANY,
+        "test timer",
+        total_seconds,
+        ANY,
         True,
     )
 

--- a/tests/components/intent/test_timers.py
+++ b/tests/components/intent/test_timers.py
@@ -54,6 +54,7 @@ async def test_start_finish_timer(hass: HomeAssistant, init_components) -> None:
         assert timer.start_minutes is None
         assert timer.start_seconds == 0
         assert timer.seconds_left == 0
+        assert timer.created_seconds == 0
 
         if event_type == TimerEventType.STARTED:
             timer_id = timer.id
@@ -196,6 +197,7 @@ async def test_increase_timer(hass: HomeAssistant, init_components) -> None:
     timer_name = "test timer"
     timer_id: str | None = None
     original_total_seconds = -1
+    seconds_added = 0
 
     @callback
     def handle_timer(event_type: TimerEventType, timer: TimerInfo) -> None:
@@ -216,12 +218,14 @@ async def test_increase_timer(hass: HomeAssistant, init_components) -> None:
                 + (60 * timer.start_minutes)
                 + timer.start_seconds
             )
+            assert timer.created_seconds == original_total_seconds
             started_event.set()
         elif event_type == TimerEventType.UPDATED:
             assert timer.id == timer_id
 
             # Timer was increased
             assert timer.seconds_left > original_total_seconds
+            assert timer.created_seconds == original_total_seconds + seconds_added
             updated_event.set()
         elif event_type == TimerEventType.CANCELLED:
             assert timer.id == timer_id
@@ -248,6 +252,7 @@ async def test_increase_timer(hass: HomeAssistant, init_components) -> None:
         await started_event.wait()
 
     # Adding 0 seconds has no effect
+    seconds_added = 0
     result = await intent.async_handle(
         hass,
         "test",
@@ -267,6 +272,7 @@ async def test_increase_timer(hass: HomeAssistant, init_components) -> None:
     assert not updated_event.is_set()
 
     # Add 30 seconds to the timer
+    seconds_added = (1 * 60 * 60) + (5 * 60) + 30
     result = await intent.async_handle(
         hass,
         "test",
@@ -338,6 +344,7 @@ async def test_decrease_timer(hass: HomeAssistant, init_components) -> None:
 
             # Timer was decreased
             assert timer.seconds_left <= (original_total_seconds - 30)
+            assert timer.created_seconds == original_total_seconds
 
             updated_event.set()
         elif event_type == TimerEventType.CANCELLED:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When time is added or removed from a timer, the `seconds` property of the timer info is shifted accordingly. This makes it difficult for ESPHome devices to display how much time is remaining because the original duration is not reported.

This PR adds a `created_seconds` property to the timer info, and passes it to ESPHome devices in timer events. This value will not change unless more time is added to the timer than its original duration ("add 10 minutes to my 5 minute timer"), so `seconds_left / created_seconds` can always be used as percentage of time remaining.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
