### PR TITLE
Tolerate integration removed device

### DIFF
--- a/homeassistant/components/config/device_registry.py
+++ b/homeassistant/components/config/device_registry.py
@@ -138,10 +138,14 @@ async def websocket_remove_config_entry_from_device(
             "Failed to remove device entry, rejected by integration"
         )
 
-    entry = registry.async_update_device(
-        device_id, remove_config_entry_id=config_entry_id
-    )
+    # Integration might have removed the config entry already, that is fine.
+    try:
+        entry = registry.async_update_device(
+            device_id, remove_config_entry_id=config_entry_id
+        )
 
-    entry_as_dict = entry.dict_repr if entry else None
+        entry_as_dict = entry.dict_repr if entry else None
+    except KeyError:
+        entry_as_dict = None
 
     connection.send_message(websocket_api.result_message(msg["id"], entry_as_dict))

--- a/homeassistant/components/config/device_registry.py
+++ b/homeassistant/components/config/device_registry.py
@@ -139,13 +139,13 @@ async def websocket_remove_config_entry_from_device(
         )
 
     # Integration might have removed the config entry already, that is fine.
-    try:
+    if registry.async_get(device_id):
         entry = registry.async_update_device(
             device_id, remove_config_entry_id=config_entry_id
         )
 
         entry_as_dict = entry.dict_repr if entry else None
-    except KeyError:
+    else:
         entry_as_dict = None
 
     connection.send_message(websocket_api.result_message(msg["id"], entry_as_dict))

--- a/tests/components/config/test_device_registry.py
+++ b/tests/components/config/test_device_registry.py
@@ -423,3 +423,91 @@ async def test_remove_config_entry_from_device_fails(
     assert not response["success"]
     assert response["error"]["code"] == "home_assistant_error"
     assert response["error"]["message"] == "Integration not found"
+
+
+async def test_remove_config_entry_from_device_if_integration_remove(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test removing config entry from device doesn't lead to an error when the integration removes the entry."""
+    assert await async_setup_component(hass, "config", {})
+    ws_client = await hass_ws_client(hass)
+
+    can_remove = False
+
+    async def async_remove_config_entry_device(hass, config_entry, device_entry):
+        if can_remove:
+            device_registry.async_update_device(
+                device_entry.id, remove_config_entry_id=config_entry.entry_id
+            )
+        return can_remove
+
+    mock_integration(
+        hass,
+        MockModule(
+            "comp1", async_remove_config_entry_device=async_remove_config_entry_device
+        ),
+    )
+    mock_integration(
+        hass,
+        MockModule(
+            "comp2", async_remove_config_entry_device=async_remove_config_entry_device
+        ),
+    )
+
+    entry_1 = MockConfigEntry(
+        domain="comp1",
+        title="Test 1",
+        source="bla",
+    )
+    entry_1.supports_remove_device = True
+    entry_1.add_to_hass(hass)
+
+    entry_2 = MockConfigEntry(
+        domain="comp1",
+        title="Test 1",
+        source="bla",
+    )
+    entry_2.supports_remove_device = True
+    entry_2.add_to_hass(hass)
+
+    device_registry.async_get_or_create(
+        config_entry_id=entry_1.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=entry_2.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    assert device_entry.config_entries == {entry_1.entry_id, entry_2.entry_id}
+
+    # Try removing a config entry from the device, it should fail because
+    # async_remove_config_entry_device returns False
+    response = await ws_client.remove_device(device_entry.id, entry_1.entry_id)
+
+    assert not response["success"]
+    assert response["error"]["code"] == "home_assistant_error"
+
+    # Make async_remove_config_entry_device return True
+    can_remove = True
+
+    # Remove the 1st config entry
+    response = await ws_client.remove_device(device_entry.id, entry_1.entry_id)
+
+    assert response["success"]
+    assert response["result"]["config_entries"] == [entry_2.entry_id]
+
+    # Check that the config entry was removed from the device
+    assert device_registry.async_get(device_entry.id).config_entries == {
+        entry_2.entry_id
+    }
+
+    # Remove the 2nd config entry
+    response = await ws_client.remove_device(device_entry.id, entry_2.entry_id)
+
+    assert response["success"]
+    assert response["result"] is None
+
+    # This was the last config entry, the device is removed
+    assert not device_registry.async_get(device_entry.id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Tolerate if the integration removes the device on it's own. This is useful especially for devices which have via devices, all managed by the integration (e.g. Matter).

This is an alternative variant to fix the problem in #120721.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
