### PR TITLE
Improve type hints in forked_daapd tests

### DIFF
--- a/tests/components/forked_daapd/conftest.py
+++ b/tests/components/forked_daapd/conftest.py
@@ -10,7 +10,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture(name="config_entry")
-def config_entry_fixture():
+def config_entry_fixture() -> MockConfigEntry:
     """Create hass config_entry fixture."""
     data = {
         CONF_HOST: "192.168.1.1",

--- a/tests/components/forked_daapd/test_browse_media.py
+++ b/tests/components/forked_daapd/test_browse_media.py
@@ -3,8 +3,6 @@
 from http import HTTPStatus
 from unittest.mock import patch
 
-import pytest
-
 from homeassistant.components import media_source, spotify
 from homeassistant.components.forked_daapd.browse_media import (
     MediaContent,
@@ -19,13 +17,16 @@ from homeassistant.components.websocket_api import TYPE_RESULT
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
+from tests.common import MockConfigEntry
 from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 TEST_MASTER_ENTITY_NAME = "media_player.owntone_server"
 
 
 async def test_async_browse_media(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, config_entry
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    config_entry: MockConfigEntry,
 ) -> None:
     """Test browse media."""
 
@@ -203,7 +204,9 @@ async def test_async_browse_media(
 
 
 async def test_async_browse_media_not_found(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, config_entry
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    config_entry: MockConfigEntry,
 ) -> None:
     """Test browse media not found."""
 
@@ -261,7 +264,9 @@ async def test_async_browse_media_not_found(
 
 
 async def test_async_browse_spotify(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, config_entry
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    config_entry: MockConfigEntry,
 ) -> None:
     """Test browsing spotify."""
 
@@ -313,7 +318,9 @@ async def test_async_browse_spotify(
 
 
 async def test_async_browse_media_source(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, config_entry
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    config_entry: MockConfigEntry,
 ) -> None:
     """Test browsing media_source."""
 
@@ -361,7 +368,9 @@ async def test_async_browse_media_source(
 
 
 async def test_async_browse_image(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator, config_entry
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    config_entry: MockConfigEntry,
 ) -> None:
     """Test browse media images."""
 
@@ -416,8 +425,7 @@ async def test_async_browse_image(
 async def test_async_browse_image_missing(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
-    config_entry,
-    caplog: pytest.LogCaptureFixture,
+    config_entry: MockConfigEntry,
 ) -> None:
     """Test browse media images with no image available."""
 

--- a/tests/components/forked_daapd/test_config_flow.py
+++ b/tests/components/forked_daapd/test_config_flow.py
@@ -67,7 +67,7 @@ async def test_show_form(hass: HomeAssistant) -> None:
     assert result["step_id"] == "user"
 
 
-async def test_config_flow(hass: HomeAssistant, config_entry) -> None:
+async def test_config_flow(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
     """Test that the user step works."""
     with (
         patch(
@@ -102,7 +102,9 @@ async def test_config_flow(hass: HomeAssistant, config_entry) -> None:
         assert result["type"] is FlowResultType.ABORT
 
 
-async def test_zeroconf_updates_title(hass: HomeAssistant, config_entry) -> None:
+async def test_zeroconf_updates_title(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
     """Test that zeroconf updates title and aborts with same host."""
     MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "different host"}).add_to_hass(hass)
     config_entry.add_to_hass(hass)
@@ -125,7 +127,9 @@ async def test_zeroconf_updates_title(hass: HomeAssistant, config_entry) -> None
     assert len(hass.config_entries.async_entries(DOMAIN)) == 2
 
 
-async def test_config_flow_no_websocket(hass: HomeAssistant, config_entry) -> None:
+async def test_config_flow_no_websocket(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
     """Test config flow setup without websocket enabled on server."""
     with patch(
         "homeassistant.components.forked_daapd.config_flow.ForkedDaapdAPI.test_connection",
@@ -224,7 +228,7 @@ async def test_config_flow_zeroconf_valid(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
 
 
-async def test_options_flow(hass: HomeAssistant, config_entry) -> None:
+async def test_options_flow(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
     """Test config flow options."""
 
     with patch(
@@ -251,7 +255,9 @@ async def test_options_flow(hass: HomeAssistant, config_entry) -> None:
         assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
-async def test_async_setup_entry_not_ready(hass: HomeAssistant, config_entry) -> None:
+async def test_async_setup_entry_not_ready(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
     """Test that a PlatformNotReady exception is thrown during platform setup."""
 
     with patch(

--- a/tests/components/forked_daapd/test_media_player.py
+++ b/tests/components/forked_daapd/test_media_player.py
@@ -1,6 +1,7 @@
 """The media player tests for the forked_daapd media player platform."""
 
-from unittest.mock import patch
+from typing import Any
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -63,9 +64,9 @@ from homeassistant.const import (
     STATE_PAUSED,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceResponse
 
-from tests.common import async_mock_signal
+from tests.common import MockConfigEntry, async_mock_signal
 
 TEST_MASTER_ENTITY_NAME = "media_player.owntone_server"
 TEST_ZONE_ENTITY_NAMES = [
@@ -288,7 +289,7 @@ SAMPLE_PLAYLISTS = [{"id": 7, "name": "test_playlist", "uri": "library:playlist:
 
 
 @pytest.fixture(name="get_request_return_values")
-async def get_request_return_values_fixture():
+async def get_request_return_values_fixture() -> dict[str, Any]:
     """Get request return values we can change later."""
     return {
         "config": SAMPLE_CONFIG,
@@ -299,7 +300,11 @@ async def get_request_return_values_fixture():
 
 
 @pytest.fixture(name="mock_api_object")
-async def mock_api_object_fixture(hass, config_entry, get_request_return_values):
+async def mock_api_object_fixture(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    get_request_return_values: dict[str, Any],
+) -> Mock:
     """Create mock api fixture."""
 
     async def get_request_side_effect(update_type):
@@ -341,8 +346,9 @@ async def mock_api_object_fixture(hass, config_entry, get_request_return_values)
     return mock_api.return_value
 
 
+@pytest.mark.usefixtures("mock_api_object")
 async def test_unload_config_entry(
-    hass: HomeAssistant, config_entry, mock_api_object
+    hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:
     """Test the player is set unavailable when the config entry is unloaded."""
     assert hass.states.get(TEST_MASTER_ENTITY_NAME)
@@ -352,7 +358,8 @@ async def test_unload_config_entry(
     assert hass.states.get(TEST_ZONE_ENTITY_NAMES[0]).state == STATE_UNAVAILABLE
 
 
-def test_master_state(hass: HomeAssistant, mock_api_object) -> None:
+@pytest.mark.usefixtures("mock_api_object")
+def test_master_state(hass: HomeAssistant) -> None:
     """Test master state attributes."""
     state = hass.states.get(TEST_MASTER_ENTITY_NAME)
     assert state.state == STATE_PAUSED
@@ -373,7 +380,7 @@ def test_master_state(hass: HomeAssistant, mock_api_object) -> None:
 
 
 async def test_no_update_when_get_request_returns_none(
-    hass: HomeAssistant, config_entry, mock_api_object
+    hass: HomeAssistant, config_entry: MockConfigEntry, mock_api_object: Mock
 ) -> None:
     """Test when get request returns None."""
 
@@ -399,8 +406,12 @@ async def test_no_update_when_get_request_returns_none(
 
 
 async def _service_call(
-    hass, entity_name, service, additional_service_data=None, blocking=True
-):
+    hass: HomeAssistant,
+    entity_name: str,
+    service: str,
+    additional_service_data: dict[str, Any] | None = None,
+    blocking: bool = True,
+) -> ServiceResponse:
     if additional_service_data is None:
         additional_service_data = {}
     return await hass.services.async_call(
@@ -411,7 +422,7 @@ async def _service_call(
     )
 
 
-async def test_zone(hass: HomeAssistant, mock_api_object) -> None:
+async def test_zone(hass: HomeAssistant, mock_api_object: Mock) -> None:
     """Test zone attributes and methods."""
     zone_entity_name = TEST_ZONE_ENTITY_NAMES[0]
     state = hass.states.get(zone_entity_name)
@@ -450,7 +461,7 @@ async def test_zone(hass: HomeAssistant, mock_api_object) -> None:
     mock_api_object.change_output.assert_any_call(output_id, selected=True)
 
 
-async def test_last_outputs_master(hass: HomeAssistant, mock_api_object) -> None:
+async def test_last_outputs_master(hass: HomeAssistant, mock_api_object: Mock) -> None:
     """Test restoration of _last_outputs."""
     # Test turning on sends API call
     await _service_call(hass, TEST_MASTER_ENTITY_NAME, SERVICE_TURN_ON)
@@ -467,7 +478,9 @@ async def test_last_outputs_master(hass: HomeAssistant, mock_api_object) -> None
 
 
 async def test_bunch_of_stuff_master(
-    hass: HomeAssistant, get_request_return_values, mock_api_object
+    hass: HomeAssistant,
+    get_request_return_values: dict[str, Any],
+    mock_api_object: Mock,
 ) -> None:
     """Run bunch of stuff."""
     await _service_call(hass, TEST_MASTER_ENTITY_NAME, SERVICE_TURN_ON)
@@ -551,9 +564,8 @@ async def test_bunch_of_stuff_master(
     mock_api_object.clear_queue.assert_called_once()
 
 
-async def test_async_play_media_from_paused(
-    hass: HomeAssistant, mock_api_object
-) -> None:
+@pytest.mark.usefixtures("mock_api_object")
+async def test_async_play_media_from_paused(hass: HomeAssistant) -> None:
     """Test async play media from paused."""
     initial_state = hass.states.get(TEST_MASTER_ENTITY_NAME)
     await _service_call(
@@ -571,7 +583,9 @@ async def test_async_play_media_from_paused(
 
 
 async def test_async_play_media_announcement_from_stopped(
-    hass: HomeAssistant, get_request_return_values, mock_api_object
+    hass: HomeAssistant,
+    get_request_return_values: dict[str, Any],
+    mock_api_object: Mock,
 ) -> None:
     """Test async play media announcement (from stopped)."""
     updater_update = mock_api_object.start_websocket_handler.call_args[0][2]
@@ -597,9 +611,8 @@ async def test_async_play_media_announcement_from_stopped(
     assert state.last_updated > initial_state.last_updated
 
 
-async def test_async_play_media_unsupported(
-    hass: HomeAssistant, mock_api_object
-) -> None:
+@pytest.mark.usefixtures("mock_api_object")
+async def test_async_play_media_unsupported(hass: HomeAssistant) -> None:
     """Test async play media on unsupported media type."""
     initial_state = hass.states.get(TEST_MASTER_ENTITY_NAME)
     await _service_call(
@@ -616,7 +629,7 @@ async def test_async_play_media_unsupported(
 
 
 async def test_async_play_media_announcement_tts_timeout(
-    hass: HomeAssistant, mock_api_object
+    hass: HomeAssistant, mock_api_object: Mock
 ) -> None:
     """Test async play media announcement with TTS timeout."""
     mock_api_object.add_to_queue.side_effect = None
@@ -638,7 +651,7 @@ async def test_async_play_media_announcement_tts_timeout(
 
 
 async def test_use_pipe_control_with_no_api(
-    hass: HomeAssistant, mock_api_object
+    hass: HomeAssistant, mock_api_object: Mock
 ) -> None:
     """Test using pipe control with no api set."""
     await _service_call(
@@ -651,7 +664,8 @@ async def test_use_pipe_control_with_no_api(
     assert mock_api_object.start_playback.call_count == 0
 
 
-async def test_clear_source(hass: HomeAssistant, mock_api_object) -> None:
+@pytest.mark.usefixtures("mock_api_object")
+async def test_clear_source(hass: HomeAssistant) -> None:
     """Test changing source to clear."""
     await _service_call(
         hass,
@@ -665,8 +679,11 @@ async def test_clear_source(hass: HomeAssistant, mock_api_object) -> None:
 
 @pytest.fixture(name="pipe_control_api_object")
 async def pipe_control_api_object_fixture(
-    hass, config_entry, get_request_return_values, mock_api_object
-):
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    get_request_return_values: dict[str, Any],
+    mock_api_object: Mock,
+) -> Mock:
     """Fixture for mock librespot_java api."""
     with patch(
         "homeassistant.components.forked_daapd.media_player.LibrespotJavaAPI",
@@ -697,9 +714,9 @@ async def pipe_control_api_object_fixture(
 
 async def test_librespot_java_stuff(
     hass: HomeAssistant,
-    get_request_return_values,
-    mock_api_object,
-    pipe_control_api_object,
+    get_request_return_values: dict[str, Any],
+    mock_api_object: Mock,
+    pipe_control_api_object: Mock,
 ) -> None:
     """Test options update and librespot-java stuff."""
     state = hass.states.get(TEST_MASTER_ENTITY_NAME)
@@ -734,9 +751,8 @@ async def test_librespot_java_stuff(
     assert state.attributes[ATTR_MEDIA_ALBUM_NAME] == "some album"
 
 
-async def test_librespot_java_play_announcement(
-    hass: HomeAssistant, pipe_control_api_object
-) -> None:
+@pytest.mark.usefixtures("pipe_control_api_object")
+async def test_librespot_java_play_announcement(hass: HomeAssistant) -> None:
     """Test play announcement with librespot-java pipe."""
     initial_state = hass.states.get(TEST_MASTER_ENTITY_NAME)
     await _service_call(
@@ -755,7 +771,7 @@ async def test_librespot_java_play_announcement(
 
 
 async def test_librespot_java_play_media_pause_timeout(
-    hass: HomeAssistant, pipe_control_api_object
+    hass: HomeAssistant, pipe_control_api_object: Mock
 ) -> None:
     """Test play media with librespot-java pipe."""
     # test media play with pause timeout
@@ -778,7 +794,7 @@ async def test_librespot_java_play_media_pause_timeout(
         assert state.last_updated > initial_state.last_updated
 
 
-async def test_unsupported_update(hass: HomeAssistant, mock_api_object) -> None:
+async def test_unsupported_update(hass: HomeAssistant, mock_api_object: Mock) -> None:
     """Test unsupported update type."""
     last_updated = hass.states.get(TEST_MASTER_ENTITY_NAME).last_updated
     updater_update = mock_api_object.start_websocket_handler.call_args[0][2]
@@ -787,7 +803,9 @@ async def test_unsupported_update(hass: HomeAssistant, mock_api_object) -> None:
     assert hass.states.get(TEST_MASTER_ENTITY_NAME).last_updated == last_updated
 
 
-async def test_invalid_websocket_port(hass: HomeAssistant, config_entry) -> None:
+async def test_invalid_websocket_port(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
     """Test invalid websocket port on async_init."""
     with patch(
         "homeassistant.components.forked_daapd.media_player.ForkedDaapdAPI",
@@ -800,7 +818,7 @@ async def test_invalid_websocket_port(hass: HomeAssistant, config_entry) -> None
         assert hass.states.get(TEST_MASTER_ENTITY_NAME).state == STATE_UNAVAILABLE
 
 
-async def test_websocket_disconnect(hass: HomeAssistant, mock_api_object) -> None:
+async def test_websocket_disconnect(hass: HomeAssistant, mock_api_object: Mock) -> None:
     """Test websocket disconnection."""
     assert hass.states.get(TEST_MASTER_ENTITY_NAME).state != STATE_UNAVAILABLE
     assert hass.states.get(TEST_ZONE_ENTITY_NAMES[0]).state != STATE_UNAVAILABLE
@@ -811,7 +829,9 @@ async def test_websocket_disconnect(hass: HomeAssistant, mock_api_object) -> Non
     assert hass.states.get(TEST_ZONE_ENTITY_NAMES[0]).state == STATE_UNAVAILABLE
 
 
-async def test_async_play_media_enqueue(hass: HomeAssistant, mock_api_object) -> None:
+async def test_async_play_media_enqueue(
+    hass: HomeAssistant, mock_api_object: Mock
+) -> None:
     """Test async play media with different enqueue options."""
     initial_state = hass.states.get(TEST_MASTER_ENTITY_NAME)
     await _service_call(
@@ -887,7 +907,7 @@ async def test_async_play_media_enqueue(hass: HomeAssistant, mock_api_object) ->
     )
 
 
-async def test_play_owntone_media(hass: HomeAssistant, mock_api_object) -> None:
+async def test_play_owntone_media(hass: HomeAssistant, mock_api_object: Mock) -> None:
     """Test async play media with an owntone source."""
     initial_state = hass.states.get(TEST_MASTER_ENTITY_NAME)
     await _service_call(
@@ -913,7 +933,7 @@ async def test_play_owntone_media(hass: HomeAssistant, mock_api_object) -> None:
     )
 
 
-async def test_play_spotify_media(hass: HomeAssistant, mock_api_object) -> None:
+async def test_play_spotify_media(hass: HomeAssistant, mock_api_object: Mock) -> None:
     """Test async play media with a spotify source."""
     initial_state = hass.states.get(TEST_MASTER_ENTITY_NAME)
     await _service_call(
@@ -937,7 +957,7 @@ async def test_play_spotify_media(hass: HomeAssistant, mock_api_object) -> None:
     )
 
 
-async def test_play_media_source(hass: HomeAssistant, mock_api_object) -> None:
+async def test_play_media_source(hass: HomeAssistant, mock_api_object: Mock) -> None:
     """Test async play media with a spotify source."""
     initial_state = hass.states.get(TEST_MASTER_ENTITY_NAME)
     with patch(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
