### PR TITLE
Improve type hints in dsmr tests

### DIFF
--- a/tests/components/dsmr/conftest.py
+++ b/tests/components/dsmr/conftest.py
@@ -15,10 +15,11 @@ from dsmr_parser.obis_references import (
 )
 from dsmr_parser.objects import CosemObject
 import pytest
+from typing_extensions import Generator
 
 
 @pytest.fixture
-async def dsmr_connection_fixture(hass):
+def dsmr_connection_fixture() -> Generator[tuple[MagicMock, MagicMock, MagicMock]]:
     """Fixture that mocks serial connection."""
 
     transport = MagicMock(spec=asyncio.Transport)
@@ -44,7 +45,9 @@ async def dsmr_connection_fixture(hass):
 
 
 @pytest.fixture
-async def rfxtrx_dsmr_connection_fixture(hass):
+def rfxtrx_dsmr_connection_fixture() -> (
+    Generator[tuple[MagicMock, MagicMock, MagicMock]]
+):
     """Fixture that mocks RFXtrx connection."""
 
     transport = MagicMock(spec=asyncio.Transport)
@@ -70,7 +73,9 @@ async def rfxtrx_dsmr_connection_fixture(hass):
 
 
 @pytest.fixture
-async def dsmr_connection_send_validate_fixture(hass):
+def dsmr_connection_send_validate_fixture() -> (
+    Generator[tuple[MagicMock, MagicMock, MagicMock]]
+):
     """Fixture that mocks serial connection."""
 
     transport = MagicMock(spec=asyncio.Transport)
@@ -151,7 +156,9 @@ async def dsmr_connection_send_validate_fixture(hass):
 
 
 @pytest.fixture
-async def rfxtrx_dsmr_connection_send_validate_fixture(hass):
+def rfxtrx_dsmr_connection_send_validate_fixture() -> (
+    Generator[tuple[MagicMock, MagicMock, MagicMock]]
+):
     """Fixture that mocks serial connection."""
 
     transport = MagicMock(spec=asyncio.Transport)

--- a/tests/components/dsmr/test_config_flow.py
+++ b/tests/components/dsmr/test_config_flow.py
@@ -32,7 +32,8 @@ def com_port():
 
 
 async def test_setup_network(
-    hass: HomeAssistant, dsmr_connection_send_validate_fixture
+    hass: HomeAssistant,
+    dsmr_connection_send_validate_fixture: tuple[MagicMock, MagicMock, MagicMock],
 ) -> None:
     """Test we can setup network."""
     result = await hass.config_entries.flow.async_init(
@@ -77,8 +78,10 @@ async def test_setup_network(
 
 async def test_setup_network_rfxtrx(
     hass: HomeAssistant,
-    dsmr_connection_send_validate_fixture,
-    rfxtrx_dsmr_connection_send_validate_fixture,
+    dsmr_connection_send_validate_fixture: tuple[MagicMock, MagicMock, MagicMock],
+    rfxtrx_dsmr_connection_send_validate_fixture: tuple[
+        MagicMock, MagicMock, MagicMock
+    ],
 ) -> None:
     """Test we can setup network."""
     (connection_factory, transport, protocol) = dsmr_connection_send_validate_fixture
@@ -185,7 +188,7 @@ async def test_setup_network_rfxtrx(
 async def test_setup_serial(
     com_mock,
     hass: HomeAssistant,
-    dsmr_connection_send_validate_fixture,
+    dsmr_connection_send_validate_fixture: tuple[MagicMock, MagicMock, MagicMock],
     version: str,
     entry_data: dict[str, Any],
 ) -> None:
@@ -225,8 +228,10 @@ async def test_setup_serial(
 async def test_setup_serial_rfxtrx(
     com_mock,
     hass: HomeAssistant,
-    dsmr_connection_send_validate_fixture,
-    rfxtrx_dsmr_connection_send_validate_fixture,
+    dsmr_connection_send_validate_fixture: tuple[MagicMock, MagicMock, MagicMock],
+    rfxtrx_dsmr_connection_send_validate_fixture: tuple[
+        MagicMock, MagicMock, MagicMock
+    ],
 ) -> None:
     """Test we can setup serial."""
     (connection_factory, transport, protocol) = dsmr_connection_send_validate_fixture
@@ -273,7 +278,9 @@ async def test_setup_serial_rfxtrx(
 
 @patch("serial.tools.list_ports.comports", return_value=[com_port()])
 async def test_setup_serial_manual(
-    com_mock, hass: HomeAssistant, dsmr_connection_send_validate_fixture
+    com_mock,
+    hass: HomeAssistant,
+    dsmr_connection_send_validate_fixture: tuple[MagicMock, MagicMock, MagicMock],
 ) -> None:
     """Test we can setup serial with manual entry."""
     result = await hass.config_entries.flow.async_init(
@@ -321,7 +328,9 @@ async def test_setup_serial_manual(
 
 @patch("serial.tools.list_ports.comports", return_value=[com_port()])
 async def test_setup_serial_fail(
-    com_mock, hass: HomeAssistant, dsmr_connection_send_validate_fixture
+    com_mock,
+    hass: HomeAssistant,
+    dsmr_connection_send_validate_fixture: tuple[MagicMock, MagicMock, MagicMock],
 ) -> None:
     """Test failed serial connection."""
     (connection_factory, transport, protocol) = dsmr_connection_send_validate_fixture
@@ -369,8 +378,10 @@ async def test_setup_serial_fail(
 async def test_setup_serial_timeout(
     com_mock,
     hass: HomeAssistant,
-    dsmr_connection_send_validate_fixture,
-    rfxtrx_dsmr_connection_send_validate_fixture,
+    dsmr_connection_send_validate_fixture: tuple[MagicMock, MagicMock, MagicMock],
+    rfxtrx_dsmr_connection_send_validate_fixture: tuple[
+        MagicMock, MagicMock, MagicMock
+    ],
 ) -> None:
     """Test failed serial connection."""
     (connection_factory, transport, protocol) = dsmr_connection_send_validate_fixture
@@ -425,8 +436,10 @@ async def test_setup_serial_timeout(
 async def test_setup_serial_wrong_telegram(
     com_mock,
     hass: HomeAssistant,
-    dsmr_connection_send_validate_fixture,
-    rfxtrx_dsmr_connection_send_validate_fixture,
+    dsmr_connection_send_validate_fixture: tuple[MagicMock, MagicMock, MagicMock],
+    rfxtrx_dsmr_connection_send_validate_fixture: tuple[
+        MagicMock, MagicMock, MagicMock
+    ],
 ) -> None:
     """Test failed telegram data."""
     (connection_factory, transport, protocol) = dsmr_connection_send_validate_fixture

--- a/tests/components/dsmr/test_mbus_migration.py
+++ b/tests/components/dsmr/test_mbus_migration.py
@@ -2,6 +2,7 @@
 
 import datetime
 from decimal import Decimal
+from unittest.mock import MagicMock
 
 from dsmr_parser.obis_references import (
     BELGIUM_MBUS1_DEVICE_TYPE,
@@ -22,7 +23,7 @@ async def test_migrate_gas_to_mbus(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     device_registry: dr.DeviceRegistry,
-    dsmr_connection_fixture,
+    dsmr_connection_fixture: tuple[MagicMock, MagicMock, MagicMock],
 ) -> None:
     """Test migration of unique_id."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
@@ -113,7 +114,7 @@ async def test_migrate_gas_to_mbus_exists(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     device_registry: dr.DeviceRegistry,
-    dsmr_connection_fixture,
+    dsmr_connection_fixture: tuple[MagicMock, MagicMock, MagicMock],
 ) -> None:
     """Test migration of unique_id."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -63,7 +63,9 @@ from tests.common import MockConfigEntry, patch
 
 
 async def test_default_setup(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, dsmr_connection_fixture
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    dsmr_connection_fixture: tuple[MagicMock, MagicMock, MagicMock],
 ) -> None:
     """Test the default setup."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
@@ -191,7 +193,9 @@ async def test_default_setup(
 
 
 async def test_setup_only_energy(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, dsmr_connection_fixture
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    dsmr_connection_fixture: tuple[MagicMock, MagicMock, MagicMock],
 ) -> None:
     """Test the default setup."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
@@ -240,7 +244,9 @@ async def test_setup_only_energy(
     assert not entry
 
 
-async def test_v4_meter(hass: HomeAssistant, dsmr_connection_fixture) -> None:
+async def test_v4_meter(
+    hass: HomeAssistant, dsmr_connection_fixture: tuple[MagicMock, MagicMock, MagicMock]
+) -> None:
     """Test if v4 meter is correctly parsed."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
 
@@ -319,7 +325,10 @@ async def test_v4_meter(hass: HomeAssistant, dsmr_connection_fixture) -> None:
     ],
 )
 async def test_v5_meter(
-    hass: HomeAssistant, dsmr_connection_fixture, value: Decimal, state: str
+    hass: HomeAssistant,
+    dsmr_connection_fixture: tuple[MagicMock, MagicMock, MagicMock],
+    value: Decimal,
+    state: str,
 ) -> None:
     """Test if v5 meter is correctly parsed."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
@@ -386,7 +395,9 @@ async def test_v5_meter(
     )
 
 
-async def test_luxembourg_meter(hass: HomeAssistant, dsmr_connection_fixture) -> None:
+async def test_luxembourg_meter(
+    hass: HomeAssistant, dsmr_connection_fixture: tuple[MagicMock, MagicMock, MagicMock]
+) -> None:
     """Test if v5 meter is correctly parsed."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
 
@@ -468,7 +479,9 @@ async def test_luxembourg_meter(hass: HomeAssistant, dsmr_connection_fixture) ->
     )
 
 
-async def test_belgian_meter(hass: HomeAssistant, dsmr_connection_fixture) -> None:
+async def test_belgian_meter(
+    hass: HomeAssistant, dsmr_connection_fixture: tuple[MagicMock, MagicMock, MagicMock]
+) -> None:
     """Test if Belgian meter is correctly parsed."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
 
@@ -651,7 +664,9 @@ async def test_belgian_meter(hass: HomeAssistant, dsmr_connection_fixture) -> No
     )
 
 
-async def test_belgian_meter_alt(hass: HomeAssistant, dsmr_connection_fixture) -> None:
+async def test_belgian_meter_alt(
+    hass: HomeAssistant, dsmr_connection_fixture: tuple[MagicMock, MagicMock, MagicMock]
+) -> None:
     """Test if Belgian meter is correctly parsed."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
 
@@ -798,7 +813,9 @@ async def test_belgian_meter_alt(hass: HomeAssistant, dsmr_connection_fixture) -
     )
 
 
-async def test_belgian_meter_mbus(hass: HomeAssistant, dsmr_connection_fixture) -> None:
+async def test_belgian_meter_mbus(
+    hass: HomeAssistant, dsmr_connection_fixture: tuple[MagicMock, MagicMock, MagicMock]
+) -> None:
     """Test if Belgian meter is correctly parsed."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
 
@@ -905,7 +922,9 @@ async def test_belgian_meter_mbus(hass: HomeAssistant, dsmr_connection_fixture) 
     )
 
 
-async def test_belgian_meter_low(hass: HomeAssistant, dsmr_connection_fixture) -> None:
+async def test_belgian_meter_low(
+    hass: HomeAssistant, dsmr_connection_fixture: tuple[MagicMock, MagicMock, MagicMock]
+) -> None:
     """Test if Belgian meter is correctly parsed."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
 
@@ -951,7 +970,9 @@ async def test_belgian_meter_low(hass: HomeAssistant, dsmr_connection_fixture) -
     assert active_tariff.attributes.get(ATTR_UNIT_OF_MEASUREMENT) is None
 
 
-async def test_swedish_meter(hass: HomeAssistant, dsmr_connection_fixture) -> None:
+async def test_swedish_meter(
+    hass: HomeAssistant, dsmr_connection_fixture: tuple[MagicMock, MagicMock, MagicMock]
+) -> None:
     """Test if v5 meter is correctly parsed."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
 
@@ -1017,7 +1038,9 @@ async def test_swedish_meter(hass: HomeAssistant, dsmr_connection_fixture) -> No
     )
 
 
-async def test_easymeter(hass: HomeAssistant, dsmr_connection_fixture) -> None:
+async def test_easymeter(
+    hass: HomeAssistant, dsmr_connection_fixture: tuple[MagicMock, MagicMock, MagicMock]
+) -> None:
     """Test if Q3D meter is correctly parsed."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
 
@@ -1086,7 +1109,9 @@ async def test_easymeter(hass: HomeAssistant, dsmr_connection_fixture) -> None:
     )
 
 
-async def test_tcp(hass: HomeAssistant, dsmr_connection_fixture) -> None:
+async def test_tcp(
+    hass: HomeAssistant, dsmr_connection_fixture: tuple[MagicMock, MagicMock, MagicMock]
+) -> None:
     """If proper config provided TCP connection should be made."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
 
@@ -1112,7 +1137,10 @@ async def test_tcp(hass: HomeAssistant, dsmr_connection_fixture) -> None:
     assert connection_factory.call_args_list[0][0][1] == "1234"
 
 
-async def test_rfxtrx_tcp(hass: HomeAssistant, rfxtrx_dsmr_connection_fixture) -> None:
+async def test_rfxtrx_tcp(
+    hass: HomeAssistant,
+    rfxtrx_dsmr_connection_fixture: tuple[MagicMock, MagicMock, MagicMock],
+) -> None:
     """If proper config provided RFXtrx TCP connection should be made."""
     (connection_factory, transport, protocol) = rfxtrx_dsmr_connection_fixture
 
@@ -1140,7 +1168,7 @@ async def test_rfxtrx_tcp(hass: HomeAssistant, rfxtrx_dsmr_connection_fixture) -
 
 @patch("homeassistant.components.dsmr.sensor.DEFAULT_RECONNECT_INTERVAL", 0)
 async def test_connection_errors_retry(
-    hass: HomeAssistant, dsmr_connection_fixture
+    hass: HomeAssistant, dsmr_connection_fixture: tuple[MagicMock, MagicMock, MagicMock]
 ) -> None:
     """Connection should be retried on error during setup."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture
@@ -1177,7 +1205,9 @@ async def test_connection_errors_retry(
 
 
 @patch("homeassistant.components.dsmr.sensor.DEFAULT_RECONNECT_INTERVAL", 0)
-async def test_reconnect(hass: HomeAssistant, dsmr_connection_fixture) -> None:
+async def test_reconnect(
+    hass: HomeAssistant, dsmr_connection_fixture: tuple[MagicMock, MagicMock, MagicMock]
+) -> None:
     """If transport disconnects, the connection should be retried."""
 
     (connection_factory, transport, protocol) = dsmr_connection_fixture
@@ -1255,7 +1285,7 @@ async def test_reconnect(hass: HomeAssistant, dsmr_connection_fixture) -> None:
 
 
 async def test_gas_meter_providing_energy_reading(
-    hass: HomeAssistant, dsmr_connection_fixture
+    hass: HomeAssistant, dsmr_connection_fixture: tuple[MagicMock, MagicMock, MagicMock]
 ) -> None:
     """Test that gas providing energy readings use the correct device class."""
     (connection_factory, transport, protocol) = dsmr_connection_fixture


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302
https://github.com/home-assistant/core/actions/runs/9643593124/job/26593942586?pr=120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
