### PR TITLE
Add last_error reporting to Shelly diagnostics

### DIFF
--- a/homeassistant/components/shelly/diagnostics.py
+++ b/homeassistant/components/shelly/diagnostics.py
@@ -24,6 +24,8 @@ async def async_get_config_entry_diagnostics(
     device_settings: str | dict = "not initialized"
     device_status: str | dict = "not initialized"
     bluetooth: str | dict = "not initialized"
+    last_error: str = "not initialized"
+
     if shelly_entry_data.block:
         block_coordinator = shelly_entry_data.block
         assert block_coordinator
@@ -55,6 +57,10 @@ async def async_get_config_entry_diagnostics(
                     "uptime",
                 ]
             }
+
+        if block_coordinator.device.last_error:
+            last_error = repr(block_coordinator.device.last_error)
+
     else:
         rpc_coordinator = shelly_entry_data.rpc
         assert rpc_coordinator
@@ -79,6 +85,9 @@ async def async_get_config_entry_diagnostics(
                 "scanner": await scanner.async_diagnostics(),
             }
 
+        if rpc_coordinator.device.last_error:
+            last_error = repr(rpc_coordinator.device.last_error)
+
     if isinstance(device_status, dict):
         device_status = async_redact_data(device_status, ["ssid"])
 
@@ -87,5 +96,6 @@ async def async_get_config_entry_diagnostics(
         "device_info": device_info,
         "device_settings": device_settings,
         "device_status": device_status,
+        "last_error": last_error,
         "bluetooth": bluetooth,
     }

--- a/tests/components/shelly/test_diagnostics.py
+++ b/tests/components/shelly/test_diagnostics.py
@@ -1,9 +1,10 @@
 """Tests for Shelly diagnostics platform."""
 
-from unittest.mock import ANY, Mock
+from unittest.mock import ANY, Mock, PropertyMock
 
 from aioshelly.ble.const import BLE_SCAN_RESULT_EVENT
 from aioshelly.const import MODEL_25
+from aioshelly.exceptions import DeviceConnectionError
 import pytest
 
 from homeassistant.components.diagnostics import REDACTED
@@ -36,6 +37,10 @@ async def test_block_config_entry_diagnostics(
         {key: REDACTED for key in TO_REDACT if key in entry_dict["data"]}
     )
 
+    type(mock_block_device).last_error = PropertyMock(
+        return_value=DeviceConnectionError()
+    )
+
     result = await get_diagnostics_for_config_entry(hass, hass_client, entry)
 
     assert result == {
@@ -48,6 +53,7 @@ async def test_block_config_entry_diagnostics(
         },
         "device_settings": {"coiot": {"update_period": 15}},
         "device_status": MOCK_STATUS_COAP,
+        "last_error": "DeviceConnectionError()",
     }
 
 
@@ -89,6 +95,10 @@ async def test_rpc_config_entry_diagnostics(
     entry_dict = entry.as_dict()
     entry_dict["data"].update(
         {key: REDACTED for key in TO_REDACT if key in entry_dict["data"]}
+    )
+
+    type(mock_rpc_device).last_error = PropertyMock(
+        return_value=DeviceConnectionError()
     )
 
     result = await get_diagnostics_for_config_entry(hass, hass_client, entry)
@@ -152,4 +162,5 @@ async def test_rpc_config_entry_diagnostics(
             },
             "wifi": {"rssi": -63},
         },
+        "last_error": "DeviceConnectionError()",
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `last_error` property from `aioshelly` to diagnostics, since first thing we ask is diagnostics, we might see the error there without the need for logs.

An example of a timeout error in diagnsotics:
```
    "last_error": "DeviceConnectionError(TimeoutError())",
```

To simulate an error:
Disconnect a device after it is ready (unfortunately it is not possible to download diagnostics from devices that are not ready), try to send a command to the device (switch toggle) and download diagnostics after.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
