### PR TITLE
Adjust imports in samsungtv tests

### DIFF
--- a/tests/components/samsungtv/test_init.py
+++ b/tests/components/samsungtv/test_init.py
@@ -6,13 +6,16 @@ import pytest
 from samsungtvws.async_remote import SamsungTVWSAsyncRemote
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.media_player import DOMAIN, MediaPlayerEntityFeature
+from homeassistant.components.media_player import (
+    DOMAIN as MP_DOMAIN,
+    MediaPlayerEntityFeature,
+)
 from homeassistant.components.samsungtv.const import (
     CONF_MANUFACTURER,
     CONF_SESSION_ID,
     CONF_SSDP_MAIN_TV_AGENT_LOCATION,
     CONF_SSDP_RENDERING_CONTROL_LOCATION,
-    DOMAIN as SAMSUNGTV_DOMAIN,
+    DOMAIN,
     LEGACY_PORT,
     METHOD_LEGACY,
     METHOD_WEBSOCKET,
@@ -47,7 +50,7 @@ from .const import (
 
 from tests.common import MockConfigEntry
 
-ENTITY_ID = f"{DOMAIN}.fake_name"
+ENTITY_ID = f"{MP_DOMAIN}.fake_name"
 MOCK_CONFIG = {
     CONF_HOST: "fake_host",
     CONF_NAME: "fake_name",
@@ -71,7 +74,7 @@ async def test_setup(hass: HomeAssistant) -> None:
 
     # test host and port
     await hass.services.async_call(
-        DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
 
 
@@ -94,7 +97,7 @@ async def test_setup_without_port_device_offline(hass: HomeAssistant) -> None:
     ):
         await setup_samsungtv_entry(hass, MOCK_CONFIG)
 
-    config_entries_domain = hass.config_entries.async_entries(SAMSUNGTV_DOMAIN)
+    config_entries_domain = hass.config_entries.async_entries(DOMAIN)
     assert len(config_entries_domain) == 1
     assert config_entries_domain[0].state is ConfigEntryState.SETUP_RETRY
 
@@ -104,7 +107,7 @@ async def test_setup_without_port_device_online(hass: HomeAssistant) -> None:
     """Test import from yaml when the device is online."""
     await setup_samsungtv_entry(hass, MOCK_CONFIG)
 
-    config_entries_domain = hass.config_entries.async_entries(SAMSUNGTV_DOMAIN)
+    config_entries_domain = hass.config_entries.async_entries(DOMAIN)
     assert len(config_entries_domain) == 1
     assert config_entries_domain[0].data[CONF_MAC] == "aa:bb:aa:aa:aa:aa"
 
@@ -183,7 +186,7 @@ async def test_update_imported_legacy_without_method(hass: HomeAssistant) -> Non
         hass, {CONF_HOST: "fake_host", CONF_MANUFACTURER: "Samsung"}
     )
 
-    entries = hass.config_entries.async_entries(SAMSUNGTV_DOMAIN)
+    entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
     assert entries[0].data[CONF_METHOD] == METHOD_LEGACY
     assert entries[0].data[CONF_PORT] == LEGACY_PORT
@@ -214,7 +217,7 @@ async def test_incorrectly_formatted_mac_fixed(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        config_entries = hass.config_entries.async_entries(SAMSUNGTV_DOMAIN)
+        config_entries = hass.config_entries.async_entries(DOMAIN)
         assert len(config_entries) == 1
         assert config_entries[0].data[CONF_MAC] == "aa:bb:aa:aa:aa:aa"
 
@@ -229,7 +232,7 @@ async def test_cleanup_mac(
     Reverted due to device registry collisions in #119249 / #119082
     """
     entry = MockConfigEntry(
-        domain=SAMSUNGTV_DOMAIN,
+        domain=DOMAIN,
         data=MOCK_ENTRY_WS_WITH_MAC,
         entry_id="123456",
         unique_id="any",

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -31,7 +31,7 @@ from homeassistant.components.media_player import (
     ATTR_MEDIA_CONTENT_TYPE,
     ATTR_MEDIA_VOLUME_LEVEL,
     ATTR_MEDIA_VOLUME_MUTED,
-    DOMAIN,
+    DOMAIN as MP_DOMAIN,
     SERVICE_PLAY_MEDIA,
     SERVICE_SELECT_SOURCE,
     MediaPlayerDeviceClass,
@@ -39,7 +39,7 @@ from homeassistant.components.media_player import (
 )
 from homeassistant.components.samsungtv.const import (
     CONF_SSDP_RENDERING_CONTROL_LOCATION,
-    DOMAIN as SAMSUNGTV_DOMAIN,
+    DOMAIN,
     ENCRYPTED_WEBSOCKET_PORT,
     METHOD_ENCRYPTED_WEBSOCKET,
     METHOD_WEBSOCKET,
@@ -91,7 +91,7 @@ from .const import (
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
-ENTITY_ID = f"{DOMAIN}.fake"
+ENTITY_ID = f"{MP_DOMAIN}.fake"
 MOCK_CONFIGWS = {
     CONF_HOST: "fake_host",
     CONF_NAME: "fake",
@@ -145,7 +145,7 @@ async def test_setup_websocket(hass: HomeAssistant) -> None:
 
         await hass.async_block_till_done()
 
-        config_entries = hass.config_entries.async_entries(SAMSUNGTV_DOMAIN)
+        config_entries = hass.config_entries.async_entries(DOMAIN)
         assert len(config_entries) == 1
         assert config_entries[0].data[CONF_MAC] == "aa:bb:aa:aa:aa:aa"
 
@@ -155,16 +155,16 @@ async def test_setup_websocket_2(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory, mock_now: datetime
 ) -> None:
     """Test setup of platform from config entry."""
-    entity_id = f"{DOMAIN}.fake"
+    entity_id = f"{MP_DOMAIN}.fake"
 
     entry = MockConfigEntry(
-        domain=SAMSUNGTV_DOMAIN,
+        domain=DOMAIN,
         data=MOCK_ENTRY_WS,
         unique_id=entity_id,
     )
     entry.add_to_hass(hass)
 
-    config_entries = hass.config_entries.async_entries(SAMSUNGTV_DOMAIN)
+    config_entries = hass.config_entries.async_entries(DOMAIN)
     assert len(config_entries) == 1
     assert entry is config_entries[0]
 
@@ -549,7 +549,7 @@ async def test_send_key(hass: HomeAssistant, remote: Mock) -> None:
     """Test for send key."""
     await setup_samsungtv_entry(hass, MOCK_CONFIG)
     await hass.services.async_call(
-        DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     state = hass.states.get(ENTITY_ID)
     # key called
@@ -563,7 +563,7 @@ async def test_send_key_broken_pipe(hass: HomeAssistant, remote: Mock) -> None:
     await setup_samsungtv_entry(hass, MOCK_CONFIG)
     remote.control = Mock(side_effect=BrokenPipeError("Boom"))
     await hass.services.async_call(
-        DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     state = hass.states.get(ENTITY_ID)
     assert state.state == STATE_ON
@@ -578,7 +578,7 @@ async def test_send_key_connection_closed_retry_succeed(
         side_effect=[exceptions.ConnectionClosed("Boom"), DEFAULT_MOCK, DEFAULT_MOCK]
     )
     await hass.services.async_call(
-        DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     state = hass.states.get(ENTITY_ID)
     # key because of retry two times
@@ -595,7 +595,7 @@ async def test_send_key_unhandled_response(hass: HomeAssistant, remote: Mock) ->
     await setup_samsungtv_entry(hass, MOCK_CONFIG)
     remote.control = Mock(side_effect=exceptions.UnhandledResponse("Boom"))
     await hass.services.async_call(
-        DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     state = hass.states.get(ENTITY_ID)
     assert state.state == STATE_ON
@@ -607,7 +607,7 @@ async def test_send_key_websocketexception(hass: HomeAssistant, remotews: Mock) 
     await setup_samsungtv_entry(hass, MOCK_CONFIGWS)
     remotews.send_commands = Mock(side_effect=WebSocketException("Boom"))
     await hass.services.async_call(
-        DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     state = hass.states.get(ENTITY_ID)
     assert state.state == STATE_ON
@@ -621,7 +621,7 @@ async def test_send_key_websocketexception_encrypted(
     await setup_samsungtv_entry(hass, MOCK_ENTRYDATA_ENCRYPTED_WS)
     remoteencws.send_commands = Mock(side_effect=WebSocketException("Boom"))
     await hass.services.async_call(
-        DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     state = hass.states.get(ENTITY_ID)
     assert state.state == STATE_ON
@@ -633,7 +633,7 @@ async def test_send_key_os_error_ws(hass: HomeAssistant, remotews: Mock) -> None
     await setup_samsungtv_entry(hass, MOCK_CONFIGWS)
     remotews.send_commands = Mock(side_effect=OSError("Boom"))
     await hass.services.async_call(
-        DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     state = hass.states.get(ENTITY_ID)
     assert state.state == STATE_ON
@@ -647,7 +647,7 @@ async def test_send_key_os_error_ws_encrypted(
     await setup_samsungtv_entry(hass, MOCK_ENTRYDATA_ENCRYPTED_WS)
     remoteencws.send_commands = Mock(side_effect=OSError("Boom"))
     await hass.services.async_call(
-        DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     state = hass.states.get(ENTITY_ID)
     assert state.state == STATE_ON
@@ -658,7 +658,7 @@ async def test_send_key_os_error(hass: HomeAssistant, remote: Mock) -> None:
     await setup_samsungtv_entry(hass, MOCK_CONFIG)
     remote.control = Mock(side_effect=OSError("Boom"))
     await hass.services.async_call(
-        DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     state = hass.states.get(ENTITY_ID)
     assert state.state == STATE_ON
@@ -677,12 +677,12 @@ async def test_state(hass: HomeAssistant, freezer: FrozenDateTimeFactory) -> Non
     """Test for state property."""
     await setup_samsungtv_entry(hass, MOCK_CONFIG)
     await hass.services.async_call(
-        DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     state = hass.states.get(ENTITY_ID)
     assert state.state == STATE_ON
     await hass.services.async_call(
-        DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     state = hass.states.get(ENTITY_ID)
     # Should be STATE_UNAVAILABLE after the timer expires
@@ -733,7 +733,7 @@ async def test_turn_off_websocket(
     remotews.send_commands.reset_mock()
 
     await hass.services.async_call(
-        DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     # key called
     assert remotews.send_commands.call_count == 1
@@ -745,11 +745,11 @@ async def test_turn_off_websocket(
     # commands not sent : power off in progress
     remotews.send_commands.reset_mock()
     await hass.services.async_call(
-        DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     assert "TV is powering off, not sending keys: ['KEY_VOLUP']" in caplog.text
     await hass.services.async_call(
-        DOMAIN,
+        MP_DOMAIN,
         SERVICE_SELECT_SOURCE,
         {ATTR_ENTITY_ID: ENTITY_ID, ATTR_INPUT_SOURCE: "Deezer"},
         True,
@@ -772,7 +772,7 @@ async def test_turn_off_websocket_frame(
     remotews.send_commands.reset_mock()
 
     await hass.services.async_call(
-        DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     # key called
     assert remotews.send_commands.call_count == 1
@@ -800,7 +800,7 @@ async def test_turn_off_encrypted_websocket(
 
     caplog.clear()
     await hass.services.async_call(
-        DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     # key called
     assert remoteencws.send_commands.call_count == 1
@@ -815,7 +815,7 @@ async def test_turn_off_encrypted_websocket(
     # commands not sent : power off in progress
     remoteencws.send_commands.reset_mock()
     await hass.services.async_call(
-        DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     assert "TV is powering off, not sending keys: ['KEY_VOLUP']" in caplog.text
     remoteencws.send_commands.assert_not_called()
@@ -841,7 +841,7 @@ async def test_turn_off_encrypted_websocket_key_type(
 
     caplog.clear()
     await hass.services.async_call(
-        DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     # key called
     assert remoteencws.send_commands.call_count == 1
@@ -856,7 +856,7 @@ async def test_turn_off_legacy(hass: HomeAssistant, remote: Mock) -> None:
     """Test for turn_off."""
     await setup_samsungtv_entry(hass, MOCK_CONFIG)
     await hass.services.async_call(
-        DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     # key called
     assert remote.control.call_count == 1
@@ -871,7 +871,7 @@ async def test_turn_off_os_error(
     await setup_samsungtv_entry(hass, MOCK_CONFIG)
     remote.close = Mock(side_effect=OSError("BOOM"))
     await hass.services.async_call(
-        DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     assert "Could not establish connection" in caplog.text
 
@@ -885,7 +885,7 @@ async def test_turn_off_ws_os_error(
     await setup_samsungtv_entry(hass, MOCK_CONFIGWS)
     remotews.close = Mock(side_effect=OSError("BOOM"))
     await hass.services.async_call(
-        DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     assert "Error closing connection" in caplog.text
 
@@ -899,7 +899,7 @@ async def test_turn_off_encryptedws_os_error(
     await setup_samsungtv_entry(hass, MOCK_ENTRYDATA_ENCRYPTED_WS)
     remoteencws.close = Mock(side_effect=OSError("BOOM"))
     await hass.services.async_call(
-        DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     assert "Error closing connection" in caplog.text
 
@@ -908,7 +908,7 @@ async def test_volume_up(hass: HomeAssistant, remote: Mock) -> None:
     """Test for volume_up."""
     await setup_samsungtv_entry(hass, MOCK_CONFIG)
     await hass.services.async_call(
-        DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     # key called
     assert remote.control.call_count == 1
@@ -919,7 +919,7 @@ async def test_volume_down(hass: HomeAssistant, remote: Mock) -> None:
     """Test for volume_down."""
     await setup_samsungtv_entry(hass, MOCK_CONFIG)
     await hass.services.async_call(
-        DOMAIN, SERVICE_VOLUME_DOWN, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_VOLUME_DOWN, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     # key called
     assert remote.control.call_count == 1
@@ -930,7 +930,7 @@ async def test_mute_volume(hass: HomeAssistant, remote: Mock) -> None:
     """Test for mute_volume."""
     await setup_samsungtv_entry(hass, MOCK_CONFIG)
     await hass.services.async_call(
-        DOMAIN,
+        MP_DOMAIN,
         SERVICE_VOLUME_MUTE,
         {ATTR_ENTITY_ID: ENTITY_ID, ATTR_MEDIA_VOLUME_MUTED: True},
         True,
@@ -944,14 +944,14 @@ async def test_media_play(hass: HomeAssistant, remote: Mock) -> None:
     """Test for media_play."""
     await setup_samsungtv_entry(hass, MOCK_CONFIG)
     await hass.services.async_call(
-        DOMAIN, SERVICE_MEDIA_PLAY, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_MEDIA_PLAY, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     # key called
     assert remote.control.call_count == 1
     assert remote.control.call_args_list == [call("KEY_PLAY")]
 
     await hass.services.async_call(
-        DOMAIN, SERVICE_MEDIA_PLAY_PAUSE, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_MEDIA_PLAY_PAUSE, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     # key called
     assert remote.control.call_count == 2
@@ -962,14 +962,14 @@ async def test_media_pause(hass: HomeAssistant, remote: Mock) -> None:
     """Test for media_pause."""
     await setup_samsungtv_entry(hass, MOCK_CONFIG)
     await hass.services.async_call(
-        DOMAIN, SERVICE_MEDIA_PAUSE, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_MEDIA_PAUSE, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     # key called
     assert remote.control.call_count == 1
     assert remote.control.call_args_list == [call("KEY_PAUSE")]
 
     await hass.services.async_call(
-        DOMAIN, SERVICE_MEDIA_PLAY_PAUSE, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_MEDIA_PLAY_PAUSE, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     # key called
     assert remote.control.call_count == 2
@@ -980,7 +980,7 @@ async def test_media_next_track(hass: HomeAssistant, remote: Mock) -> None:
     """Test for media_next_track."""
     await setup_samsungtv_entry(hass, MOCK_CONFIG)
     await hass.services.async_call(
-        DOMAIN, SERVICE_MEDIA_NEXT_TRACK, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_MEDIA_NEXT_TRACK, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     # key  called
     assert remote.control.call_count == 1
@@ -991,7 +991,7 @@ async def test_media_previous_track(hass: HomeAssistant, remote: Mock) -> None:
     """Test for media_previous_track."""
     await setup_samsungtv_entry(hass, MOCK_CONFIG)
     await hass.services.async_call(
-        DOMAIN, SERVICE_MEDIA_PREVIOUS_TRACK, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_MEDIA_PREVIOUS_TRACK, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     # key called
     assert remote.control.call_count == 1
@@ -1002,7 +1002,7 @@ async def test_media_previous_track(hass: HomeAssistant, remote: Mock) -> None:
 async def test_turn_on_wol(hass: HomeAssistant) -> None:
     """Test turn on."""
     entry = MockConfigEntry(
-        domain=SAMSUNGTV_DOMAIN,
+        domain=DOMAIN,
         data=MOCK_ENTRY_WS_WITH_MAC,
         unique_id="any",
     )
@@ -1013,7 +1013,7 @@ async def test_turn_on_wol(hass: HomeAssistant) -> None:
         "homeassistant.components.samsungtv.entity.send_magic_packet"
     ) as mock_send_magic_packet:
         await hass.services.async_call(
-            DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: ENTITY_ID}, True
+            MP_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: ENTITY_ID}, True
         )
         await hass.async_block_till_done()
     assert mock_send_magic_packet.called
@@ -1024,7 +1024,7 @@ async def test_turn_on_without_turnon(hass: HomeAssistant, remote: Mock) -> None
     await setup_samsungtv_entry(hass, MOCK_CONFIG)
     with pytest.raises(HomeAssistantError, match="does not support this service"):
         await hass.services.async_call(
-            DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: ENTITY_ID}, True
+            MP_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: ENTITY_ID}, True
         )
     # nothing called as not supported feature
     assert remote.control.call_count == 0
@@ -1035,7 +1035,7 @@ async def test_play_media(hass: HomeAssistant, remote: Mock) -> None:
     await setup_samsungtv_entry(hass, MOCK_CONFIG)
     with patch("homeassistant.components.samsungtv.bridge.asyncio.sleep") as sleep:
         await hass.services.async_call(
-            DOMAIN,
+            MP_DOMAIN,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: ENTITY_ID,
@@ -1062,7 +1062,7 @@ async def test_play_media_invalid_type(hass: HomeAssistant) -> None:
         await setup_samsungtv_entry(hass, MOCK_CONFIG)
         remote.reset_mock()
         await hass.services.async_call(
-            DOMAIN,
+            MP_DOMAIN,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: ENTITY_ID,
@@ -1082,7 +1082,7 @@ async def test_play_media_channel_as_string(hass: HomeAssistant) -> None:
         await setup_samsungtv_entry(hass, MOCK_CONFIG)
         remote.reset_mock()
         await hass.services.async_call(
-            DOMAIN,
+            MP_DOMAIN,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: ENTITY_ID,
@@ -1101,7 +1101,7 @@ async def test_play_media_channel_as_non_positive(hass: HomeAssistant) -> None:
         await setup_samsungtv_entry(hass, MOCK_CONFIG)
         remote.reset_mock()
         await hass.services.async_call(
-            DOMAIN,
+            MP_DOMAIN,
             SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: ENTITY_ID,
@@ -1118,7 +1118,7 @@ async def test_select_source(hass: HomeAssistant, remote: Mock) -> None:
     """Test for select_source."""
     await setup_samsungtv_entry(hass, MOCK_CONFIG)
     await hass.services.async_call(
-        DOMAIN,
+        MP_DOMAIN,
         SERVICE_SELECT_SOURCE,
         {ATTR_ENTITY_ID: ENTITY_ID, ATTR_INPUT_SOURCE: "HDMI"},
         True,
@@ -1134,7 +1134,7 @@ async def test_select_source_invalid_source(hass: HomeAssistant) -> None:
         await setup_samsungtv_entry(hass, MOCK_CONFIG)
         remote.reset_mock()
         await hass.services.async_call(
-            DOMAIN,
+            MP_DOMAIN,
             SERVICE_SELECT_SOURCE,
             {ATTR_ENTITY_ID: ENTITY_ID, ATTR_INPUT_SOURCE: "INVALID"},
             True,
@@ -1150,7 +1150,7 @@ async def test_play_media_app(hass: HomeAssistant, remotews: Mock) -> None:
     remotews.send_commands.reset_mock()
 
     await hass.services.async_call(
-        DOMAIN,
+        MP_DOMAIN,
         SERVICE_PLAY_MEDIA,
         {
             ATTR_ENTITY_ID: ENTITY_ID,
@@ -1174,7 +1174,7 @@ async def test_select_source_app(hass: HomeAssistant, remotews: Mock) -> None:
     remotews.send_commands.reset_mock()
 
     await hass.services.async_call(
-        DOMAIN,
+        MP_DOMAIN,
         SERVICE_SELECT_SOURCE,
         {ATTR_ENTITY_ID: ENTITY_ID, ATTR_INPUT_SOURCE: "Deezer"},
         True,
@@ -1199,7 +1199,7 @@ async def test_websocket_unsupported_remote_control(
     remotews.send_commands.reset_mock()
 
     await hass.services.async_call(
-        DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
+        MP_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
     )
     remotews.raise_mock_ws_event_callback(
         "ms.error",
@@ -1248,7 +1248,7 @@ async def test_volume_control_upnp(
 
     # Upnp action succeeds
     await hass.services.async_call(
-        DOMAIN,
+        MP_DOMAIN,
         SERVICE_VOLUME_SET,
         {ATTR_ENTITY_ID: ENTITY_ID, ATTR_MEDIA_VOLUME_LEVEL: 0.5},
         True,
@@ -1262,7 +1262,7 @@ async def test_volume_control_upnp(
         status=500, error_code=501, error_desc="Action Failed"
     )
     await hass.services.async_call(
-        DOMAIN,
+        MP_DOMAIN,
         SERVICE_VOLUME_SET,
         {ATTR_ENTITY_ID: ENTITY_ID, ATTR_MEDIA_VOLUME_LEVEL: 0.6},
         True,
@@ -1281,7 +1281,7 @@ async def test_upnp_not_available(
 
     # Upnp action fails
     await hass.services.async_call(
-        DOMAIN,
+        MP_DOMAIN,
         SERVICE_VOLUME_SET,
         {ATTR_ENTITY_ID: ENTITY_ID, ATTR_MEDIA_VOLUME_LEVEL: 0.6},
         True,
@@ -1299,7 +1299,7 @@ async def test_upnp_missing_service(
 
     # Upnp action fails
     await hass.services.async_call(
-        DOMAIN,
+        MP_DOMAIN,
         SERVICE_VOLUME_SET,
         {ATTR_ENTITY_ID: ENTITY_ID, ATTR_MEDIA_VOLUME_LEVEL: 0.6},
         True,

--- a/tests/components/samsungtv/test_remote.py
+++ b/tests/components/samsungtv/test_remote.py
@@ -10,7 +10,7 @@ from homeassistant.components.remote import (
     DOMAIN as REMOTE_DOMAIN,
     SERVICE_SEND_COMMAND,
 )
-from homeassistant.components.samsungtv.const import DOMAIN as SAMSUNGTV_DOMAIN
+from homeassistant.components.samsungtv.const import DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -102,7 +102,7 @@ async def test_send_command_service(hass: HomeAssistant, remoteencws: Mock) -> N
 async def test_turn_on_wol(hass: HomeAssistant) -> None:
     """Test turn on."""
     entry = MockConfigEntry(
-        domain=SAMSUNGTV_DOMAIN,
+        domain=DOMAIN,
         data=MOCK_ENTRY_WS_WITH_MAC,
         unique_id="any",
     )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, make sure that DOMAIN refers to the SamsungTV domain, and other domains are renamed on import.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
