### PR TITLE
Catch exceptions in service calls by buttons/switches in pyLoad integration

### DIFF
--- a/homeassistant/components/pyload/button.py
+++ b/homeassistant/components/pyload/button.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
 
-from aiohttp import ClientConnectorError
 from pyloadapi.api import CannotConnect, InvalidAuth, PyLoadAPI
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
@@ -85,8 +84,13 @@ class PyLoadBinarySensor(BasePyLoadEntity, ButtonEntity):
         """Handle the button press."""
         try:
             await self.entity_description.press_fn(self.coordinator.pyload)
-        except (CannotConnect, InvalidAuth, OSError, ClientConnectorError) as e:
+        except CannotConnect as e:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="service_call_exception",
+            ) from e
+        except InvalidAuth as e:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="service_call_auth_exception",
             ) from e

--- a/homeassistant/components/pyload/button.py
+++ b/homeassistant/components/pyload/button.py
@@ -88,5 +88,5 @@ class PyLoadBinarySensor(BasePyLoadEntity, ButtonEntity):
         except (CannotConnect, InvalidAuth, OSError, ClientConnectorError) as e:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
-                translation_key=f"press_{self.entity_description.key}_exception",
+                translation_key="service_call_exception",
             ) from e

--- a/homeassistant/components/pyload/strings.json
+++ b/homeassistant/components/pyload/strings.json
@@ -98,6 +98,36 @@
     },
     "setup_authentication_exception": {
       "message": "Authentication failed for {username}, verify your login credentials"
+    },
+    "press_abort_downloads_exception": {
+      "message": "Unable to abort running downloads, try again later"
+    },
+    "press_restart_failed_exception": {
+      "message": "Unable to restart failed downloads, try again later"
+    },
+    "press_delete_finished_exception": {
+      "message": "Unable to delete finished downloads, try again later"
+    },
+    "press_restart_exception": {
+      "message": "Unable to restart pyLoad, try again later"
+    },
+    "turn_on_download_exception": {
+      "message": "Unable to resume download queue, try again later"
+    },
+    "turn_off_download_exception": {
+      "message": "Unable to pause download queue, try again later"
+    },
+    "toggle_download_failed_exception": {
+      "message": "Unable to pause/resume download queue, try again later"
+    },
+    "turn_on_reconnect_exception": {
+      "message": "Unable to turn on auto-reconnect, try again later"
+    },
+    "turn_off_reconnect_exception": {
+      "message": "Unable to turn off auto-reconnect, try again later"
+    },
+    "toggle_reconnect_failed_exception": {
+      "message": "Unable to toggle auto-reconnect, try again later"
     }
   },
   "issues": {

--- a/homeassistant/components/pyload/strings.json
+++ b/homeassistant/components/pyload/strings.json
@@ -101,6 +101,9 @@
     },
     "service_call_exception": {
       "message": "Unable to send command to pyLoad due to a connection error, try again later"
+    },
+    "service_call_auth_exception": {
+      "message": "Unable to send command to pyLoad due to an authentication error, try again later"
     }
   },
   "issues": {

--- a/homeassistant/components/pyload/strings.json
+++ b/homeassistant/components/pyload/strings.json
@@ -99,35 +99,8 @@
     "setup_authentication_exception": {
       "message": "Authentication failed for {username}, verify your login credentials"
     },
-    "press_abort_downloads_exception": {
-      "message": "Unable to abort running downloads, try again later"
-    },
-    "press_restart_failed_exception": {
-      "message": "Unable to restart failed downloads, try again later"
-    },
-    "press_delete_finished_exception": {
-      "message": "Unable to delete finished downloads, try again later"
-    },
-    "press_restart_exception": {
-      "message": "Unable to restart pyLoad, try again later"
-    },
-    "turn_on_download_exception": {
-      "message": "Unable to resume download queue, try again later"
-    },
-    "turn_off_download_exception": {
-      "message": "Unable to pause download queue, try again later"
-    },
-    "toggle_download_failed_exception": {
-      "message": "Unable to pause/resume download queue, try again later"
-    },
-    "turn_on_reconnect_exception": {
-      "message": "Unable to turn on auto-reconnect, try again later"
-    },
-    "turn_off_reconnect_exception": {
-      "message": "Unable to turn off auto-reconnect, try again later"
-    },
-    "toggle_reconnect_failed_exception": {
-      "message": "Unable to toggle auto-reconnect, try again later"
+    "service_call_exception": {
+      "message": "Unable to send command to pyLoad due to a connection error, try again later"
     }
   },
   "issues": {

--- a/homeassistant/components/pyload/switch.py
+++ b/homeassistant/components/pyload/switch.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
 
-from aiohttp import ClientConnectorError
 from pyloadapi.api import CannotConnect, InvalidAuth, PyLoadAPI
 
 from homeassistant.components.switch import (
@@ -95,10 +94,15 @@ class PyLoadSwitchEntity(BasePyLoadEntity, SwitchEntity):
         """Turn the entity on."""
         try:
             await self.entity_description.turn_on_fn(self.coordinator.pyload)
-        except (CannotConnect, InvalidAuth, ClientConnectorError) as e:
+        except CannotConnect as e:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="service_call_exception",
+            ) from e
+        except InvalidAuth as e:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="service_call_auth_exception",
             ) from e
 
         await self.coordinator.async_refresh()
@@ -107,10 +111,15 @@ class PyLoadSwitchEntity(BasePyLoadEntity, SwitchEntity):
         """Turn the entity on."""
         try:
             await self.entity_description.turn_off_fn(self.coordinator.pyload)
-        except (CannotConnect, InvalidAuth, OSError, ClientConnectorError) as e:
+        except CannotConnect as e:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="service_call_exception",
+            ) from e
+        except InvalidAuth as e:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="service_call_auth_exception",
             ) from e
 
         await self.coordinator.async_refresh()
@@ -119,10 +128,15 @@ class PyLoadSwitchEntity(BasePyLoadEntity, SwitchEntity):
         """Toggle the entity."""
         try:
             await self.entity_description.toggle_fn(self.coordinator.pyload)
-        except (CannotConnect, InvalidAuth) as e:
+        except CannotConnect as e:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="service_call_exception",
+            ) from e
+        except InvalidAuth as e:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="service_call_auth_exception",
             ) from e
 
         await self.coordinator.async_refresh()

--- a/homeassistant/components/pyload/switch.py
+++ b/homeassistant/components/pyload/switch.py
@@ -98,7 +98,7 @@ class PyLoadSwitchEntity(BasePyLoadEntity, SwitchEntity):
         except (CannotConnect, InvalidAuth, ClientConnectorError) as e:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
-                translation_key=f"turn_on_{self.entity_description.key}_exception",
+                translation_key="service_call_exception",
             ) from e
 
         await self.coordinator.async_refresh()
@@ -110,7 +110,7 @@ class PyLoadSwitchEntity(BasePyLoadEntity, SwitchEntity):
         except (CannotConnect, InvalidAuth, OSError, ClientConnectorError) as e:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
-                translation_key=f"turn_off_{self.entity_description.key}_exception",
+                translation_key="service_call_exception",
             ) from e
 
         await self.coordinator.async_refresh()
@@ -122,7 +122,7 @@ class PyLoadSwitchEntity(BasePyLoadEntity, SwitchEntity):
         except (CannotConnect, InvalidAuth) as e:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
-                translation_key=f"toggle_{self.entity_description.key}_exception",
+                translation_key="service_call_exception",
             ) from e
 
         await self.coordinator.async_refresh()

--- a/tests/components/pyload/test_button.py
+++ b/tests/components/pyload/test_button.py
@@ -3,6 +3,7 @@
 from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, call, patch
 
+from pyloadapi import CannotConnect
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -11,6 +12,7 @@ from homeassistant.components.pyload.button import PyLoadButtonEntity
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry, snapshot_platform
@@ -78,6 +80,38 @@ async def test_button_press(
             {ATTR_ENTITY_ID: entity_entry.entity_id},
             blocking=True,
         )
-        await hass.async_block_till_done()
         assert API_CALL[entity_entry.translation_key] in mock_pyloadapi.method_calls
         mock_pyloadapi.reset_mock()
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_button_press_errors(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_pyloadapi: AsyncMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test button press method."""
+
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    entity_entries = er.async_entries_for_config_entry(
+        entity_registry, config_entry.entry_id
+    )
+    mock_pyloadapi.stop_all_downloads.side_effect = CannotConnect
+    mock_pyloadapi.restart_failed.side_effect = CannotConnect
+    mock_pyloadapi.delete_finished.side_effect = CannotConnect
+    mock_pyloadapi.restart.side_effect = CannotConnect
+
+    for entity_entry in entity_entries:
+        with pytest.raises(ServiceValidationError):
+            await hass.services.async_call(
+                BUTTON_DOMAIN,
+                SERVICE_PRESS,
+                {ATTR_ENTITY_ID: entity_entry.entity_id},
+                blocking=True,
+            )

--- a/tests/components/pyload/test_switch.py
+++ b/tests/components/pyload/test_switch.py
@@ -3,6 +3,7 @@
 from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, call, patch
 
+from pyloadapi import CannotConnect
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -16,6 +17,7 @@ from homeassistant.components.switch import (
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry, snapshot_platform
@@ -102,3 +104,44 @@ async def test_turn_on_off(
             in mock_pyloadapi.method_calls
         )
         mock_pyloadapi.reset_mock()
+
+
+@pytest.mark.parametrize(
+    ("service_call"),
+    [
+        SERVICE_TURN_ON,
+        SERVICE_TURN_OFF,
+        SERVICE_TOGGLE,
+    ],
+)
+async def test_turn_on_off_errors(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_pyloadapi: AsyncMock,
+    service_call: str,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test switch turn on/off, toggle method."""
+
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    entity_entries = er.async_entries_for_config_entry(
+        entity_registry, config_entry.entry_id
+    )
+    mock_pyloadapi.unpause.side_effect = CannotConnect
+    mock_pyloadapi.pause.side_effect = CannotConnect
+    mock_pyloadapi.toggle_pause.side_effect = CannotConnect
+    mock_pyloadapi.toggle_reconnect.side_effect = CannotConnect
+
+    for entity_entry in entity_entries:
+        with pytest.raises(ServiceValidationError):
+            await hass.services.async_call(
+                SWITCH_DOMAIN,
+                service_call,
+                {ATTR_ENTITY_ID: entity_entry.entity_id},
+                blocking=True,
+            )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This adds proper exception handling to service calls of switches (turn_on/turn_off/toggle) and to buttons (press) and displays suitable (translatable) error messages. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
