### PR TITLE
Set Jewish Calendar quality scale

### DIFF
--- a/homeassistant/components/jewish_calendar/manifest.json
+++ b/homeassistant/components/jewish_calendar/manifest.json
@@ -6,6 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/jewish_calendar",
   "iot_class": "calculated",
   "loggers": ["hdate"],
+  "quality_scale": "platinum",
   "requirements": ["hdate==0.10.9"],
   "single_config_entry": true
 }

--- a/homeassistant/components/jewish_calendar/manifest.json
+++ b/homeassistant/components/jewish_calendar/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/jewish_calendar",
   "iot_class": "calculated",
   "loggers": ["hdate"],
-  "quality_scale": "platinum",
+  "quality_scale": "silver",
   "requirements": ["hdate==0.10.9"],
   "single_config_entry": true
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Set Jewish Calendar quality scale

## Silver 🥈

- [x] Connection/configuration is handled via a component.
- ~Set an appropriate `SCAN_INTERVAL` (if a polling integration)~
- ~Raise [`PlatformNotReady`](integration_setup_failures.md#integrations-using-async_setup_platform) if unable to connect during platform setup (if appropriate)~
- ~Handles expiration of auth credentials. Refresh if possible or print correct error and fail setup. If based on a config entry, should trigger a new config entry flow to re-authorize.  ([docs](config_entries_config_flow_handler.md#reauthentication))~
- ~Handles internet unavailable. Log a warning once when unavailable, log once when reconnected.~
- ~Handles device/service unavailable. Log a warning once when unavailable, log once when reconnected.~
- ~Operations like service calls and entity methods (e.g. *Set HVAC Mode*) have proper exception handling. Raise `ServiceValidationError` on invalid user input and raise `HomeAssistantError` for other failures such as a problem communicating with a device. [Read more](/docs/core/platform/raising_exceptions) about raising exceptions.~
- ~Set `available` property to `False` if appropriate ([docs](core/entity.md#generic-properties))~
- [X] Entities have unique ID (if available) ([docs](entity_registry_index.md#unique-id-requirements))

## Gold 🥇

This is a solid integration that is able to survive poor conditions and can be configured via the user interface.

- [x] Satisfying all Silver level requirements.
- [x] Configurable via config entries.
  - [x] Don't allow configuring already configured device/service (example: no 2 entries for same hub)
  - ~Discoverable (if available)~
  - [x] Set unique ID in config flow (if available)
  - ~Raise [`ConfigEntryNotReady`](integration_setup_failures.md#integrations-using-async_setup_entry) if unable to connect during entry setup (if appropriate)~
- [x] Entities have device info (if available) ([docs](device_registry_index.md#defining-devices))
- [x] Tests
  - [x] Full test coverage for the config flow
  - [x] Above average test coverage for all integration modules
  - [x] Tests for fetching data from the integration and controlling it ([docs](development_testing.md))
- [x] Has a code owner ([docs](creating_integration_manifest.md#code-owners))
- [ ] Entities only subscribe to updates inside `async_added_to_hass` and unsubscribe inside `async_will_remove_from_hass` ([docs](core/entity.md#lifecycle-hooks))
- [x] Entities have correct device classes where appropriate ([docs](core/entity.md#generic-properties))
- [x] Supports entities being disabled and leverages `Entity.entity_registry_enabled_default` to disable less popular entities ([docs](core/entity.md#advanced-properties))
- ~If the device/service API can remove entities, the integration should make sure to clean up the entity and device registry.~
- ~When communicating with a device or service, the integration implements the diagnostics platform which redacts sensitive information.~

## Platinum 🏆

Best of the best. The integration is completely async, meaning it's super fast. Integrations that reach platinum level will require approval by the code owner for each PR.

- [ ] Satisfying all Gold level requirements.
- [ ] Set appropriate `PARALLEL_UPDATES` constant ([docs](integration_fetching_data.md#request-parallelism))
- [x] Support config entry unloading (called when config entry is removed)
- [ ] Integration + dependency are async ([docs](asyncio_working_with_async.md))
- ~Uses aiohttp or httpx and allows passing in websession (if making HTTP requests)~
- ~[Handles expired credentials](integration_setup_failures.md#handling-expired-credentials) (if appropriate)~


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
