### PR TITLE
Improve type hints in flo tests

### DIFF
--- a/tests/components/flo/conftest.py
+++ b/tests/components/flo/conftest.py
@@ -16,7 +16,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 @pytest.fixture
-def config_entry(hass):
+def config_entry() -> MockConfigEntry:
     """Config entry version 1 fixture."""
     return MockConfigEntry(
         domain=FLO_DOMAIN,

--- a/tests/components/flo/test_binary_sensor.py
+++ b/tests/components/flo/test_binary_sensor.py
@@ -1,5 +1,7 @@
 """Test Flo by Moen binary sensor entities."""
 
+import pytest
+
 from homeassistant.components.flo.const import DOMAIN as FLO_DOMAIN
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
@@ -13,9 +15,12 @@ from homeassistant.setup import async_setup_component
 
 from .common import TEST_PASSWORD, TEST_USER_ID
 
+from tests.common import MockConfigEntry
 
+
+@pytest.mark.usefixtures("aioclient_mock_fixture")
 async def test_binary_sensors(
-    hass: HomeAssistant, config_entry, aioclient_mock_fixture
+    hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:
     """Test Flo by Moen sensors."""
     config_entry.add_to_hass(hass)

--- a/tests/components/flo/test_config_flow.py
+++ b/tests/components/flo/test_config_flow.py
@@ -5,6 +5,8 @@ import json
 import time
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant import config_entries
 from homeassistant.components.flo.const import DOMAIN
 from homeassistant.const import CONTENT_TYPE_JSON
@@ -16,7 +18,8 @@ from .common import TEST_EMAIL_ADDRESS, TEST_PASSWORD, TEST_TOKEN, TEST_USER_ID
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_form(hass: HomeAssistant, aioclient_mock_fixture) -> None:
+@pytest.mark.usefixtures("aioclient_mock_fixture")
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/flo/test_device.py
+++ b/tests/components/flo/test_device.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from aioflo.errors import RequestError
 from freezegun.api import FrozenDateTimeFactory
+import pytest
 
 from homeassistant.components.flo.const import DOMAIN as FLO_DOMAIN
 from homeassistant.components.flo.coordinator import FloDeviceDataUpdateCoordinator
@@ -14,14 +15,14 @@ from homeassistant.setup import async_setup_component
 
 from .common import TEST_PASSWORD, TEST_USER_ID
 
-from tests.common import async_fire_time_changed
+from tests.common import MockConfigEntry, async_fire_time_changed
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
+@pytest.mark.usefixtures("aioclient_mock_fixture")
 async def test_device(
     hass: HomeAssistant,
-    config_entry,
-    aioclient_mock_fixture,
+    config_entry: MockConfigEntry,
     aioclient_mock: AiohttpClientMocker,
     freezer: FrozenDateTimeFactory,
 ) -> None:
@@ -90,10 +91,10 @@ async def test_device(
     assert aioclient_mock.call_count == call_count + 6
 
 
+@pytest.mark.usefixtures("aioclient_mock_fixture")
 async def test_device_failures(
     hass: HomeAssistant,
-    config_entry,
-    aioclient_mock_fixture,
+    config_entry: MockConfigEntry,
     aioclient_mock: AiohttpClientMocker,
     freezer: FrozenDateTimeFactory,
 ) -> None:

--- a/tests/components/flo/test_init.py
+++ b/tests/components/flo/test_init.py
@@ -1,5 +1,7 @@
 """Test init."""
 
+import pytest
+
 from homeassistant.components.flo.const import DOMAIN as FLO_DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
@@ -7,10 +9,11 @@ from homeassistant.setup import async_setup_component
 
 from .common import TEST_PASSWORD, TEST_USER_ID
 
+from tests.common import MockConfigEntry
 
-async def test_setup_entry(
-    hass: HomeAssistant, config_entry, aioclient_mock_fixture
-) -> None:
+
+@pytest.mark.usefixtures("aioclient_mock_fixture")
+async def test_setup_entry(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
     """Test migration of config entry from v1."""
     config_entry.add_to_hass(hass)
     assert await async_setup_component(

--- a/tests/components/flo/test_sensor.py
+++ b/tests/components/flo/test_sensor.py
@@ -1,5 +1,7 @@
 """Test Flo by Moen sensor entities."""
 
+import pytest
+
 from homeassistant.components.flo.const import DOMAIN as FLO_DOMAIN
 from homeassistant.components.sensor import ATTR_STATE_CLASS, SensorStateClass
 from homeassistant.const import ATTR_ENTITY_ID, CONF_PASSWORD, CONF_USERNAME
@@ -9,12 +11,12 @@ from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from .common import TEST_PASSWORD, TEST_USER_ID
 
+from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_sensors(
-    hass: HomeAssistant, config_entry, aioclient_mock_fixture
-) -> None:
+@pytest.mark.usefixtures("aioclient_mock_fixture")
+async def test_sensors(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
     """Test Flo by Moen sensors."""
     hass.config.units = US_CUSTOMARY_SYSTEM
     config_entry.add_to_hass(hass)
@@ -85,10 +87,10 @@ async def test_sensors(
     )
 
 
+@pytest.mark.usefixtures("aioclient_mock_fixture")
 async def test_manual_update_entity(
     hass: HomeAssistant,
-    config_entry,
-    aioclient_mock_fixture,
+    config_entry: MockConfigEntry,
     aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test manual update entity via service homeasasistant/update_entity."""

--- a/tests/components/flo/test_services.py
+++ b/tests/components/flo/test_services.py
@@ -19,15 +19,16 @@ from homeassistant.setup import async_setup_component
 
 from .common import TEST_PASSWORD, TEST_USER_ID
 
+from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 SWITCH_ENTITY_ID = "switch.smart_water_shutoff_shutoff_valve"
 
 
+@pytest.mark.usefixtures("aioclient_mock_fixture")
 async def test_services(
     hass: HomeAssistant,
-    config_entry,
-    aioclient_mock_fixture,
+    config_entry: MockConfigEntry,
     aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test Flo services."""

--- a/tests/components/flo/test_switch.py
+++ b/tests/components/flo/test_switch.py
@@ -1,5 +1,7 @@
 """Tests for the switch domain for Flo by Moen."""
 
+import pytest
+
 from homeassistant.components.flo.const import DOMAIN as FLO_DOMAIN
 from homeassistant.components.switch import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, STATE_OFF, STATE_ON
@@ -8,9 +10,12 @@ from homeassistant.setup import async_setup_component
 
 from .common import TEST_PASSWORD, TEST_USER_ID
 
+from tests.common import MockConfigEntry
 
+
+@pytest.mark.usefixtures("aioclient_mock_fixture")
 async def test_valve_switches(
-    hass: HomeAssistant, config_entry, aioclient_mock_fixture
+    hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:
     """Test Flo by Moen valve switches."""
     config_entry.add_to_hass(hass)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
