### PR TITLE
Remove legacy foreign key constraint from sqlite states table

### DIFF
--- a/homeassistant/components/recorder/db_schema.py
+++ b/homeassistant/components/recorder/db_schema.py
@@ -73,7 +73,7 @@ class Base(DeclarativeBase):
     """Base class for tables."""
 
 
-SCHEMA_VERSION = 43
+SCHEMA_VERSION = 44
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/recorder/db_schema.py
+++ b/homeassistant/components/recorder/db_schema.py
@@ -73,7 +73,7 @@ class Base(DeclarativeBase):
     """Base class for tables."""
 
 
-SCHEMA_VERSION = 44
+SCHEMA_VERSION = 43
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -1910,32 +1910,32 @@ def rebuild_sqlite_table(
     will likely fail.
     """
     table_table = cast(Table, table.__table__)
-    table_name = table_table.name
-    temp_table_name = f"{table_table.name}_temp_{int(time())}"
+    orig_name = table_table.name
+    temp_name = f"{table_table.name}_temp_{int(time())}"
     try:
         # 12 step SQLite table rebuild
         # https://www.sqlite.org/draft/lang_altertable.html
         with session_scope(session=session_maker()) as session:
             # Step 1 - Disable foreign keys
             session.connection().execute(text("PRAGMA foreign_keys=OFF"))
-            # Step 2 - already in a transaction
+        # Step 2 - create a transaction
+        with session_scope(session=session_maker()) as session:
             # Step 3 - we know all the indexes, triggers, and views associated with table X
             new_sql = str(CreateTable(table_table).compile(engine)).strip("\n") + ";"
-            new_sql = new_sql.replace(
-                f"CREATE TABLE {table_name}", f"CREATE TABLE {temp_table_name}"
-            )
+            source_sql = f"CREATE TABLE {orig_name}"
+            replacement_sql = f"CREATE TABLE {temp_name}"
+            assert source_sql in new_sql, f"{source_sql} should be in new_sql"
+            new_sql = new_sql.replace(source_sql, replacement_sql)
             # Step 4 - Create temp table
             session.execute(text(new_sql))
             column_names = ",".join([column.name for column in table_table.columns])
             # Step 5 - Transfer content
-            sql = f"INSERT INTO {temp_table_name} SELECT {column_names} FROM {table_name};"  # noqa: S608
+            sql = f"INSERT INTO {temp_name} SELECT {column_names} FROM {orig_name};"  # noqa: S608
             session.execute(text(sql))
             # Step 6 - Drop the original table
-            session.execute(text(f"DROP TABLE {table_name}"))
+            session.execute(text(f"DROP TABLE {orig_name}"))
             # Step 7 - Rename the temp table
-            session.execute(
-                text(f"ALTER TABLE {temp_table_name} RENAME TO {table_name}")
-            )
+            session.execute(text(f"ALTER TABLE {temp_name} RENAME TO {orig_name}"))
             # Step 8 - Recreate indexes
             for index in table_table.indexes:
                 index.create(session.connection())
@@ -1944,8 +1944,10 @@ def rebuild_sqlite_table(
             session.execute(text("PRAGMA foreign_key_check"))
             # Step 11 - Commit transaction
             session.commit()
-            # Step 12 - Re-enable foreign keys
-            session.connection().execute(text("PRAGMA foreign_keys=ON"))
     except SQLAlchemyError:
         _LOGGER.exception("Error recreating SQLite table %s", table_table.name)
         # Swallow the exception since we do not want to crash the recorder
+    finally:
+        with session_scope(session=session_maker()) as session:
+            # Step 12 - Re-enable foreign keys
+            session.connection().execute(text("PRAGMA foreign_keys=ON"))

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -1912,6 +1912,12 @@ def rebuild_sqlite_table(
     table_table = cast(Table, table.__table__)
     orig_name = table_table.name
     temp_name = f"{table_table.name}_temp_{int(time())}"
+
+    _LOGGER.warning(
+        "Rebuilding SQLite table %s; This will take a while; Please be patient!",
+        orig_name,
+    )
+
     try:
         # 12 step SQLite table rebuild
         # https://www.sqlite.org/draft/lang_altertable.html

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -1919,7 +1919,7 @@ def rebuild_sqlite_table(
 
     try:
         # 12 step SQLite table rebuild
-        # https://www.sqlite.org/draft/lang_altertable.html
+        # https://www.sqlite.org/lang_altertable.html
         with session_scope(session=session_maker()) as session:
             # Step 1 - Disable foreign keys
             session.connection().execute(text("PRAGMA foreign_keys=OFF"))

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -1739,11 +1739,10 @@ def cleanup_legacy_states_event_ids(instance: Recorder) -> bool:
         # ex all NULL
         assert instance.engine is not None, "engine should never be None"
         if instance.dialect_name == SupportedDialect.SQLITE:
+            # SQLite does not support dropping foreign key constraints
+            # so we have to rebuild the table
             rebuild_sqlite_table(session_maker, instance.engine, States)
         else:
-            # SQLite does not support dropping foreign key constraints
-            # so we can't drop the index at this time but we can avoid
-            # looking for legacy rows during purge
             _drop_foreign_key_constraints(
                 session_maker, instance.engine, TABLE_STATES, ["event_id"]
             )

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -1739,7 +1739,7 @@ def cleanup_legacy_states_event_ids(instance: Recorder) -> bool:
         # ex all NULL
         assert instance.engine is not None, "engine should never be None"
         if instance.dialect_name == SupportedDialect.SQLITE:
-            rebuild_sqlite_table_schema(session_maker, instance.engine, States)
+            rebuild_sqlite_table(session_maker, instance.engine, States)
         else:
             # SQLite does not support dropping foreign key constraints
             # so we can't drop the index at this time but we can avoid
@@ -1898,21 +1898,16 @@ def _mark_migration_done(
     )
 
 
-def rebuild_sqlite_table_schema(
+def rebuild_sqlite_table(
     session_maker: Callable[[], Session], engine: Engine, table: type[Base]
 ) -> None:
-    """Rebuild the SQLite schema for a table.
+    """Rebuild an SQLite table.
 
     This must only be called after all migrations are complete
-    and the database is in a consistent state since it will
-    replace the schema for the table with the current schema.
+    and the database is in a consistent state.
 
     If the table is not migrated to the current schema this
-    will fail with an integrity error.
-
-    If the schema has been manually altered in an incompatible
-    way this will fail with an integrity error, or it may not
-    fail but the database will be in an inconsistent state.
+    will likely fail.
     """
     table_table = cast(Table, table.__table__)
     table_name = table_table.name

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -1954,6 +1954,8 @@ def rebuild_sqlite_table(
         # Swallow the exception since we do not want to ever raise
         # an integrity error as it would cause the database
         # to be discarded and recreated from scratch
+    else:
+        _LOGGER.warning("Rebuilding SQLite table %s finished", orig_name)
     finally:
         with session_scope(session=session_maker()) as session:
             # Step 12 - Re-enable foreign keys

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -1946,7 +1946,9 @@ def rebuild_sqlite_table(
             session.commit()
     except SQLAlchemyError:
         _LOGGER.exception("Error recreating SQLite table %s", table_table.name)
-        # Swallow the exception since we do not want to crash the recorder
+        # Swallow the exception since we do not want to ever raise
+        # an integrity error as it would cause the database
+        # to be discarded and recreated from scratch
     finally:
         with session_scope(session=session_maker()) as session:
             # Step 12 - Re-enable foreign keys

--- a/tests/components/recorder/test_v32_migration.py
+++ b/tests/components/recorder/test_v32_migration.py
@@ -211,10 +211,9 @@ async def test_migrate_times(caplog: pytest.LogCaptureFixture, tmp_path: Path) -
         )
         states_index_names = {index["name"] for index in states_indexes}
 
-        # sqlite does not support dropping foreign keys so the
-        # ix_states_event_id index is not dropped in this case
-        # but use_legacy_events_index is still False
-        assert "ix_states_event_id" in states_index_names
+        # sqlite does not support dropping foreign keys so we had to
+        # create a new table and copy the data over
+        assert "ix_states_event_id" not in states_index_names
 
         assert recorder.get_instance(hass).use_legacy_events_index is False
 
@@ -341,8 +340,6 @@ async def test_migrate_can_resume_entity_id_post_migration(
             states_index_names = {index["name"] for index in states_indexes}
             await hass.async_stop()
             await hass.async_block_till_done()
-
-    assert "ix_states_entity_id_last_updated_ts" in states_index_names
 
     async with async_test_home_assistant() as hass:
         recorder_helper.async_initialize_recorder(hass)


### PR DESCRIPTION
**~~Do not tag this for backport~~. It should bake in dev for at least a week, ~~and than beta before appearing in a release.~~ Since we were unable to test in beta, we have instead enough people test the custom component in https://github.com/home-assistant/core/issues/117263.  While a 12 step migration should be quite safe (and in most cases what sqlite actually does under the hood for complex alters), this is brand new for this code base and we cannot fully predict impact.** 

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some old databases have `FOREIGN KEY(event_id) REFERENCES events (event_id) ON DELETE CASCADE,` in the states table and the index is now empty which results in a full table scan per each event_id.

Unfortunately sqlite does not support dropping a foreign key constraint.

To fix this the whole states table needs to be recreated with a [12 step table rebuild](https://www.sqlite.org/lang_altertable.html) to remove the legacy foreign key from the `states` table 

Thankfully a table rebuild is very fast in sqlite.  With 2GiB database taking about 20s (1GiB took < 10s).  One iteration of the purge cycle that was happening in the issue would take longer than a table rebuild.
```
2024-06-28 09:39:57.325 WARNING (Recorder) [homeassistant.components.recorder.migration] Rebuilding SQLite table states; This will take a while; Please be patient!
2024-06-28 09:40:18.633 WARNING (Recorder) [homeassistant.components.recorder.migration] Rebuilding SQLite table states finished
```

A nice side effect is it will reduce the database size by ~4-8% on average after the next repack (2nd sunday of the month) and improve insert performance a tiny bit.





## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #117263
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
