### PR TITLE
Merge devices on connection or identifier collision

### DIFF
--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -1146,12 +1146,14 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         # device in the set
         main_device = self.devices[next(iter(device_ids))]
 
+        merged_config_entries = set()
         merged_connections = set()
         merged_identifiers = set()
 
         # Disable other devices, and clear their connections and identifiers
         for device_id in device_ids:
             device = self.devices[device_id]
+            merged_config_entries |= device.config_entries
             merged_connections |= device.connections
             merged_identifiers |= device.identifiers
 
@@ -1170,6 +1172,11 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             new_connections=merged_connections,
             new_identifiers=merged_identifiers,
         )
+        for config_entry_id in merged_config_entries:
+            self.async_update_device(
+                main_device.id,
+                add_config_entry_id=config_entry_id,
+            )
 
         return main_device
 

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -15,6 +15,7 @@ from yarl import URL
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import (
+    DOMAIN,
     Event,
     HomeAssistant,
     ReleaseChannel,
@@ -75,6 +76,7 @@ class DeviceEntryDisabler(StrEnum):
     """What disabled a device entry."""
 
     CONFIG_ENTRY = "config_entry"
+    DUPLICATE = "duplicate"
     INTEGRATION = "integration"
     USER = "user"
 
@@ -522,12 +524,36 @@ class DeviceRegistryItems[_EntryTypeT: (DeviceEntry, DeletedDeviceEntry)](
         for identifier in old_entry.identifiers:
             del self._identifiers[identifier]
 
+    def get_entries(
+        self,
+        identifiers: set[tuple[str, str]] | None,
+        connections: set[tuple[str, str]] | None,
+    ) -> set[str]:
+        """Get all matching entry ids from identifiers or connections."""
+        entries = set()
+        if identifiers:
+            entries = {
+                self._identifiers[identifier].id
+                for identifier in identifiers
+                if identifier in self._identifiers
+            }
+        if not connections:
+            return entries
+        return entries | {
+            self._connections[connection].id
+            for connection in _normalize_connections(connections)
+            if connection in self._connections
+        }
+
     def get_entry(
         self,
         identifiers: set[tuple[str, str]] | None,
         connections: set[tuple[str, str]] | None,
     ) -> _EntryTypeT | None:
-        """Get entry from identifiers or connections."""
+        """Get the first matching entry from identifiers or connections.
+
+        Identifiers are tried first, then connections.
+        """
         if identifiers:
             for identifier in identifiers:
                 if identifier in self._identifiers:
@@ -754,9 +780,11 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         else:
             connections = _normalize_connections(connections)
 
-        device = self.async_get_device(identifiers=identifiers, connections=connections)
+        device_ids = self.devices.get_entries(identifiers, connections)
 
-        if device is None:
+        if len(device_ids) > 1:
+            device = self._merge_devices(device_ids)
+        elif not device_ids:
             deleted_device = self._async_get_deleted_device(identifiers, connections)
             if deleted_device is None:
                 device = DeviceEntry(is_new=True)
@@ -769,6 +797,8 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             # If creating a new device, default to the config entry name
             if device_info_type == "primary" and (not name or name is UNDEFINED):
                 name = config_entry.title
+        else:
+            device = self.devices[next(iter(device_ids))]
 
         if default_manufacturer is not UNDEFINED and device.manufacturer is None:
             manufacturer = default_manufacturer
@@ -796,7 +826,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             )
             entry_type = DeviceEntryType(entry_type)
 
-        device = self.async_update_device(
+        updated_device = self.async_update_device(
             device.id,
             allow_collisions=True,
             add_config_entry_id=config_entry_id,
@@ -819,8 +849,8 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
 
         # This is safe because _async_update_device will always return a device
         # in this use case.
-        assert device
-        return device
+        assert updated_device
+        return updated_device
 
     @callback
     def async_update_device(  # noqa: C901
@@ -1109,6 +1139,39 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             ),
         )
         self.async_schedule_save()
+
+    @callback
+    def _merge_devices(self, device_ids: set[str]) -> DeviceEntry:
+        # Pick a device to be the main device. For now, we just pick the first
+        # device in the set
+        main_device = self.devices[next(iter(device_ids))]
+
+        merged_connections = set()
+        merged_identifiers = set()
+
+        # Disable other devices, and clear their connections and identifiers
+        for device_id in device_ids:
+            device = self.devices[device_id]
+            merged_connections |= device.connections
+            merged_identifiers |= device.identifiers
+
+            if device.id == main_device.id:
+                continue
+
+            self.async_update_device(
+                device.id,
+                disabled_by=DeviceEntryDisabler.DUPLICATE,
+                new_connections=set(),
+                new_identifiers={(DOMAIN, device.id)},
+            )
+
+        self.async_update_device(
+            main_device.id,
+            new_connections=merged_connections,
+            new_identifiers=merged_identifiers,
+        )
+
+        return main_device
 
     async def async_load(self) -> None:
         """Load the device registry."""

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -2829,17 +2829,19 @@ async def test_device_registry_connections_collision(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry
 ) -> None:
     """Test connection collisions in the device registry."""
-    config_entry = MockConfigEntry()
-    config_entry.add_to_hass(hass)
+    config_entry_1 = MockConfigEntry()
+    config_entry_1.add_to_hass(hass)
+    config_entry_2 = MockConfigEntry()
+    config_entry_2.add_to_hass(hass)
 
     device1 = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id=config_entry_1.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "none")},
         manufacturer="manufacturer",
         model="model",
     )
     device2 = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id=config_entry_1.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "none")},
         manufacturer="manufacturer",
         model="model",
@@ -2848,7 +2850,7 @@ async def test_device_registry_connections_collision(
     assert device1.id == device2.id
 
     device3 = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id=config_entry_2.entry_id,
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
         model="model",
@@ -2898,7 +2900,7 @@ async def test_device_registry_connections_collision(
     # Attempt to implicitly merge connection for device3 with the same
     # connection that already exists in device1
     device4 = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id=config_entry_2.entry_id,
         identifiers={("bridgeid", "0123")},
         connections={
             (dr.CONNECTION_NETWORK_MAC, "EE:EE:EE:EE:EE:EE"),
@@ -2924,8 +2926,16 @@ async def test_device_registry_connections_collision(
 
     assert duplicate_device.disabled_by is dr.DeviceEntryDisabler.DUPLICATE
     assert main_device.disabled_by is None
+    assert duplicate_device.config_entries in (
+        {config_entry_1.entry_id},
+        {config_entry_2.entry_id},
+    )
     assert duplicate_device.connections == set()
     assert duplicate_device.identifiers == {("homeassistant", duplicate_device.id)}
+    assert main_device.config_entries == {
+        config_entry_1.entry_id,
+        config_entry_2.entry_id,
+    }
     assert main_device.connections == {
         (dr.CONNECTION_NETWORK_MAC, "ee:ee:ee:ee:ee:ee"),
         (dr.CONNECTION_NETWORK_MAC, "none"),
@@ -2937,17 +2947,19 @@ async def test_device_registry_identifiers_collision(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry
 ) -> None:
     """Test identifiers collisions in the device registry."""
-    config_entry = MockConfigEntry()
-    config_entry.add_to_hass(hass)
+    config_entry_1 = MockConfigEntry()
+    config_entry_1.add_to_hass(hass)
+    config_entry_2 = MockConfigEntry()
+    config_entry_2.add_to_hass(hass)
 
     device1 = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id=config_entry_1.entry_id,
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
         model="model",
     )
     device2 = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id=config_entry_1.entry_id,
         identifiers={("bridgeid", "0123")},
         manufacturer="manufacturer",
         model="model",
@@ -2956,7 +2968,7 @@ async def test_device_registry_identifiers_collision(
     assert device1.id == device2.id
 
     device3 = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id=config_entry_2.entry_id,
         identifiers={("bridgeid", "4567")},
         manufacturer="manufacturer",
         model="model",
@@ -2998,7 +3010,7 @@ async def test_device_registry_identifiers_collision(
     # Attempt to implicitly merge identifiers for device3 with the same
     # connection that already exists in device1
     device4 = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id=config_entry_2.entry_id,
         identifiers={("bridgeid", "4567"), ("bridgeid", "0123")},
     )
     assert len(device_registry.devices) == 2
@@ -3020,8 +3032,16 @@ async def test_device_registry_identifiers_collision(
 
     assert duplicate_device.disabled_by is dr.DeviceEntryDisabler.DUPLICATE
     assert main_device.disabled_by is None
+    assert duplicate_device.config_entries in (
+        {config_entry_1.entry_id},
+        {config_entry_2.entry_id},
+    )
     assert duplicate_device.connections == set()
     assert duplicate_device.identifiers == {("homeassistant", duplicate_device.id)}
+    assert main_device.config_entries == {
+        config_entry_1.entry_id,
+        config_entry_2.entry_id,
+    }
     assert main_device.connections == set()
     assert main_device.identifiers == {("bridgeid", "0123"), ("bridgeid", "4567")}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Merge devices on connection or identifier collision

When merging, we will:
- Select one of the colliding devices as main device
- The main device will have the union of config entries, connections and identifiers of all colliding devices
- Colliding devices will:
  - Have their connections and identifiers cleared
  - Be hidden

TODO:
- Inform the user and allow them to take action, the user should be able to
  - Select the primary config entry
  - Confirm area, labels, name and other user configurable settings
- Decide what to do with entities tied to the duplicate devices, moving them to the main device could make a device service target behave differently, maybe we can do this when the user resolves the collisions?
- Consider a better way to select the main device when merging, for example try to pick a device which is not hidden and has a primary config entry
- Consider adding links to the main device from duplicate devices
- Consider what should happen to duplicates if a main device is deleted
- Consider setting the primary config entry when merging if the picked main device does not have one or has a "weak" one (matter, mqtt, etc.)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
