### PR TITLE
Bump Bang & Olufsen mozart-open-api to 3.4.1.8.6 fixing blocking IO call

### DIFF
--- a/homeassistant/components/bang_olufsen/manifest.json
+++ b/homeassistant/components/bang_olufsen/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/bang_olufsen",
   "integration_type": "device",
   "iot_class": "local_push",
-  "requirements": ["mozart-api==3.4.1.8.5"],
+  "requirements": ["mozart-api==3.4.1.8.6"],
   "zeroconf": ["_bangolufsen._tcp.local."]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1359,7 +1359,7 @@ motionblindsble==0.1.0
 motioneye-client==0.3.14
 
 # homeassistant.components.bang_olufsen
-mozart-api==3.4.1.8.5
+mozart-api==3.4.1.8.6
 
 # homeassistant.components.mullvad
 mullvad-api==1.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1107,7 +1107,7 @@ motionblindsble==0.1.0
 motioneye-client==0.3.14
 
 # homeassistant.components.bang_olufsen
-mozart-api==3.4.1.8.5
+mozart-api==3.4.1.8.6
 
 # homeassistant.components.mullvad
 mullvad-api==1.0.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update API to fix blocking IO call for each API call.
API update has the fix and an OpenAPI generator update, which modifies a lot of files with minor changes.
Changelog: https://github.com/bang-olufsen/mozart-open-api/compare/3.4.1.8.5...3.4.1.8.6

Example error message
```
Detected blocking call to open with args ('/Users/markusjacobsen/.netrc',) inside the event loop by integration 'bang_olufsen' at homeassistant/components/bang_olufsen/media_player.py, line 204: self._software_status = await self._client.get_softwareupdate_status() (offender: /opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/netrc.py, line 74: with open(file, encoding="utf-8") as fp:), please create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+bang_olufsen%22
For developers, please see https://developers.home-assistant.io/docs/asyncio_blocking_operations/#open
Traceback (most recent call last):
  File "/Users/markusjacobsen/Documents/forks/core/venv/bin/hass", line 8, in <module>
    sys.exit(main())
  File "/Users/markusjacobsen/Documents/forks/core/homeassistant/__main__.py", line 209, in main
    exit_code = runner.run(runtime_conf)
  File "/Users/markusjacobsen/Documents/forks/core/homeassistant/runner.py", line 190, in run
    return loop.run_until_complete(setup_and_run_hass(runtime_config))
  File "/opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/base_events.py", line 674, in run_until_complete
    self.run_forever()
  File "/opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/base_events.py", line 641, in run_forever
    self._run_once()
  File "/opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/base_events.py", line 1987, in _run_once
    handle._run()
  File "/opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/events.py", line 88, in _run
    self._context.run(self._callback, *self._args)
  File "/Users/markusjacobsen/Documents/forks/core/homeassistant/config_entries.py", line 734, in async_setup_locked
    await self.async_setup(hass, integration=integration)
  File "/Users/markusjacobsen/Documents/forks/core/homeassistant/config_entries.py", line 586, in async_setup
    result = await component.async_setup_entry(hass, self)
  File "/Users/markusjacobsen/Documents/forks/core/homeassistant/components/bang_olufsen/__init__.py", line 77, in async_setup_entry
    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
  File "/Users/markusjacobsen/Documents/forks/core/homeassistant/config_entries.py", line 2059, in async_forward_entry_setups
    await self._async_forward_entry_setups_locked(entry, platforms)
  File "/Users/markusjacobsen/Documents/forks/core/homeassistant/config_entries.py", line 2070, in _async_forward_entry_setups_locked
    await asyncio.gather(
  File "/Users/markusjacobsen/Documents/forks/core/homeassistant/config_entries.py", line 2072, in <genexpr>
    create_eager_task(
  File "/Users/markusjacobsen/Documents/forks/core/homeassistant/util/async_.py", line 37, in create_eager_task
    return Task(coro, loop=loop, name=name, eager_start=True)
  File "/Users/markusjacobsen/Documents/forks/core/homeassistant/config_entries.py", line 2152, in _async_forward_entry_setup
    await entry.async_setup(self.hass, integration=integration)
  File "/Users/markusjacobsen/Documents/forks/core/homeassistant/config_entries.py", line 586, in async_setup
    result = await component.async_setup_entry(hass, self)
  File "/Users/markusjacobsen/Documents/forks/core/homeassistant/components/media_player/__init__.py", line 445, in async_setup_entry
    return await component.async_setup_entry(entry)
  File "/Users/markusjacobsen/Documents/forks/core/homeassistant/helpers/entity_component.py", line 196, in async_setup_entry
    return await self._platforms[key].async_setup_entry(config_entry)
  File "/Users/markusjacobsen/Documents/forks/core/homeassistant/helpers/entity_platform.py", line 333, in async_setup_entry
    return await self._async_setup_platform(async_create_setup_awaitable)
  File "/Users/markusjacobsen/Documents/forks/core/homeassistant/helpers/entity_platform.py", line 363, in _async_setup_platform
    awaitable = create_eager_task(awaitable, loop=hass.loop)
  File "/Users/markusjacobsen/Documents/forks/core/homeassistant/util/async_.py", line 37, in create_eager_task
    return Task(coro, loop=loop, name=name, eager_start=True)
  File "/Users/markusjacobsen/Documents/forks/core/homeassistant/components/bang_olufsen/media_player.py", line 98, in async_setup_entry
    async_add_entities(new_entities=[BangOlufsenMediaPlayer(config_entry, data.client)])
  File "/Users/markusjacobsen/Documents/forks/core/homeassistant/helpers/entity_platform.py", line 515, in _async_schedule_add_entities_for_entry
    task = self.config_entry.async_create_task(
  File "/Users/markusjacobsen/Documents/forks/core/homeassistant/config_entries.py", line 1126, in async_create_task
    task = hass.async_create_task_internal(
  File "/Users/markusjacobsen/Documents/forks/core/homeassistant/core.py", line 813, in async_create_task_internal
    task = create_eager_task(target, name=name, loop=self.loop)
  File "/Users/markusjacobsen/Documents/forks/core/homeassistant/util/async_.py", line 37, in create_eager_task
    return Task(coro, loop=loop, name=name, eager_start=True)
  File "/Users/markusjacobsen/Documents/forks/core/homeassistant/helpers/entity_platform.py", line 649, in async_add_entities
    await add_func(coros, entities, timeout)
  File "/Users/markusjacobsen/Documents/forks/core/homeassistant/helpers/entity_platform.py", line 600, in _async_add_entities
    await coro
  File "/Users/markusjacobsen/Documents/forks/core/homeassistant/helpers/entity_platform.py", line 914, in _async_add_entity
    await entity.add_to_platform_finish()
  File "/Users/markusjacobsen/Documents/forks/core/homeassistant/helpers/entity.py", line 1361, in add_to_platform_finish
    await self.async_added_to_hass()
  File "/Users/markusjacobsen/Documents/forks/core/homeassistant/components/bang_olufsen/media_player.py", line 138, in async_added_to_hass
    await self._initialize()
  File "/Users/markusjacobsen/Documents/forks/core/homeassistant/components/bang_olufsen/media_player.py", line 204, in _initialize
    self._software_status = await self._client.get_softwareupdate_status()
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
