### PR TITLE
Improve type hints in demo tests

### DIFF
--- a/tests/components/demo/test_camera.py
+++ b/tests/components/demo/test_camera.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.camera import (
     DOMAIN as CAMERA_DOMAIN,
@@ -24,7 +25,7 @@ ENTITY_CAMERA = "camera.demo_camera"
 
 
 @pytest.fixture
-async def camera_only() -> None:
+def camera_only() -> Generator[None]:
     """Enable only the button platform."""
     with patch(
         "homeassistant.components.demo.COMPONENTS_WITH_CONFIG_ENTRY_DEMO_PLATFORM",
@@ -34,7 +35,7 @@ async def camera_only() -> None:
 
 
 @pytest.fixture(autouse=True)
-async def demo_camera(hass, camera_only):
+async def demo_camera(hass: HomeAssistant, camera_only: None) -> None:
     """Initialize a demo camera platform."""
     assert await async_setup_component(
         hass, CAMERA_DOMAIN, {CAMERA_DOMAIN: {"platform": DOMAIN}}

--- a/tests/components/demo/test_climate.py
+++ b/tests/components/demo/test_climate.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 import pytest
+from typing_extensions import Generator
 import voluptuous as vol
 
 from homeassistant.components.climate import (
@@ -50,7 +51,7 @@ ENTITY_HEATPUMP = "climate.heatpump"
 
 
 @pytest.fixture
-async def climate_only() -> None:
+def climate_only() -> Generator[None]:
     """Enable only the climate platform."""
     with patch(
         "homeassistant.components.demo.COMPONENTS_WITH_CONFIG_ENTRY_DEMO_PLATFORM",
@@ -60,7 +61,7 @@ async def climate_only() -> None:
 
 
 @pytest.fixture(autouse=True)
-async def setup_demo_climate(hass, climate_only):
+async def setup_demo_climate(hass: HomeAssistant, climate_only: None) -> None:
     """Initialize setup demo climate."""
     hass.config.units = METRIC_SYSTEM
     assert await async_setup_component(hass, DOMAIN, {"climate": {"platform": "demo"}})

--- a/tests/components/demo/test_cover.py
+++ b/tests/components/demo/test_cover.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
@@ -42,7 +43,7 @@ ENTITY_COVER = "cover.living_room_window"
 
 
 @pytest.fixture
-async def cover_only() -> None:
+def cover_only() -> Generator[None]:
     """Enable only the climate platform."""
     with patch(
         "homeassistant.components.demo.COMPONENTS_WITH_CONFIG_ENTRY_DEMO_PLATFORM",
@@ -51,15 +52,15 @@ async def cover_only() -> None:
         yield
 
 
-@pytest.fixture
-async def setup_comp(hass, cover_only):
+@pytest.fixture(autouse=True)
+async def setup_comp(hass: HomeAssistant, cover_only: None) -> None:
     """Set up demo cover component."""
     with assert_setup_component(1, DOMAIN):
         await async_setup_component(hass, DOMAIN, CONFIG)
         await hass.async_block_till_done()
 
 
-async def test_supported_features(hass: HomeAssistant, setup_comp) -> None:
+async def test_supported_features(hass: HomeAssistant) -> None:
     """Test cover supported features."""
     state = hass.states.get("cover.garage_door")
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 3
@@ -71,7 +72,7 @@ async def test_supported_features(hass: HomeAssistant, setup_comp) -> None:
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 255
 
 
-async def test_close_cover(hass: HomeAssistant, setup_comp) -> None:
+async def test_close_cover(hass: HomeAssistant) -> None:
     """Test closing the cover."""
     state = hass.states.get(ENTITY_COVER)
     assert state.state == STATE_OPEN
@@ -92,7 +93,7 @@ async def test_close_cover(hass: HomeAssistant, setup_comp) -> None:
     assert state.attributes[ATTR_CURRENT_POSITION] == 0
 
 
-async def test_open_cover(hass: HomeAssistant, setup_comp) -> None:
+async def test_open_cover(hass: HomeAssistant) -> None:
     """Test opening the cover."""
     state = hass.states.get(ENTITY_COVER)
     assert state.state == STATE_OPEN
@@ -112,7 +113,7 @@ async def test_open_cover(hass: HomeAssistant, setup_comp) -> None:
     assert state.attributes[ATTR_CURRENT_POSITION] == 100
 
 
-async def test_toggle_cover(hass: HomeAssistant, setup_comp) -> None:
+async def test_toggle_cover(hass: HomeAssistant) -> None:
     """Test toggling the cover."""
     # Start open
     await hass.services.async_call(
@@ -152,7 +153,7 @@ async def test_toggle_cover(hass: HomeAssistant, setup_comp) -> None:
     assert state.attributes[ATTR_CURRENT_POSITION] == 100
 
 
-async def test_set_cover_position(hass: HomeAssistant, setup_comp) -> None:
+async def test_set_cover_position(hass: HomeAssistant) -> None:
     """Test moving the cover to a specific position."""
     state = hass.states.get(ENTITY_COVER)
     assert state.attributes[ATTR_CURRENT_POSITION] == 70
@@ -171,7 +172,7 @@ async def test_set_cover_position(hass: HomeAssistant, setup_comp) -> None:
     assert state.attributes[ATTR_CURRENT_POSITION] == 10
 
 
-async def test_stop_cover(hass: HomeAssistant, setup_comp) -> None:
+async def test_stop_cover(hass: HomeAssistant) -> None:
     """Test stopping the cover."""
     state = hass.states.get(ENTITY_COVER)
     assert state.attributes[ATTR_CURRENT_POSITION] == 70
@@ -190,7 +191,7 @@ async def test_stop_cover(hass: HomeAssistant, setup_comp) -> None:
     assert state.attributes[ATTR_CURRENT_POSITION] == 80
 
 
-async def test_close_cover_tilt(hass: HomeAssistant, setup_comp) -> None:
+async def test_close_cover_tilt(hass: HomeAssistant) -> None:
     """Test closing the cover tilt."""
     state = hass.states.get(ENTITY_COVER)
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 50
@@ -206,7 +207,7 @@ async def test_close_cover_tilt(hass: HomeAssistant, setup_comp) -> None:
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 0
 
 
-async def test_open_cover_tilt(hass: HomeAssistant, setup_comp) -> None:
+async def test_open_cover_tilt(hass: HomeAssistant) -> None:
     """Test opening the cover tilt."""
     state = hass.states.get(ENTITY_COVER)
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 50
@@ -222,7 +223,7 @@ async def test_open_cover_tilt(hass: HomeAssistant, setup_comp) -> None:
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 100
 
 
-async def test_toggle_cover_tilt(hass: HomeAssistant, setup_comp) -> None:
+async def test_toggle_cover_tilt(hass: HomeAssistant) -> None:
     """Test toggling the cover tilt."""
     # Start open
     await hass.services.async_call(
@@ -259,7 +260,7 @@ async def test_toggle_cover_tilt(hass: HomeAssistant, setup_comp) -> None:
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 100
 
 
-async def test_set_cover_tilt_position(hass: HomeAssistant, setup_comp) -> None:
+async def test_set_cover_tilt_position(hass: HomeAssistant) -> None:
     """Test moving the cover til to a specific position."""
     state = hass.states.get(ENTITY_COVER)
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 50
@@ -278,7 +279,7 @@ async def test_set_cover_tilt_position(hass: HomeAssistant, setup_comp) -> None:
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 90
 
 
-async def test_stop_cover_tilt(hass: HomeAssistant, setup_comp) -> None:
+async def test_stop_cover_tilt(hass: HomeAssistant) -> None:
     """Test stopping the cover tilt."""
     state = hass.states.get(ENTITY_COVER)
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 50

--- a/tests/components/demo/test_init.py
+++ b/tests/components/demo/test_init.py
@@ -4,6 +4,7 @@ import json
 from unittest.mock import patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.demo import DOMAIN
 from homeassistant.core import HomeAssistant
@@ -12,19 +13,19 @@ from homeassistant.setup import async_setup_component
 
 
 @pytest.fixture
-def mock_history(hass):
+def mock_history(hass: HomeAssistant) -> None:
     """Mock history component loaded."""
     hass.config.components.add("history")
 
 
 @pytest.fixture(autouse=True)
-def mock_device_tracker_update_config():
+def mock_device_tracker_update_config() -> Generator[None]:
     """Prevent device tracker from creating known devices file."""
     with patch("homeassistant.components.device_tracker.legacy.update_config"):
         yield
 
 
-async def test_setting_up_demo(mock_history, hass: HomeAssistant) -> None:
+async def test_setting_up_demo(mock_history: None, hass: HomeAssistant) -> None:
     """Test if we can set up the demo and dump it to JSON."""
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     await hass.async_block_till_done()

--- a/tests/components/demo/test_light.py
+++ b/tests/components/demo/test_light.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.demo import DOMAIN
 from homeassistant.components.light import (
@@ -27,7 +28,7 @@ ENTITY_LIGHT = "light.bed_light"
 
 
 @pytest.fixture
-async def light_only() -> None:
+def light_only() -> Generator[None]:
     """Enable only the light platform."""
     with patch(
         "homeassistant.components.demo.COMPONENTS_WITH_CONFIG_ENTRY_DEMO_PLATFORM",
@@ -37,7 +38,7 @@ async def light_only() -> None:
 
 
 @pytest.fixture(autouse=True)
-async def setup_comp(hass, light_only):
+async def setup_comp(hass: HomeAssistant, light_only: None) -> None:
     """Set up demo component."""
     assert await async_setup_component(
         hass, LIGHT_DOMAIN, {LIGHT_DOMAIN: {"platform": DOMAIN}}

--- a/tests/components/demo/test_number.py
+++ b/tests/components/demo/test_number.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 import pytest
+from typing_extensions import Generator
 import voluptuous as vol
 
 from homeassistant.components.number import (
@@ -26,7 +27,7 @@ ENTITY_SMALL_RANGE = "number.small_range"
 
 
 @pytest.fixture
-async def number_only() -> None:
+def number_only() -> Generator[None]:
     """Enable only the number platform."""
     with patch(
         "homeassistant.components.demo.COMPONENTS_WITH_CONFIG_ENTRY_DEMO_PLATFORM",
@@ -36,7 +37,7 @@ async def number_only() -> None:
 
 
 @pytest.fixture(autouse=True)
-async def setup_demo_number(hass, number_only):
+async def setup_demo_number(hass: HomeAssistant, number_only: None) -> None:
     """Initialize setup demo Number entity."""
     assert await async_setup_component(hass, DOMAIN, {"number": {"platform": "demo"}})
     await hass.async_block_till_done()

--- a/tests/components/demo/test_switch.py
+++ b/tests/components/demo/test_switch.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.demo import DOMAIN
 from homeassistant.components.switch import (
@@ -18,7 +19,7 @@ SWITCH_ENTITY_IDS = ["switch.decorative_lights", "switch.ac"]
 
 
 @pytest.fixture
-async def switch_only() -> None:
+def switch_only() -> Generator[None]:
     """Enable only the switch platform."""
     with patch(
         "homeassistant.components.demo.COMPONENTS_WITH_CONFIG_ENTRY_DEMO_PLATFORM",
@@ -28,7 +29,7 @@ async def switch_only() -> None:
 
 
 @pytest.fixture(autouse=True)
-async def setup_comp(hass, switch_only):
+async def setup_comp(hass: HomeAssistant, switch_only: None) -> None:
     """Set up demo component."""
     assert await async_setup_component(
         hass, SWITCH_DOMAIN, {SWITCH_DOMAIN: {"platform": DOMAIN}}
@@ -37,7 +38,7 @@ async def setup_comp(hass, switch_only):
 
 
 @pytest.mark.parametrize("switch_entity_id", SWITCH_ENTITY_IDS)
-async def test_turn_on(hass: HomeAssistant, switch_entity_id) -> None:
+async def test_turn_on(hass: HomeAssistant, switch_entity_id: str) -> None:
     """Test switch turn on method."""
     await hass.services.async_call(
         SWITCH_DOMAIN,
@@ -61,7 +62,7 @@ async def test_turn_on(hass: HomeAssistant, switch_entity_id) -> None:
 
 
 @pytest.mark.parametrize("switch_entity_id", SWITCH_ENTITY_IDS)
-async def test_turn_off(hass: HomeAssistant, switch_entity_id) -> None:
+async def test_turn_off(hass: HomeAssistant, switch_entity_id: str) -> None:
     """Test switch turn off method."""
     await hass.services.async_call(
         SWITCH_DOMAIN,
@@ -86,7 +87,7 @@ async def test_turn_off(hass: HomeAssistant, switch_entity_id) -> None:
 
 @pytest.mark.parametrize("switch_entity_id", SWITCH_ENTITY_IDS)
 async def test_turn_off_without_entity_id(
-    hass: HomeAssistant, switch_entity_id
+    hass: HomeAssistant, switch_entity_id: str
 ) -> None:
     """Test switch turn off all switches."""
     await hass.services.async_call(

--- a/tests/components/demo/test_text.py
+++ b/tests/components/demo/test_text.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.text import (
     ATTR_MAX,
@@ -25,7 +26,7 @@ ENTITY_TEXT = "text.text"
 
 
 @pytest.fixture
-async def text_only() -> None:
+def text_only() -> Generator[None]:
     """Enable only the text platform."""
     with patch(
         "homeassistant.components.demo.COMPONENTS_WITH_CONFIG_ENTRY_DEMO_PLATFORM",
@@ -35,7 +36,7 @@ async def text_only() -> None:
 
 
 @pytest.fixture(autouse=True)
-async def setup_demo_text(hass, text_only):
+async def setup_demo_text(hass: HomeAssistant, text_only: None) -> None:
     """Initialize setup demo text."""
     assert await async_setup_component(hass, DOMAIN, {"text": {"platform": "demo"}})
     await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302
https://github.com/home-assistant/core/actions/runs/9643593124/job/26593942586?pr=120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
