### PR TITLE
Check Tessie scopes to fix startup bug

### DIFF
--- a/homeassistant/components/teslemetry/manifest.json
+++ b/homeassistant/components/teslemetry/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["tesla-fleet-api"],
   "quality_scale": "platinum",
-  "requirements": ["tesla-fleet-api==0.6.1"]
+  "requirements": ["tesla-fleet-api==0.6.2"]
 }

--- a/homeassistant/components/tessie/__init__.py
+++ b/homeassistant/components/tessie/__init__.py
@@ -6,6 +6,7 @@ import logging
 
 from aiohttp import ClientError, ClientResponseError
 from tesla_fleet_api import EnergySpecific, Tessie
+from tesla_fleet_api.const import Scope
 from tesla_fleet_api.exceptions import TeslaFleetError
 from tessie_api import get_state_of_all_vehicles
 
@@ -94,41 +95,48 @@ async def async_setup_entry(hass: HomeAssistant, entry: TessieConfigEntry) -> bo
 
     # Energy Sites
     tessie = Tessie(session, api_key)
+    energysites: list[TessieEnergyData] = []
+
     try:
-        products = (await tessie.products())["response"]
+        scopes = await tessie.scopes()
     except TeslaFleetError as e:
         raise ConfigEntryNotReady from e
 
-    energysites: list[TessieEnergyData] = []
-    for product in products:
-        if "energy_site_id" in product:
-            site_id = product["energy_site_id"]
-            api = EnergySpecific(tessie.energy, site_id)
-            energysites.append(
-                TessieEnergyData(
-                    api=api,
-                    id=site_id,
-                    live_coordinator=TessieEnergySiteLiveCoordinator(hass, api),
-                    info_coordinator=TessieEnergySiteInfoCoordinator(hass, api),
-                    device=DeviceInfo(
-                        identifiers={(DOMAIN, str(site_id))},
-                        manufacturer="Tesla",
-                        name=product.get("site_name", "Energy Site"),
-                    ),
-                )
-            )
+    if Scope.ENERGY_DEVICE_DATA in scopes:
+        try:
+            products = (await tessie.products())["response"]
+        except TeslaFleetError as e:
+            raise ConfigEntryNotReady from e
 
-    # Populate coordinator data before forwarding to platforms
-    await asyncio.gather(
-        *(
-            energysite.live_coordinator.async_config_entry_first_refresh()
-            for energysite in energysites
-        ),
-        *(
-            energysite.info_coordinator.async_config_entry_first_refresh()
-            for energysite in energysites
-        ),
-    )
+        for product in products:
+            if "energy_site_id" in product:
+                site_id = product["energy_site_id"]
+                api = EnergySpecific(tessie.energy, site_id)
+                energysites.append(
+                    TessieEnergyData(
+                        api=api,
+                        id=site_id,
+                        live_coordinator=TessieEnergySiteLiveCoordinator(hass, api),
+                        info_coordinator=TessieEnergySiteInfoCoordinator(hass, api),
+                        device=DeviceInfo(
+                            identifiers={(DOMAIN, str(site_id))},
+                            manufacturer="Tesla",
+                            name=product.get("site_name", "Energy Site"),
+                        ),
+                    )
+                )
+
+        # Populate coordinator data before forwarding to platforms
+        await asyncio.gather(
+            *(
+                energysite.live_coordinator.async_config_entry_first_refresh()
+                for energysite in energysites
+            ),
+            *(
+                energysite.info_coordinator.async_config_entry_first_refresh()
+                for energysite in energysites
+            ),
+        )
 
     entry.runtime_data = TessieData(vehicles, energysites)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/tessie/manifest.json
+++ b/homeassistant/components/tessie/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/tessie",
   "iot_class": "cloud_polling",
   "loggers": ["tessie"],
-  "requirements": ["tessie-api==0.0.9", "tesla-fleet-api==0.6.1"]
+  "requirements": ["tessie-api==0.0.9", "tesla-fleet-api==0.6.2"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2710,8 +2710,6 @@ temperusb==1.6.1
 # tensorflow==2.5.0
 
 # homeassistant.components.teslemetry
-tesla-fleet-api==0.6.1
-
 # homeassistant.components.tessie
 tesla-fleet-api==0.6.2
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2710,8 +2710,10 @@ temperusb==1.6.1
 # tensorflow==2.5.0
 
 # homeassistant.components.teslemetry
-# homeassistant.components.tessie
 tesla-fleet-api==0.6.1
+
+# homeassistant.components.tessie
+tesla-fleet-api==0.6.2
 
 # homeassistant.components.powerwall
 tesla-powerwall==0.5.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2108,8 +2108,6 @@ temescal==0.5
 temperusb==1.6.1
 
 # homeassistant.components.teslemetry
-tesla-fleet-api==0.6.1
-
 # homeassistant.components.tessie
 tesla-fleet-api==0.6.2
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2108,8 +2108,10 @@ temescal==0.5
 temperusb==1.6.1
 
 # homeassistant.components.teslemetry
-# homeassistant.components.tessie
 tesla-fleet-api==0.6.1
+
+# homeassistant.components.tessie
+tesla-fleet-api==0.6.2
 
 # homeassistant.components.powerwall
 tesla-powerwall==0.5.2

--- a/tests/components/tessie/common.py
+++ b/tests/components/tessie/common.py
@@ -54,6 +54,17 @@ LIVE_STATUS = load_json_object_fixture("live_status.json", DOMAIN)
 SITE_INFO = load_json_object_fixture("site_info.json", DOMAIN)
 RESPONSE_OK = {"response": {}, "error": None}
 COMMAND_OK = {"response": {"result": True, "reason": ""}}
+SCOPES = [
+    "user_data",
+    "vehicle_device_data",
+    "vehicle_cmds",
+    "vehicle_charging_cmds",
+    "energy_device_data",
+    "energy_cmds",
+    "offline_access",
+    "openid",
+]
+NO_SCOPES = ["user_data", "offline_access", "openid"]
 
 
 async def setup_platform(

--- a/tests/components/tessie/conftest.py
+++ b/tests/components/tessie/conftest.py
@@ -11,6 +11,7 @@ from .common import (
     COMMAND_OK,
     LIVE_STATUS,
     PRODUCTS,
+    SCOPES,
     SITE_INFO,
     TEST_STATE_OF_ALL_VEHICLES,
     TEST_VEHICLE_STATE_ONLINE,
@@ -51,6 +52,16 @@ def mock_get_state_of_all_vehicles():
 
 
 # Fleet API
+@pytest.fixture(autouse=True)
+def mock_scopes():
+    """Mock scopes function."""
+    with patch(
+        "homeassistant.components.tessie.Tessie.scopes",
+        return_value=SCOPES,
+    ) as mock_scopes:
+        yield mock_scopes
+
+
 @pytest.fixture(autouse=True)
 def mock_products():
     """Mock Tesla Fleet Api products method."""

--- a/tests/components/tessie/test_init.py
+++ b/tests/components/tessie/test_init.py
@@ -50,11 +50,21 @@ async def test_connection_failure(
     assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_fleet_error(hass: HomeAssistant) -> None:
-    """Test init with a fleet error."""
+async def test_products_error(hass: HomeAssistant) -> None:
+    """Test init with a fleet error on products."""
 
     with patch(
         "homeassistant.components.tessie.Tessie.products", side_effect=TeslaFleetError
+    ):
+        entry = await setup_platform(hass)
+        assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_scopes_error(hass: HomeAssistant) -> None:
+    """Test init with a fleet error on scopes."""
+
+    with patch(
+        "homeassistant.components.tessie.Tessie.scopes", side_effect=TeslaFleetError
     ):
         entry = await setup_platform(hass)
         assert entry.state is ConfigEntryState.SETUP_RETRY


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If a user hasnt granted Tessie permission to energy scopes it causes a setup error due to the way that the products API works. This PR implements the bare minimum of Scope checking to avoid triggering this failure.

Please beta hotfix

https://github.com/Teslemetry/python-tesla-fleet-api/compare/v0.6.1...v0.6.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #120666
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
