### PR TITLE
Store tplink credentials_hash outside of device_config

### DIFF
--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -173,6 +173,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: TPLinkConfigEntry) -> bo
 
     device_credentials_hash = device.credentials_hash
     device_config_dict = device.config.to_dict(exclude_credentials=True)
+    # Do not store the credentials hash inside the device_config
+    device_config_dict.pop(CONF_CREDENTIALS_HASH, None)
     updates: dict[str, Any] = {}
     if device_credentials_hash and device_credentials_hash != entry_credentials_hash:
         updates[CONF_CREDENTIALS_HASH] = device_credentials_hash

--- a/homeassistant/components/tplink/config_flow.py
+++ b/homeassistant/components/tplink/config_flow.py
@@ -285,6 +285,7 @@ class TPLinkConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the step to pick discovered device."""
+        credentials = await get_credentials(self.hass)
         if user_input is not None:
             mac = user_input[CONF_DEVICE]
             await self.async_set_unique_id(mac, raise_on_progress=False)
@@ -292,7 +293,6 @@ class TPLinkConfigFlow(ConfigFlow, domain=DOMAIN):
             host = self._discovered_device.host
 
             self.context[CONF_HOST] = host
-            credentials = await get_credentials(self.hass)
 
             try:
                 device = await self._async_try_connect(
@@ -307,7 +307,7 @@ class TPLinkConfigFlow(ConfigFlow, domain=DOMAIN):
         configured_devices = {
             entry.unique_id for entry in self._async_current_entries()
         }
-        self._discovered_devices = await async_discover_devices(self.hass)
+        self._discovered_devices = await async_discover_devices(self.hass, credentials)
         devices_name = {
             formatted_mac: (
                 f"{device.alias or mac_alias(device.mac)} {device.model} ({device.host}) {formatted_mac}"

--- a/homeassistant/components/tplink/config_flow.py
+++ b/homeassistant/components/tplink/config_flow.py
@@ -44,7 +44,13 @@ from . import (
     mac_alias,
     set_credentials,
 )
-from .const import CONF_DEVICE_CONFIG, CONNECT_TIMEOUT, DOMAIN
+from .const import (
+    CONF_CONNECTION_TYPE,
+    CONF_CREDENTIALS_HASH,
+    CONF_DEVICE_CONFIG,
+    CONNECT_TIMEOUT,
+    DOMAIN,
+)
 
 STEP_AUTH_DATA_SCHEMA = vol.Schema(
     {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
@@ -55,7 +61,7 @@ class TPLinkConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for tplink."""
 
     VERSION = 1
-    MINOR_VERSION = 3
+    MINOR_VERSION = 4
     reauth_entry: ConfigEntry | None = None
 
     def __init__(self) -> None:
@@ -95,9 +101,18 @@ class TPLinkConfigFlow(ConfigFlow, domain=DOMAIN):
         entry_config_dict = entry_data.get(CONF_DEVICE_CONFIG)
         if entry_config_dict == config and entry_data[CONF_HOST] == host:
             return None
+        updates = {**entry.data, CONF_DEVICE_CONFIG: config, CONF_HOST: host}
+        # If the connection parameters have changed the credentials_hash will be invalid.
+        if (
+            entry_config_dict
+            and isinstance(entry_config_dict, dict)
+            and entry_config_dict.get(CONF_CONNECTION_TYPE)
+            != config.get(CONF_CONNECTION_TYPE)
+        ):
+            updates.pop(CONF_CREDENTIALS_HASH, None)
         return self.async_update_reload_and_abort(
             entry,
-            data={**entry.data, CONF_DEVICE_CONFIG: config, CONF_HOST: host},
+            data=updates,
             reason="already_configured",
         )
 
@@ -307,7 +322,7 @@ class TPLinkConfigFlow(ConfigFlow, domain=DOMAIN):
         configured_devices = {
             entry.unique_id for entry in self._async_current_entries()
         }
-        self._discovered_devices = await async_discover_devices(self.hass, credentials)
+        self._discovered_devices = await async_discover_devices(self.hass)
         devices_name = {
             formatted_mac: (
                 f"{device.alias or mac_alias(device.mac)} {device.model} ({device.host}) {formatted_mac}"
@@ -345,18 +360,22 @@ class TPLinkConfigFlow(ConfigFlow, domain=DOMAIN):
     @callback
     def _async_create_entry_from_device(self, device: Device) -> ConfigFlowResult:
         """Create a config entry from a smart device."""
+        # This is only ever called after a successful device update so we know that
+        # the credential_hash is correct and should be saved.
         self._abort_if_unique_id_configured(updates={CONF_HOST: device.host})
+        data = {
+            CONF_HOST: device.host,
+            CONF_ALIAS: device.alias,
+            CONF_MODEL: device.model,
+            CONF_DEVICE_CONFIG: device.config.to_dict(
+                exclude_credentials=True,
+            ),
+        }
+        if device.credentials_hash:
+            data[CONF_CREDENTIALS_HASH] = device.credentials_hash
         return self.async_create_entry(
             title=f"{device.alias} {device.model}",
-            data={
-                CONF_HOST: device.host,
-                CONF_ALIAS: device.alias,
-                CONF_MODEL: device.model,
-                CONF_DEVICE_CONFIG: device.config.to_dict(
-                    credentials_hash=device.credentials_hash,
-                    exclude_credentials=True,
-                ),
-            },
+            data=data,
         )
 
     async def _async_try_discover_and_update(

--- a/homeassistant/components/tplink/config_flow.py
+++ b/homeassistant/components/tplink/config_flow.py
@@ -300,7 +300,6 @@ class TPLinkConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the step to pick discovered device."""
-        credentials = await get_credentials(self.hass)
         if user_input is not None:
             mac = user_input[CONF_DEVICE]
             await self.async_set_unique_id(mac, raise_on_progress=False)
@@ -308,6 +307,7 @@ class TPLinkConfigFlow(ConfigFlow, domain=DOMAIN):
             host = self._discovered_device.host
 
             self.context[CONF_HOST] = host
+            credentials = await get_credentials(self.hass)
 
             try:
                 device = await self._async_try_connect(

--- a/homeassistant/components/tplink/const.py
+++ b/homeassistant/components/tplink/const.py
@@ -20,6 +20,7 @@ ATTR_TODAY_ENERGY_KWH: Final = "today_energy_kwh"
 ATTR_TOTAL_ENERGY_KWH: Final = "total_energy_kwh"
 
 CONF_DEVICE_CONFIG: Final = "device_config"
+CONF_CREDENTIALS_HASH: Final = "credentials_hash"
 
 PLATFORMS: Final = [
     Platform.BINARY_SENSOR,

--- a/homeassistant/components/tplink/const.py
+++ b/homeassistant/components/tplink/const.py
@@ -21,6 +21,7 @@ ATTR_TOTAL_ENERGY_KWH: Final = "total_energy_kwh"
 
 CONF_DEVICE_CONFIG: Final = "device_config"
 CONF_CREDENTIALS_HASH: Final = "credentials_hash"
+CONF_CONNECTION_TYPE: Final = "connection_type"
 
 PLATFORMS: Final = [
     Platform.BINARY_SENSOR,

--- a/tests/components/tplink/__init__.py
+++ b/tests/components/tplink/__init__.py
@@ -438,20 +438,16 @@ def _patch_connect(device=None, no_device=False):
 
 
 async def initialize_config_entry_for_device(
-    hass: HomeAssistant, dev: Device, *, config_entry: MockConfigEntry | None = None
+    hass: HomeAssistant, dev: Device
 ) -> MockConfigEntry:
     """Create a mocked configuration entry for the given device.
 
     Note, the rest of the tests should probably be converted over to use this
     instead of repeating the initialization routine for each test separately
     """
-    if not config_entry:
-        config_entry = MockConfigEntry(
-            title="TP-Link",
-            domain=DOMAIN,
-            unique_id=dev.mac,
-            data={CONF_HOST: dev.host},
-        )
+    config_entry = MockConfigEntry(
+        title="TP-Link", domain=DOMAIN, unique_id=dev.mac, data={CONF_HOST: dev.host}
+    )
     config_entry.add_to_hass(hass)
 
     with (
@@ -460,6 +456,6 @@ async def initialize_config_entry_for_device(
         _patch_connect(device=dev),
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done(wait_background_tasks=True)
+        await hass.async_block_till_done()
 
     return config_entry

--- a/tests/components/tplink/test_config_flow.py
+++ b/tests/components/tplink/test_config_flow.py
@@ -823,7 +823,10 @@ async def test_integration_discovery_with_connection_change(
     mock_discovery: AsyncMock,
     mock_connect: AsyncMock,
 ) -> None:
-    """Test that config entry is updated with new device config and that connection_hash is removed.."""
+    """Test that config entry is updated with new device config.
+
+    And that connection_hash is removed as it will be invalid.
+    """
     mock_connect["connect"].side_effect = KasaException()
 
     mock_config_entry = MockConfigEntry(

--- a/tests/components/tplink/test_config_flow.py
+++ b/tests/components/tplink/test_config_flow.py
@@ -14,8 +14,12 @@ from homeassistant.components.tplink import (
     DeviceConfig,
     KasaException,
 )
-from homeassistant.components.tplink.const import CONF_DEVICE_CONFIG
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.components.tplink.const import (
+    CONF_CONNECTION_TYPE,
+    CONF_CREDENTIALS_HASH,
+    CONF_DEVICE_CONFIG,
+)
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import (
     CONF_ALIAS,
     CONF_DEVICE,
@@ -32,6 +36,7 @@ from . import (
     CREATE_ENTRY_DATA_AUTH,
     CREATE_ENTRY_DATA_AUTH2,
     CREATE_ENTRY_DATA_LEGACY,
+    CREDENTIALS_HASH_AUTH,
     DEFAULT_ENTRY_TITLE,
     DEVICE_CONFIG_DICT_AUTH,
     DEVICE_CONFIG_DICT_LEGACY,
@@ -40,6 +45,7 @@ from . import (
     MAC_ADDRESS,
     MAC_ADDRESS2,
     MODULE,
+    NEW_CONNECTION_TYPE_DICT,
     _mocked_device,
     _patch_connect,
     _patch_discovery,
@@ -808,6 +814,74 @@ async def test_integration_discovery_with_ip_change(
     # Check that init set the new host correctly before calling connect
     assert config.host == "127.0.0.1"
     config.host = "127.0.0.2"
+    mock_connect["connect"].assert_awaited_once_with(config=config)
+
+
+async def test_integration_discovery_with_connection_change(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_discovery: AsyncMock,
+    mock_connect: AsyncMock,
+) -> None:
+    """Test that config entry is updated with new device config and that connection_hash is removed.."""
+    mock_connect["connect"].side_effect = KasaException()
+
+    mock_config_entry = MockConfigEntry(
+        title="TPLink",
+        domain=DOMAIN,
+        data=CREATE_ENTRY_DATA_AUTH,
+        unique_id=MAC_ADDRESS,
+    )
+    mock_config_entry.add_to_hass(hass)
+    with patch("homeassistant.components.tplink.Discover.discover", return_value={}):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert (
+        len(
+            hass.config_entries.flow.async_progress_by_handler(
+                DOMAIN, match_context={"source": SOURCE_REAUTH}
+            )
+        )
+        == 0
+    )
+    assert mock_config_entry.data[CONF_DEVICE_CONFIG] == DEVICE_CONFIG_DICT_AUTH
+    assert mock_config_entry.data[CONF_DEVICE_CONFIG].get(CONF_HOST) == "127.0.0.1"
+    assert mock_config_entry.data[CONF_CREDENTIALS_HASH] == CREDENTIALS_HASH_AUTH
+
+    NEW_DEVICE_CONFIG = {
+        **DEVICE_CONFIG_DICT_AUTH,
+        CONF_CONNECTION_TYPE: NEW_CONNECTION_TYPE_DICT,
+    }
+    config = DeviceConfig.from_dict(NEW_DEVICE_CONFIG)
+    # Reset the connect mock so when the config flow reloads the entry it succeeds
+    mock_connect["connect"].reset_mock(side_effect=True)
+    bulb = _mocked_device(
+        device_config=config,
+        mac=mock_config_entry.unique_id,
+    )
+    mock_connect["connect"].return_value = bulb
+
+    discovery_result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+        data={
+            CONF_HOST: "127.0.0.1",
+            CONF_MAC: MAC_ADDRESS,
+            CONF_ALIAS: ALIAS,
+            CONF_DEVICE_CONFIG: NEW_DEVICE_CONFIG,
+        },
+    )
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert discovery_result["type"] is FlowResultType.ABORT
+    assert discovery_result["reason"] == "already_configured"
+    assert mock_config_entry.data[CONF_DEVICE_CONFIG] == NEW_DEVICE_CONFIG
+    assert mock_config_entry.data[CONF_HOST] == "127.0.0.1"
+    assert CREDENTIALS_HASH_AUTH not in mock_config_entry.data
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
     mock_connect["connect"].assert_awaited_once_with(config=config)
 
 

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -472,7 +472,11 @@ async def test_move_credentials_hash(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test credentials hash moved to parent."""
+    """Test credentials hash moved to parent.
+
+    As async_setup_entry will succeed the hash on the parent is updated
+    from the device.
+    """
     device_config = {
         **DEVICE_CONFIG_AUTH.to_dict(
             exclude_credentials=True, credentials_hash="theHash"
@@ -511,7 +515,11 @@ async def test_move_credentials_hash(
 async def test_move_credentials_hash_auth_error(
     hass: HomeAssistant,
 ) -> None:
-    """Test credentials hash moved to parent."""
+    """Test credentials hash moved to parent.
+
+    If there is an auth error it should be deleted after migration
+    in async_setup_entry.
+    """
     device_config = {
         **DEVICE_CONFIG_AUTH.to_dict(
             exclude_credentials=True, credentials_hash="theHash"
@@ -550,7 +558,11 @@ async def test_move_credentials_hash_auth_error(
 async def test_move_credentials_hash_other_error(
     hass: HomeAssistant,
 ) -> None:
-    """Test credentials hash moved to parent."""
+    """Test credentials hash moved to parent.
+
+    When there is a KasaException the same hash should still be on the parent
+    at the end of the test.
+    """
     device_config = {
         **DEVICE_CONFIG_AUTH.to_dict(
             exclude_credentials=True, credentials_hash="theHash"
@@ -588,7 +600,7 @@ async def test_move_credentials_hash_other_error(
 async def test_credentials_hash(
     hass: HomeAssistant,
 ) -> None:
-    """Test credentials hash used to call connect."""
+    """Test credentials_hash used to call connect."""
     device_config = {**DEVICE_CONFIG_AUTH.to_dict(exclude_credentials=True)}
     entry_data = {
         **CREATE_ENTRY_DATA_AUTH,
@@ -626,7 +638,7 @@ async def test_credentials_hash(
 async def test_credentials_hash_auth_error(
     hass: HomeAssistant,
 ) -> None:
-    """Test credentials hash moved to parent."""
+    """Test credentials_hash is deleted after an auth failure."""
     device_config = {**DEVICE_CONFIG_AUTH.to_dict(exclude_credentials=True)}
     entry_data = {
         **CREATE_ENTRY_DATA_AUTH,

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -7,12 +7,16 @@ from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
-from kasa import AuthenticationError, Feature, KasaException, Module
+from kasa import AuthenticationError, DeviceConfig, Feature, KasaException, Module
 import pytest
 
 from homeassistant import setup
 from homeassistant.components import tplink
-from homeassistant.components.tplink.const import CONF_DEVICE_CONFIG, DOMAIN
+from homeassistant.components.tplink.const import (
+    CONF_CREDENTIALS_HASH,
+    CONF_DEVICE_CONFIG,
+    DOMAIN,
+)
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import (
     CONF_AUTHENTICATION,
@@ -458,7 +462,199 @@ async def test_unlink_devices(
     expected_identifiers = identifiers[:expected_count]
     assert device_entries[0].identifiers == set(expected_identifiers)
     assert entry.version == 1
-    assert entry.minor_version == 3
+    assert entry.minor_version == 4
 
     msg = f"{expected_message} identifiers for device dummy (hs300): {set(identifiers)}"
     assert msg in caplog.text
+
+
+async def test_move_credentials_hash(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test credentials hash moved to parent."""
+    device_config = {
+        **DEVICE_CONFIG_AUTH.to_dict(
+            exclude_credentials=True, credentials_hash="theHash"
+        )
+    }
+    entry_data = {**CREATE_ENTRY_DATA_AUTH, CONF_DEVICE_CONFIG: device_config}
+
+    entry = MockConfigEntry(
+        title="TPLink",
+        domain=DOMAIN,
+        data=entry_data,
+        entry_id="123456",
+        unique_id=MAC_ADDRESS,
+        version=1,
+        minor_version=3,
+    )
+    assert entry.data[CONF_DEVICE_CONFIG][CONF_CREDENTIALS_HASH] == "theHash"
+    entry.add_to_hass(hass)
+    device = _mocked_device(credentials_hash="theNewHash")
+    with (
+        patch("homeassistant.components.tplink.Device.connect", return_value=device),
+        patch("homeassistant.components.tplink.PLATFORMS", []),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.minor_version == 4
+    assert entry.state is ConfigEntryState.LOADED
+    assert CONF_CREDENTIALS_HASH not in entry.data[CONF_DEVICE_CONFIG]
+    assert CONF_CREDENTIALS_HASH in entry.data
+    # Gets the new hash from the successful connection.
+    assert entry.data[CONF_CREDENTIALS_HASH] == "theNewHash"
+    assert "Migration to version 1.4 complete" in caplog.text
+
+
+async def test_move_credentials_hash_auth_error(
+    hass: HomeAssistant,
+) -> None:
+    """Test credentials hash moved to parent."""
+    device_config = {
+        **DEVICE_CONFIG_AUTH.to_dict(
+            exclude_credentials=True, credentials_hash="theHash"
+        )
+    }
+    entry_data = {**CREATE_ENTRY_DATA_AUTH, CONF_DEVICE_CONFIG: device_config}
+
+    entry = MockConfigEntry(
+        title="TPLink",
+        domain=DOMAIN,
+        data=entry_data,
+        unique_id=MAC_ADDRESS,
+        version=1,
+        minor_version=3,
+    )
+    assert entry.data[CONF_DEVICE_CONFIG][CONF_CREDENTIALS_HASH] == "theHash"
+
+    with (
+        patch(
+            "homeassistant.components.tplink.Device.connect",
+            side_effect=AuthenticationError,
+        ),
+        patch("homeassistant.components.tplink.PLATFORMS", []),
+    ):
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.minor_version == 4
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+    assert CONF_CREDENTIALS_HASH not in entry.data[CONF_DEVICE_CONFIG]
+    # Auth failure deletes the hash
+    assert CONF_CREDENTIALS_HASH not in entry.data
+
+
+async def test_move_credentials_hash_other_error(
+    hass: HomeAssistant,
+) -> None:
+    """Test credentials hash moved to parent."""
+    device_config = {
+        **DEVICE_CONFIG_AUTH.to_dict(
+            exclude_credentials=True, credentials_hash="theHash"
+        )
+    }
+    entry_data = {**CREATE_ENTRY_DATA_AUTH, CONF_DEVICE_CONFIG: device_config}
+
+    entry = MockConfigEntry(
+        title="TPLink",
+        domain=DOMAIN,
+        data=entry_data,
+        unique_id=MAC_ADDRESS,
+        version=1,
+        minor_version=3,
+    )
+    assert entry.data[CONF_DEVICE_CONFIG][CONF_CREDENTIALS_HASH] == "theHash"
+
+    with (
+        patch(
+            "homeassistant.components.tplink.Device.connect", side_effect=KasaException
+        ),
+        patch("homeassistant.components.tplink.PLATFORMS", []),
+    ):
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.minor_version == 4
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert CONF_CREDENTIALS_HASH not in entry.data[CONF_DEVICE_CONFIG]
+    assert CONF_CREDENTIALS_HASH in entry.data
+    assert entry.data[CONF_CREDENTIALS_HASH] == "theHash"
+
+
+async def test_credentials_hash(
+    hass: HomeAssistant,
+) -> None:
+    """Test credentials hash used to call connect."""
+    device_config = {**DEVICE_CONFIG_AUTH.to_dict(exclude_credentials=True)}
+    entry_data = {
+        **CREATE_ENTRY_DATA_AUTH,
+        CONF_DEVICE_CONFIG: device_config,
+        CONF_CREDENTIALS_HASH: "theHash",
+    }
+
+    entry = MockConfigEntry(
+        title="TPLink",
+        domain=DOMAIN,
+        data=entry_data,
+        unique_id=MAC_ADDRESS,
+    )
+
+    device = _mocked_device()
+    with (
+        patch("homeassistant.components.tplink.PLATFORMS", []),
+        patch(
+            "homeassistant.components.tplink.Device.connect", return_value=device
+        ) as connect_mock,
+    ):
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    expected_config = DeviceConfig.from_dict(
+        DEVICE_CONFIG_AUTH.to_dict(exclude_credentials=True, credentials_hash="theHash")
+    )
+    connect_mock.assert_called_with(config=expected_config)
+    assert entry.state is ConfigEntryState.LOADED
+    assert CONF_CREDENTIALS_HASH in entry.data
+    assert entry.data[CONF_CREDENTIALS_HASH] == "theHash"
+
+
+async def test_credentials_hash_auth_error(
+    hass: HomeAssistant,
+) -> None:
+    """Test credentials hash moved to parent."""
+    device_config = {**DEVICE_CONFIG_AUTH.to_dict(exclude_credentials=True)}
+    entry_data = {
+        **CREATE_ENTRY_DATA_AUTH,
+        CONF_DEVICE_CONFIG: device_config,
+        CONF_CREDENTIALS_HASH: "theHash",
+    }
+
+    entry = MockConfigEntry(
+        title="TPLink",
+        domain=DOMAIN,
+        data=entry_data,
+        unique_id=MAC_ADDRESS,
+    )
+
+    with (
+        patch("homeassistant.components.tplink.PLATFORMS", []),
+        patch(
+            "homeassistant.components.tplink.Device.connect",
+            side_effect=AuthenticationError,
+        ) as connect_mock,
+    ):
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    expected_config = DeviceConfig.from_dict(
+        DEVICE_CONFIG_AUTH.to_dict(exclude_credentials=True, credentials_hash="theHash")
+    )
+    connect_mock.assert_called_with(config=expected_config)
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+    assert CONF_CREDENTIALS_HASH not in entry.data


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix ongoing tplink re-auth issues due to `credentials_hash` for blank credentials being stored in device_config.

The issue is caused by the logic for discovery to update `device_config` when it has changed and the device is in `SETUP_ERROR` or `SETUP_RETRY` overwriting the correct hash with a hash from blank credentials. This PR moves the `credentials_hash` out for the device config so HA has more control over it and can ensure it is only saved after successful authentication.

Chances are if a device is requiring re-auth it has the following hash in the config entry: `uGKKuRx09TFgP21bRecw5UwSOnJHuJeCcsA/HhNWDOo=`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #117093
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
