### PR TITLE
Handle http connection errors to Prusa printers

### DIFF
--- a/homeassistant/components/prusalink/coordinator.py
+++ b/homeassistant/components/prusalink/coordinator.py
@@ -9,6 +9,7 @@ import logging
 from time import monotonic
 from typing import TypeVar
 
+from httpx import ConnectError
 from pyprusalink import JobInfo, LegacyPrinterStatus, PrinterStatus, PrusaLink
 from pyprusalink.types import InvalidAuth, PrusaLinkError
 
@@ -47,6 +48,8 @@ class PrusaLinkUpdateCoordinator(DataUpdateCoordinator[T], ABC):
             raise UpdateFailed("Invalid authentication") from None
         except PrusaLinkError as err:
             raise UpdateFailed(str(err)) from err
+        except (TimeoutError, ConnectError) as err:
+            raise UpdateFailed("Cannot connect") from err
 
         self.update_interval = self._get_update_interval(data)
         return data

--- a/tests/components/prusalink/test_init.py
+++ b/tests/components/prusalink/test_init.py
@@ -3,6 +3,7 @@
 from datetime import timedelta
 from unittest.mock import patch
 
+from httpx import ConnectError
 from pyprusalink.types import InvalidAuth, PrusaLinkError
 import pytest
 
@@ -36,7 +37,7 @@ async def test_unloading(
         assert state.state == "unavailable"
 
 
-@pytest.mark.parametrize("exception", [InvalidAuth, PrusaLinkError])
+@pytest.mark.parametrize("exception", [InvalidAuth, PrusaLinkError, ConnectError])
 async def test_failed_update(
     hass: HomeAssistant, mock_config_entry: ConfigEntry, exception
 ) -> None:

--- a/tests/components/prusalink/test_init.py
+++ b/tests/components/prusalink/test_init.py
@@ -37,7 +37,10 @@ async def test_unloading(
         assert state.state == "unavailable"
 
 
-@pytest.mark.parametrize("exception", [InvalidAuth, PrusaLinkError, ConnectError])
+@pytest.mark.parametrize(
+    "exception",
+    [InvalidAuth, PrusaLinkError, ConnectError("All connection attempts failed")],
+)
 async def test_failed_update(
     hass: HomeAssistant, mock_config_entry: ConfigEntry, exception
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Handle the httpx.ConnectError exception that is raised when the connection to the printer fails. This is typically the case when the printer is offline.

As discussed in https://github.com/home-assistant-libs/pyprusalink/pull/94 this adds the error handling in Home Assistant Core.

Fixes: #116218

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
