### PR TITLE
Add capsys to enforce-type-hints plugin

### DIFF
--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -79,7 +79,7 @@ _INNER_MATCH_POSSIBILITIES = [i + 1 for i in range(5)]
 _TYPE_HINT_MATCHERS.update(
     {
         f"x_of_y_{i}": re.compile(
-            rf"^(\w+)\[{_INNER_MATCH}" + f", {_INNER_MATCH}" * (i - 1) + r"\]$"
+            rf"^([\w\.]+)\[{_INNER_MATCH}" + f", {_INNER_MATCH}" * (i - 1) + r"\]$"
         )
         for i in _INNER_MATCH_POSSIBILITIES
     }
@@ -102,6 +102,7 @@ _TEST_FIXTURES: dict[str, list[str] | str] = {
     "area_registry": "AreaRegistry",
     "async_setup_recorder_instance": "RecorderInstanceGenerator",
     "caplog": "pytest.LogCaptureFixture",
+    "capsys": "pytest.CaptureFixture[str]",
     "current_request_with_host": "None",
     "device_registry": "DeviceRegistry",
     "enable_bluetooth": "None",

--- a/tests/components/srp_energy/test_config_flow.py
+++ b/tests/components/srp_energy/test_config_flow.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from homeassistant.components.srp_energy.const import CONF_IS_TOU, DOMAIN
 from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
 from homeassistant.const import CONF_ID, CONF_PASSWORD, CONF_SOURCE, CONF_USERNAME
@@ -23,8 +25,9 @@ from . import (
 from tests.common import MockConfigEntry
 
 
+@pytest.mark.usefixtures("mock_srp_energy_config_flow")
 async def test_show_form(
-    hass: HomeAssistant, mock_srp_energy_config_flow: MagicMock, capsys
+    hass: HomeAssistant, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """Test show configuration form."""
     result = await hass.config_entries.flow.async_init(
@@ -140,7 +143,7 @@ async def test_flow_entry_already_configured(
 
 
 async def test_flow_multiple_configs(
-    hass: HomeAssistant, init_integration: MockConfigEntry, capsys
+    hass: HomeAssistant, init_integration: MockConfigEntry
 ) -> None:
     """Test multiple config entries."""
     # Verify mock config setup from fixture

--- a/tests/pylint/test_enforce_type_hints.py
+++ b/tests/pylint/test_enforce_type_hints.py
@@ -55,6 +55,7 @@ def test_regex_get_module_platform(
         ("list[dict[str, Any]]", 1, ("list", "dict[str, Any]")),
         ("tuple[bytes | None, str | None]", 2, ("tuple", "bytes | None", "str | None")),
         ("Callable[[], TestServer]", 2, ("Callable", "[]", "TestServer")),
+        ("pytest.CaptureFixture[str]", 1, ("pytest.CaptureFixture", "str")),
     ],
 )
 def test_regex_x_of_y_i(
@@ -1264,6 +1265,7 @@ def test_pytest_fixture(linter: UnittestLinter, type_hint_checker: BaseChecker) 
     def sample_fixture( #@
         hass: HomeAssistant,
         caplog: pytest.LogCaptureFixture,
+        capsys: pytest.CaptureFixture[str],
         aiohttp_server: Callable[[], TestServer],
         unused_tcp_port_factory: Callable[[], int],
         enable_custom_integrations: None,

--- a/tests/scripts/test_auth.py
+++ b/tests/scripts/test_auth.py
@@ -6,6 +6,7 @@ from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.auth.providers import homeassistant as hass_auth
 from homeassistant.core import HomeAssistant
@@ -15,7 +16,7 @@ from tests.common import register_auth_provider
 
 
 @pytest.fixture(autouse=True)
-def reset_log_level():
+def reset_log_level() -> Generator[None]:
     """Reset log level after each test case."""
     logger = logging.getLogger("homeassistant.core")
     orig_level = logger.level
@@ -24,7 +25,7 @@ def reset_log_level():
 
 
 @pytest.fixture
-def provider(hass):
+def provider(hass: HomeAssistant) -> hass_auth.HassAuthProvider:
     """Home Assistant auth provider."""
     provider = hass.loop.run_until_complete(
         register_auth_provider(hass, {"type": "homeassistant"})
@@ -33,7 +34,11 @@ def provider(hass):
     return provider
 
 
-async def test_list_user(hass: HomeAssistant, provider, capsys) -> None:
+async def test_list_user(
+    hass: HomeAssistant,
+    provider: hass_auth.HassAuthProvider,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     """Test we can list users."""
     data = provider.data
     data.add_auth("test-user", "test-pass")
@@ -47,7 +52,10 @@ async def test_list_user(hass: HomeAssistant, provider, capsys) -> None:
 
 
 async def test_add_user(
-    hass: HomeAssistant, provider, capsys, hass_storage: dict[str, Any]
+    hass: HomeAssistant,
+    provider: hass_auth.HassAuthProvider,
+    capsys: pytest.CaptureFixture[str],
+    hass_storage: dict[str, Any],
 ) -> None:
     """Test we can add a user."""
     data = provider.data
@@ -64,7 +72,11 @@ async def test_add_user(
     data.validate_login("paulus", "test-pass")
 
 
-async def test_validate_login(hass: HomeAssistant, provider, capsys) -> None:
+async def test_validate_login(
+    hass: HomeAssistant,
+    provider: hass_auth.HassAuthProvider,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     """Test we can validate a user login."""
     data = provider.data
     data.add_auth("test-user", "test-pass")
@@ -89,7 +101,10 @@ async def test_validate_login(hass: HomeAssistant, provider, capsys) -> None:
 
 
 async def test_change_password(
-    hass: HomeAssistant, provider, capsys, hass_storage: dict[str, Any]
+    hass: HomeAssistant,
+    provider: hass_auth.HassAuthProvider,
+    capsys: pytest.CaptureFixture[str],
+    hass_storage: dict[str, Any],
 ) -> None:
     """Test we can change a password."""
     data = provider.data
@@ -108,7 +123,10 @@ async def test_change_password(
 
 
 async def test_change_password_invalid_user(
-    hass: HomeAssistant, provider, capsys, hass_storage: dict[str, Any]
+    hass: HomeAssistant,
+    provider: hass_auth.HassAuthProvider,
+    capsys: pytest.CaptureFixture[str],
+    hass_storage: dict[str, Any],
 ) -> None:
     """Test changing password of non-existing user."""
     data = provider.data


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
