### PR TITLE
Improve flume test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -441,7 +441,6 @@ omit =
     homeassistant/components/flick_electric/__init__.py
     homeassistant/components/flick_electric/sensor.py
     homeassistant/components/flock/notify.py
-    homeassistant/components/flume/__init__.py
     homeassistant/components/flume/binary_sensor.py
     homeassistant/components/flume/coordinator.py
     homeassistant/components/flume/entity.py

--- a/tests/components/flume/conftest.py
+++ b/tests/components/flume/conftest.py
@@ -1,4 +1,4 @@
-"""Test the flume init."""
+"""Flume test fixtures."""
 
 from collections.abc import Generator
 import datetime

--- a/tests/components/flume/conftest.py
+++ b/tests/components/flume/conftest.py
@@ -1,0 +1,103 @@
+"""Test the flume init."""
+
+from collections.abc import Generator
+import datetime
+from http import HTTPStatus
+import json
+from unittest.mock import mock_open, patch
+
+import jwt
+import pytest
+from requests_mock.mocker import Mocker
+
+from homeassistant.components.flume.const import DOMAIN
+from homeassistant.const import (
+    CONF_CLIENT_ID,
+    CONF_CLIENT_SECRET,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+)
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+USER_ID = "test-user-id"
+REFRESH_TOKEN = "refresh-token"
+TOKEN_URL = "https://api.flumetech.com/oauth/token"
+DEVICE_LIST_URL = (
+    "https://api.flumetech.com/users/test-user-id/devices?user=true&location=true"
+)
+BRIDGE_DEVICE = {
+    "id": "1234",
+    "type": 1,  # Bridge
+    "location": {
+        "name": "Bridge Location",
+    },
+    "name": "Flume Bridge",
+}
+SENSOR_DEVICE = {
+    "id": "1234",
+    "type": 2,  # Sensor
+    "location": {
+        "name": "Sensor Location",
+    },
+    "name": "Flume Sensor",
+}
+DEVICE_LIST = [BRIDGE_DEVICE, SENSOR_DEVICE]
+
+
+@pytest.fixture(name="config_entry")
+def config_entry_fixture(hass: HomeAssistant) -> MockConfigEntry:
+    """Fixture to create a config entry."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test-username",
+        data={
+            CONF_USERNAME: "test-username",
+            CONF_PASSWORD: "test-password",
+            CONF_CLIENT_ID: "client_id",
+            CONF_CLIENT_SECRET: "client_secret",
+        },
+    )
+    config_entry.add_to_hass(hass)
+    return config_entry
+
+
+def encode_access_token() -> str:
+    """Encode the payload of the access token."""
+    expiration_time = datetime.datetime.now() + datetime.timedelta(hours=12)
+    payload = {
+        "user_id": USER_ID,
+        "exp": int(expiration_time.timestamp()),
+    }
+    return jwt.encode(payload, key="secret")
+
+
+@pytest.fixture(name="access_token")
+def access_token_fixture(requests_mock: Mocker) -> Generator[None, None, None]:
+    """Fixture to setup the access token."""
+    token_response = {
+        "refresh_token": REFRESH_TOKEN,
+        "access_token": encode_access_token(),
+    }
+    requests_mock.register_uri(
+        "POST",
+        TOKEN_URL,
+        status_code=HTTPStatus.OK,
+        json={"data": [token_response]},
+    )
+    with patch("builtins.open", mock_open(read_data=json.dumps(token_response))):
+        yield
+
+
+@pytest.fixture(name="device_list")
+def device_list_fixture(requests_mock: Mocker) -> None:
+    """Fixture to setup the device list API response access token."""
+    requests_mock.register_uri(
+        "GET",
+        DEVICE_LIST_URL,
+        status_code=HTTPStatus.OK,
+        json={
+            "data": DEVICE_LIST,
+        },
+    )

--- a/tests/components/flume/test_config_flow.py
+++ b/tests/components/flume/test_config_flow.py
@@ -3,6 +3,7 @@
 from http import HTTPStatus
 from unittest.mock import patch
 
+import pytest
 import requests.exceptions
 from requests_mock.mocker import Mocker
 
@@ -22,7 +23,8 @@ from .conftest import DEVICE_LIST, DEVICE_LIST_URL
 from tests.common import MockConfigEntry
 
 
-async def test_form(hass: HomeAssistant, access_token: None, device_list: None) -> None:
+@pytest.mark.usefixtures("access_token", "device_list")
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form and can setup from user input."""
 
     result = await hass.config_entries.flow.async_init(
@@ -59,9 +61,8 @@ async def test_form(hass: HomeAssistant, access_token: None, device_list: None) 
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_invalid_auth(
-    hass: HomeAssistant, access_token: None, requests_mock: Mocker
-) -> None:
+@pytest.mark.usefixtures("access_token")
+async def test_form_invalid_auth(hass: HomeAssistant, requests_mock: Mocker) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -88,9 +89,8 @@ async def test_form_invalid_auth(
     assert result2["errors"] == {"password": "invalid_auth"}
 
 
-async def test_form_cannot_connect(
-    hass: HomeAssistant, access_token: None, device_list_timeout: None
-) -> None:
+@pytest.mark.usefixtures("access_token", "device_list_timeout")
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -110,9 +110,8 @@ async def test_form_cannot_connect(
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_reauth(
-    hass: HomeAssistant, access_token: None, requests_mock: Mocker
-) -> None:
+@pytest.mark.usefixtures("access_token")
+async def test_reauth(hass: HomeAssistant, requests_mock: Mocker) -> None:
     """Test we can reauth."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -195,9 +194,8 @@ async def test_reauth(
     assert result4["reason"] == "reauth_successful"
 
 
-async def test_form_no_devices(
-    hass: HomeAssistant, access_token: None, requests_mock: Mocker
-) -> None:
+@pytest.mark.usefixtures("access_token")
+async def test_form_no_devices(hass: HomeAssistant, requests_mock: Mocker) -> None:
     """Test a device list response that contains no values will raise an error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/flume/test_config_flow.py
+++ b/tests/components/flume/test_config_flow.py
@@ -1,8 +1,10 @@
 """Test the flume config flow."""
 
-from unittest.mock import MagicMock, patch
+from http import HTTPStatus
+from unittest.mock import patch
 
 import requests.exceptions
+from requests_mock.mocker import Mocker
 
 from homeassistant import config_entries
 from homeassistant.components.flume.const import DOMAIN
@@ -15,16 +17,12 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
+from .conftest import DEVICE_LIST_URL
+
 from tests.common import MockConfigEntry
 
 
-def _get_mocked_flume_device_list():
-    flume_device_list_mock = MagicMock()
-    type(flume_device_list_mock).device_list = ["mock"]
-    return flume_device_list_mock
-
-
-async def test_form(hass: HomeAssistant) -> None:
+async def test_form(hass: HomeAssistant, access_token: None, device_list: None) -> None:
     """Test we get the form and can setup from user input."""
 
     result = await hass.config_entries.flow.async_init(
@@ -33,17 +31,7 @@ async def test_form(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
-    mock_flume_device_list = _get_mocked_flume_device_list()
-
     with (
-        patch(
-            "homeassistant.components.flume.config_flow.FlumeAuth",
-            return_value=True,
-        ),
-        patch(
-            "homeassistant.components.flume.config_flow.FlumeDeviceList",
-            return_value=mock_flume_device_list,
-        ),
         patch(
             "homeassistant.components.flume.async_setup_entry",
             return_value=True,
@@ -71,66 +59,66 @@ async def test_form(hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_invalid_auth(hass: HomeAssistant) -> None:
+async def test_form_invalid_auth(
+    hass: HomeAssistant, access_token: None, requests_mock: Mocker
+) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    with (
-        patch(
-            "homeassistant.components.flume.config_flow.FlumeAuth",
-            return_value=True,
-        ),
-        patch(
-            "homeassistant.components.flume.config_flow.FlumeDeviceList",
-            side_effect=Exception,
-        ),
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_USERNAME: "test-username",
-                CONF_PASSWORD: "test-password",
-                CONF_CLIENT_ID: "client_id",
-                CONF_CLIENT_SECRET: "client_secret",
-            },
-        )
+    requests_mock.register_uri(
+        "GET",
+        DEVICE_LIST_URL,
+        status_code=HTTPStatus.UNAUTHORIZED,
+        json={},
+    )
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_USERNAME: "test-username",
+            CONF_PASSWORD: "test-password",
+            CONF_CLIENT_ID: "client_id",
+            CONF_CLIENT_SECRET: "client_secret",
+        },
+    )
 
     assert result2["type"] is FlowResultType.FORM
     assert result2["errors"] == {"password": "invalid_auth"}
 
 
-async def test_form_cannot_connect(hass: HomeAssistant) -> None:
+async def test_form_cannot_connect(
+    hass: HomeAssistant, access_token: None, requests_mock: Mocker
+) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    with (
-        patch(
-            "homeassistant.components.flume.config_flow.FlumeAuth",
-            return_value=True,
-        ),
-        patch(
-            "homeassistant.components.flume.config_flow.FlumeDeviceList",
-            side_effect=requests.exceptions.ConnectionError(),
-        ),
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_USERNAME: "test-username",
-                CONF_PASSWORD: "test-password",
-                CONF_CLIENT_ID: "client_id",
-                CONF_CLIENT_SECRET: "client_secret",
-            },
-        )
+
+    requests_mock.register_uri(
+        "GET",
+        DEVICE_LIST_URL,
+        exc=requests.exceptions.ConnectTimeout,
+    )
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_USERNAME: "test-username",
+            CONF_PASSWORD: "test-password",
+            CONF_CLIENT_ID: "client_id",
+            CONF_CLIENT_SECRET: "client_secret",
+        },
+    )
 
     assert result2["type"] is FlowResultType.FORM
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_reauth(hass: HomeAssistant) -> None:
+async def test_reauth(
+    hass: HomeAssistant, access_token: None, requests_mock: Mocker
+) -> None:
     """Test we can reauth."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -151,57 +139,42 @@ async def test_reauth(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
-    with (
-        patch(
-            "homeassistant.components.flume.config_flow.FlumeAuth",
-            return_value=True,
-        ),
-        patch(
-            "homeassistant.components.flume.config_flow.FlumeDeviceList",
-            side_effect=Exception,
-        ),
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_PASSWORD: "test-password",
-            },
-        )
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_PASSWORD: "test-password",
+        },
+    )
 
     assert result2["type"] is FlowResultType.FORM
     assert result2["errors"] == {"password": "invalid_auth"}
 
-    with (
-        patch(
-            "homeassistant.components.flume.config_flow.FlumeAuth",
-            return_value=True,
-        ),
-        patch(
-            "homeassistant.components.flume.config_flow.FlumeDeviceList",
-            side_effect=requests.exceptions.ConnectionError(),
-        ),
-    ):
-        result3 = await hass.config_entries.flow.async_configure(
-            result2["flow_id"],
-            {
-                CONF_PASSWORD: "test-password",
-            },
-        )
+    requests_mock.register_uri(
+        "GET",
+        DEVICE_LIST_URL,
+        exc=requests.exceptions.ConnectTimeout,
+    )
+
+    result3 = await hass.config_entries.flow.async_configure(
+        result2["flow_id"],
+        {
+            CONF_PASSWORD: "test-password",
+        },
+    )
 
     assert result3["type"] is FlowResultType.FORM
     assert result3["errors"] == {"base": "cannot_connect"}
 
-    mock_flume_device_list = _get_mocked_flume_device_list()
+    requests_mock.register_uri(
+        "GET",
+        DEVICE_LIST_URL,
+        status_code=HTTPStatus.OK,
+        json={
+            "data": [{"id": 1}],
+        },
+    )
 
     with (
-        patch(
-            "homeassistant.components.flume.config_flow.FlumeAuth",
-            return_value=True,
-        ),
-        patch(
-            "homeassistant.components.flume.config_flow.FlumeDeviceList",
-            return_value=mock_flume_device_list,
-        ),
         patch(
             "homeassistant.components.flume.async_setup_entry",
             return_value=True,

--- a/tests/components/flume/test_init.py
+++ b/tests/components/flume/test_init.py
@@ -48,7 +48,7 @@ async def test_device_list_timeout(
     access_token: None,
     device_list_timeout: None,
 ) -> None:
-    """Test load and unload of a ConfigEntry."""
+    """Test error handling for a timeout when listing devices."""
     assert not await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
@@ -62,7 +62,7 @@ async def test_reauth_when_unauthorized(
     access_token: None,
     device_list_unauthorized: None,
 ) -> None:
-    """Test load and unload of a ConfigEntry."""
+    """Test error handling for an authentication error when listing devices."""
     assert not await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
@@ -81,7 +81,7 @@ async def test_list_notifications_service(
     device_list: None,
     notifications_list: None,
 ) -> None:
-    """Test load and unload of a ConfigEntry."""
+    """Test the list notifications service."""
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
     assert config_entry.state is config_entries.ConfigEntryState.LOADED
@@ -110,7 +110,7 @@ async def test_list_notifications_service_config_entry_errors(
     device_list: None,
     notifications_list: None,
 ) -> None:
-    """Test load and unload of a ConfigEntry."""
+    """Test error handling for notification service with invalid config entries."""
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
     assert config_entry.state is config_entries.ConfigEntryState.LOADED

--- a/tests/components/flume/test_init.py
+++ b/tests/components/flume/test_init.py
@@ -24,12 +24,11 @@ def platforms_fixture() -> Generator[list[str]]:
         yield
 
 
+@pytest.mark.usefixtures("access_token", "device_list")
 async def test_setup_config_entry(
     hass: HomeAssistant,
     requests_mock: Mocker,
     config_entry: MockConfigEntry,
-    access_token: None,
-    device_list: None,
 ) -> None:
     """Test load and unload of a ConfigEntry."""
     assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -41,12 +40,11 @@ async def test_setup_config_entry(
     assert config_entry.state is config_entries.ConfigEntryState.NOT_LOADED
 
 
+@pytest.mark.usefixtures("access_token", "device_list_timeout")
 async def test_device_list_timeout(
     hass: HomeAssistant,
     requests_mock: Mocker,
     config_entry: MockConfigEntry,
-    access_token: None,
-    device_list_timeout: None,
 ) -> None:
     """Test error handling for a timeout when listing devices."""
     assert not await hass.config_entries.async_setup(config_entry.entry_id)
@@ -55,12 +53,11 @@ async def test_device_list_timeout(
     assert config_entry.state is config_entries.ConfigEntryState.SETUP_RETRY
 
 
+@pytest.mark.usefixtures("access_token", "device_list_unauthorized")
 async def test_reauth_when_unauthorized(
     hass: HomeAssistant,
     requests_mock: Mocker,
     config_entry: MockConfigEntry,
-    access_token: None,
-    device_list_unauthorized: None,
 ) -> None:
     """Test error handling for an authentication error when listing devices."""
     assert not await hass.config_entries.async_setup(config_entry.entry_id)
@@ -73,13 +70,11 @@ async def test_reauth_when_unauthorized(
     assert flows[0]["step_id"] == "reauth_confirm"
 
 
+@pytest.mark.usefixtures("access_token", "device_list", "notifications_list")
 async def test_list_notifications_service(
     hass: HomeAssistant,
     requests_mock: Mocker,
     config_entry: MockConfigEntry,
-    access_token: None,
-    device_list: None,
-    notifications_list: None,
 ) -> None:
     """Test the list notifications service."""
     assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -102,13 +97,11 @@ async def test_list_notifications_service(
     assert notifications[0].get("user_id") == USER_ID
 
 
+@pytest.mark.usefixtures("access_token", "device_list", "notifications_list")
 async def test_list_notifications_service_config_entry_errors(
     hass: HomeAssistant,
     requests_mock: Mocker,
     config_entry: MockConfigEntry,
-    access_token: None,
-    device_list: None,
-    notifications_list: None,
 ) -> None:
     """Test error handling for notification service with invalid config entries."""
     assert await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/components/flume/test_init.py
+++ b/tests/components/flume/test_init.py
@@ -19,6 +19,7 @@ from tests.common import MockConfigEntry
 @pytest.fixture(autouse=True)
 def platforms_fixture() -> Generator[list[str]]:
     """Return the platforms to be loaded for this test."""
+    # Arbitrary platform to ensure notifications are loaded
     with patch("homeassistant.components.flume.PLATFORMS", [Platform.BINARY_SENSOR]):
         yield
 

--- a/tests/components/flume/test_init.py
+++ b/tests/components/flume/test_init.py
@@ -7,7 +7,11 @@ import pytest
 from requests_mock.mocker import Mocker
 
 from homeassistant import config_entries
+from homeassistant.components.flume.const import DOMAIN
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+
+from .conftest import USER_ID
 
 from tests.common import MockConfigEntry
 
@@ -15,7 +19,7 @@ from tests.common import MockConfigEntry
 @pytest.fixture(autouse=True)
 def platforms_fixture() -> Generator[list[str]]:
     """Return the platforms to be loaded for this test."""
-    with patch("homeassistant.components.flume.PLATFORMS", []):
+    with patch("homeassistant.components.flume.PLATFORMS", [Platform.BINARY_SENSOR]):
         yield
 
 
@@ -34,3 +38,104 @@ async def test_setup_config_entry(
 
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     assert config_entry.state is config_entries.ConfigEntryState.NOT_LOADED
+
+
+async def test_device_list_timeout(
+    hass: HomeAssistant,
+    requests_mock: Mocker,
+    config_entry: MockConfigEntry,
+    access_token: None,
+    device_list_timeout: None,
+) -> None:
+    """Test load and unload of a ConfigEntry."""
+    assert not await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is config_entries.ConfigEntryState.SETUP_RETRY
+
+
+async def test_reauth_when_unauthorized(
+    hass: HomeAssistant,
+    requests_mock: Mocker,
+    config_entry: MockConfigEntry,
+    access_token: None,
+    device_list_unauthorized: None,
+) -> None:
+    """Test load and unload of a ConfigEntry."""
+    assert not await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is config_entries.ConfigEntryState.SETUP_ERROR
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    assert flows[0]["step_id"] == "reauth_confirm"
+
+
+async def test_list_notifications_service(
+    hass: HomeAssistant,
+    requests_mock: Mocker,
+    config_entry: MockConfigEntry,
+    access_token: None,
+    device_list: None,
+    notifications_list: None,
+) -> None:
+    """Test load and unload of a ConfigEntry."""
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is config_entries.ConfigEntryState.LOADED
+
+    response = await hass.services.async_call(
+        DOMAIN,
+        "list_notifications",
+        {},
+        target={
+            "config_entry": config_entry.entry_id,
+        },
+        blocking=True,
+        return_response=True,
+    )
+    notifications = response.get("notifications")
+    assert notifications
+    assert len(notifications) == 1
+    assert notifications[0].get("user_id") == USER_ID
+
+
+async def test_list_notifications_service_config_entry_errors(
+    hass: HomeAssistant,
+    requests_mock: Mocker,
+    config_entry: MockConfigEntry,
+    access_token: None,
+    device_list: None,
+    notifications_list: None,
+) -> None:
+    """Test load and unload of a ConfigEntry."""
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is config_entries.ConfigEntryState.LOADED
+    assert await hass.config_entries.async_unload(config_entry.entry_id)
+    assert config_entry.state is config_entries.ConfigEntryState.NOT_LOADED
+
+    with pytest.raises(ValueError, match="Config entry not loaded"):
+        await hass.services.async_call(
+            DOMAIN,
+            "list_notifications",
+            {},
+            target={
+                "config_entry": config_entry.entry_id,
+            },
+            blocking=True,
+            return_response=True,
+        )
+
+    with pytest.raises(ValueError, match="Invalid config entry: does-not-exist"):
+        await hass.services.async_call(
+            DOMAIN,
+            "list_notifications",
+            {},
+            target={
+                "config_entry": "does-not-exist",
+            },
+            blocking=True,
+            return_response=True,
+        )

--- a/tests/components/flume/test_init.py
+++ b/tests/components/flume/test_init.py
@@ -1,0 +1,36 @@
+"""Test the flume init."""
+
+from collections.abc import Generator
+from unittest.mock import patch
+
+import pytest
+from requests_mock.mocker import Mocker
+
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture(autouse=True)
+def platforms_fixture() -> Generator[list[str]]:
+    """Return the platforms to be loaded for this test."""
+    with patch("homeassistant.components.flume.PLATFORMS", []):
+        yield
+
+
+async def test_setup_config_entry(
+    hass: HomeAssistant,
+    requests_mock: Mocker,
+    config_entry: MockConfigEntry,
+    access_token: None,
+    device_list: None,
+) -> None:
+    """Test load and unload of a ConfigEntry."""
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is config_entries.ConfigEntryState.LOADED
+
+    assert await hass.config_entries.async_unload(config_entry.entry_id)
+    assert config_entry.state is config_entries.ConfigEntryState.NOT_LOADED


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add tests for the Flume integration init which reproduces the issue in #120618 and can help make sure the next upgrade is working. The tests use the requests mocker exercising the flume library instead of mocking out the entire thing.

```
$ py.test tests/components/flume --cov-report=term-missing --cov=homeassistant.
components.flume 
Name                                            Stmts   Miss  Cover   Missing
-----------------------------------------------------------------------------
homeassistant/components/flume/__init__.py         55      0   100%
homeassistant/components/flume/config_flow.py      69      0   100%
homeassistant/components/flume/const.py            30      0   100%
-----------------------------------------------------------------------------
TOTAL                                             154      0   100%
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: #120618
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
