### PR TITLE
Strip whitespace characters from token in One-Time-Passwort (OTP) integration

### DIFF
--- a/homeassistant/components/otp/config_flow.py
+++ b/homeassistant/components/otp/config_flow.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import binascii
 import logging
+from re import sub
 from typing import Any
 
 import pyotp
@@ -47,6 +48,7 @@ class TOTPConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         if user_input is not None:
             if user_input.get(CONF_TOKEN) and not user_input.get(CONF_NEW_TOKEN):
+                user_input[CONF_TOKEN] = sub(r"\s+", "", user_input[CONF_TOKEN])
                 try:
                     await self.hass.async_add_executor_job(
                         pyotp.TOTP(user_input[CONF_TOKEN]).now

--- a/tests/components/otp/test_config_flow.py
+++ b/tests/components/otp/test_config_flow.py
@@ -13,6 +13,10 @@ from homeassistant.data_entry_flow import FlowResultType
 
 TEST_DATA = {
     CONF_NAME: "OTP Sensor",
+    CONF_TOKEN: "2FX5 FBSY RE6V EC2F SHBQ CRKO 2GND VZ52",
+}
+TEST_DATA_RESULT = {
+    CONF_NAME: "OTP Sensor",
     CONF_TOKEN: "2FX5FBSYRE6VEC2FSHBQCRKO2GNDVZ52",
 }
 
@@ -41,7 +45,11 @@ async def test_form(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
         result["flow_id"],
         TEST_DATA,
     )
-    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "OTP Sensor"
+    assert result["data"] == TEST_DATA_RESULT
+    assert len(mock_setup_entry.mock_calls) == 1
 
 
 @pytest.mark.parametrize(
@@ -85,7 +93,7 @@ async def test_errors_and_recover(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "OTP Sensor"
-    assert result["data"] == TEST_DATA
+    assert result["data"] == TEST_DATA_RESULT
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -96,13 +104,13 @@ async def test_flow_import(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_IMPORT},
-        data=TEST_DATA,
+        data=TEST_DATA_RESULT,
     )
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "OTP Sensor"
-    assert result["data"] == TEST_DATA
+    assert result["data"] == TEST_DATA_RESULT
 
 
 @pytest.mark.usefixtures("mock_pyotp")
@@ -134,7 +142,7 @@ async def test_generate_new_token(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "OTP Sensor"
-    assert result["data"] == TEST_DATA
+    assert result["data"] == TEST_DATA_RESULT
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -181,5 +189,5 @@ async def test_generate_new_token_errors(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "OTP Sensor"
-    assert result["data"] == TEST_DATA
+    assert result["data"] == TEST_DATA_RESULT
     assert len(mock_setup_entry.mock_calls) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Sometimes OTP token  are shown on websites with the token split in groups of 4 characters and white-space in between. This  is easier readable when the user types in the token manually into an authenticator app but copy/pasting it into the form of the OTP integration will lead to an error stating invalid token. 
With this, white-spaces will be stript from the inserted token before validating iand saving it in the config entry.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
