### PR TITLE
Fix issue where an MQTT device is removed linked to two config entries

### DIFF
--- a/homeassistant/components/mqtt/debug_info.py
+++ b/homeassistant/components/mqtt/debug_info.py
@@ -138,7 +138,9 @@ def remove_trigger_discovery_data(
     hass: HomeAssistant, discovery_hash: tuple[str, str]
 ) -> None:
     """Remove discovery data."""
-    del hass.data[DATA_MQTT].debug_info_triggers[discovery_hash]
+    debug_info_triggers = hass.data[DATA_MQTT].debug_info_triggers
+    if discovery_hash in debug_info_triggers:
+        del debug_info_triggers[discovery_hash]
 
 
 def _info_for_entity(hass: HomeAssistant, entity_id: str) -> dict[str, Any]:

--- a/homeassistant/components/mqtt/debug_info.py
+++ b/homeassistant/components/mqtt/debug_info.py
@@ -138,9 +138,7 @@ def remove_trigger_discovery_data(
     hass: HomeAssistant, discovery_hash: tuple[str, str]
 ) -> None:
     """Remove discovery data."""
-    debug_info_triggers = hass.data[DATA_MQTT].debug_info_triggers
-    if discovery_hash in debug_info_triggers:
-        del debug_info_triggers[discovery_hash]
+    hass.data[DATA_MQTT].debug_info_triggers.pop(discovery_hash, None)
 
 
 def _info_for_entity(hass: HomeAssistant, entity_id: str) -> dict[str, Any]:

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -73,7 +73,9 @@ class MQTTDiscoveryPayload(dict[str, Any]):
 
 def clear_discovery_hash(hass: HomeAssistant, discovery_hash: tuple[str, str]) -> None:
     """Clear entry from already discovered list."""
-    hass.data[DATA_MQTT].discovery_already_discovered.remove(discovery_hash)
+    already_discovered = hass.data[DATA_MQTT].discovery_already_discovered
+    if discovery_hash in already_discovered:
+        already_discovered.remove(discovery_hash)
 
 
 def set_discovery_hash(hass: HomeAssistant, discovery_hash: tuple[str, str]) -> None:

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -73,9 +73,7 @@ class MQTTDiscoveryPayload(dict[str, Any]):
 
 def clear_discovery_hash(hass: HomeAssistant, discovery_hash: tuple[str, str]) -> None:
     """Clear entry from already discovered list."""
-    already_discovered = hass.data[DATA_MQTT].discovery_already_discovered
-    if discovery_hash in already_discovered:
-        already_discovered.remove(discovery_hash)
+    hass.data[DATA_MQTT].discovery_already_discovered.discard(discovery_hash)
 
 
 def set_discovery_hash(hass: HomeAssistant, discovery_hash: tuple[str, str]) -> None:

--- a/homeassistant/components/mqtt/tag.py
+++ b/homeassistant/components/mqtt/tag.py
@@ -180,5 +180,6 @@ class MQTTTagScanner(MqttDiscoveryDeviceUpdateMixin):
         self._sub_state = subscription.async_unsubscribe_topics(
             self.hass, self._sub_state
         )
-        if self.device_id:
-            del self.hass.data[DATA_MQTT].tags[self.device_id][discovery_id]
+        tags = self.hass.data[DATA_MQTT].tags
+        if self.device_id in tags and discovery_id in tags[self.device_id]:
+            del tags[self.device_id][discovery_id]

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -823,7 +823,7 @@ async def test_duplicate_removal(
     assert "Component has already been discovered: binary_sensor bla" not in caplog.text
 
 
-async def test_cleanup_device(
+async def test_cleanup_device_manual(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     device_registry: dr.DeviceRegistry,
@@ -1026,6 +1026,7 @@ async def test_cleanup_device_multiple_config_entries(
 
 async def test_cleanup_device_multiple_config_entries_mqtt(
     hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     mqtt_mock_entry: MqttMockHAClientGenerator,
@@ -1107,6 +1108,7 @@ async def test_cleanup_device_multiple_config_entries_mqtt(
 
     # Verify retained discovery topics have not been cleared again
     mqtt_mock.async_publish.assert_not_called()
+    assert "KeyError:" not in caplog.text
 
 
 async def test_discovery_expansion(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
pytest tests/components/mqtt/test_discovery.py -k "test_cleanup_device_multiple_config_entries_mqtt" -vvvs

shows

```
ERROR:homeassistant.config_entries:Error unloading entry MQTT for mqtt
Traceback (most recent call last):
  File "/workspaces/core/homeassistant/config_entries.py", line 807, in async_unload
    await self._async_process_on_unload(hass)
  File "/workspaces/core/homeassistant/config_entries.py", line 972, in _async_process_on_unload
    if job := self._on_unload.pop()():
              ^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/components/mqtt/mixins.py", line 707, in _entry_unload
    stop_discovery_updates(
  File "/workspaces/core/homeassistant/components/mqtt/mixins.py", line 639, in stop_discovery_updates
    clear_discovery_hash(hass, discovery_hash)
  File "/workspaces/core/homeassistant/components/mqtt/discovery.py", line 76, in clear_discovery_hash
    hass.data[DATA_MQTT].discovery_already_discovered.remove(discovery_hash)
KeyError: ('device_automation', 'bla')
```

and if this is fixed:

```
ERROR:homeassistant.config_entries:Error unloading entry MQTT for mqtt
Traceback (most recent call last):
  File "/workspaces/core/homeassistant/config_entries.py", line 807, in async_unload
    await self._async_process_on_unload(hass)
  File "/workspaces/core/homeassistant/config_entries.py", line 972, in _async_process_on_unload
    if job := self._on_unload.pop()():
              ^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/components/mqtt/mixins.py", line 707, in _entry_unload
    stop_discovery_updates(
  File "/workspaces/core/homeassistant/components/mqtt/mixins.py", line 639, in stop_discovery_updates
    clear_discovery_hash(hass, discovery_hash)
  File "/workspaces/core/homeassistant/components/mqtt/discovery.py", line 76, in clear_discovery_hash
    hass.data[DATA_MQTT].discovery_already_discovered.remove(discovery_hash)
KeyError: ('device_automation', 'bla')
```

and

```
  File "/workspaces/core/homeassistant/components/mqtt/device_trigger.py", line 286, in async_tear_down
    debug_info.remove_trigger_discovery_data(self.hass, discovery_hash)
  File "/workspaces/core/homeassistant/components/mqtt/debug_info.py", line 141, in remove_trigger_discovery_data
    del hass.data[DATA_MQTT].debug_info_triggers[discovery_hash]
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
```

This indicates the cleanup is triggered twice, causing a `KeyError`. This PR fixes that.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
