### PR TITLE
Handle None aliases and add wall switches to parent device

### DIFF
--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -228,6 +228,24 @@ def legacy_device_id(device: Device) -> str:
     return device_id.split("_")[1]
 
 
+def get_device_name(device: Device, parent: Device | None = None) -> str:
+    """Get a name for the device. alias can be none on some devices."""
+    if device.alias:
+        return device.alias
+    # Return the child device type with an index if there's more than one child device
+    # of the same type. i.e. Devices like the ks240 with one child of each type
+    # skip the suffix
+    if parent:
+        devices = [
+            child.device_id
+            for child in parent.children
+            if child.device_type is device.device_type
+        ]
+        suffix = f" {devices.index(device.device_id) + 1}" if len(devices) > 1 else ""
+        return f"{device.device_type.value.capitalize()}{suffix}"
+    return f"Unnamed {device.model}"
+
+
 async def get_credentials(hass: HomeAssistant) -> Credentials | None:
     """Retrieve the credentials from hass data."""
     if DOMAIN in hass.data and CONF_AUTHENTICATION in hass.data[DOMAIN]:

--- a/homeassistant/components/tplink/binary_sensor.py
+++ b/homeassistant/components/tplink/binary_sensor.py
@@ -26,7 +26,7 @@ class TPLinkBinarySensorEntityDescription(
     """Base class for a TPLink feature based sensor entity description."""
 
 
-BINARYSENSOR_DESCRIPTIONS: Final = (
+BINARY_SENSOR_DESCRIPTIONS: Final = (
     TPLinkBinarySensorEntityDescription(
         key="overheated",
         device_class=BinarySensorDeviceClass.PROBLEM,
@@ -60,7 +60,7 @@ BINARYSENSOR_DESCRIPTIONS: Final = (
     ),
 )
 
-BINARYSENSOR_DESCRIPTIONS_MAP = {desc.key: desc for desc in BINARYSENSOR_DESCRIPTIONS}
+BINARYSENSOR_DESCRIPTIONS_MAP = {desc.key: desc for desc in BINARY_SENSOR_DESCRIPTIONS}
 
 
 async def async_setup_entry(
@@ -78,14 +78,14 @@ async def async_setup_entry(
         device=device,
         coordinator=parent_coordinator,
         feature_type=Feature.Type.BinarySensor,
-        entity_class=BinarySensor,
+        entity_class=TPLinkBinarySensorEntity,
         descriptions=BINARYSENSOR_DESCRIPTIONS_MAP,
         child_coordinators=children_coordinators,
     )
     async_add_entities(entities)
 
 
-class BinarySensor(CoordinatedTPLinkFeatureEntity, BinarySensorEntity):
+class TPLinkBinarySensorEntity(CoordinatedTPLinkFeatureEntity, BinarySensorEntity):
     """Representation of a TPLink binary sensor."""
 
     entity_description: TPLinkBinarySensorEntityDescription

--- a/homeassistant/components/tplink/button.py
+++ b/homeassistant/components/tplink/button.py
@@ -49,14 +49,14 @@ async def async_setup_entry(
         device=device,
         coordinator=parent_coordinator,
         feature_type=Feature.Type.Action,
-        entity_class=Button,
+        entity_class=TPLinkButtonEntity,
         descriptions=BUTTON_DESCRIPTIONS_MAP,
         child_coordinators=children_coordinators,
     )
     async_add_entities(entities)
 
 
-class Button(CoordinatedTPLinkFeatureEntity, ButtonEntity):
+class TPLinkButtonEntity(CoordinatedTPLinkFeatureEntity, ButtonEntity):
     """Representation of a TPLink button entity."""
 
     entity_description: TPLinkButtonEntityDescription

--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -144,16 +144,19 @@ class CoordinatedTPLinkEntity(CoordinatorEntity[TPLinkDataUpdateCoordinator], AB
         device_name = get_device_name(device, parent=parent)
         if parent and parent.device_type is not Device.Type.Hub:
             if not feature or feature.id == PRIMARY_STATE_ID:
-                # Entity will be added to parent if not a hub and no feature parameter
-                # (i.e. core platform like Light, Fan) or the feature is the primary state
+                # Entity will be added to parent if not a hub and no feature
+                # parameter (i.e. core platform like Light, Fan) or the feature
+                # is the primary state
                 registry_device = parent
                 device_name = get_device_name(registry_device)
             else:
-                # Prefix the device name with the parent name unless it is a hub attached device.
-                # Sensible default for child devices like strip plugs or the ks240 where the child
-                # alias makes more sense in the context of the parent.
-                # i.e. Hall Ceiling Fan & Bedroom Ceiling Fan; Child device aliases will be Ceiling Fan
-                # and Dimmer Switch for both so should be distinguished by the parent name.
+                # Prefix the device name with the parent name unless it is a
+                # hub attached device. Sensible default for child devices like
+                # strip plugs or the ks240 where the child alias makes more
+                # sense in the context of the parent. i.e. Hall Ceiling Fan &
+                # Bedroom Ceiling Fan; Child device aliases will be Ceiling Fan
+                # and Dimmer Switch for both so should be distinguished by the
+                # parent name.
                 device_name = f"{get_device_name(parent)} {get_device_name(device, parent=parent)}"
 
         self._attr_device_info = DeviceInfo(
@@ -252,13 +255,15 @@ class CoordinatedTPLinkFeatureEntity(CoordinatedTPLinkEntity, ABC):
     def _get_unique_id(self) -> str:
         """Return unique ID for the entity."""
         key = self.entity_description.key
-        # The unique id for the state feature in the switch platform is the device_id
+        # The unique id for the state feature in the switch platform is the
+        # device_id
         if key == PRIMARY_STATE_ID:
             return legacy_device_id(self._device)
 
-        # Historically the legacy device emeter attributes which are now replaced with
-        # features used slightly different keys. This ensures that those entities
-        # are not orphaned. Returns the mapped key or the provided key if not mapped.
+        # Historically the legacy device emeter attributes which are now
+        # replaced with features used slightly different keys. This ensures
+        # that those entities are not orphaned. Returns the mapped key or the
+        # provided key if not mapped.
         key = LEGACY_KEY_MAPPING.get(key, key)
         return f"{legacy_device_id(self._device)}_{key}"
 
@@ -290,8 +295,8 @@ class CoordinatedTPLinkFeatureEntity(CoordinatedTPLinkEntity, ABC):
     ) -> _D | None:
         """Return description object for the given feature.
 
-        This is responsible for setting the common parameters & deciding based on feature id
-        which additional parameters are passed.
+        This is responsible for setting the common parameters & deciding
+        based on feature id which additional parameters are passed.
         """
 
         if descriptions and (desc := descriptions.get(feature.id)):
@@ -400,8 +405,9 @@ class CoordinatedTPLinkFeatureEntity(CoordinatedTPLinkEntity, ABC):
         if device.children:
             _LOGGER.debug("Initializing device with %s children", len(device.children))
             for idx, child in enumerate(device.children):
-                # HS300 does not like too many concurrent requests and its emeter data requires
-                # a request for each socket, so we receive separate coordinators.
+                # HS300 does not like too many concurrent requests and its
+                # emeter data requires a request for each socket, so we receive
+                # separate coordinators.
                 if child_coordinators:
                     child_coordinator = child_coordinators[idx]
                 else:

--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -26,7 +26,7 @@ from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.typing import UNDEFINED, UndefinedType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import legacy_device_id
+from . import get_device_name, legacy_device_id
 from .const import (
     ATTR_CURRENT_A,
     ATTR_CURRENT_POWER_W,
@@ -141,20 +141,20 @@ class CoordinatedTPLinkEntity(CoordinatorEntity[TPLinkDataUpdateCoordinator], AB
         self._feature = feature
 
         registry_device = device
-        device_name = device.alias
-        if parent and parent.device_type != Device.Type.Hub:
+        device_name = get_device_name(device, parent=parent)
+        if parent and parent.device_type is not Device.Type.Hub:
             if not feature or feature.id == PRIMARY_STATE_ID:
                 # Entity will be added to parent if not a hub and no feature parameter
                 # (i.e. core platform like Light, Fan) or the feature is the primary state
                 registry_device = parent
-                device_name = registry_device.alias
+                device_name = get_device_name(registry_device)
             else:
                 # Prefix the device name with the parent name unless it is a hub attached device.
                 # Sensible default for child devices like strip plugs or the ks240 where the child
                 # alias makes more sense in the context of the parent.
                 # i.e. Hall Ceiling Fan & Bedroom Ceiling Fan; Child device aliases will be Ceiling Fan
                 # and Dimmer Switch for both so should be distinguished by the parent name.
-                device_name = f"{parent.alias} {device.alias}"
+                device_name = f"{get_device_name(parent)} {get_device_name(device, parent=parent)}"
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, str(registry_device.device_id))},
@@ -165,7 +165,11 @@ class CoordinatedTPLinkEntity(CoordinatorEntity[TPLinkDataUpdateCoordinator], AB
             hw_version=registry_device.hw_info["hw_ver"],
         )
 
-        if parent is not None and parent != registry_device:
+        if (
+            parent is not None
+            and parent != registry_device
+            and parent.device_type is not Device.Type.WallSwitch
+        ):
             self._attr_device_info["via_device"] = (DOMAIN, parent.device_id)
         else:
             self._attr_device_info["connections"] = {
@@ -281,7 +285,8 @@ class CoordinatedTPLinkFeatureEntity(CoordinatedTPLinkEntity, ABC):
         feature: Feature,
         descriptions: Mapping[str, _D],
         *,
-        child_alias: str | None = None,
+        device: Device,
+        parent: Device | None = None,
     ) -> _D | None:
         """Return description object for the given feature.
 
@@ -294,18 +299,19 @@ class CoordinatedTPLinkFeatureEntity(CoordinatedTPLinkEntity, ABC):
             # HA logic is to name entities based on the following logic:
             # _attr_name > translation.name > description.name
             # > device_class (if base platform supports).
-            entity_name: str | None | UndefinedType = UNDEFINED
+            name: str | None | UndefinedType = UNDEFINED
 
             # The state feature gets the device name or the child device
             # name if it's a child device
             if feature.id == PRIMARY_STATE_ID:
                 translation_key = None
-                entity_name = child_alias  # if None will use device name
+                # if None will use device name
+                name = get_device_name(device, parent=parent) if parent else None
 
             return replace(
                 desc,
                 translation_key=translation_key,
-                name=entity_name,  # if undefined will use translation key
+                name=name,  # if undefined will use translation key
                 entity_category=cls._category_for_feature(feature),
                 # enabled_default can be overridden to False in the description
                 entity_registry_enabled_default=feature.category
@@ -356,7 +362,7 @@ class CoordinatedTPLinkFeatureEntity(CoordinatedTPLinkEntity, ABC):
             )
             and (
                 desc := cls._description_for_feature(
-                    feat, descriptions, child_alias=device.alias if parent else None
+                    feat, descriptions, device=device, parent=parent
                 )
             )
         ]

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -138,12 +138,12 @@ async def async_setup_entry(
     data = config_entry.runtime_data
     parent_coordinator = data.parent_coordinator
     device = parent_coordinator.device
-    entities: list[TPLinkSmartBulb | TPLinkSmartLightStrip] = []
+    entities: list[TPLinkLightEntity | TPLinkLightEffectEntity] = []
     if (
         effect_module := device.modules.get(Module.LightEffect)
     ) and effect_module.has_custom_effects:
         entities.append(
-            TPLinkSmartLightStrip(
+            TPLinkLightEffectEntity(
                 device,
                 parent_coordinator,
                 light_module=device.modules[Module.Light],
@@ -163,12 +163,12 @@ async def async_setup_entry(
         )
     elif Module.Light in device.modules:
         entities.append(
-            TPLinkSmartBulb(
+            TPLinkLightEntity(
                 device, parent_coordinator, light_module=device.modules[Module.Light]
             )
         )
     entities.extend(
-        TPLinkSmartBulb(
+        TPLinkLightEntity(
             child,
             parent_coordinator,
             light_module=child.modules[Module.Light],
@@ -180,7 +180,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
+class TPLinkLightEntity(CoordinatedTPLinkEntity, LightEntity):
     """Representation of a TPLink Smart Bulb."""
 
     _attr_supported_features = LightEntityFeature.TRANSITION
@@ -227,7 +227,8 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
             # Dimmers used to use the switch format since
             # pyHS100 treated them as SmartPlug but the old code
             # created them as lights
-            # https://github.com/home-assistant/core/blob/2021.9.7/homeassistant/components/tplink/common.py#L86
+            # https://github.com/home-assistant/core/blob/2021.9.7/ \
+            # homeassistant/components/tplink/common.py#L86
             return legacy_device_id(device)
 
         # Newer devices can have child lights. While there isn't currently
@@ -249,11 +250,11 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
             brightness = round((brightness * 100.0) / 255.0)
 
         if self._device.device_type == DeviceType.Dimmer and transition is None:
-            # This is a stopgap solution for inconsistent set_brightness handling
-            # in the upstream library, see #57265.
+            # This is a stopgap solution for inconsistent set_brightness
+            # handling in the upstream library, see #57265.
             # This should be removed when the upstream has fixed the issue.
             # The device logic is to change the settings without turning it on
-            # except when transition is defined, so we leverage that here for now.
+            # except when transition is defined so we leverage that for now.
             transition = 1
 
         return brightness, transition
@@ -345,7 +346,7 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
             self._attr_hs_color = hue, saturation
 
 
-class TPLinkSmartLightStrip(TPLinkSmartBulb):
+class TPLinkLightEffectEntity(TPLinkLightEntity):
     """Representation of a TPLink Smart Light Strip."""
 
     def __init__(

--- a/homeassistant/components/tplink/number.py
+++ b/homeassistant/components/tplink/number.py
@@ -68,7 +68,7 @@ async def async_setup_entry(
         device=device,
         coordinator=parent_coordinator,
         feature_type=Feature.Type.Number,
-        entity_class=Number,
+        entity_class=TPLinkNumberEntity,
         descriptions=NUMBER_DESCRIPTIONS_MAP,
         child_coordinators=children_coordinators,
     )
@@ -76,7 +76,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class Number(CoordinatedTPLinkFeatureEntity, NumberEntity):
+class TPLinkNumberEntity(CoordinatedTPLinkFeatureEntity, NumberEntity):
     """Representation of a feature-based TPLink sensor."""
 
     entity_description: TPLinkNumberEntityDescription

--- a/homeassistant/components/tplink/select.py
+++ b/homeassistant/components/tplink/select.py
@@ -57,14 +57,14 @@ async def async_setup_entry(
         device=device,
         coordinator=parent_coordinator,
         feature_type=Feature.Type.Choice,
-        entity_class=Select,
+        entity_class=TPLinkSelectEntity,
         descriptions=SELECT_DESCRIPTIONS_MAP,
         child_coordinators=children_coordinators,
     )
     async_add_entities(entities)
 
 
-class Select(CoordinatedTPLinkFeatureEntity, SelectEntity):
+class TPLinkSelectEntity(CoordinatedTPLinkFeatureEntity, SelectEntity):
     """Representation of a tplink select entity."""
 
     entity_description: TPLinkSelectEntityDescription

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -137,14 +137,14 @@ async def async_setup_entry(
         device=device,
         coordinator=parent_coordinator,
         feature_type=Feature.Type.Sensor,
-        entity_class=Sensor,
+        entity_class=TPLinkSensorEntity,
         descriptions=SENSOR_DESCRIPTIONS_MAP,
         child_coordinators=children_coordinators,
     )
     async_add_entities(entities)
 
 
-class Sensor(CoordinatedTPLinkFeatureEntity, SensorEntity):
+class TPLinkSensorEntity(CoordinatedTPLinkFeatureEntity, SensorEntity):
     """Representation of a feature-based TPLink sensor."""
 
     entity_description: TPLinkSensorEntityDescription

--- a/tests/components/tplink/__init__.py
+++ b/tests/components/tplink/__init__.py
@@ -234,7 +234,7 @@ def _mocked_device(
         not device_type
         and device.children
         and all(
-            child.device_type == DeviceType.StripSocket for child in device.children
+            child.device_type is DeviceType.StripSocket for child in device.children
         )
     ):
         device.device_type = DeviceType.Strip

--- a/tests/components/tplink/test_binary_sensor.py
+++ b/tests/components/tplink/test_binary_sensor.py
@@ -5,7 +5,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components import tplink
-from homeassistant.components.tplink.binary_sensor import BINARYSENSOR_DESCRIPTIONS
+from homeassistant.components.tplink.binary_sensor import BINARY_SENSOR_DESCRIPTIONS
 from homeassistant.components.tplink.const import DOMAIN
 from homeassistant.components.tplink.entity import EXCLUDED_FEATURES
 from homeassistant.const import CONF_HOST, Platform
@@ -48,7 +48,7 @@ async def test_states(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test a sensor unique ids."""
-    features = {description.key for description in BINARYSENSOR_DESCRIPTIONS}
+    features = {description.key for description in BINARY_SENSOR_DESCRIPTIONS}
     features.update(EXCLUDED_FEATURES)
     device = _mocked_device(alias="my_device", features=features)
 

--- a/tests/components/tplink/test_sensor.py
+++ b/tests/components/tplink/test_sensor.py
@@ -212,21 +212,12 @@ async def test_undefined_sensor(
     assert msg in caplog.text
 
 
-@pytest.mark.parametrize(
-    ("device_type", "on_parent_device"),
-    [
-        pytest.param(Device.Type.Strip, False, id="Strip"),
-        pytest.param(Device.Type.WallSwitch, True, id="WallSwitch"),
-    ],
-)
-async def test_sensor_children(
+async def test_sensor_children_on_parent(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     device_registry: dr.DeviceRegistry,
-    device_type,
-    on_parent_device,
 ) -> None:
-    """Test a sensor unique ids."""
+    """Test a WallSwitch sensor entities are added to parent."""
     already_migrated_config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
     )
@@ -246,7 +237,7 @@ async def test_sensor_children(
         alias="my_plug",
         features=[feature],
         children=_mocked_strip_children(features=[feature]),
-        device_type=device_type,
+        device_type=Device.Type.WallSwitch,
     )
     with _patch_discovery(device=plug), _patch_connect(device=plug):
         await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
@@ -264,12 +255,57 @@ async def test_sensor_children(
         assert child_entity.unique_id == f"PLUG{plug_id}DEVICEID_consumption_this_month"
         child_device = device_registry.async_get(child_entity.device_id)
         assert child_device
-        if on_parent_device:
-            assert child_entity.device_id == entity.device_id
-            assert child_device.connections == device.connections
-        else:
-            assert child_entity.device_id != entity.device_id
-            assert child_device.via_device_id == device.id
+
+        assert child_entity.device_id == entity.device_id
+        assert child_device.connections == device.connections
+
+
+async def test_sensor_children_on_child(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test strip sensors are on child device."""
+    already_migrated_config_entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
+    )
+    already_migrated_config_entry.add_to_hass(hass)
+    feature = _mocked_feature(
+        "consumption_this_month",
+        value=5.2,
+        # integration should ignore name and use the value from strings.json:
+        # This month's consumption
+        name="Consumption for month",
+        type_=Feature.Type.Sensor,
+        category=Feature.Category.Primary,
+        unit="A",
+        precision_hint=2,
+    )
+    plug = _mocked_device(
+        alias="my_plug",
+        features=[feature],
+        children=_mocked_strip_children(features=[feature]),
+        device_type=Device.Type.Strip,
+    )
+    with _patch_discovery(device=plug), _patch_connect(device=plug):
+        await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "sensor.my_plug_this_month_s_consumption"
+    entity = entity_registry.async_get(entity_id)
+    assert entity
+    device = device_registry.async_get(entity.device_id)
+
+    for plug_id in range(2):
+        child_entity_id = f"sensor.my_plug_plug{plug_id}_this_month_s_consumption"
+        child_entity = entity_registry.async_get(child_entity_id)
+        assert child_entity
+        assert child_entity.unique_id == f"PLUG{plug_id}DEVICEID_consumption_this_month"
+        child_device = device_registry.async_get(child_entity.device_id)
+        assert child_device
+
+        assert child_entity.device_id != entity.device_id
+        assert child_device.via_device_id == device.id
 
 
 @pytest.mark.skip

--- a/tests/components/tplink/test_switch.py
+++ b/tests/components/tplink/test_switch.py
@@ -259,6 +259,30 @@ async def test_strip_unique_ids(
         )
 
 
+async def test_strip_blank_alias(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test a strip unique id."""
+    already_migrated_config_entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
+    )
+    already_migrated_config_entry.add_to_hass(hass)
+    strip = _mocked_device(
+        alias="",
+        model="KS123",
+        children=_mocked_strip_children(features=["state", "led"], alias=""),
+        features=["state", "led"],
+    )
+    with _patch_discovery(device=strip), _patch_connect(device=strip):
+        await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    for plug_id in range(2):
+        entity_id = f"switch.unnamed_ks123_stripsocket_{plug_id + 1}"
+        state = hass.states.get(entity_id)
+        assert state.name == f"Unnamed KS123 Stripsocket {plug_id + 1}"
+
+
 @pytest.mark.parametrize(
     ("exception_type", "msg", "reauth_expected"),
     [


### PR DESCRIPTION
## This PR is part of the tplink rewrite series, to be merged into `tplink_rewrite` branch (see #120060).

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Address review comments on https://github.com/home-assistant/core/pull/120060 and integrate non fan-platform related changes from https://github.com/home-assistant/core/pull/120070 relating to device naming and adding all `DeviceType.WallSwitch` entities to the parent device.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
