### PR TITLE
Add unit and state_class to heating sensor in ista EcoTrend

### DIFF
--- a/homeassistant/components/ista_ecotrend/const.py
+++ b/homeassistant/components/ista_ecotrend/const.py
@@ -1,3 +1,5 @@
 """Constants for the ista Ecotrend integration."""
 
 DOMAIN = "ista_ecotrend"
+
+HEATING_UNIT = "Units"

--- a/homeassistant/components/ista_ecotrend/const.py
+++ b/homeassistant/components/ista_ecotrend/const.py
@@ -1,5 +1,3 @@
 """Constants for the ista Ecotrend integration."""
 
 DOMAIN = "ista_ecotrend"
-
-HEATING_UNIT = "Units"

--- a/homeassistant/components/ista_ecotrend/sensor.py
+++ b/homeassistant/components/ista_ecotrend/sensor.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import IstaConfigEntry
-from .const import DOMAIN
+from .const import DOMAIN, HEATING_UNIT
 from .coordinator import IstaCoordinator
 from .util import IstaConsumptionType, IstaValueType, get_native_value
 
@@ -56,6 +56,8 @@ SENSOR_DESCRIPTIONS: tuple[IstaSensorEntityDescription, ...] = (
         translation_key=IstaSensorEntity.HEATING,
         suggested_display_precision=0,
         consumption_type=IstaConsumptionType.HEATING,
+        native_unit_of_measurement=HEATING_UNIT,
+        state_class=SensorStateClass.TOTAL,
     ),
     IstaSensorEntityDescription(
         key=IstaSensorEntity.HEATING_ENERGY,

--- a/homeassistant/components/ista_ecotrend/sensor.py
+++ b/homeassistant/components/ista_ecotrend/sensor.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import IstaConfigEntry
-from .const import DOMAIN, HEATING_UNIT
+from .const import DOMAIN
 from .coordinator import IstaCoordinator
 from .util import IstaConsumptionType, IstaValueType, get_native_value
 
@@ -56,7 +56,7 @@ SENSOR_DESCRIPTIONS: tuple[IstaSensorEntityDescription, ...] = (
         translation_key=IstaSensorEntity.HEATING,
         suggested_display_precision=0,
         consumption_type=IstaConsumptionType.HEATING,
-        native_unit_of_measurement=HEATING_UNIT,
+        native_unit_of_measurement="units",
         state_class=SensorStateClass.TOTAL,
     ),
     IstaSensorEntityDescription(

--- a/tests/components/ista_ecotrend/snapshots/test_sensor.ambr
+++ b/tests/components/ista_ecotrend/snapshots/test_sensor.ambr
@@ -64,7 +64,9 @@
     'aliases': set({
     }),
     'area_id': None,
-    'capabilities': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL: 'total'>,
+    }),
     'config_entry_id': <ANY>,
     'device_class': None,
     'device_id': <ANY>,
@@ -92,13 +94,15 @@
     'supported_features': 0,
     'translation_key': <IstaSensorEntity.HEATING: 'heating'>,
     'unique_id': 'eaf5c5c8-889f-4a3c-b68c-e9a676505762_heating',
-    'unit_of_measurement': None,
+    'unit_of_measurement': 'Units',
   })
 # ---
 # name: test_setup[sensor.bahnhofsstr_1a_heating-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Bahnhofsstr. 1A Heating',
+      'state_class': <SensorStateClass.TOTAL: 'total'>,
+      'unit_of_measurement': 'Units',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.bahnhofsstr_1a_heating',
@@ -491,7 +495,9 @@
     'aliases': set({
     }),
     'area_id': None,
-    'capabilities': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL: 'total'>,
+    }),
     'config_entry_id': <ANY>,
     'device_class': None,
     'device_id': <ANY>,
@@ -519,13 +525,15 @@
     'supported_features': 0,
     'translation_key': <IstaSensorEntity.HEATING: 'heating'>,
     'unique_id': '26e93f1a-c828-11ea-87d0-0242ac130003_heating',
-    'unit_of_measurement': None,
+    'unit_of_measurement': 'Units',
   })
 # ---
 # name: test_setup[sensor.luxemburger_str_1_heating-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Luxemburger Str. 1 Heating',
+      'state_class': <SensorStateClass.TOTAL: 'total'>,
+      'unit_of_measurement': 'Units',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.luxemburger_str_1_heating',

--- a/tests/components/ista_ecotrend/snapshots/test_sensor.ambr
+++ b/tests/components/ista_ecotrend/snapshots/test_sensor.ambr
@@ -94,7 +94,7 @@
     'supported_features': 0,
     'translation_key': <IstaSensorEntity.HEATING: 'heating'>,
     'unique_id': 'eaf5c5c8-889f-4a3c-b68c-e9a676505762_heating',
-    'unit_of_measurement': 'Units',
+    'unit_of_measurement': 'units',
   })
 # ---
 # name: test_setup[sensor.bahnhofsstr_1a_heating-state]
@@ -102,7 +102,7 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'Bahnhofsstr. 1A Heating',
       'state_class': <SensorStateClass.TOTAL: 'total'>,
-      'unit_of_measurement': 'Units',
+      'unit_of_measurement': 'units',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.bahnhofsstr_1a_heating',
@@ -525,7 +525,7 @@
     'supported_features': 0,
     'translation_key': <IstaSensorEntity.HEATING: 'heating'>,
     'unique_id': '26e93f1a-c828-11ea-87d0-0242ac130003_heating',
-    'unit_of_measurement': 'Units',
+    'unit_of_measurement': 'units',
   })
 # ---
 # name: test_setup[sensor.luxemburger_str_1_heating-state]
@@ -533,7 +533,7 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'Luxemburger Str. 1 Heating',
       'state_class': <SensorStateClass.TOTAL: 'total'>,
-      'unit_of_measurement': 'Units',
+      'unit_of_measurement': 'units',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.luxemburger_str_1_heating',


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add unit and state class to heating consumption sensor



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
