### PR TITLE
Add unique id to emoncms

### DIFF
--- a/homeassistant/components/emoncms/manifest.json
+++ b/homeassistant/components/emoncms/manifest.json
@@ -4,5 +4,5 @@
   "codeowners": ["@borpin", "@alexandrecuer"],
   "documentation": "https://www.home-assistant.io/integrations/emoncms",
   "iot_class": "local_polling",
-  "requirements": ["pyemoncms==0.1.0"]
+  "requirements": ["pyemoncms==0.1.1"]
 }

--- a/homeassistant/components/emoncms/manifest.json
+++ b/homeassistant/components/emoncms/manifest.json
@@ -4,5 +4,5 @@
   "codeowners": ["@borpin", "@alexandrecuer"],
   "documentation": "https://www.home-assistant.io/integrations/emoncms",
   "iot_class": "local_polling",
-  "requirements": ["pyemoncms==0.0.7"]
+  "requirements": ["pyemoncms==0.1.0"]
 }

--- a/homeassistant/components/emoncms/sensor.py
+++ b/homeassistant/components/emoncms/sensor.py
@@ -168,7 +168,6 @@ class EmonCmsSensor(CoordinatorEntity[EmoncmsCoordinator], SensorEntity):
         self._sensorid = sensorid
         if uuid is not None:
             self._attr_unique_id = f'{uuid}-{elem["id"]}'
-            self._attr_name = f"Emoncms{id_for_name}|{elem['tag']}|{elem['name']}"
 
         if unit_of_measurement in ("kWh", "Wh"):
             self._attr_device_class = SensorDeviceClass.ENERGY

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1824,7 +1824,7 @@ pyegps==0.2.5
 pyeiscp==0.0.7
 
 # homeassistant.components.emoncms
-pyemoncms==0.1.0
+pyemoncms==0.1.1
 
 # homeassistant.components.enphase_envoy
 pyenphase==1.20.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1824,7 +1824,7 @@ pyegps==0.2.5
 pyeiscp==0.0.7
 
 # homeassistant.components.emoncms
-pyemoncms==0.0.7
+pyemoncms==0.1.0
 
 # homeassistant.components.enphase_envoy
 pyenphase==1.20.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

emoncms has been adapted to produce an unique identifier

The pyemoncms library has been modified with a async_get_uuid methode which : 
- returns None if the emoncms version used does not ship an uuid (version < 11.5.7 or version 11.5.7 and above with a database non yet migrated)
- returns the uuid if the version of emoncms is 11.5.7 or above with a migrated database

The integration documentation has been modified accordingly to inform users.

We will inform on the open energy monitor forum that users upgrading to a version above 11.5.7 and using the home assistant core integration must migrate their database

diff changes in the pyemoncms library : https://github.com/Open-Building-Management/pyemoncms/compare/v0.0.7...v0.1.1

the uuid commit in emoncms : https://github.com/emoncms/emoncms/pull/1888/files

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/106850
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33473

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
