### PR TITLE
Use VolDictType for service schemas

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -64,7 +64,7 @@ from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.network import get_url
 from homeassistant.helpers.template import Template
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.typing import ConfigType, VolDictType
 from homeassistant.loader import bind_hass
 
 from .const import (  # noqa: F401
@@ -130,14 +130,14 @@ _RND: Final = SystemRandom()
 
 MIN_STREAM_INTERVAL: Final = 0.5  # seconds
 
-CAMERA_SERVICE_SNAPSHOT: Final = {vol.Required(ATTR_FILENAME): cv.template}
+CAMERA_SERVICE_SNAPSHOT: VolDictType = {vol.Required(ATTR_FILENAME): cv.template}
 
-CAMERA_SERVICE_PLAY_STREAM: Final = {
+CAMERA_SERVICE_PLAY_STREAM: VolDictType = {
     vol.Required(ATTR_MEDIA_PLAYER): cv.entities_domain(DOMAIN_MP),
     vol.Optional(ATTR_FORMAT, default="hls"): vol.In(OUTPUT_FORMATS),
 }
 
-CAMERA_SERVICE_RECORD: Final = {
+CAMERA_SERVICE_RECORD: VolDictType = {
     vol.Required(CONF_FILENAME): cv.template,
     vol.Optional(CONF_DURATION, default=30): vol.Coerce(int),
     vol.Optional(CONF_LOOKBACK, default=0): vol.Coerce(int),

--- a/homeassistant/components/elkm1/alarm_control_panel.py
+++ b/homeassistant/components/elkm1/alarm_control_panel.py
@@ -31,6 +31,7 @@ from homeassistant.helpers import entity_platform
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.typing import VolDictType
 
 from . import ElkAttachedEntity, ElkEntity, ElkM1ConfigEntry, create_elk_entities
 from .const import (
@@ -41,7 +42,7 @@ from .const import (
 )
 from .models import ELKM1Data
 
-DISPLAY_MESSAGE_SERVICE_SCHEMA = {
+DISPLAY_MESSAGE_SERVICE_SCHEMA: VolDictType = {
     vol.Optional("clear", default=2): vol.All(vol.Coerce(int), vol.In([0, 1, 2])),
     vol.Optional("beep", default=False): cv.boolean,
     vol.Optional("timeout", default=0): vol.All(

--- a/homeassistant/components/elkm1/const.py
+++ b/homeassistant/components/elkm1/const.py
@@ -6,6 +6,7 @@ from elkm1_lib.const import Max
 import voluptuous as vol
 
 from homeassistant.const import ATTR_CODE, CONF_ZONE
+from homeassistant.helpers.typing import VolDictType
 
 DOMAIN = "elkm1"
 
@@ -48,6 +49,6 @@ ATTR_CHANGED_BY_ID = "changed_by_id"
 ATTR_CHANGED_BY_TIME = "changed_by_time"
 ATTR_VALUE = "value"
 
-ELK_USER_CODE_SERVICE_SCHEMA = {
+ELK_USER_CODE_SERVICE_SCHEMA: VolDictType = {
     vol.Required(ATTR_CODE): vol.All(vol.Coerce(int), vol.Range(0, 999999))
 }

--- a/homeassistant/components/elkm1/sensor.py
+++ b/homeassistant/components/elkm1/sensor.py
@@ -20,6 +20,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import VolDictType
 
 from . import ElkAttachedEntity, ElkEntity, ElkM1ConfigEntry, create_elk_entities
 from .const import ATTR_VALUE, ELK_USER_CODE_SERVICE_SCHEMA
@@ -30,7 +31,7 @@ SERVICE_SENSOR_ZONE_BYPASS = "sensor_zone_bypass"
 SERVICE_SENSOR_ZONE_TRIGGER = "sensor_zone_trigger"
 UNDEFINED_TEMPERATURE = -40
 
-ELK_SET_COUNTER_SERVICE_SCHEMA = {
+ELK_SET_COUNTER_SERVICE_SCHEMA: VolDictType = {
     vol.Required(ATTR_VALUE): vol.All(vol.Coerce(int), vol.Range(0, 65535))
 }
 

--- a/homeassistant/components/environment_canada/camera.py
+++ b/homeassistant/components/environment_canada/camera.py
@@ -11,13 +11,14 @@ from homeassistant.helpers.entity_platform import (
     AddEntitiesCallback,
     async_get_current_platform,
 )
+from homeassistant.helpers.typing import VolDictType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import device_info
 from .const import ATTR_OBSERVATION_TIME, DOMAIN
 
 SERVICE_SET_RADAR_TYPE = "set_radar_type"
-SET_RADAR_TYPE_SCHEMA = {
+SET_RADAR_TYPE_SCHEMA: VolDictType = {
     vol.Required("radar_type"): vol.In(["Auto", "Rain", "Snow"]),
 }
 

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -28,6 +28,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_platform
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import VolDictType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util.color import (
     color_temperature_kelvin_to_mired,
@@ -88,7 +89,7 @@ SERVICE_CUSTOM_EFFECT: Final = "set_custom_effect"
 SERVICE_SET_ZONES: Final = "set_zones"
 SERVICE_SET_MUSIC_MODE: Final = "set_music_mode"
 
-CUSTOM_EFFECT_DICT: Final = {
+CUSTOM_EFFECT_DICT: VolDictType = {
     vol.Required(CONF_COLORS): vol.All(
         cv.ensure_list,
         vol.Length(min=1, max=16),
@@ -102,7 +103,7 @@ CUSTOM_EFFECT_DICT: Final = {
     ),
 }
 
-SET_MUSIC_MODE_DICT: Final = {
+SET_MUSIC_MODE_DICT: VolDictType = {
     vol.Optional(ATTR_SENSITIVITY, default=100): vol.All(
         vol.Coerce(int), vol.Range(min=0, max=100)
     ),
@@ -121,7 +122,7 @@ SET_MUSIC_MODE_DICT: Final = {
     ),
 }
 
-SET_ZONES_DICT: Final = {
+SET_ZONES_DICT: VolDictType = {
     vol.Required(CONF_COLORS): vol.All(
         cv.ensure_list,
         vol.Length(min=1, max=2048),

--- a/homeassistant/components/geniushub/switch.py
+++ b/homeassistant/components/geniushub/switch.py
@@ -11,7 +11,7 @@ from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, VolDictType
 
 from . import ATTR_DURATION, DOMAIN, GeniusZone
 
@@ -19,7 +19,7 @@ GH_ON_OFF_ZONE = "on / off"
 
 SVC_SET_SWITCH_OVERRIDE = "set_switch_override"
 
-SET_SWITCH_OVERRIDE_SCHEMA = {
+SET_SWITCH_OVERRIDE_SCHEMA: VolDictType = {
     vol.Optional(ATTR_DURATION): vol.All(
         cv.time_period,
         vol.Range(min=timedelta(minutes=5), max=timedelta(days=1)),

--- a/homeassistant/components/harmony/remote.py
+++ b/homeassistant/components/harmony/remote.py
@@ -26,6 +26,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.typing import VolDictType
 
 from .const import (
     ACTIVITY_POWER_OFF,
@@ -50,7 +51,7 @@ PARALLEL_UPDATES = 0
 
 ATTR_CHANNEL = "channel"
 
-HARMONY_CHANGE_CHANNEL_SCHEMA = {
+HARMONY_CHANGE_CHANNEL_SCHEMA: VolDictType = {
     vol.Required(ATTR_CHANNEL): cv.positive_int,
 }
 

--- a/homeassistant/components/isy994/services.py
+++ b/homeassistant/components/isy994/services.py
@@ -18,6 +18,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import async_get_platforms
 from homeassistant.helpers.service import entity_service_call
+from homeassistant.helpers.typing import VolDictType
 
 from .const import _LOGGER, DOMAIN
 
@@ -102,12 +103,14 @@ SERVICE_SET_ZWAVE_PARAMETER_SCHEMA = {
     vol.Required(CONF_SIZE): vol.All(vol.Coerce(int), vol.In(VALID_PARAMETER_SIZES)),
 }
 
-SERVICE_SET_USER_CODE_SCHEMA = {
+SERVICE_SET_USER_CODE_SCHEMA: VolDictType = {
     vol.Required(CONF_USER_NUM): vol.Coerce(int),
     vol.Required(CONF_CODE): vol.Coerce(int),
 }
 
-SERVICE_DELETE_USER_CODE_SCHEMA = {vol.Required(CONF_USER_NUM): vol.Coerce(int)}
+SERVICE_DELETE_USER_CODE_SCHEMA: VolDictType = {
+    vol.Required(CONF_USER_NUM): vol.Coerce(int)
+}
 
 SERVICE_SEND_PROGRAM_COMMAND_SCHEMA = vol.All(
     cv.has_at_least_one_key(CONF_ADDRESS, CONF_NAME),

--- a/homeassistant/components/izone/climate.py
+++ b/homeassistant/components/izone/climate.py
@@ -35,7 +35,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.temperature import display_temp as show_temp
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.typing import ConfigType, VolDictType
 
 from .const import (
     DATA_CONFIG,
@@ -65,7 +65,7 @@ ATTR_AIRFLOW = "airflow"
 IZONE_SERVICE_AIRFLOW_MIN = "airflow_min"
 IZONE_SERVICE_AIRFLOW_MAX = "airflow_max"
 
-IZONE_SERVICE_AIRFLOW_SCHEMA = {
+IZONE_SERVICE_AIRFLOW_SCHEMA: VolDictType = {
     vol.Required(ATTR_AIRFLOW): vol.All(
         vol.Coerce(int), vol.Range(min=0, max=100), msg="invalid airflow"
     ),

--- a/homeassistant/components/keymitt_ble/switch.py
+++ b/homeassistant/components/keymitt_ble/switch.py
@@ -14,13 +14,14 @@ from homeassistant.helpers.entity_platform import (
     AddEntitiesCallback,
     async_get_current_platform,
 )
+from homeassistant.helpers.typing import VolDictType
 
 from .const import DOMAIN
 from .coordinator import MicroBotDataUpdateCoordinator
 from .entity import MicroBotEntity
 
 CALIBRATE = "calibrate"
-CALIBRATE_SCHEMA = {
+CALIBRATE_SCHEMA: VolDictType = {
     vol.Required("depth"): cv.positive_int,
     vol.Required("duration"): cv.positive_int,
     vol.Required("mode"): vol.In(["normal", "invert", "toggle"]),

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -49,7 +49,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.network import is_internal_request
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, VolDictType
 import homeassistant.util.dt as dt_util
 
 from .browse_media import (
@@ -147,7 +147,7 @@ ATTR_MEDIA_ID = "media_id"
 ATTR_METHOD = "method"
 
 
-KODI_ADD_MEDIA_SCHEMA = {
+KODI_ADD_MEDIA_SCHEMA: VolDictType = {
     vol.Required(ATTR_MEDIA_TYPE): cv.string,
     vol.Optional(ATTR_MEDIA_ID): cv.string,
     vol.Optional(ATTR_MEDIA_NAME): cv.string,

--- a/homeassistant/components/lifx/light.py
+++ b/homeassistant/components/lifx/light.py
@@ -25,6 +25,7 @@ from homeassistant.helpers import entity_platform
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_call_later
+from homeassistant.helpers.typing import VolDictType
 
 from .const import (
     _LOGGER,
@@ -53,7 +54,7 @@ LIFX_STATE_SETTLE_DELAY = 0.3
 
 SERVICE_LIFX_SET_STATE = "set_state"
 
-LIFX_SET_STATE_SCHEMA = {
+LIFX_SET_STATE_SCHEMA: VolDictType = {
     **LIGHT_TURN_ON_SCHEMA,
     ATTR_INFRARED: vol.All(vol.Coerce(int), vol.Clamp(min=0, max=255)),
     ATTR_ZONES: vol.All(cv.ensure_list, [cv.positive_int]),
@@ -63,7 +64,7 @@ LIFX_SET_STATE_SCHEMA = {
 
 SERVICE_LIFX_SET_HEV_CYCLE_STATE = "set_hev_cycle_state"
 
-LIFX_SET_HEV_CYCLE_STATE_SCHEMA = {
+LIFX_SET_HEV_CYCLE_STATE_SCHEMA: VolDictType = {
     ATTR_POWER: vol.Required(cv.boolean),
     ATTR_DURATION: vol.All(vol.Coerce(float), vol.Clamp(min=0, max=86400)),
 }

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -31,7 +31,7 @@ from homeassistant.helpers.config_validation import (  # noqa: F401
 )
 from homeassistant.helpers.entity import ToggleEntity, ToggleEntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.typing import ConfigType, VolDictType
 from homeassistant.loader import bind_hass
 import homeassistant.util.color as color_util
 
@@ -247,7 +247,7 @@ VALID_BRIGHTNESS_STEP = vol.All(vol.Coerce(int), vol.Clamp(min=-255, max=255))
 VALID_BRIGHTNESS_STEP_PCT = vol.All(vol.Coerce(float), vol.Clamp(min=-100, max=100))
 VALID_FLASH = vol.In([FLASH_SHORT, FLASH_LONG])
 
-LIGHT_TURN_ON_SCHEMA = {
+LIGHT_TURN_ON_SCHEMA: VolDictType = {
     vol.Exclusive(ATTR_PROFILE, COLOR_GROUP): cv.string,
     ATTR_TRANSITION: VALID_TRANSITION,
     vol.Exclusive(ATTR_BRIGHTNESS, ATTR_BRIGHTNESS): VALID_BRIGHTNESS,
@@ -286,7 +286,10 @@ LIGHT_TURN_ON_SCHEMA = {
     ATTR_EFFECT: cv.string,
 }
 
-LIGHT_TURN_OFF_SCHEMA = {ATTR_TRANSITION: VALID_TRANSITION, ATTR_FLASH: VALID_FLASH}
+LIGHT_TURN_OFF_SCHEMA: VolDictType = {
+    ATTR_TRANSITION: VALID_TRANSITION,
+    ATTR_FLASH: VALID_FLASH,
+}
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -37,6 +37,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_platform
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import VolDictType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from . import LyricDeviceEntity
@@ -111,7 +112,7 @@ HVAC_ACTIONS = {
 SERVICE_HOLD_TIME = "set_hold_time"
 ATTR_TIME_PERIOD = "time_period"
 
-SCHEMA_HOLD_TIME = {
+SCHEMA_HOLD_TIME: VolDictType = {
     vol.Required(ATTR_TIME_PERIOD, default="01:00:00"): vol.All(
         cv.time_period,
         cv.positive_timedelta,

--- a/homeassistant/components/motion_blinds/cover.py
+++ b/homeassistant/components/motion_blinds/cover.py
@@ -20,6 +20,7 @@ from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_call_later
+from homeassistant.helpers.typing import VolDictType
 
 from .const import (
     ATTR_ABSOLUTE_POSITION,
@@ -75,7 +76,7 @@ TDBU_DEVICE_MAP = {
 }
 
 
-SET_ABSOLUTE_POSITION_SCHEMA = {
+SET_ABSOLUTE_POSITION_SCHEMA: VolDictType = {
     vol.Required(ATTR_ABSOLUTE_POSITION): vol.All(cv.positive_int, vol.Range(max=100)),
     vol.Optional(ATTR_TILT_POSITION): vol.All(cv.positive_int, vol.Range(max=100)),
     vol.Optional(ATTR_WIDTH): vol.All(cv.positive_int, vol.Range(max=100)),

--- a/homeassistant/components/nexia/climate.py
+++ b/homeassistant/components/nexia/climate.py
@@ -37,6 +37,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_platform
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import VolDictType
 
 from .const import (
     ATTR_AIRCLEANER_MODE,
@@ -55,11 +56,11 @@ SERVICE_SET_AIRCLEANER_MODE = "set_aircleaner_mode"
 SERVICE_SET_HUMIDIFY_SETPOINT = "set_humidify_setpoint"
 SERVICE_SET_HVAC_RUN_MODE = "set_hvac_run_mode"
 
-SET_AIRCLEANER_SCHEMA = {
+SET_AIRCLEANER_SCHEMA: VolDictType = {
     vol.Required(ATTR_AIRCLEANER_MODE): cv.string,
 }
 
-SET_HUMIDITY_SCHEMA = {
+SET_HUMIDITY_SCHEMA: VolDictType = {
     vol.Required(ATTR_HUMIDITY): vol.All(vol.Coerce(int), vol.Range(min=35, max=65)),
 }
 

--- a/homeassistant/components/rainbird/switch.py
+++ b/homeassistant/components/rainbird/switch.py
@@ -14,6 +14,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import VolDictType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import ATTR_DURATION, CONF_IMPORTED_NAMES, DOMAIN, MANUFACTURER
@@ -23,7 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 
 SERVICE_START_IRRIGATION = "start_irrigation"
 
-SERVICE_SCHEMA_IRRIGATION = {
+SERVICE_SCHEMA_IRRIGATION: VolDictType = {
     vol.Required(ATTR_DURATION): cv.positive_float,
 }
 

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -6,7 +6,7 @@ import asyncio
 from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Concatenate
+from typing import Any, Concatenate, cast
 
 from regenmaschine.errors import RainMachineError
 import voluptuous as vol
@@ -18,6 +18,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import VolDictType
 
 from . import RainMachineData, RainMachineEntity, async_update_programs_and_zones
 from .const import (
@@ -191,7 +192,8 @@ async def async_setup_entry(
         ("stop_program", {}, "async_stop_program"),
         ("stop_zone", {}, "async_stop_zone"),
     ):
-        platform.async_register_entity_service(service_name, schema, method)
+        schema_dict = cast(VolDictType, schema)
+        platform.async_register_entity_service(service_name, schema_dict, method)
 
     data: RainMachineData = hass.data[DOMAIN][entry.entry_id]
     entities: list[RainMachineBaseSwitch] = []

--- a/homeassistant/components/renson/fan.py
+++ b/homeassistant/components/renson/fan.py
@@ -21,6 +21,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_platform
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import VolDictType
 from homeassistant.util.percentage import (
     percentage_to_ranged_value,
     ranged_value_to_percentage,
@@ -51,20 +52,20 @@ SPEED_MAPPING = {
     Level.LEVEL4.value: 4,
 }
 
-SET_TIMER_LEVEL_SCHEMA = {
+SET_TIMER_LEVEL_SCHEMA: VolDictType = {
     vol.Required("timer_level"): vol.In(
         ["level1", "level2", "level3", "level4", "holiday", "breeze"]
     ),
     vol.Required("minutes"): cv.positive_int,
 }
 
-SET_BREEZE_SCHEMA = {
+SET_BREEZE_SCHEMA: VolDictType = {
     vol.Required("breeze_level"): vol.In(["level1", "level2", "level3", "level4"]),
     vol.Required("temperature"): cv.positive_int,
     vol.Required("activate"): bool,
 }
 
-SET_POLLUTION_SETTINGS_SCHEMA = {
+SET_POLLUTION_SETTINGS_SCHEMA: VolDictType = {
     vol.Required("day_pollution_level"): vol.In(
         ["level1", "level2", "level3", "level4"]
     ),

--- a/homeassistant/components/roku/media_player.py
+++ b/homeassistant/components/roku/media_player.py
@@ -28,6 +28,7 @@ from homeassistant.const import ATTR_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import VolDictType
 
 from .browse_media import async_browse_media
 from .const import (
@@ -78,7 +79,7 @@ ATTRS_TO_PLAY_ON_ROKU_AUDIO_PARAMS = {
     ATTR_THUMBNAIL: "albumArtUrl",
 }
 
-SEARCH_SCHEMA = {vol.Required(ATTR_KEYWORD): str}
+SEARCH_SCHEMA: VolDictType = {vol.Required(ATTR_KEYWORD): str}
 
 
 async def async_setup_entry(

--- a/homeassistant/components/siren/__init__.py
+++ b/homeassistant/components/siren/__init__.py
@@ -24,7 +24,7 @@ from homeassistant.helpers.deprecation import (
 )
 from homeassistant.helpers.entity import ToggleEntity, ToggleEntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.typing import ConfigType, VolDictType
 
 from .const import (  # noqa: F401
     _DEPRECATED_SUPPORT_DURATION,
@@ -44,7 +44,7 @@ _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(seconds=60)
 
-TURN_ON_SCHEMA = {
+TURN_ON_SCHEMA: VolDictType = {
     vol.Optional(ATTR_TONE): vol.Any(vol.Coerce(int), cv.string),
     vol.Optional(ATTR_DURATION): cv.positive_int,
     vol.Optional(ATTR_VOLUME_LEVEL): cv.small_float,

--- a/homeassistant/components/smarttub/binary_sensor.py
+++ b/homeassistant/components/smarttub/binary_sensor.py
@@ -13,6 +13,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import VolDictType
 
 from .const import ATTR_ERRORS, ATTR_REMINDERS, DOMAIN, SMARTTUB_CONTROLLER
 from .entity import SmartTubEntity, SmartTubSensorBase
@@ -29,12 +30,12 @@ ATTR_UPDATED_AT = "updated_at"
 
 # how many days to snooze the reminder for
 ATTR_REMINDER_DAYS = "days"
-RESET_REMINDER_SCHEMA = {
+RESET_REMINDER_SCHEMA: VolDictType = {
     vol.Required(ATTR_REMINDER_DAYS): vol.All(
         vol.Coerce(int), vol.Range(min=30, max=365)
     )
 }
-SNOOZE_REMINDER_SCHEMA = {
+SNOOZE_REMINDER_SCHEMA: VolDictType = {
     vol.Required(ATTR_REMINDER_DAYS): vol.All(
         vol.Coerce(int), vol.Range(min=10, max=120)
     )

--- a/homeassistant/components/smarttub/sensor.py
+++ b/homeassistant/components/smarttub/sensor.py
@@ -10,6 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import VolDictType
 
 from .const import DOMAIN, SMARTTUB_CONTROLLER
 from .entity import SmartTubSensorBase
@@ -31,7 +32,7 @@ SET_PRIMARY_FILTRATION_SCHEMA = vol.All(
     ),
 )
 
-SET_SECONDARY_FILTRATION_SCHEMA = {
+SET_SECONDARY_FILTRATION_SCHEMA: VolDictType = {
     vol.Required(ATTR_MODE): vol.In(
         {
             mode.name.lower()

--- a/homeassistant/components/switcher_kis/switch.py
+++ b/homeassistant/components/switcher_kis/switch.py
@@ -21,6 +21,7 @@ from homeassistant.helpers import (
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import VolDictType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
@@ -37,11 +38,11 @@ _LOGGER = logging.getLogger(__name__)
 API_CONTROL_DEVICE = "control_device"
 API_SET_AUTO_SHUTDOWN = "set_auto_shutdown"
 
-SERVICE_SET_AUTO_OFF_SCHEMA = {
+SERVICE_SET_AUTO_OFF_SCHEMA: VolDictType = {
     vol.Required(CONF_AUTO_OFF): cv.time_period_str,
 }
 
-SERVICE_TURN_ON_WITH_TIMER_SCHEMA = {
+SERVICE_TURN_ON_WITH_TIMER_SCHEMA: VolDictType = {
     vol.Required(CONF_TIMER_MINUTES): vol.All(
         cv.positive_int, vol.Range(min=1, max=150)
     ),

--- a/homeassistant/components/tado/climate.py
+++ b/homeassistant/components/tado/climate.py
@@ -28,6 +28,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import VolDictType
 
 from . import TadoConnector
 from .const import (
@@ -80,7 +81,7 @@ SERVICE_CLIMATE_TIMER = "set_climate_timer"
 ATTR_TIME_PERIOD = "time_period"
 ATTR_REQUESTED_OVERLAY = "requested_overlay"
 
-CLIMATE_TIMER_SCHEMA = {
+CLIMATE_TIMER_SCHEMA: VolDictType = {
     vol.Required(ATTR_TEMPERATURE): vol.Coerce(float),
     vol.Exclusive(ATTR_TIME_PERIOD, CONST_EXCLUSIVE_OVERLAY_GROUP): vol.All(
         cv.time_period, cv.positive_timedelta, lambda td: td.total_seconds()
@@ -93,7 +94,7 @@ CLIMATE_TIMER_SCHEMA = {
 SERVICE_TEMP_OFFSET = "set_climate_temperature_offset"
 ATTR_OFFSET = "offset"
 
-CLIMATE_TEMP_OFFSET_SCHEMA = {
+CLIMATE_TEMP_OFFSET_SCHEMA: VolDictType = {
     vol.Required(ATTR_OFFSET, default=0): vol.Coerce(float),
 }
 

--- a/homeassistant/components/tado/water_heater.py
+++ b/homeassistant/components/tado/water_heater.py
@@ -15,6 +15,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import VolDictType
 
 from . import TadoConnector
 from .const import (
@@ -55,7 +56,7 @@ WATER_HEATER_MAP_TADO = {
 SERVICE_WATER_HEATER_TIMER = "set_water_heater_timer"
 ATTR_TIME_PERIOD = "time_period"
 
-WATER_HEATER_TIMER_SCHEMA = {
+WATER_HEATER_TIMER_SCHEMA: VolDictType = {
     vol.Required(ATTR_TIME_PERIOD, default="01:00:00"): vol.All(
         cv.time_period, cv.positive_timedelta, lambda td: td.total_seconds()
     ),

--- a/homeassistant/components/upb/const.py
+++ b/homeassistant/components/upb/const.py
@@ -3,6 +3,7 @@
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.typing import VolDictType
 
 DOMAIN = "upb"
 
@@ -29,7 +30,7 @@ UPB_BRIGHTNESS_RATE_SCHEMA = vol.All(
     ),
 )
 
-UPB_BLINK_RATE_SCHEMA = {
+UPB_BLINK_RATE_SCHEMA: VolDictType = {
     vol.Required(ATTR_BLINK_RATE, default=0.5): vol.All(
         vol.Coerce(float), vol.Range(min=0, max=4.25)
     )

--- a/homeassistant/components/vizio/const.py
+++ b/homeassistant/components/vizio/const.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
     CONF_NAME,
 )
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.typing import VolDictType
 
 SERVICE_UPDATE_SETTING = "update_setting"
 
@@ -26,7 +27,7 @@ ATTR_SETTING_TYPE = "setting_type"
 ATTR_SETTING_NAME = "setting_name"
 ATTR_NEW_VALUE = "new_value"
 
-UPDATE_SETTING_SCHEMA = {
+UPDATE_SETTING_SCHEMA: VolDictType = {
     vol.Required(ATTR_SETTING_TYPE): vol.All(cv.string, vol.Lower, cv.slugify),
     vol.Required(ATTR_SETTING_NAME): vol.All(cv.string, vol.Lower, cv.slugify),
     vol.Required(ATTR_NEW_VALUE): vol.Any(vol.Coerce(int), cv.string),

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -14,6 +14,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import VolDictType
 from homeassistant.util.percentage import (
     percentage_to_ranged_value,
     ranged_value_to_percentage,
@@ -37,7 +38,7 @@ ATTR_WATER_LEVEL = "water_level"
 
 SPEED_RANGE = (FanMode.Minimum, FanMode.Maximum)  # off is not included
 
-SET_HUMIDITY_SCHEMA = {
+SET_HUMIDITY_SCHEMA: VolDictType = {
     vol.Required(ATTR_TARGET_HUMIDITY): vol.All(
         vol.Coerce(float), vol.Range(min=0, max=100)
     ),

--- a/homeassistant/components/yardian/switch.py
+++ b/homeassistant/components/yardian/switch.py
@@ -11,13 +11,14 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import VolDictType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DEFAULT_WATERING_DURATION, DOMAIN
 from .coordinator import YardianUpdateCoordinator
 
 SERVICE_START_IRRIGATION = "start_irrigation"
-SERVICE_SCHEMA_START_IRRIGATION = {
+SERVICE_SCHEMA_START_IRRIGATION: VolDictType = {
     vol.Required("duration"): cv.positive_int,
 }
 

--- a/homeassistant/components/yeelight/__init__.py
+++ b/homeassistant/components/yeelight/__init__.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.typing import ConfigType, VolDictType
 
 from .const import (
     ACTION_OFF,
@@ -59,7 +59,7 @@ from .scanner import YeelightScanner
 _LOGGER = logging.getLogger(__name__)
 
 
-YEELIGHT_FLOW_TRANSITION_SCHEMA = {
+YEELIGHT_FLOW_TRANSITION_SCHEMA: VolDictType = {
     vol.Optional(ATTR_COUNT, default=0): cv.positive_int,
     vol.Optional(ATTR_ACTION, default=ACTION_RECOVER): vol.Any(
         ACTION_RECOVER, ACTION_OFF, ACTION_STAY

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -38,6 +38,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_call_later
+from homeassistant.helpers.typing import VolDictType
 import homeassistant.util.color as color_util
 from homeassistant.util.color import (
     color_temperature_kelvin_to_mired as kelvin_to_mired,
@@ -170,22 +171,22 @@ EFFECTS_MAP = {
 
 VALID_BRIGHTNESS = vol.All(vol.Coerce(int), vol.Range(min=1, max=100))
 
-SERVICE_SCHEMA_SET_MODE = {
+SERVICE_SCHEMA_SET_MODE: VolDictType = {
     vol.Required(ATTR_MODE): vol.In([mode.name.lower() for mode in PowerMode])
 }
 
-SERVICE_SCHEMA_SET_MUSIC_MODE = {vol.Required(ATTR_MODE_MUSIC): cv.boolean}
+SERVICE_SCHEMA_SET_MUSIC_MODE: VolDictType = {vol.Required(ATTR_MODE_MUSIC): cv.boolean}
 
 SERVICE_SCHEMA_START_FLOW = YEELIGHT_FLOW_TRANSITION_SCHEMA
 
-SERVICE_SCHEMA_SET_COLOR_SCENE = {
+SERVICE_SCHEMA_SET_COLOR_SCENE: VolDictType = {
     vol.Required(ATTR_RGB_COLOR): vol.All(
         vol.Coerce(tuple), vol.ExactSequence((cv.byte, cv.byte, cv.byte))
     ),
     vol.Required(ATTR_BRIGHTNESS): VALID_BRIGHTNESS,
 }
 
-SERVICE_SCHEMA_SET_HSV_SCENE = {
+SERVICE_SCHEMA_SET_HSV_SCENE: VolDictType = {
     vol.Required(ATTR_HS_COLOR): vol.All(
         vol.Coerce(tuple),
         vol.ExactSequence(
@@ -198,14 +199,14 @@ SERVICE_SCHEMA_SET_HSV_SCENE = {
     vol.Required(ATTR_BRIGHTNESS): VALID_BRIGHTNESS,
 }
 
-SERVICE_SCHEMA_SET_COLOR_TEMP_SCENE = {
+SERVICE_SCHEMA_SET_COLOR_TEMP_SCENE: VolDictType = {
     vol.Required(ATTR_KELVIN): vol.All(vol.Coerce(int), vol.Range(min=1700, max=6500)),
     vol.Required(ATTR_BRIGHTNESS): VALID_BRIGHTNESS,
 }
 
 SERVICE_SCHEMA_SET_COLOR_FLOW_SCENE = YEELIGHT_FLOW_TRANSITION_SCHEMA
 
-SERVICE_SCHEMA_SET_AUTO_DELAY_OFF_SCENE = {
+SERVICE_SCHEMA_SET_AUTO_DELAY_OFF_SCENE: VolDictType = {
     vol.Required(ATTR_MINUTES): vol.All(vol.Coerce(int), vol.Range(min=1, max=60)),
     vol.Required(ATTR_BRIGHTNESS): VALID_BRIGHTNESS,
 }


### PR DESCRIPTION
## Proposed change
Next step for the voluptuous update. Ref https://github.com/home-assistant/core/pull/120268
This PR fixes these kinds of mypy errors by "forcing" the schema dict type to be `VolDictType` instead.
```py
Argument 2 to "async_register_entity_service" of "EntityPlatform" has incompatible type
    "dict[Required, All]"; expected "dict[str | Marker, Any] | Schema | All | voluptuous.validators.Any"
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
