### PR TITLE
Allow timer management from any device

### DIFF
--- a/homeassistant/components/intent/timers.py
+++ b/homeassistant/components/intent/timers.py
@@ -490,7 +490,7 @@ class FindTimerFilter(StrEnum):
 
 def _find_timer(
     hass: HomeAssistant,
-    device_id: str,
+    device_id: str | None,
     slots: dict[str, Any],
     find_filter: FindTimerFilter | None = None,
 ) -> TimerInfo:
@@ -577,7 +577,7 @@ def _find_timer(
         return matching_timers[0]
 
     # Use device id
-    if matching_timers:
+    if matching_timers and device_id:
         matching_device_timers = [
             t for t in matching_timers if (t.device_id == device_id)
         ]
@@ -626,7 +626,7 @@ def _find_timer(
 
 
 def _find_timers(
-    hass: HomeAssistant, device_id: str, slots: dict[str, Any]
+    hass: HomeAssistant, device_id: str | None, slots: dict[str, Any]
 ) -> list[TimerInfo]:
     """Match multiple timers with constraints or raise an error."""
     timer_manager: TimerManager = hass.data[TIMER_DATA]
@@ -688,6 +688,10 @@ def _find_timers(
         if not matching_timers:
             # No matches
             return matching_timers
+
+    if not device_id:
+        # Can't order using area/floor
+        return matching_timers
 
     # Use device id to order remaining timers
     device_registry = dr.async_get(hass)
@@ -861,12 +865,6 @@ class CancelTimerIntentHandler(intent.IntentHandler):
         timer_manager: TimerManager = hass.data[TIMER_DATA]
         slots = self.async_validate_slots(intent_obj.slots)
 
-        if not (
-            intent_obj.device_id and timer_manager.is_timer_device(intent_obj.device_id)
-        ):
-            # Fail early
-            raise TimersNotSupportedError(intent_obj.device_id)
-
         timer = _find_timer(hass, intent_obj.device_id, slots)
         timer_manager.cancel_timer(timer.id)
         return intent_obj.create_response()
@@ -889,12 +887,6 @@ class IncreaseTimerIntentHandler(intent.IntentHandler):
         hass = intent_obj.hass
         timer_manager: TimerManager = hass.data[TIMER_DATA]
         slots = self.async_validate_slots(intent_obj.slots)
-
-        if not (
-            intent_obj.device_id and timer_manager.is_timer_device(intent_obj.device_id)
-        ):
-            # Fail early
-            raise TimersNotSupportedError(intent_obj.device_id)
 
         total_seconds = _get_total_seconds(slots)
         timer = _find_timer(hass, intent_obj.device_id, slots)
@@ -920,12 +912,6 @@ class DecreaseTimerIntentHandler(intent.IntentHandler):
         timer_manager: TimerManager = hass.data[TIMER_DATA]
         slots = self.async_validate_slots(intent_obj.slots)
 
-        if not (
-            intent_obj.device_id and timer_manager.is_timer_device(intent_obj.device_id)
-        ):
-            # Fail early
-            raise TimersNotSupportedError(intent_obj.device_id)
-
         total_seconds = _get_total_seconds(slots)
         timer = _find_timer(hass, intent_obj.device_id, slots)
         timer_manager.remove_time(timer.id, total_seconds)
@@ -948,12 +934,6 @@ class PauseTimerIntentHandler(intent.IntentHandler):
         hass = intent_obj.hass
         timer_manager: TimerManager = hass.data[TIMER_DATA]
         slots = self.async_validate_slots(intent_obj.slots)
-
-        if not (
-            intent_obj.device_id and timer_manager.is_timer_device(intent_obj.device_id)
-        ):
-            # Fail early
-            raise TimersNotSupportedError(intent_obj.device_id)
 
         timer = _find_timer(
             hass, intent_obj.device_id, slots, find_filter=FindTimerFilter.ONLY_ACTIVE
@@ -979,12 +959,6 @@ class UnpauseTimerIntentHandler(intent.IntentHandler):
         timer_manager: TimerManager = hass.data[TIMER_DATA]
         slots = self.async_validate_slots(intent_obj.slots)
 
-        if not (
-            intent_obj.device_id and timer_manager.is_timer_device(intent_obj.device_id)
-        ):
-            # Fail early
-            raise TimersNotSupportedError(intent_obj.device_id)
-
         timer = _find_timer(
             hass, intent_obj.device_id, slots, find_filter=FindTimerFilter.ONLY_INACTIVE
         )
@@ -1006,14 +980,7 @@ class TimerStatusIntentHandler(intent.IntentHandler):
     async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         """Handle the intent."""
         hass = intent_obj.hass
-        timer_manager: TimerManager = hass.data[TIMER_DATA]
         slots = self.async_validate_slots(intent_obj.slots)
-
-        if not (
-            intent_obj.device_id and timer_manager.is_timer_device(intent_obj.device_id)
-        ):
-            # Fail early
-            raise TimersNotSupportedError(intent_obj.device_id)
 
         statuses: list[dict[str, Any]] = []
         for timer in _find_timers(hass, intent_obj.device_id, slots):

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -355,7 +355,7 @@ class AssistAPI(API):
         if not llm_context.device_id or not async_device_supports_timers(
             self.hass, llm_context.device_id
         ):
-            prompt.append("This device does not support timers.")
+            prompt.append("This device is not able to start timers.")
 
         if exposed_entities:
             prompt.append(

--- a/tests/components/intent/test_timers.py
+++ b/tests/components/intent/test_timers.py
@@ -64,6 +64,7 @@ async def test_start_finish_timer(hass: HomeAssistant, init_components) -> None:
 
     async_register_timer_handler(hass, device_id, handle_timer)
 
+    # A device that has been registered to handle timers is required
     result = await intent.async_handle(
         hass,
         "test",
@@ -185,6 +186,27 @@ async def test_cancel_timer(hass: HomeAssistant, init_components) -> None:
     async with asyncio.timeout(1):
         await cancelled_event.wait()
 
+    # Cancel without a device
+    timer_name = None
+    started_event.clear()
+    result = await intent.async_handle(
+        hass,
+        "test",
+        intent.INTENT_START_TIMER,
+        {
+            "hours": {"value": 1},
+            "minutes": {"value": 2},
+            "seconds": {"value": 3},
+        },
+        device_id=device_id,
+    )
+
+    async with asyncio.timeout(1):
+        await started_event.wait()
+
+    result = await intent.async_handle(hass, "test", intent.INTENT_CANCEL_TIMER, {})
+    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+
 
 async def test_increase_timer(hass: HomeAssistant, init_components) -> None:
     """Test increasing the time of a running timer."""
@@ -260,7 +282,6 @@ async def test_increase_timer(hass: HomeAssistant, init_components) -> None:
             "minutes": {"value": 0},
             "seconds": {"value": 0},
         },
-        device_id=device_id,
     )
 
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
@@ -279,7 +300,6 @@ async def test_increase_timer(hass: HomeAssistant, init_components) -> None:
             "minutes": {"value": 5},
             "seconds": {"value": 30},
         },
-        device_id=device_id,
     )
 
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
@@ -293,7 +313,6 @@ async def test_increase_timer(hass: HomeAssistant, init_components) -> None:
         "test",
         intent.INTENT_CANCEL_TIMER,
         {"name": {"value": timer_name}},
-        device_id=device_id,
     )
 
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
@@ -375,7 +394,6 @@ async def test_decrease_timer(hass: HomeAssistant, init_components) -> None:
             "start_seconds": {"value": 3},
             "seconds": {"value": 30},
         },
-        device_id=device_id,
     )
 
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
@@ -389,7 +407,6 @@ async def test_decrease_timer(hass: HomeAssistant, init_components) -> None:
         "test",
         intent.INTENT_CANCEL_TIMER,
         {"name": {"value": timer_name}},
-        device_id=device_id,
     )
 
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
@@ -467,7 +484,6 @@ async def test_decrease_timer_below_zero(hass: HomeAssistant, init_components) -
             "start_seconds": {"value": 3},
             "seconds": {"value": original_total_seconds + 1},
         },
-        device_id=device_id,
     )
 
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
@@ -482,43 +498,25 @@ async def test_find_timer_failed(hass: HomeAssistant, init_components) -> None:
     """Test finding a timer with the wrong info."""
     device_id = "test_device"
 
-    for intent_name in (
-        intent.INTENT_START_TIMER,
-        intent.INTENT_CANCEL_TIMER,
-        intent.INTENT_PAUSE_TIMER,
-        intent.INTENT_UNPAUSE_TIMER,
-        intent.INTENT_INCREASE_TIMER,
-        intent.INTENT_DECREASE_TIMER,
-        intent.INTENT_TIMER_STATUS,
-    ):
-        if intent_name in (
+    # No device id
+    with pytest.raises(TimersNotSupportedError):
+        await intent.async_handle(
+            hass,
+            "test",
             intent.INTENT_START_TIMER,
-            intent.INTENT_INCREASE_TIMER,
-            intent.INTENT_DECREASE_TIMER,
-        ):
-            slots = {"minutes": {"value": 5}}
-        else:
-            slots = {}
+            {"minutes": {"value": 5}},
+            device_id=None,
+        )
 
-        # No device id
-        with pytest.raises(TimersNotSupportedError):
-            await intent.async_handle(
-                hass,
-                "test",
-                intent_name,
-                slots,
-                device_id=None,
-            )
-
-        # Unregistered device
-        with pytest.raises(TimersNotSupportedError):
-            await intent.async_handle(
-                hass,
-                "test",
-                intent_name,
-                slots,
-                device_id=device_id,
-            )
+    # Unregistered device
+    with pytest.raises(TimersNotSupportedError):
+        await intent.async_handle(
+            hass,
+            "test",
+            intent.INTENT_START_TIMER,
+            {"minutes": {"value": 5}},
+            device_id=device_id,
+        )
 
     # Must register a handler before we can do anything with timers
     @callback
@@ -543,7 +541,6 @@ async def test_find_timer_failed(hass: HomeAssistant, init_components) -> None:
         "test",
         intent.INTENT_INCREASE_TIMER,
         {"name": {"value": "PIZZA "}, "minutes": {"value": 1}},
-        device_id=device_id,
     )
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
 
@@ -554,7 +551,6 @@ async def test_find_timer_failed(hass: HomeAssistant, init_components) -> None:
             "test",
             intent.INTENT_CANCEL_TIMER,
             {"name": {"value": "does-not-exist"}},
-            device_id=device_id,
         )
 
     # Right start time
@@ -563,7 +559,6 @@ async def test_find_timer_failed(hass: HomeAssistant, init_components) -> None:
         "test",
         intent.INTENT_INCREASE_TIMER,
         {"start_minutes": {"value": 5}, "minutes": {"value": 1}},
-        device_id=device_id,
     )
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
 
@@ -574,7 +569,6 @@ async def test_find_timer_failed(hass: HomeAssistant, init_components) -> None:
             "test",
             intent.INTENT_CANCEL_TIMER,
             {"start_minutes": {"value": 1}},
-            device_id=device_id,
         )
 
 
@@ -903,9 +897,7 @@ async def test_pause_unpause_timer(hass: HomeAssistant, init_components) -> None
 
     # Pause the timer
     expected_active = False
-    result = await intent.async_handle(
-        hass, "test", intent.INTENT_PAUSE_TIMER, {}, device_id=device_id
-    )
+    result = await intent.async_handle(hass, "test", intent.INTENT_PAUSE_TIMER, {})
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
@@ -913,16 +905,12 @@ async def test_pause_unpause_timer(hass: HomeAssistant, init_components) -> None
 
     # Pausing again will fail because there are no running timers
     with pytest.raises(TimerNotFoundError):
-        await intent.async_handle(
-            hass, "test", intent.INTENT_PAUSE_TIMER, {}, device_id=device_id
-        )
+        await intent.async_handle(hass, "test", intent.INTENT_PAUSE_TIMER, {})
 
     # Unpause the timer
     updated_event.clear()
     expected_active = True
-    result = await intent.async_handle(
-        hass, "test", intent.INTENT_UNPAUSE_TIMER, {}, device_id=device_id
-    )
+    result = await intent.async_handle(hass, "test", intent.INTENT_UNPAUSE_TIMER, {})
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
 
     async with asyncio.timeout(1):
@@ -930,9 +918,7 @@ async def test_pause_unpause_timer(hass: HomeAssistant, init_components) -> None
 
     # Unpausing again will fail because there are no paused timers
     with pytest.raises(TimerNotFoundError):
-        await intent.async_handle(
-            hass, "test", intent.INTENT_UNPAUSE_TIMER, {}, device_id=device_id
-        )
+        await intent.async_handle(hass, "test", intent.INTENT_UNPAUSE_TIMER, {})
 
 
 async def test_timer_not_found(hass: HomeAssistant) -> None:
@@ -1101,13 +1087,14 @@ async def test_timer_status_with_names(hass: HomeAssistant, init_components) -> 
         await started_event.wait()
 
     # No constraints returns all timers
-    result = await intent.async_handle(
-        hass, "test", intent.INTENT_TIMER_STATUS, {}, device_id=device_id
-    )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
-    timers = result.speech_slots.get("timers", [])
-    assert len(timers) == 4
-    assert {t.get(ATTR_NAME) for t in timers} == {"pizza", "cookies", "chicken"}
+    for handle_device_id in (device_id, None):
+        result = await intent.async_handle(
+            hass, "test", intent.INTENT_TIMER_STATUS, {}, device_id=handle_device_id
+        )
+        assert result.response_type == intent.IntentResponseType.ACTION_DONE
+        timers = result.speech_slots.get("timers", [])
+        assert len(timers) == 4
+        assert {t.get(ATTR_NAME) for t in timers} == {"pizza", "cookies", "chicken"}
 
     # Get status of cookie timer
     result = await intent.async_handle(

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -578,7 +578,7 @@ async def test_assist_api_prompt(
         "(what comes before the dot in its entity id). "
         "When controlling an area, prefer passing just area name and domain."
     )
-    no_timer_prompt = "This device does not support timers."
+    no_timer_prompt = "This device is not able to start timers."
 
     area_prompt = (
         "When a user asks to turn on all devices of a specific type, "


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Timers can only be started from devices that support them, but the timer management commands (cancel, pause, etc.) were also restricted to those devices.
This PR allows all timer management commands to be executed from any device, including the web UI.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
