### PR TITLE
Bump Environment Canada to 0.7.0

### DIFF
--- a/homeassistant/components/environment_canada/manifest.json
+++ b/homeassistant/components/environment_canada/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/environment_canada",
   "iot_class": "cloud_polling",
   "loggers": ["env_canada"],
-  "requirements": ["env-canada==0.6.3"]
+  "requirements": ["env-canada==0.7.0"]
 }

--- a/homeassistant/components/environment_canada/sensor.py
+++ b/homeassistant/components/environment_canada/sensor.py
@@ -19,7 +19,6 @@ from homeassistant.const import (
     PERCENTAGE,
     UV_INDEX,
     UnitOfLength,
-    UnitOfPrecipitationDepth,
     UnitOfPressure,
     UnitOfSpeed,
     UnitOfTemperature,
@@ -113,14 +112,6 @@ SENSOR_TYPES: tuple[ECSensorEntityDescription, ...] = (
         translation_key="pop",
         native_unit_of_measurement=PERCENTAGE,
         value_fn=lambda data: data.conditions.get("pop", {}).get("value"),
-    ),
-    ECSensorEntityDescription(
-        key="precip_yesterday",
-        translation_key="precip_yesterday",
-        device_class=SensorDeviceClass.PRECIPITATION,
-        native_unit_of_measurement=UnitOfPrecipitationDepth.MILLIMETERS,
-        state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: data.conditions.get("precip_yesterday", {}).get("value"),
     ),
     ECSensorEntityDescription(
         key="pressure",

--- a/homeassistant/components/environment_canada/strings.json
+++ b/homeassistant/components/environment_canada/strings.json
@@ -52,9 +52,6 @@
       "pop": {
         "name": "Chance of precipitation"
       },
-      "precip_yesterday": {
-        "name": "Precipitation yesterday"
-      },
       "pressure": {
         "name": "Barometric pressure"
       },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -816,7 +816,7 @@ enocean==0.50
 enturclient==0.2.4
 
 # homeassistant.components.environment_canada
-env-canada==0.6.3
+env-canada==0.7.0
 
 # homeassistant.components.season
 ephem==4.1.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -673,7 +673,7 @@ energyzero==2.1.0
 enocean==0.50
 
 # homeassistant.components.environment_canada
-env-canada==0.6.3
+env-canada==0.7.0
 
 # homeassistant.components.season
 ephem==4.1.5


### PR DESCRIPTION
## Breaking change
Environment Canada has removed *_yesterday sensors from their data. `precip_yesterday` is now deprecated in this integration.

## Proposed change
Bump library to remove deprecated sensors.

https://github.com/michaeldavie/env_canada/compare/v0.6.3...v0.7.0

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.


To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
