### PR TITLE
Do not wait on Reolink firmware check

### DIFF
--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -134,7 +134,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     # If camera WAN blocked, firmware check fails and takes long, do not prevent setup
     config_entry.async_create_task(hass, firmware_coordinator.async_refresh())
-    await asyncio.sleep(0.01) # needed to pass tests....
+    await asyncio.sleep(0.01)  # needed to pass tests....
     # Fetch initial data so we have data when entities subscribe
     try:
         await device_coordinator.async_config_entry_first_refresh()

--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -134,7 +134,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     # If camera WAN blocked, firmware check fails and takes long, do not prevent setup
     config_entry.async_create_task(hass, firmware_coordinator.async_refresh())
-    await asyncio.sleep(0.01)  # needed to pass tests....
     # Fetch initial data so we have data when entities subscribe
     try:
         await device_coordinator.async_config_entry_first_refresh()

--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -134,6 +134,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     # If camera WAN blocked, firmware check fails and takes long, do not prevent setup
     config_entry.async_create_task(hass, firmware_coordinator.async_refresh())
+    await asyncio.sleep(0.01) # needed to pass tests....
     # Fetch initial data so we have data when entities subscribe
     try:
         await device_coordinator.async_config_entry_first_refresh()

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -79,6 +79,7 @@ class ReolinkHost:
         )
         self.firmware_ch_list: list[int | None] = []
 
+        self.starting: bool = True
         self.credential_errors: int = 0
 
         self.webhook_id: str | None = None

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -87,6 +87,7 @@ def reolink_connect_class() -> Generator[MagicMock]:
         host_mock.camera_name.return_value = TEST_NVR_NAME
         host_mock.camera_hardware_version.return_value = "IPC_00001"
         host_mock.camera_sw_version.return_value = "v1.1.0.0.0.0000"
+        host_mock.camera_sw_version_update_required.return_value = False
         host_mock.camera_uid.return_value = TEST_UID_CAM
         host_mock.channel_for_uid.return_value = 0
         host_mock.get_encoding.return_value = "h264"

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -397,7 +397,7 @@ async def test_dhcp_flow(hass: HomeAssistant, mock_setup_entry: MagicMock) -> No
             None,
             None,
             TEST_HOST2,
-            [TEST_HOST, TEST_HOST2, TEST_HOST2],
+            [TEST_HOST, TEST_HOST2],
         ),
         (
             True,
@@ -475,8 +475,8 @@ async def test_dhcp_ip_update(
         const.DOMAIN, context={"source": config_entries.SOURCE_DHCP}, data=dhcp_data
     )
 
-    expected_calls = [
-        call(
+    for host in host_call_list:
+        expected_call = call(
             host,
             TEST_USERNAME,
             TEST_PASSWORD,
@@ -485,10 +485,10 @@ async def test_dhcp_ip_update(
             protocol=DEFAULT_PROTOCOL,
             timeout=DEFAULT_TIMEOUT,
         )
-        for host in host_call_list
-    ]
+        assert expected_call in reolink_connect_class.call_args_list
 
-    assert reolink_connect_class.call_args_list == expected_calls
+    for exc_call in reolink_connect_class.call_args_list:
+        assert exc_call[0][0] in host_call_list
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -397,7 +397,7 @@ async def test_dhcp_flow(hass: HomeAssistant, mock_setup_entry: MagicMock) -> No
             None,
             None,
             TEST_HOST2,
-            [TEST_HOST, TEST_HOST2, TEST_HOST2, TEST_HOST2],
+            [TEST_HOST, TEST_HOST2, TEST_HOST2],
         ),
         (
             True,
@@ -458,7 +458,7 @@ async def test_dhcp_ip_update(
         # ensure the last_update_succes is False for the device_coordinator.
         reolink_connect.get_states = AsyncMock(side_effect=ReolinkError("Test error"))
         async_fire_time_changed(
-            hass, utcnow() + DEVICE_UPDATE_INTERVAL + timedelta(seconds=30)
+            hass, utcnow() + DEVICE_UPDATE_INTERVAL + timedelta(minutes=1)
         )
         await hass.async_block_till_done()
 

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -397,7 +397,7 @@ async def test_dhcp_flow(hass: HomeAssistant, mock_setup_entry: MagicMock) -> No
             None,
             None,
             TEST_HOST2,
-            [TEST_HOST, TEST_HOST2, TEST_HOST2],
+            [TEST_HOST, TEST_HOST2, TEST_HOST2, TEST_HOST2],
         ),
         (
             True,
@@ -458,7 +458,7 @@ async def test_dhcp_ip_update(
         # ensure the last_update_succes is False for the device_coordinator.
         reolink_connect.get_states = AsyncMock(side_effect=ReolinkError("Test error"))
         async_fire_time_changed(
-            hass, utcnow() + DEVICE_UPDATE_INTERVAL + timedelta(minutes=1)
+            hass, utcnow() + DEVICE_UPDATE_INTERVAL + timedelta(seconds=30)
         )
         await hass.async_block_till_done()
 

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -1,5 +1,6 @@
 """Test the Reolink init."""
 
+import asyncio
 from datetime import timedelta
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
@@ -37,6 +38,11 @@ from .conftest import (
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 pytestmark = pytest.mark.usefixtures("reolink_connect", "reolink_platforms")
+
+
+async def test_wait(*args, **key_args):
+    """Ensure a mocked function takes a bit of time to be able to timeout in test."""
+    await asyncio.sleep(0.01)
 
 
 @pytest.mark.parametrize(
@@ -377,9 +383,13 @@ async def test_no_repair_issue(
 
 
 async def test_https_repair_issue(
-    hass: HomeAssistant, config_entry: MockConfigEntry, issue_registry: ir.IssueRegistry
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_connect: MagicMock,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test repairs issue is raised when https local url is used."""
+    reolink_connect.get_states = test_wait
     await async_process_ha_core_config(
         hass, {"country": "GB", "internal_url": "https://test_homeassistant_address"}
     )
@@ -400,9 +410,13 @@ async def test_https_repair_issue(
 
 
 async def test_ssl_repair_issue(
-    hass: HomeAssistant, config_entry: MockConfigEntry, issue_registry: ir.IssueRegistry
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_connect: MagicMock,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test repairs issue is raised when global ssl certificate is used."""
+    reolink_connect.get_states = test_wait
     assert await async_setup_component(hass, "webhook", {})
     hass.config.api.use_ssl = True
 
@@ -446,9 +460,13 @@ async def test_port_repair_issue(
 
 
 async def test_webhook_repair_issue(
-    hass: HomeAssistant, config_entry: MockConfigEntry, issue_registry: ir.IssueRegistry
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_connect: MagicMock,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test repairs issue is raised when the webhook url is unreachable."""
+    reolink_connect.get_states = test_wait
     with (
         patch("homeassistant.components.reolink.host.FIRST_ONVIF_TIMEOUT", new=0),
         patch(

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -471,7 +471,7 @@ async def test_firmware_repair_issue(
     issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test firmware issue is raised when too old firmware is used."""
-    reolink_connect.sw_version_update_required = True
+    reolink_connect.camera_sw_version_update_required.return_value = True
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -42,7 +42,7 @@ pytestmark = pytest.mark.usefixtures("reolink_connect", "reolink_platforms")
 
 async def test_wait(*args, **key_args):
     """Ensure a mocked function takes a bit of time to be able to timeout in test."""
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Do not wait and hold startup for the firmware check, since when internet access is blocked to a camera this will timeout and take quite a long time. This holds startup.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/111640
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
