### PR TITLE
Improve type hints in ezviz tests

### DIFF
--- a/tests/components/ezviz/__init__.py
+++ b/tests/components/ezviz/__init__.py
@@ -1,6 +1,6 @@
 """Tests for the EZVIZ integration."""
 
-from unittest.mock import patch
+from unittest.mock import _patch, patch
 
 from homeassistant.components.ezviz.const import (
     ATTR_SERIAL,
@@ -83,10 +83,11 @@ API_LOGIN_RETURN_VALIDATE = {
 }
 
 
-def _patch_async_setup_entry(return_value=True):
+def patch_async_setup_entry() -> _patch:
+    """Patch async_setup_entry."""
     return patch(
         "homeassistant.components.ezviz.async_setup_entry",
-        return_value=return_value,
+        return_value=True,
     )
 
 

--- a/tests/components/ezviz/conftest.py
+++ b/tests/components/ezviz/conftest.py
@@ -5,6 +5,9 @@ from unittest.mock import MagicMock, patch
 from pyezviz import EzvizClient
 from pyezviz.test_cam_rtsp import TestRTSPAuth
 import pytest
+from typing_extensions import Generator
+
+from homeassistant.core import HomeAssistant
 
 ezviz_login_token_return = {
     "session_id": "fake_token",
@@ -14,13 +17,13 @@ ezviz_login_token_return = {
 
 
 @pytest.fixture(autouse=True)
-def mock_ffmpeg(hass):
+def mock_ffmpeg(hass: HomeAssistant) -> None:
     """Mock ffmpeg is loaded."""
     hass.config.components.add("ffmpeg")
 
 
 @pytest.fixture
-def ezviz_test_rtsp_config_flow(hass):
+def ezviz_test_rtsp_config_flow() -> Generator[MagicMock]:
     """Mock the EzvizApi for easier testing."""
     with (
         patch.object(TestRTSPAuth, "main", return_value=True),
@@ -40,7 +43,7 @@ def ezviz_test_rtsp_config_flow(hass):
 
 
 @pytest.fixture
-def ezviz_config_flow(hass):
+def ezviz_config_flow() -> Generator[MagicMock]:
     """Mock the EzvizAPI for easier config flow testing."""
     with (
         patch.object(EzvizClient, "login", return_value=True),


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
