### PR TITLE
Add MockOf typing helper

### DIFF
--- a/tests/components/dlna_dmr/test_data.py
+++ b/tests/components/dlna_dmr/test_data.py
@@ -2,21 +2,23 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
 from unittest.mock import ANY, Mock, patch
 
 from async_upnp_client.aiohttp import AiohttpNotifyServer
 from async_upnp_client.event_handler import UpnpEventHandler
 import pytest
+from typing_extensions import Generator
 
 from homeassistant.components.dlna_dmr.const import DOMAIN
 from homeassistant.components.dlna_dmr.data import EventListenAddr, get_domain_data
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant
 
+from tests.typing import MockConstructorOf
+
 
 @pytest.fixture
-def aiohttp_notify_servers_mock() -> Iterable[Mock]:
+def aiohttp_notify_servers_mock() -> Generator[MockConstructorOf[AiohttpNotifyServer]]:
     """Construct mock AiohttpNotifyServer on demand, eliminating network use.
 
     This fixture provides a list of the constructed servers.
@@ -53,7 +55,8 @@ async def test_get_domain_data(hass: HomeAssistant) -> None:
 
 
 async def test_event_notifier(
-    hass: HomeAssistant, aiohttp_notify_servers_mock: Mock
+    hass: HomeAssistant,
+    aiohttp_notify_servers_mock: MockConstructorOf[AiohttpNotifyServer],
 ) -> None:
     """Test getting and releasing event notifiers."""
     domain_data = get_domain_data(hass)
@@ -110,9 +113,8 @@ async def test_event_notifier(
     assert domain_data.stop_listener_remove is None
 
 
-async def test_cleanup_event_notifiers(
-    hass: HomeAssistant, aiohttp_notify_servers_mock: Mock
-) -> None:
+@pytest.mark.usefixtures("aiohttp_notify_servers_mock")
+async def test_cleanup_event_notifiers(hass: HomeAssistant) -> None:
     """Test cleanup function clears all event notifiers."""
     domain_data = get_domain_data(hass)
     await domain_data.async_get_event_notifier(EventListenAddr(None, 0, None), hass)

--- a/tests/components/dlna_dmr/test_data.py
+++ b/tests/components/dlna_dmr/test_data.py
@@ -2,23 +2,21 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from unittest.mock import ANY, Mock, patch
 
 from async_upnp_client.aiohttp import AiohttpNotifyServer
 from async_upnp_client.event_handler import UpnpEventHandler
 import pytest
-from typing_extensions import Generator
 
 from homeassistant.components.dlna_dmr.const import DOMAIN
 from homeassistant.components.dlna_dmr.data import EventListenAddr, get_domain_data
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant
 
-from tests.typing import MockConstructorOf
-
 
 @pytest.fixture
-def aiohttp_notify_servers_mock() -> Generator[MockConstructorOf[AiohttpNotifyServer]]:
+def aiohttp_notify_servers_mock() -> Iterable[Mock]:
     """Construct mock AiohttpNotifyServer on demand, eliminating network use.
 
     This fixture provides a list of the constructed servers.
@@ -55,8 +53,7 @@ async def test_get_domain_data(hass: HomeAssistant) -> None:
 
 
 async def test_event_notifier(
-    hass: HomeAssistant,
-    aiohttp_notify_servers_mock: MockConstructorOf[AiohttpNotifyServer],
+    hass: HomeAssistant, aiohttp_notify_servers_mock: Mock
 ) -> None:
     """Test getting and releasing event notifiers."""
     domain_data = get_domain_data(hass)
@@ -113,8 +110,9 @@ async def test_event_notifier(
     assert domain_data.stop_listener_remove is None
 
 
-@pytest.mark.usefixtures("aiohttp_notify_servers_mock")
-async def test_cleanup_event_notifiers(hass: HomeAssistant) -> None:
+async def test_cleanup_event_notifiers(
+    hass: HomeAssistant, aiohttp_notify_servers_mock: Mock
+) -> None:
     """Test cleanup function clears all event notifiers."""
     domain_data = get_domain_data(hass)
     await domain_data.async_get_event_notifier(EventListenAddr(None, 0, None), hass)

--- a/tests/components/govee_light_local/conftest.py
+++ b/tests/components/govee_light_local/conftest.py
@@ -2,18 +2,20 @@
 
 from asyncio import Event
 from collections.abc import Generator
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from govee_local_api import GoveeLightCapability
 import pytest
 
 from homeassistant.components.govee_light_local.coordinator import GoveeController
 
+from tests.typing import MockOf
+
 
 @pytest.fixture(name="mock_govee_api")
-def fixture_mock_govee_api():
+def fixture_mock_govee_api() -> MockOf[GoveeController]:
     """Set up Govee Local API fixture."""
-    mock_api = AsyncMock(spec=GoveeController)
+    mock_api = Mock(spec=GoveeController)
     mock_api.start = AsyncMock()
     mock_api.cleanup = MagicMock(return_value=Event())
     mock_api.cleanup.return_value.set()

--- a/tests/components/govee_light_local/test_config_flow.py
+++ b/tests/components/govee_light_local/test_config_flow.py
@@ -3,7 +3,7 @@
 from errno import EADDRINUSE
 from unittest.mock import AsyncMock, patch
 
-from govee_local_api import GoveeDevice
+from govee_local_api import GoveeController, GoveeDevice
 
 from homeassistant import config_entries
 from homeassistant.components.govee_light_local.const import DOMAIN
@@ -12,8 +12,10 @@ from homeassistant.data_entry_flow import FlowResultType
 
 from .conftest import DEFAULT_CAPABILITEIS
 
+from tests.typing import MockOf
 
-def _get_devices(mock_govee_api: AsyncMock) -> list[GoveeDevice]:
+
+def _get_devices(mock_govee_api: MockOf[GoveeController]) -> list[GoveeDevice]:
     return [
         GoveeDevice(
             controller=mock_govee_api,
@@ -26,7 +28,9 @@ def _get_devices(mock_govee_api: AsyncMock) -> list[GoveeDevice]:
 
 
 async def test_creating_entry_has_no_devices(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_govee_api: AsyncMock
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_govee_api: MockOf[GoveeController],
 ) -> None:
     """Test setting up Govee with no devices."""
 
@@ -61,7 +65,7 @@ async def test_creating_entry_has_no_devices(
 async def test_creating_entry_has_with_devices(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
-    mock_govee_api: AsyncMock,
+    mock_govee_api: MockOf[GoveeController],
 ) -> None:
     """Test setting up Govee with devices."""
 
@@ -90,7 +94,7 @@ async def test_creating_entry_has_with_devices(
 async def test_creating_entry_errno(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
-    mock_govee_api: AsyncMock,
+    mock_govee_api: MockOf[GoveeController],
 ) -> None:
     """Test setting up Govee with devices."""
 

--- a/tests/components/govee_light_local/test_light.py
+++ b/tests/components/govee_light_local/test_light.py
@@ -1,9 +1,9 @@
 """Test Govee light local."""
 
 from errno import EADDRINUSE, ENETDOWN
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import patch
 
-from govee_local_api import GoveeDevice
+from govee_local_api import GoveeController, GoveeDevice
 
 from homeassistant.components.govee_light_local.const import DOMAIN
 from homeassistant.components.light import ATTR_SUPPORTED_COLOR_MODES, ColorMode
@@ -13,10 +13,11 @@ from homeassistant.core import HomeAssistant
 from .conftest import DEFAULT_CAPABILITEIS
 
 from tests.common import MockConfigEntry
+from tests.typing import MockOf
 
 
 async def test_light_known_device(
-    hass: HomeAssistant, mock_govee_api: AsyncMock
+    hass: HomeAssistant, mock_govee_api: MockOf[GoveeController]
 ) -> None:
     """Test adding a known device."""
 
@@ -55,7 +56,7 @@ async def test_light_known_device(
 
 
 async def test_light_unknown_device(
-    hass: HomeAssistant, mock_govee_api: AsyncMock
+    hass: HomeAssistant, mock_govee_api: MockOf[GoveeController]
 ) -> None:
     """Test adding an unknown device."""
 
@@ -87,7 +88,9 @@ async def test_light_unknown_device(
         assert light.attributes[ATTR_SUPPORTED_COLOR_MODES] == [ColorMode.ONOFF]
 
 
-async def test_light_remove(hass: HomeAssistant, mock_govee_api: AsyncMock) -> None:
+async def test_light_remove(
+    hass: HomeAssistant, mock_govee_api: MockOf[GoveeController]
+) -> None:
     """Test adding a known device."""
 
     mock_govee_api.devices = [
@@ -118,7 +121,7 @@ async def test_light_remove(hass: HomeAssistant, mock_govee_api: AsyncMock) -> N
 
 
 async def test_light_setup_retry(
-    hass: HomeAssistant, mock_govee_api: AsyncMock
+    hass: HomeAssistant, mock_govee_api: MockOf[GoveeController]
 ) -> None:
     """Test adding an unknown device."""
 
@@ -140,7 +143,7 @@ async def test_light_setup_retry(
 
 
 async def test_light_setup_retry_eaddrinuse(
-    hass: HomeAssistant, mock_govee_api: AsyncMock
+    hass: HomeAssistant, mock_govee_api: MockOf[GoveeController]
 ) -> None:
     """Test adding an unknown device."""
 
@@ -168,7 +171,7 @@ async def test_light_setup_retry_eaddrinuse(
 
 
 async def test_light_setup_error(
-    hass: HomeAssistant, mock_govee_api: AsyncMock
+    hass: HomeAssistant, mock_govee_api: MockOf[GoveeController]
 ) -> None:
     """Test adding an unknown device."""
 
@@ -195,7 +198,9 @@ async def test_light_setup_error(
         assert entry.state is ConfigEntryState.SETUP_ERROR
 
 
-async def test_light_on_off(hass: HomeAssistant, mock_govee_api: MagicMock) -> None:
+async def test_light_on_off(
+    hass: HomeAssistant, mock_govee_api: MockOf[GoveeController]
+) -> None:
     """Test adding a known device."""
 
     mock_govee_api.devices = [
@@ -252,7 +257,9 @@ async def test_light_on_off(hass: HomeAssistant, mock_govee_api: MagicMock) -> N
         mock_govee_api.turn_on_off.assert_awaited_with(mock_govee_api.devices[0], False)
 
 
-async def test_light_brightness(hass: HomeAssistant, mock_govee_api: MagicMock) -> None:
+async def test_light_brightness(
+    hass: HomeAssistant, mock_govee_api: MockOf[GoveeController]
+) -> None:
     """Test changing brightness."""
     mock_govee_api.devices = [
         GoveeDevice(
@@ -327,7 +334,9 @@ async def test_light_brightness(hass: HomeAssistant, mock_govee_api: MagicMock) 
         )
 
 
-async def test_light_color(hass: HomeAssistant, mock_govee_api: MagicMock) -> None:
+async def test_light_color(
+    hass: HomeAssistant, mock_govee_api: MockOf[GoveeController]
+) -> None:
     """Test changing brightness."""
     mock_govee_api.devices = [
         GoveeDevice(

--- a/tests/typing.py
+++ b/tests/typing.py
@@ -21,10 +21,6 @@ class MockOf(Mock, Generic[_T]):
     """Add ability to set underlying type for Mock."""
 
 
-class MockConstructorOf(MagicMock, Generic[_T]):
-    """Add ability to set underlying type for MagicMock."""
-
-
 class MockHAClientWebSocket(ClientWebSocketResponse):
     """Protocol for a wrapped ClientWebSocketResponse."""
 

--- a/tests/typing.py
+++ b/tests/typing.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
-from typing import TYPE_CHECKING, Any
-from unittest.mock import MagicMock
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from unittest.mock import MagicMock, Mock
 
 from aiohttp import ClientWebSocketResponse
 from aiohttp.test_utils import TestClient
@@ -13,6 +13,16 @@ if TYPE_CHECKING:
     # Local import to avoid processing recorder module when running a
     # testcase which does not use the recorder.
     from homeassistant.components.recorder import Recorder
+
+_T = TypeVar("_T")
+
+
+class MockOf(Mock, Generic[_T]):
+    """Add ability to set underlying type for Mock."""
+
+
+class MockConstructorOf(MagicMock, Generic[_T]):
+    """Add ability to set underlying type for MagicMock."""
 
 
 class MockHAClientWebSocket(ClientWebSocketResponse):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add some typing helpers for `Mock`, when used in conjuction with a class constructor.

It is completely pointless from a type-checking perspective (ie. mypy/pylance), but I think it makes the code more readable:

```python
from tests.typing import MockOf

@pytest.fixture
def mock_api_client() -> MockOf[ApiClient]:
    """Fixture for ApiClient."""
    return Mock(spec=ApiClient)

async def test_blah(
    hass: HomeAssistant, mock_api_client: MockOf[ApiClient]
) -> None:
    """Test blah."""
    # Use it as an ApiClient
    assert isinstance(mock_api_client, ApiClient) # returns True
    d = Device(client=mock_api_client)

    # Use it as a Mock
    assert isinstance(mock_api_client, Mock) # also returns True
    assert mock_govee_api.start.assert_awaited_once()
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
