### PR TITLE
Bump `nextdns` to version 3.1.0

### DIFF
--- a/homeassistant/components/nextdns/__init__.py
+++ b/homeassistant/components/nextdns/__init__.py
@@ -18,6 +18,7 @@ from nextdns import (
     NextDns,
     Settings,
 )
+from tenacity import RetryError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, Platform
@@ -84,9 +85,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: NextDnsConfigEntry) -> b
 
     websession = async_get_clientsession(hass)
     try:
-        async with asyncio.timeout(10):
-            nextdns = await NextDns.create(websession, api_key)
-    except (ApiError, ClientConnectorError, TimeoutError) as err:
+        nextdns = await NextDns.create(websession, api_key)
+    except (ApiError, ClientConnectorError, RetryError, TimeoutError) as err:
         raise ConfigEntryNotReady from err
 
     tasks = []

--- a/homeassistant/components/nextdns/coordinator.py
+++ b/homeassistant/components/nextdns/coordinator.py
@@ -18,6 +18,7 @@ from nextdns import (
     Settings,
 )
 from nextdns.model import NextDnsData
+from tenacity import RetryError
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
@@ -62,7 +63,7 @@ class NextDnsUpdateCoordinator(DataUpdateCoordinator[CoordinatorDataT]):
             ApiError,
             ClientConnectorError,
             InvalidApiKeyError,
-            TimeoutError,
+            RetryError,
         ) as err:
             raise UpdateFailed(err) from err
 

--- a/homeassistant/components/nextdns/coordinator.py
+++ b/homeassistant/components/nextdns/coordinator.py
@@ -1,6 +1,5 @@
 """NextDns coordinator."""
 
-import asyncio
 from datetime import timedelta
 import logging
 from typing import TypeVar
@@ -58,9 +57,13 @@ class NextDnsUpdateCoordinator(DataUpdateCoordinator[CoordinatorDataT]):
     async def _async_update_data(self) -> CoordinatorDataT:
         """Update data via internal method."""
         try:
-            async with asyncio.timeout(10):
-                return await self._async_update_data_internal()
-        except (ApiError, ClientConnectorError, InvalidApiKeyError) as err:
+            return await self._async_update_data_internal()
+        except (
+            ApiError,
+            ClientConnectorError,
+            InvalidApiKeyError,
+            TimeoutError,
+        ) as err:
             raise UpdateFailed(err) from err
 
     async def _async_update_data_internal(self) -> CoordinatorDataT:

--- a/homeassistant/components/nextdns/manifest.json
+++ b/homeassistant/components/nextdns/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["nextdns"],
   "quality_scale": "platinum",
-  "requirements": ["nextdns==3.0.0"]
+  "requirements": ["nextdns==3.1.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1407,7 +1407,7 @@ nextcloudmonitor==1.5.0
 nextcord==2.6.0
 
 # homeassistant.components.nextdns
-nextdns==3.0.0
+nextdns==3.1.0
 
 # homeassistant.components.nibe_heatpump
 nibe==2.8.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1146,7 +1146,7 @@ nextcloudmonitor==1.5.0
 nextcord==2.6.0
 
 # homeassistant.components.nextdns
-nextdns==3.0.0
+nextdns==3.1.0
 
 # homeassistant.components.nibe_heatpump
 nibe==2.8.0

--- a/tests/components/nextdns/test_config_flow.py
+++ b/tests/components/nextdns/test_config_flow.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from nextdns import ApiError, InvalidApiKeyError
 import pytest
+from tenacity import RetryError
 
 from homeassistant.components.nextdns.const import CONF_PROFILE_ID, DOMAIN
 from homeassistant.config_entries import SOURCE_USER
@@ -57,6 +58,7 @@ async def test_form_create_entry(hass: HomeAssistant) -> None:
     [
         (ApiError("API Error"), "cannot_connect"),
         (InvalidApiKeyError, "invalid_api_key"),
+        (RetryError("Retry Error"), "cannot_connect"),
         (TimeoutError, "cannot_connect"),
         (ValueError, "unknown"),
     ],

--- a/tests/components/nextdns/test_switch.py
+++ b/tests/components/nextdns/test_switch.py
@@ -8,6 +8,7 @@ from aiohttp.client_exceptions import ClientConnectorError
 from nextdns import ApiError
 import pytest
 from syrupy import SnapshotAssertion
+from tenacity import RetryError
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import (
@@ -94,7 +95,15 @@ async def test_switch_off(hass: HomeAssistant) -> None:
         mock_switch_on.assert_called_once()
 
 
-async def test_availability(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    "exc",
+    [
+        ApiError("API Error"),
+        RetryError("Retry Error"),
+        TimeoutError,
+    ],
+)
+async def test_availability(hass: HomeAssistant, exc: Exception) -> None:
     """Ensure that we mark the entities unavailable correctly when service causes an error."""
     await init_integration(hass)
 
@@ -106,7 +115,7 @@ async def test_availability(hass: HomeAssistant) -> None:
     future = utcnow() + timedelta(minutes=10)
     with patch(
         "homeassistant.components.nextdns.NextDns.get_settings",
-        side_effect=ApiError("API Error"),
+        side_effect=exc,
     ):
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done(wait_background_tasks=True)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I have recently noticed that the NextDNS API responds to requests with a delay or responds with a 500/503 status. This causes the entities to become unavailable. This PR fixes these problems.

It bumps `nextdns` to version 3.1.0 to:
 - move HTTP request timeout to backend library
 - use `tenacity` to retry the request when it fails

Changelog: https://github.com/bieniu/nextdns/compare/3.0.0...3.1.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
