### PR TITLE
Improve Matter Server version incompatibility handling

### DIFF
--- a/homeassistant/components/matter/manifest.json
+++ b/homeassistant/components/matter/manifest.json
@@ -6,6 +6,6 @@
   "dependencies": ["websocket_api"],
   "documentation": "https://www.home-assistant.io/integrations/matter",
   "iot_class": "local_push",
-  "requirements": ["python-matter-server==6.1.0"],
+  "requirements": ["python-matter-server==6.2.0b1"],
   "zeroconf": ["_matter._tcp.local.", "_matterc._udp.local."]
 }

--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -157,6 +157,16 @@
       }
     }
   },
+  "issues": {
+    "server_version_version_too_old": {
+      "description": "The version of the Matter Server you are currently running is too old for this version of Home Assistant. Please update the Matter Server to the latest version to fix this issue.",
+      "title": "Newer version of Matter Server needed"
+    },
+    "server_version_version_too_new": {
+      "description": "The version of the Matter Server you are currently running is too new for this version of Home Assistant. Please update Home Assistant or downgrade the Matter Server to an older version to fix this issue.",
+      "title": "Older version of Matter Server needed"
+    }
+  },
   "services": {
     "open_commissioning_window": {
       "name": "Open commissioning window",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2284,7 +2284,7 @@ python-kasa[speedups]==0.6.2.1
 # python-lirc==1.2.3
 
 # homeassistant.components.matter
-python-matter-server==6.1.0
+python-matter-server==6.2.0b1
 
 # homeassistant.components.xiaomi_miio
 python-miio==0.5.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1781,7 +1781,7 @@ python-juicenet==1.1.0
 python-kasa[speedups]==0.6.2.1
 
 # homeassistant.components.matter
-python-matter-server==6.1.0
+python-matter-server==6.2.0b1
 
 # homeassistant.components.xiaomi_miio
 python-miio==0.5.12

--- a/tests/components/matter/test_init.py
+++ b/tests/components/matter/test_init.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
-from matter_server.client.exceptions import CannotConnect, InvalidServerVersion
+from matter_server.client.exceptions import (
+    CannotConnect,
+    ServerVersionTooNew,
+    ServerVersionTooOld,
+)
 from matter_server.client.models.node import MatterNode
 from matter_server.common.errors import MatterError
 from matter_server.common.helpers.util import dataclass_from_dict
@@ -362,12 +366,30 @@ async def test_addon_info_failure(
         "backup_calls",
         "update_addon_side_effect",
         "create_backup_side_effect",
+        "connect_side_effect",
     ),
     [
-        ("1.0.0", True, 1, 1, None, None),
-        ("1.0.0", False, 0, 0, None, None),
-        ("1.0.0", True, 1, 1, HassioAPIError("Boom"), None),
-        ("1.0.0", True, 0, 1, None, HassioAPIError("Boom")),
+        ("1.0.0", True, 1, 1, None, None, ServerVersionTooOld("Invalid version")),
+        ("1.0.0", True, 0, 0, None, None, ServerVersionTooNew("Invalid version")),
+        ("1.0.0", False, 0, 0, None, None, ServerVersionTooOld("Invalid version")),
+        (
+            "1.0.0",
+            True,
+            1,
+            1,
+            HassioAPIError("Boom"),
+            None,
+            ServerVersionTooOld("Invalid version"),
+        ),
+        (
+            "1.0.0",
+            True,
+            0,
+            1,
+            None,
+            HassioAPIError("Boom"),
+            ServerVersionTooOld("Invalid version"),
+        ),
     ],
 )
 async def test_update_addon(
@@ -386,13 +408,14 @@ async def test_update_addon(
     backup_calls: int,
     update_addon_side_effect: Exception | None,
     create_backup_side_effect: Exception | None,
+    connect_side_effect: Exception,
 ) -> None:
     """Test update the Matter add-on during entry setup."""
     addon_info.return_value["version"] = addon_version
     addon_info.return_value["update_available"] = update_available
     create_backup.side_effect = create_backup_side_effect
     update_addon.side_effect = update_addon_side_effect
-    matter_client.connect.side_effect = InvalidServerVersion("Invalid version")
+    matter_client.connect.side_effect = connect_side_effect
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="Matter",
@@ -412,13 +435,35 @@ async def test_update_addon(
 
 
 # This tests needs to be adjusted to remove lingering tasks
-@pytest.mark.parametrize("expected_lingering_tasks", [True])
+@pytest.mark.parametrize(
+    (
+        "expected_lingering_tasks",
+        "connect_side_effect",
+        "issue_raised",
+    ),
+    [
+        (
+            True,
+            ServerVersionTooOld("Invalid version"),
+            "server_version_version_too_old",
+        ),
+        (
+            True,
+            ServerVersionTooNew("Invalid version"),
+            "server_version_version_too_new",
+        ),
+    ],
+)
 async def test_issue_registry_invalid_version(
-    hass: HomeAssistant, matter_client: MagicMock, issue_registry: ir.IssueRegistry
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    issue_registry: ir.IssueRegistry,
+    connect_side_effect: Exception,
+    issue_raised: str,
 ) -> None:
     """Test issue registry for invalid version."""
     original_connect_side_effect = matter_client.connect.side_effect
-    matter_client.connect.side_effect = InvalidServerVersion("Invalid version")
+    matter_client.connect.side_effect = connect_side_effect
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="Matter",
@@ -434,7 +479,7 @@ async def test_issue_registry_invalid_version(
 
     entry_state = entry.state
     assert entry_state is ConfigEntryState.SETUP_RETRY
-    assert issue_registry.async_get_issue(DOMAIN, "invalid_server_version")
+    assert issue_registry.async_get_issue(DOMAIN, issue_raised)
 
     matter_client.connect.side_effect = original_connect_side_effect
 
@@ -442,7 +487,7 @@ async def test_issue_registry_invalid_version(
     await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.LOADED
-    assert not issue_registry.async_get_issue(DOMAIN, "invalid_server_version")
+    assert not issue_registry.async_get_issue(DOMAIN, issue_raised)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/matter/test_init.py
+++ b/tests/components/matter/test_init.py
@@ -435,20 +435,18 @@ async def test_update_addon(
 
 
 # This tests needs to be adjusted to remove lingering tasks
+@pytest.mark.parametrize("expected_lingering_tasks", [True])
 @pytest.mark.parametrize(
     (
-        "expected_lingering_tasks",
         "connect_side_effect",
         "issue_raised",
     ),
     [
         (
-            True,
             ServerVersionTooOld("Invalid version"),
             "server_version_version_too_old",
         ),
         (
-            True,
             ServerVersionTooNew("Invalid version"),
             "server_version_version_too_new",
         ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve the handling of Matter Server version. Noteably fix the issues raised (add strings for the issue) and split the version check into two cases: One if the server is too old and one if the server is too new.

Depends on https://github.com/home-assistant-libs/python-matter-server/pull/772.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
