### PR TITLE
Fix publish cancellation handling in MQTT

### DIFF
--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -1141,8 +1141,8 @@ class MQTT:
         # see https://github.com/eclipse/paho.mqtt.python/issues/687
         # properties and reason codes are not used in Home Assistant
         future = self._async_get_mid_future(mid)
-        if future.done() and future.exception():
-            # Timed out
+        if future.done() and (future.cancelled() or future.exception()):
+            # Timed out or cancelled
             return
         future.set_result(None)
 

--- a/tests/components/mqtt/test_client.py
+++ b/tests/components/mqtt/test_client.py
@@ -1200,11 +1200,11 @@ async def test_handle_mqtt_on_callback_after_cancellation(
     mqtt_mock_entry: MqttMockHAClientGenerator,
     mqtt_client_mock: MqttMockPahoClient,
 ) -> None:
-    """Test receiving an ACK after a timeout."""
+    """Test receiving an ACK after a cancellation."""
     mqtt_mock = await mqtt_mock_entry()
     # Simulate the mid future getting a cancellation
     mqtt_mock()._async_get_mid_future(101).cancel()
-    # Simulate an ACK for mid == 101, being received after the timeout
+    # Simulate an ACK for mid == 101, being received after the cancellation
     mqtt_client_mock.on_publish(mqtt_client_mock, None, 101)
     await hass.async_block_till_done()
     assert "No ACK from MQTT server" not in caplog.text

--- a/tests/components/mqtt/test_client.py
+++ b/tests/components/mqtt/test_client.py
@@ -1203,7 +1203,7 @@ async def test_handle_mqtt_on_callback_after_cancellation(
     """Test receiving an ACK after a timeout."""
     mqtt_mock = await mqtt_mock_entry()
     # Simulate the mid future getting a cancellation
-    mqtt_mock()._async_get_mid_future(101).set_exception(asyncio.CancelledError)
+    mqtt_mock()._async_get_mid_future(101).cancel()
     # Simulate an ACK for mid == 101, being received after the timeout
     mqtt_client_mock.on_publish(mqtt_client_mock, None, 101)
     await hass.async_block_till_done()

--- a/tests/components/mqtt/test_client.py
+++ b/tests/components/mqtt/test_client.py
@@ -1194,6 +1194,32 @@ async def test_handle_mqtt_on_callback(
         assert "No ACK from MQTT server" not in caplog.text
 
 
+@patch("homeassistant.components.mqtt.client.TIMEOUT_ACK", 0.3)
+async def test_handle_mqtt_on_callback_cancelled(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    setup_with_birth_msg_client_mock: MqttMockPahoClient,
+) -> None:
+    """Test cancel waiting for a publish."""
+    mqtt_client_mock = setup_with_birth_msg_client_mock
+    with patch.object(mqtt_client_mock, "get_mid", return_value=100):
+        # Simulate an ACK for mid == 100, this will call mqtt_mock._async_get_mid_future(mid)
+        mqtt_client_mock.on_publish(mqtt_client_mock, None, 100)
+        await hass.async_block_till_done()
+        # Make sure the ACK has been received
+        await hass.async_block_till_done()
+        # Now call publish without call back, this will call _async_async_wait_for_mid(msg_info.mid)
+        task = hass.async_create_task(
+            mqtt.async_publish(hass, "no_callback/test-topic", "test-payload")
+        )
+        await asyncio.sleep(0)
+        # Cancel the task so the future is cancelled
+        task.cancel()
+        # Since the future was cancelled, we should not see any timeout warning in the log
+        await hass.async_block_till_done()
+        assert "No ACK from MQTT server" not in caplog.text
+
+
 async def test_handle_mqtt_on_callback_after_timeout(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The test fail has moved in `dev` vs `rc` tagging these for 2024.7.0 as well:
- https://github.com/home-assistant/core/pull/120574
- https://github.com/home-assistant/core/pull/120636 

If publish was cancelled, cancellation should not be propagated to the mid callback.
fixes #120805


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
