### PR TITLE
Align deviceinfo entries in pyLoad integration

### DIFF
--- a/homeassistant/components/pyload/button.py
+++ b/homeassistant/components/pyload/button.py
@@ -99,7 +99,7 @@ class PyLoadBinarySensor(CoordinatorEntity[PyLoadCoordinator], ButtonEntity):
             model=SERVICE_NAME,
             configuration_url=coordinator.pyload.api_url,
             identifiers={(DOMAIN, coordinator.config_entry.entry_id)},
-            translation_key=DOMAIN,
+            sw_version=coordinator.version,
         )
 
     async def async_press(self) -> None:

--- a/homeassistant/components/pyload/sensor.py
+++ b/homeassistant/components/pyload/sensor.py
@@ -34,7 +34,15 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, StateTyp
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import PyLoadConfigEntry
-from .const import DEFAULT_HOST, DEFAULT_NAME, DEFAULT_PORT, DOMAIN, ISSUE_PLACEHOLDER
+from .const import (
+    DEFAULT_HOST,
+    DEFAULT_NAME,
+    DEFAULT_PORT,
+    DOMAIN,
+    ISSUE_PLACEHOLDER,
+    MANUFACTURER,
+    SERVICE_NAME,
+)
 from .coordinator import PyLoadCoordinator
 
 
@@ -175,8 +183,8 @@ class PyLoadSensor(CoordinatorEntity[PyLoadCoordinator], SensorEntity):
         self.entity_description = entity_description
         self.device_info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,
-            manufacturer="PyLoad Team",
-            model="pyLoad",
+            manufacturer=MANUFACTURER,
+            model=SERVICE_NAME,
             configuration_url=coordinator.pyload.api_url,
             identifiers={(DOMAIN, coordinator.config_entry.entry_id)},
             sw_version=coordinator.version,

--- a/tests/components/pyload/snapshots/test_button.ambr
+++ b/tests/components/pyload/snapshots/test_button.ambr
@@ -35,7 +35,7 @@
 # name: test_state[button.pyload_abort_all_running_downloads-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'pyload Abort all running downloads',
+      'friendly_name': 'pyLoad Abort all running downloads',
     }),
     'context': <ANY>,
     'entity_id': 'button.pyload_abort_all_running_downloads',
@@ -81,7 +81,7 @@
 # name: test_state[button.pyload_delete_finished_files_packages-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'pyload Delete finished files/packages',
+      'friendly_name': 'pyLoad Delete finished files/packages',
     }),
     'context': <ANY>,
     'entity_id': 'button.pyload_delete_finished_files_packages',
@@ -127,7 +127,7 @@
 # name: test_state[button.pyload_restart_all_failed_files-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'pyload Restart all failed files',
+      'friendly_name': 'pyLoad Restart all failed files',
     }),
     'context': <ANY>,
     'entity_id': 'button.pyload_restart_all_failed_files',
@@ -173,7 +173,7 @@
 # name: test_state[button.pyload_restart_pyload_core-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'pyload Restart pyload core',
+      'friendly_name': 'pyLoad Restart pyload core',
     }),
     'context': <ANY>,
     'entity_id': 'button.pyload_restart_pyload_core',


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Cleaning up some things i have overseen in some small PRs.
This aligns the device_info entries of both platforms to be the same



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
