### PR TITLE
Prevent changes to mutable bmw_connected_drive fixture data

### DIFF
--- a/tests/components/bmw_connected_drive/test_config_flow.py
+++ b/tests/components/bmw_connected_drive/test_config_flow.py
@@ -92,7 +92,7 @@ async def test_api_error(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_USER},
-            data=FIXTURE_USER_INPUT,
+            data=deepcopy(FIXTURE_USER_INPUT),
         )
 
     assert result["type"] is FlowResultType.FORM
@@ -116,7 +116,7 @@ async def test_full_user_flow_implementation(hass: HomeAssistant) -> None:
         result2 = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_USER},
-            data=FIXTURE_USER_INPUT,
+            data=deepcopy(FIXTURE_USER_INPUT),
         )
         assert result2["type"] is FlowResultType.CREATE_ENTRY
         assert result2["title"] == FIXTURE_COMPLETE_ENTRY[CONF_USERNAME]
@@ -137,7 +137,8 @@ async def test_options_flow_implementation(hass: HomeAssistant) -> None:
             return_value=True,
         ) as mock_setup_entry,
     ):
-        config_entry = MockConfigEntry(**FIXTURE_CONFIG_ENTRY)
+        config_entry_args = deepcopy(FIXTURE_CONFIG_ENTRY)
+        config_entry = MockConfigEntry(**config_entry_args)
         config_entry.add_to_hass(hass)
 
         await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/components/bmw_connected_drive/test_init.py
+++ b/tests/components/bmw_connected_drive/test_init.py
@@ -1,5 +1,6 @@
 """Test Axis component setup process."""
 
+from copy import deepcopy
 from unittest.mock import patch
 
 import pytest
@@ -37,7 +38,7 @@ async def test_migrate_options(
 ) -> None:
     """Test successful migration of options."""
 
-    config_entry = FIXTURE_CONFIG_ENTRY.copy()
+    config_entry = deepcopy(FIXTURE_CONFIG_ENTRY)
     config_entry["options"] = options
 
     mock_config_entry = MockConfigEntry(**config_entry)
@@ -55,7 +56,7 @@ async def test_migrate_options(
 async def test_migrate_options_from_data(hass: HomeAssistant) -> None:
     """Test successful migration of options."""
 
-    config_entry = FIXTURE_CONFIG_ENTRY.copy()
+    config_entry = deepcopy(FIXTURE_CONFIG_ENTRY)
     config_entry["options"] = {}
     config_entry["data"].update({CONF_READ_ONLY: False})
 
@@ -107,7 +108,8 @@ async def test_migrate_unique_ids(
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test successful migration of entity unique_ids."""
-    mock_config_entry = MockConfigEntry(**FIXTURE_CONFIG_ENTRY)
+    confg_entry = deepcopy(FIXTURE_CONFIG_ENTRY)
+    mock_config_entry = MockConfigEntry(**confg_entry)
     mock_config_entry.add_to_hass(hass)
 
     entity: er.RegistryEntry = entity_registry.async_get_or_create(
@@ -153,7 +155,8 @@ async def test_dont_migrate_unique_ids(
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test successful migration of entity unique_ids."""
-    mock_config_entry = MockConfigEntry(**FIXTURE_CONFIG_ENTRY)
+    confg_entry = deepcopy(FIXTURE_CONFIG_ENTRY)
+    mock_config_entry = MockConfigEntry(**confg_entry)
     mock_config_entry.add_to_hass(hass)
 
     # create existing entry with new_unique_id
@@ -196,7 +199,8 @@ async def test_remove_stale_devices(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test remove stale device registry entries."""
-    mock_config_entry = MockConfigEntry(**FIXTURE_CONFIG_ENTRY)
+    config_entry = deepcopy(FIXTURE_CONFIG_ENTRY)
+    mock_config_entry = MockConfigEntry(**config_entry)
     mock_config_entry.add_to_hass(hass)
 
     device_registry.async_get_or_create(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Prevent changes to mutable bmw_connected_drive fixture data

Possible caused by the entry migration code. The PR aims to make the fixture constants unmutable.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
