### PR TITLE
Separate BMW base entity into separate file

### DIFF
--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
-from bimmer_connected.vehicle import MyBMWVehicle
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
@@ -17,11 +15,9 @@ from homeassistant.helpers import (
     entity_registry as er,
 )
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ATTR_VIN, ATTRIBUTION, CONF_READ_ONLY, DATA_HASS_CONFIG, DOMAIN
+from .const import ATTR_VIN, CONF_READ_ONLY, DATA_HASS_CONFIG, DOMAIN
 from .coordinator import BMWDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -179,37 +175,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
-
-
-class BMWBaseEntity(CoordinatorEntity[BMWDataUpdateCoordinator]):
-    """Common base for BMW entities."""
-
-    coordinator: BMWDataUpdateCoordinator
-    _attr_attribution = ATTRIBUTION
-    _attr_has_entity_name = True
-
-    def __init__(
-        self,
-        coordinator: BMWDataUpdateCoordinator,
-        vehicle: MyBMWVehicle,
-    ) -> None:
-        """Initialize entity."""
-        super().__init__(coordinator)
-
-        self.vehicle = vehicle
-
-        self._attrs: dict[str, Any] = {
-            "car": self.vehicle.name,
-            "vin": self.vehicle.vin,
-        }
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self.vehicle.vin)},
-            manufacturer=vehicle.brand.name,
-            model=vehicle.name,
-            name=vehicle.name,
-        )
-
-    async def async_added_to_hass(self) -> None:
-        """When entity is added to hass."""
-        await super().async_added_to_hass()
-        self._handle_coordinator_update()

--- a/homeassistant/components/bmw_connected_drive/binary_sensor.py
+++ b/homeassistant/components/bmw_connected_drive/binary_sensor.py
@@ -22,9 +22,9 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.unit_system import UnitSystem
 
-from . import BMWBaseEntity
 from .const import DOMAIN, UNIT_MAP
 from .coordinator import BMWDataUpdateCoordinator
+from .entity import BMWBaseEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -241,9 +241,8 @@ class BMWBinarySensor(BMWBaseEntity, BinarySensorEntity):
         self._attr_is_on = self.entity_description.value_fn(self.vehicle)
 
         if self.entity_description.attr_fn:
-            self._attr_extra_state_attributes = dict(
-                self._attrs,
-                **self.entity_description.attr_fn(self.vehicle, self._unit_system),
+            self._attr_extra_state_attributes = self.entity_description.attr_fn(
+                self.vehicle, self._unit_system
             )
 
         super()._handle_coordinator_update()

--- a/homeassistant/components/bmw_connected_drive/button.py
+++ b/homeassistant/components/bmw_connected_drive/button.py
@@ -17,8 +17,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import BMWBaseEntity
 from .const import DOMAIN
+from .entity import BMWBaseEntity
 
 if TYPE_CHECKING:
     from .coordinator import BMWDataUpdateCoordinator

--- a/homeassistant/components/bmw_connected_drive/const.py
+++ b/homeassistant/components/bmw_connected_drive/const.py
@@ -3,7 +3,6 @@
 from homeassistant.const import UnitOfLength, UnitOfVolume
 
 DOMAIN = "bmw_connected_drive"
-ATTRIBUTION = "Data provided by MyBMW"
 
 ATTR_DIRECTION = "direction"
 ATTR_VIN = "vin"

--- a/homeassistant/components/bmw_connected_drive/device_tracker.py
+++ b/homeassistant/components/bmw_connected_drive/device_tracker.py
@@ -12,9 +12,9 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import BMWBaseEntity
 from .const import ATTR_DIRECTION, DOMAIN
 from .coordinator import BMWDataUpdateCoordinator
+from .entity import BMWBaseEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ class BMWDeviceTracker(BMWBaseEntity, TrackerEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return entity specific state attributes."""
-        return {**self._attrs, ATTR_DIRECTION: self.vehicle.vehicle_location.heading}
+        return {ATTR_DIRECTION: self.vehicle.vehicle_location.heading}
 
     @property
     def latitude(self) -> float | None:

--- a/homeassistant/components/bmw_connected_drive/entity.py
+++ b/homeassistant/components/bmw_connected_drive/entity.py
@@ -1,0 +1,41 @@
+"""Base for all BMW entities."""
+
+from __future__ import annotations
+
+from bimmer_connected.vehicle import MyBMWVehicle
+
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import BMWDataUpdateCoordinator
+
+
+class BMWBaseEntity(CoordinatorEntity[BMWDataUpdateCoordinator]):
+    """Common base for BMW entities."""
+
+    coordinator: BMWDataUpdateCoordinator
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: BMWDataUpdateCoordinator,
+        vehicle: MyBMWVehicle,
+    ) -> None:
+        """Initialize entity."""
+        super().__init__(coordinator)
+
+        self.vehicle = vehicle
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self.vehicle.vin)},
+            manufacturer=vehicle.brand.name,
+            model=vehicle.name,
+            name=vehicle.name,
+            serial_number=vehicle.vin,
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to hass."""
+        await super().async_added_to_hass()
+        self._handle_coordinator_update()

--- a/homeassistant/components/bmw_connected_drive/entity.py
+++ b/homeassistant/components/bmw_connected_drive/entity.py
@@ -14,7 +14,6 @@ from .coordinator import BMWDataUpdateCoordinator
 class BMWBaseEntity(CoordinatorEntity[BMWDataUpdateCoordinator]):
     """Common base for BMW entities."""
 
-    coordinator: BMWDataUpdateCoordinator
     _attr_has_entity_name = True
 
     def __init__(
@@ -28,7 +27,7 @@ class BMWBaseEntity(CoordinatorEntity[BMWDataUpdateCoordinator]):
         self.vehicle = vehicle
 
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self.vehicle.vin)},
+            identifiers={(DOMAIN, vehicle.vin)},
             manufacturer=vehicle.brand.name,
             model=vehicle.name,
             name=vehicle.name,

--- a/homeassistant/components/bmw_connected_drive/lock.py
+++ b/homeassistant/components/bmw_connected_drive/lock.py
@@ -15,9 +15,9 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import BMWBaseEntity
 from .const import DOMAIN
 from .coordinator import BMWDataUpdateCoordinator
+from .entity import BMWBaseEntity
 
 DOOR_LOCK_STATE = "door_lock_state"
 _LOGGER = logging.getLogger(__name__)
@@ -97,8 +97,6 @@ class BMWLock(BMWBaseEntity, LockEntity):
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         _LOGGER.debug("Updating lock data of %s", self.vehicle.name)
-        # Set default attributes
-        self._attr_extra_state_attributes = self._attrs
 
         # Only update the HA state machine if the vehicle reliably reports its lock state
         if self.door_lock_state_available:
@@ -106,8 +104,8 @@ class BMWLock(BMWBaseEntity, LockEntity):
                 LockState.LOCKED,
                 LockState.SECURED,
             }
-            self._attr_extra_state_attributes["door_lock_state"] = (
-                self.vehicle.doors_and_windows.door_lock_state.value
-            )
+            self._attr_extra_state_attributes = {
+                DOOR_LOCK_STATE: self.vehicle.doors_and_windows.door_lock_state.value
+            }
 
         super()._handle_coordinator_update()

--- a/homeassistant/components/bmw_connected_drive/number.py
+++ b/homeassistant/components/bmw_connected_drive/number.py
@@ -19,9 +19,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import BMWBaseEntity
 from .const import DOMAIN
 from .coordinator import BMWDataUpdateCoordinator
+from .entity import BMWBaseEntity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/bmw_connected_drive/select.py
+++ b/homeassistant/components/bmw_connected_drive/select.py
@@ -16,9 +16,9 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import BMWBaseEntity
 from .const import DOMAIN
 from .coordinator import BMWDataUpdateCoordinator
+from .entity import BMWBaseEntity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/bmw_connected_drive/sensor.py
+++ b/homeassistant/components/bmw_connected_drive/sensor.py
@@ -30,9 +30,9 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import dt as dt_util
 
-from . import BMWBaseEntity
 from .const import DOMAIN
 from .coordinator import BMWDataUpdateCoordinator
+from .entity import BMWBaseEntity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/bmw_connected_drive/switch.py
+++ b/homeassistant/components/bmw_connected_drive/switch.py
@@ -15,9 +15,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import BMWBaseEntity
 from .const import DOMAIN
 from .coordinator import BMWDataUpdateCoordinator
+from .entity import BMWBaseEntity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/components/bmw_connected_drive/snapshots/test_binary_sensor.ambr
+++ b/tests/components/bmw_connected_drive/snapshots/test_binary_sensor.ambr
@@ -35,7 +35,6 @@
 # name: test_entity_state_attrs[binary_sensor.i3_rex_charging_status-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'battery_charging',
       'friendly_name': 'i3 (+ REX) Charging status',
     }),
@@ -83,11 +82,8 @@
 # name: test_entity_state_attrs[binary_sensor.i3_rex_check_control_messages-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
-      'car': 'i3 (+ REX)',
       'device_class': 'problem',
       'friendly_name': 'i3 (+ REX) Check control messages',
-      'vin': 'WBY00000000REXI01',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.i3_rex_check_control_messages',
@@ -133,17 +129,14 @@
 # name: test_entity_state_attrs[binary_sensor.i3_rex_condition_based_services-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'brake_fluid': 'OK',
       'brake_fluid_date': '2022-10-01',
-      'car': 'i3 (+ REX)',
       'device_class': 'problem',
       'friendly_name': 'i3 (+ REX) Condition based services',
       'vehicle_check': 'OK',
       'vehicle_check_date': '2023-05-01',
       'vehicle_tuv': 'OK',
       'vehicle_tuv_date': '2023-05-01',
-      'vin': 'WBY00000000REXI01',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.i3_rex_condition_based_services',
@@ -189,7 +182,6 @@
 # name: test_entity_state_attrs[binary_sensor.i3_rex_connection_status-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'plug',
       'friendly_name': 'i3 (+ REX) Connection status',
     }),
@@ -237,12 +229,9 @@
 # name: test_entity_state_attrs[binary_sensor.i3_rex_door_lock_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
-      'car': 'i3 (+ REX)',
       'device_class': 'lock',
       'door_lock_state': 'UNLOCKED',
       'friendly_name': 'i3 (+ REX) Door lock state',
-      'vin': 'WBY00000000REXI01',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.i3_rex_door_lock_state',
@@ -288,8 +277,6 @@
 # name: test_entity_state_attrs[binary_sensor.i3_rex_lids-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
-      'car': 'i3 (+ REX)',
       'device_class': 'opening',
       'friendly_name': 'i3 (+ REX) Lids',
       'hood': 'CLOSED',
@@ -299,7 +286,6 @@
       'rightRear': 'CLOSED',
       'sunRoof': 'CLOSED',
       'trunk': 'CLOSED',
-      'vin': 'WBY00000000REXI01',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.i3_rex_lids',
@@ -345,7 +331,6 @@
 # name: test_entity_state_attrs[binary_sensor.i3_rex_pre_entry_climatization-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'i3 (+ REX) Pre entry climatization',
     }),
     'context': <ANY>,
@@ -392,13 +377,10 @@
 # name: test_entity_state_attrs[binary_sensor.i3_rex_windows-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
-      'car': 'i3 (+ REX)',
       'device_class': 'opening',
       'friendly_name': 'i3 (+ REX) Windows',
       'leftFront': 'CLOSED',
       'rightFront': 'CLOSED',
-      'vin': 'WBY00000000REXI01',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.i3_rex_windows',
@@ -444,7 +426,6 @@
 # name: test_entity_state_attrs[binary_sensor.i4_edrive40_charging_status-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'battery_charging',
       'friendly_name': 'i4 eDrive40 Charging status',
     }),
@@ -492,12 +473,9 @@
 # name: test_entity_state_attrs[binary_sensor.i4_edrive40_check_control_messages-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
-      'car': 'i4 eDrive40',
       'device_class': 'problem',
       'friendly_name': 'i4 eDrive40 Check control messages',
       'tire_pressure': 'LOW',
-      'vin': 'WBA00000000DEMO02',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.i4_edrive40_check_control_messages',
@@ -543,11 +521,9 @@
 # name: test_entity_state_attrs[binary_sensor.i4_edrive40_condition_based_services-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'brake_fluid': 'OK',
       'brake_fluid_date': '2024-12-01',
       'brake_fluid_distance': '50000 km',
-      'car': 'i4 eDrive40',
       'device_class': 'problem',
       'friendly_name': 'i4 eDrive40 Condition based services',
       'tire_wear_front': 'OK',
@@ -558,7 +534,6 @@
       'vehicle_tuv': 'OK',
       'vehicle_tuv_date': '2024-12-01',
       'vehicle_tuv_distance': '50000 km',
-      'vin': 'WBA00000000DEMO02',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.i4_edrive40_condition_based_services',
@@ -604,7 +579,6 @@
 # name: test_entity_state_attrs[binary_sensor.i4_edrive40_connection_status-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'plug',
       'friendly_name': 'i4 eDrive40 Connection status',
     }),
@@ -652,12 +626,9 @@
 # name: test_entity_state_attrs[binary_sensor.i4_edrive40_door_lock_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
-      'car': 'i4 eDrive40',
       'device_class': 'lock',
       'door_lock_state': 'LOCKED',
       'friendly_name': 'i4 eDrive40 Door lock state',
-      'vin': 'WBA00000000DEMO02',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.i4_edrive40_door_lock_state',
@@ -703,8 +674,6 @@
 # name: test_entity_state_attrs[binary_sensor.i4_edrive40_lids-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
-      'car': 'i4 eDrive40',
       'device_class': 'opening',
       'friendly_name': 'i4 eDrive40 Lids',
       'hood': 'CLOSED',
@@ -713,7 +682,6 @@
       'rightFront': 'CLOSED',
       'rightRear': 'CLOSED',
       'trunk': 'CLOSED',
-      'vin': 'WBA00000000DEMO02',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.i4_edrive40_lids',
@@ -759,7 +727,6 @@
 # name: test_entity_state_attrs[binary_sensor.i4_edrive40_pre_entry_climatization-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'i4 eDrive40 Pre entry climatization',
     }),
     'context': <ANY>,
@@ -806,8 +773,6 @@
 # name: test_entity_state_attrs[binary_sensor.i4_edrive40_windows-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
-      'car': 'i4 eDrive40',
       'device_class': 'opening',
       'friendly_name': 'i4 eDrive40 Windows',
       'leftFront': 'CLOSED',
@@ -815,7 +780,6 @@
       'rear': 'CLOSED',
       'rightFront': 'CLOSED',
       'rightRear': 'CLOSED',
-      'vin': 'WBA00000000DEMO02',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.i4_edrive40_windows',
@@ -861,7 +825,6 @@
 # name: test_entity_state_attrs[binary_sensor.ix_xdrive50_charging_status-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'battery_charging',
       'friendly_name': 'iX xDrive50 Charging status',
     }),
@@ -909,12 +872,9 @@
 # name: test_entity_state_attrs[binary_sensor.ix_xdrive50_check_control_messages-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
-      'car': 'iX xDrive50',
       'device_class': 'problem',
       'friendly_name': 'iX xDrive50 Check control messages',
       'tire_pressure': 'LOW',
-      'vin': 'WBA00000000DEMO01',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.ix_xdrive50_check_control_messages',
@@ -960,11 +920,9 @@
 # name: test_entity_state_attrs[binary_sensor.ix_xdrive50_condition_based_services-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'brake_fluid': 'OK',
       'brake_fluid_date': '2024-12-01',
       'brake_fluid_distance': '50000 km',
-      'car': 'iX xDrive50',
       'device_class': 'problem',
       'friendly_name': 'iX xDrive50 Condition based services',
       'tire_wear_front': 'OK',
@@ -975,7 +933,6 @@
       'vehicle_tuv': 'OK',
       'vehicle_tuv_date': '2024-12-01',
       'vehicle_tuv_distance': '50000 km',
-      'vin': 'WBA00000000DEMO01',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.ix_xdrive50_condition_based_services',
@@ -1021,7 +978,6 @@
 # name: test_entity_state_attrs[binary_sensor.ix_xdrive50_connection_status-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'plug',
       'friendly_name': 'iX xDrive50 Connection status',
     }),
@@ -1069,12 +1025,9 @@
 # name: test_entity_state_attrs[binary_sensor.ix_xdrive50_door_lock_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
-      'car': 'iX xDrive50',
       'device_class': 'lock',
       'door_lock_state': 'LOCKED',
       'friendly_name': 'iX xDrive50 Door lock state',
-      'vin': 'WBA00000000DEMO01',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.ix_xdrive50_door_lock_state',
@@ -1120,8 +1073,6 @@
 # name: test_entity_state_attrs[binary_sensor.ix_xdrive50_lids-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
-      'car': 'iX xDrive50',
       'device_class': 'opening',
       'friendly_name': 'iX xDrive50 Lids',
       'hood': 'CLOSED',
@@ -1131,7 +1082,6 @@
       'rightRear': 'CLOSED',
       'sunRoof': 'CLOSED',
       'trunk': 'CLOSED',
-      'vin': 'WBA00000000DEMO01',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.ix_xdrive50_lids',
@@ -1177,7 +1127,6 @@
 # name: test_entity_state_attrs[binary_sensor.ix_xdrive50_pre_entry_climatization-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'iX xDrive50 Pre entry climatization',
     }),
     'context': <ANY>,
@@ -1224,8 +1173,6 @@
 # name: test_entity_state_attrs[binary_sensor.ix_xdrive50_windows-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
-      'car': 'iX xDrive50',
       'device_class': 'opening',
       'friendly_name': 'iX xDrive50 Windows',
       'leftFront': 'CLOSED',
@@ -1233,7 +1180,6 @@
       'rear': 'CLOSED',
       'rightFront': 'CLOSED',
       'rightRear': 'CLOSED',
-      'vin': 'WBA00000000DEMO01',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.ix_xdrive50_windows',
@@ -1279,13 +1225,10 @@
 # name: test_entity_state_attrs[binary_sensor.m340i_xdrive_check_control_messages-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
-      'car': 'M340i xDrive',
       'device_class': 'problem',
       'engine_oil': 'LOW',
       'friendly_name': 'M340i xDrive Check control messages',
       'tire_pressure': 'LOW',
-      'vin': 'WBA00000000DEMO03',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.m340i_xdrive_check_control_messages',
@@ -1331,11 +1274,9 @@
 # name: test_entity_state_attrs[binary_sensor.m340i_xdrive_condition_based_services-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'brake_fluid': 'OK',
       'brake_fluid_date': '2024-12-01',
       'brake_fluid_distance': '50000 km',
-      'car': 'M340i xDrive',
       'device_class': 'problem',
       'friendly_name': 'M340i xDrive Condition based services',
       'oil': 'OK',
@@ -1349,7 +1290,6 @@
       'vehicle_tuv': 'OK',
       'vehicle_tuv_date': '2024-12-01',
       'vehicle_tuv_distance': '50000 km',
-      'vin': 'WBA00000000DEMO03',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.m340i_xdrive_condition_based_services',
@@ -1395,12 +1335,9 @@
 # name: test_entity_state_attrs[binary_sensor.m340i_xdrive_door_lock_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
-      'car': 'M340i xDrive',
       'device_class': 'lock',
       'door_lock_state': 'LOCKED',
       'friendly_name': 'M340i xDrive Door lock state',
-      'vin': 'WBA00000000DEMO03',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.m340i_xdrive_door_lock_state',
@@ -1446,8 +1383,6 @@
 # name: test_entity_state_attrs[binary_sensor.m340i_xdrive_lids-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
-      'car': 'M340i xDrive',
       'device_class': 'opening',
       'friendly_name': 'M340i xDrive Lids',
       'hood': 'CLOSED',
@@ -1456,7 +1391,6 @@
       'rightFront': 'CLOSED',
       'rightRear': 'CLOSED',
       'trunk': 'CLOSED',
-      'vin': 'WBA00000000DEMO03',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.m340i_xdrive_lids',
@@ -1502,8 +1436,6 @@
 # name: test_entity_state_attrs[binary_sensor.m340i_xdrive_windows-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
-      'car': 'M340i xDrive',
       'device_class': 'opening',
       'friendly_name': 'M340i xDrive Windows',
       'leftFront': 'CLOSED',
@@ -1511,7 +1443,6 @@
       'rear': 'CLOSED',
       'rightFront': 'CLOSED',
       'rightRear': 'CLOSED',
-      'vin': 'WBA00000000DEMO03',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.m340i_xdrive_windows',

--- a/tests/components/bmw_connected_drive/snapshots/test_button.ambr
+++ b/tests/components/bmw_connected_drive/snapshots/test_button.ambr
@@ -35,7 +35,6 @@
 # name: test_entity_state_attrs[button.i3_rex_activate_air_conditioning-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'i3 (+ REX) Activate air conditioning',
     }),
     'context': <ANY>,
@@ -82,7 +81,6 @@
 # name: test_entity_state_attrs[button.i3_rex_find_vehicle-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'i3 (+ REX) Find vehicle',
     }),
     'context': <ANY>,
@@ -129,7 +127,6 @@
 # name: test_entity_state_attrs[button.i3_rex_flash_lights-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'i3 (+ REX) Flash lights',
     }),
     'context': <ANY>,
@@ -176,7 +173,6 @@
 # name: test_entity_state_attrs[button.i3_rex_sound_horn-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'i3 (+ REX) Sound horn',
     }),
     'context': <ANY>,
@@ -223,7 +219,6 @@
 # name: test_entity_state_attrs[button.i4_edrive40_activate_air_conditioning-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'i4 eDrive40 Activate air conditioning',
     }),
     'context': <ANY>,
@@ -270,7 +265,6 @@
 # name: test_entity_state_attrs[button.i4_edrive40_deactivate_air_conditioning-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'i4 eDrive40 Deactivate air conditioning',
     }),
     'context': <ANY>,
@@ -317,7 +311,6 @@
 # name: test_entity_state_attrs[button.i4_edrive40_find_vehicle-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'i4 eDrive40 Find vehicle',
     }),
     'context': <ANY>,
@@ -364,7 +357,6 @@
 # name: test_entity_state_attrs[button.i4_edrive40_flash_lights-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'i4 eDrive40 Flash lights',
     }),
     'context': <ANY>,
@@ -411,7 +403,6 @@
 # name: test_entity_state_attrs[button.i4_edrive40_sound_horn-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'i4 eDrive40 Sound horn',
     }),
     'context': <ANY>,
@@ -458,7 +449,6 @@
 # name: test_entity_state_attrs[button.ix_xdrive50_activate_air_conditioning-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'iX xDrive50 Activate air conditioning',
     }),
     'context': <ANY>,
@@ -505,7 +495,6 @@
 # name: test_entity_state_attrs[button.ix_xdrive50_deactivate_air_conditioning-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'iX xDrive50 Deactivate air conditioning',
     }),
     'context': <ANY>,
@@ -552,7 +541,6 @@
 # name: test_entity_state_attrs[button.ix_xdrive50_find_vehicle-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'iX xDrive50 Find vehicle',
     }),
     'context': <ANY>,
@@ -599,7 +587,6 @@
 # name: test_entity_state_attrs[button.ix_xdrive50_flash_lights-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'iX xDrive50 Flash lights',
     }),
     'context': <ANY>,
@@ -646,7 +633,6 @@
 # name: test_entity_state_attrs[button.ix_xdrive50_sound_horn-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'iX xDrive50 Sound horn',
     }),
     'context': <ANY>,
@@ -693,7 +679,6 @@
 # name: test_entity_state_attrs[button.m340i_xdrive_activate_air_conditioning-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'M340i xDrive Activate air conditioning',
     }),
     'context': <ANY>,
@@ -740,7 +725,6 @@
 # name: test_entity_state_attrs[button.m340i_xdrive_deactivate_air_conditioning-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'M340i xDrive Deactivate air conditioning',
     }),
     'context': <ANY>,
@@ -787,7 +771,6 @@
 # name: test_entity_state_attrs[button.m340i_xdrive_find_vehicle-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'M340i xDrive Find vehicle',
     }),
     'context': <ANY>,
@@ -834,7 +817,6 @@
 # name: test_entity_state_attrs[button.m340i_xdrive_flash_lights-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'M340i xDrive Flash lights',
     }),
     'context': <ANY>,
@@ -881,7 +863,6 @@
 # name: test_entity_state_attrs[button.m340i_xdrive_sound_horn-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'M340i xDrive Sound horn',
     }),
     'context': <ANY>,

--- a/tests/components/bmw_connected_drive/snapshots/test_lock.ambr
+++ b/tests/components/bmw_connected_drive/snapshots/test_lock.ambr
@@ -35,12 +35,9 @@
 # name: test_entity_state_attrs[lock.i3_rex_lock-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
-      'car': 'i3 (+ REX)',
       'door_lock_state': 'UNLOCKED',
       'friendly_name': 'i3 (+ REX) Lock',
       'supported_features': <LockEntityFeature: 0>,
-      'vin': 'WBY00000000REXI01',
     }),
     'context': <ANY>,
     'entity_id': 'lock.i3_rex_lock',
@@ -86,12 +83,9 @@
 # name: test_entity_state_attrs[lock.i4_edrive40_lock-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
-      'car': 'i4 eDrive40',
       'door_lock_state': 'LOCKED',
       'friendly_name': 'i4 eDrive40 Lock',
       'supported_features': <LockEntityFeature: 0>,
-      'vin': 'WBA00000000DEMO02',
     }),
     'context': <ANY>,
     'entity_id': 'lock.i4_edrive40_lock',
@@ -137,12 +131,9 @@
 # name: test_entity_state_attrs[lock.ix_xdrive50_lock-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
-      'car': 'iX xDrive50',
       'door_lock_state': 'LOCKED',
       'friendly_name': 'iX xDrive50 Lock',
       'supported_features': <LockEntityFeature: 0>,
-      'vin': 'WBA00000000DEMO01',
     }),
     'context': <ANY>,
     'entity_id': 'lock.ix_xdrive50_lock',
@@ -188,12 +179,9 @@
 # name: test_entity_state_attrs[lock.m340i_xdrive_lock-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
-      'car': 'M340i xDrive',
       'door_lock_state': 'LOCKED',
       'friendly_name': 'M340i xDrive Lock',
       'supported_features': <LockEntityFeature: 0>,
-      'vin': 'WBA00000000DEMO03',
     }),
     'context': <ANY>,
     'entity_id': 'lock.m340i_xdrive_lock',

--- a/tests/components/bmw_connected_drive/snapshots/test_number.ambr
+++ b/tests/components/bmw_connected_drive/snapshots/test_number.ambr
@@ -40,7 +40,6 @@
 # name: test_entity_state_attrs[number.i4_edrive40_target_soc-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'battery',
       'friendly_name': 'i4 eDrive40 Target SoC',
       'max': 100.0,
@@ -97,7 +96,6 @@
 # name: test_entity_state_attrs[number.ix_xdrive50_target_soc-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'battery',
       'friendly_name': 'iX xDrive50 Target SoC',
       'max': 100.0,

--- a/tests/components/bmw_connected_drive/snapshots/test_select.ambr
+++ b/tests/components/bmw_connected_drive/snapshots/test_select.ambr
@@ -40,7 +40,6 @@
 # name: test_entity_state_attrs[select.i3_rex_charging_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'i3 (+ REX) Charging Mode',
       'options': list([
         'immediate_charging',
@@ -107,7 +106,6 @@
 # name: test_entity_state_attrs[select.i4_edrive40_ac_charging_limit-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'i4 eDrive40 AC Charging Limit',
       'options': list([
         '6',
@@ -175,7 +173,6 @@
 # name: test_entity_state_attrs[select.i4_edrive40_charging_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'i4 eDrive40 Charging Mode',
       'options': list([
         'immediate_charging',
@@ -242,7 +239,6 @@
 # name: test_entity_state_attrs[select.ix_xdrive50_ac_charging_limit-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'iX xDrive50 AC Charging Limit',
       'options': list([
         '6',
@@ -310,7 +306,6 @@
 # name: test_entity_state_attrs[select.ix_xdrive50_charging_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'iX xDrive50 Charging Mode',
       'options': list([
         'immediate_charging',

--- a/tests/components/bmw_connected_drive/snapshots/test_sensor.ambr
+++ b/tests/components/bmw_connected_drive/snapshots/test_sensor.ambr
@@ -38,7 +38,6 @@
 # name: test_entity_state_attrs[sensor.i3_rex_ac_current_limit-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'current',
       'friendly_name': 'i3 (+ REX) AC current limit',
       'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
@@ -87,7 +86,6 @@
 # name: test_entity_state_attrs[sensor.i3_rex_charging_end_time-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'timestamp',
       'friendly_name': 'i3 (+ REX) Charging end time',
     }),
@@ -135,7 +133,6 @@
 # name: test_entity_state_attrs[sensor.i3_rex_charging_start_time-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'timestamp',
       'friendly_name': 'i3 (+ REX) Charging start time',
     }),
@@ -198,7 +195,6 @@
 # name: test_entity_state_attrs[sensor.i3_rex_charging_status-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'enum',
       'friendly_name': 'i3 (+ REX) Charging status',
       'options': list([
@@ -263,7 +259,6 @@
 # name: test_entity_state_attrs[sensor.i3_rex_charging_target-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'battery',
       'friendly_name': 'i3 (+ REX) Charging target',
       'unit_of_measurement': '%',
@@ -317,7 +312,6 @@
 # name: test_entity_state_attrs[sensor.i3_rex_mileage-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'distance',
       'friendly_name': 'i3 (+ REX) Mileage',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -372,7 +366,6 @@
 # name: test_entity_state_attrs[sensor.i3_rex_remaining_battery_percent-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'battery',
       'friendly_name': 'i3 (+ REX) Remaining battery percent',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -427,7 +420,6 @@
 # name: test_entity_state_attrs[sensor.i3_rex_remaining_fuel-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'volume',
       'friendly_name': 'i3 (+ REX) Remaining fuel',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -482,7 +474,6 @@
 # name: test_entity_state_attrs[sensor.i3_rex_remaining_fuel_percent-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'i3 (+ REX) Remaining fuel percent',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
@@ -536,7 +527,6 @@
 # name: test_entity_state_attrs[sensor.i3_rex_remaining_range_electric-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'distance',
       'friendly_name': 'i3 (+ REX) Remaining range electric',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -591,7 +581,6 @@
 # name: test_entity_state_attrs[sensor.i3_rex_remaining_range_fuel-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'distance',
       'friendly_name': 'i3 (+ REX) Remaining range fuel',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -646,7 +635,6 @@
 # name: test_entity_state_attrs[sensor.i3_rex_remaining_range_total-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'distance',
       'friendly_name': 'i3 (+ REX) Remaining range total',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -699,7 +687,6 @@
 # name: test_entity_state_attrs[sensor.i4_edrive40_ac_current_limit-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'current',
       'friendly_name': 'i4 eDrive40 AC current limit',
       'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
@@ -748,7 +735,6 @@
 # name: test_entity_state_attrs[sensor.i4_edrive40_charging_end_time-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'timestamp',
       'friendly_name': 'i4 eDrive40 Charging end time',
     }),
@@ -796,7 +782,6 @@
 # name: test_entity_state_attrs[sensor.i4_edrive40_charging_start_time-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'timestamp',
       'friendly_name': 'i4 eDrive40 Charging start time',
     }),
@@ -859,7 +844,6 @@
 # name: test_entity_state_attrs[sensor.i4_edrive40_charging_status-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'enum',
       'friendly_name': 'i4 eDrive40 Charging status',
       'options': list([
@@ -924,7 +908,6 @@
 # name: test_entity_state_attrs[sensor.i4_edrive40_charging_target-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'battery',
       'friendly_name': 'i4 eDrive40 Charging target',
       'unit_of_measurement': '%',
@@ -980,7 +963,6 @@
 # name: test_entity_state_attrs[sensor.i4_edrive40_climate_status-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'enum',
       'friendly_name': 'i4 eDrive40 Climate status',
       'options': list([
@@ -1039,7 +1021,6 @@
 # name: test_entity_state_attrs[sensor.i4_edrive40_mileage-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'distance',
       'friendly_name': 'i4 eDrive40 Mileage',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -1094,7 +1075,6 @@
 # name: test_entity_state_attrs[sensor.i4_edrive40_remaining_battery_percent-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'battery',
       'friendly_name': 'i4 eDrive40 Remaining battery percent',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -1149,7 +1129,6 @@
 # name: test_entity_state_attrs[sensor.i4_edrive40_remaining_range_electric-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'distance',
       'friendly_name': 'i4 eDrive40 Remaining range electric',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -1204,7 +1183,6 @@
 # name: test_entity_state_attrs[sensor.i4_edrive40_remaining_range_total-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'distance',
       'friendly_name': 'i4 eDrive40 Remaining range total',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -1257,7 +1235,6 @@
 # name: test_entity_state_attrs[sensor.ix_xdrive50_ac_current_limit-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'current',
       'friendly_name': 'iX xDrive50 AC current limit',
       'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
@@ -1306,7 +1283,6 @@
 # name: test_entity_state_attrs[sensor.ix_xdrive50_charging_end_time-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'timestamp',
       'friendly_name': 'iX xDrive50 Charging end time',
     }),
@@ -1354,7 +1330,6 @@
 # name: test_entity_state_attrs[sensor.ix_xdrive50_charging_start_time-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'timestamp',
       'friendly_name': 'iX xDrive50 Charging start time',
     }),
@@ -1417,7 +1392,6 @@
 # name: test_entity_state_attrs[sensor.ix_xdrive50_charging_status-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'enum',
       'friendly_name': 'iX xDrive50 Charging status',
       'options': list([
@@ -1482,7 +1456,6 @@
 # name: test_entity_state_attrs[sensor.ix_xdrive50_charging_target-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'battery',
       'friendly_name': 'iX xDrive50 Charging target',
       'unit_of_measurement': '%',
@@ -1538,7 +1511,6 @@
 # name: test_entity_state_attrs[sensor.ix_xdrive50_climate_status-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'enum',
       'friendly_name': 'iX xDrive50 Climate status',
       'options': list([
@@ -1597,7 +1569,6 @@
 # name: test_entity_state_attrs[sensor.ix_xdrive50_mileage-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'distance',
       'friendly_name': 'iX xDrive50 Mileage',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -1652,7 +1623,6 @@
 # name: test_entity_state_attrs[sensor.ix_xdrive50_remaining_battery_percent-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'battery',
       'friendly_name': 'iX xDrive50 Remaining battery percent',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -1707,7 +1677,6 @@
 # name: test_entity_state_attrs[sensor.ix_xdrive50_remaining_range_electric-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'distance',
       'friendly_name': 'iX xDrive50 Remaining range electric',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -1762,7 +1731,6 @@
 # name: test_entity_state_attrs[sensor.ix_xdrive50_remaining_range_total-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'distance',
       'friendly_name': 'iX xDrive50 Remaining range total',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -1819,7 +1787,6 @@
 # name: test_entity_state_attrs[sensor.m340i_xdrive_climate_status-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'enum',
       'friendly_name': 'M340i xDrive Climate status',
       'options': list([
@@ -1878,7 +1845,6 @@
 # name: test_entity_state_attrs[sensor.m340i_xdrive_mileage-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'distance',
       'friendly_name': 'M340i xDrive Mileage',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -1933,7 +1899,6 @@
 # name: test_entity_state_attrs[sensor.m340i_xdrive_remaining_fuel-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'volume',
       'friendly_name': 'M340i xDrive Remaining fuel',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -1988,7 +1953,6 @@
 # name: test_entity_state_attrs[sensor.m340i_xdrive_remaining_fuel_percent-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'M340i xDrive Remaining fuel percent',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
@@ -2042,7 +2006,6 @@
 # name: test_entity_state_attrs[sensor.m340i_xdrive_remaining_range_fuel-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'distance',
       'friendly_name': 'M340i xDrive Remaining range fuel',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -2097,7 +2060,6 @@
 # name: test_entity_state_attrs[sensor.m340i_xdrive_remaining_range_total-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'device_class': 'distance',
       'friendly_name': 'M340i xDrive Remaining range total',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,

--- a/tests/components/bmw_connected_drive/snapshots/test_switch.ambr
+++ b/tests/components/bmw_connected_drive/snapshots/test_switch.ambr
@@ -35,7 +35,6 @@
 # name: test_entity_state_attrs[switch.i4_edrive40_climate-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'i4 eDrive40 Climate',
     }),
     'context': <ANY>,
@@ -82,7 +81,6 @@
 # name: test_entity_state_attrs[switch.ix_xdrive50_charging-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'iX xDrive50 Charging',
     }),
     'context': <ANY>,
@@ -129,7 +127,6 @@
 # name: test_entity_state_attrs[switch.ix_xdrive50_climate-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'iX xDrive50 Climate',
     }),
     'context': <ANY>,
@@ -176,7 +173,6 @@
 # name: test_entity_state_attrs[switch.m340i_xdrive_climate-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by MyBMW',
       'friendly_name': 'M340i xDrive Climate',
     }),
     'context': <ANY>,


### PR DESCRIPTION
## Breaking change
Describing attributes `car` and `vin` have been removed from BMW entities. If you need to look them up, please get them from the Device info screen.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR refactors the bmw_connected_drive base entity into a separate `entity.py` file.

Also removes unneeded entity attributes (attribution, car, vin) as VIN now can be shown via `DeviceInfo` and car can be definded by the user via the device name (and propagated to the entities via `has_entity_name`).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
