### PR TITLE
Add entity services to the Hydrawise integration

### DIFF
--- a/homeassistant/components/hydrawise/binary_sensor.py
+++ b/homeassistant/components/hydrawise/binary_sensor.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime
 
-from pydrawise import Zone
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import (
@@ -16,6 +15,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import VolDictType
@@ -102,9 +102,7 @@ async def async_setup_entry(
             if "rain sensor" in sensor.model.name.lower()
         )
         entities.extend(
-            HydrawiseZoneBinarySensor(
-                coordinator, description, controller, zone_id=zone.id
-            )
+            HydrawiseBinarySensor(coordinator, description, controller, zone_id=zone.id)
             for zone in controller.zones
             for description in ZONE_BINARY_SENSORS
         )
@@ -133,23 +131,22 @@ class HydrawiseBinarySensor(HydrawiseEntity, BinarySensorEntity):
             return True
         return super().available
 
-
-class HydrawiseZoneBinarySensor(HydrawiseBinarySensor):
-    """A sensor implementation for a Hydrawise irrigation zone."""
-
-    zone: Zone
-
     async def start_watering(self, duration: int | None = None) -> None:
         """Start watering in the irrigation zone."""
-        duration_secs = timedelta(minutes=duration or 0).total_seconds()
+        if self.zone is None:
+            raise ServiceValidationError("Must be called on a zone")
         await self.coordinator.api.start_zone(
-            self.zone, custom_run_duration=int(duration_secs)
+            self.zone, custom_run_duration=int((duration or 0) * 60)
         )
 
     async def suspend(self, until: datetime) -> None:
         """Suspend automatic watering in the irrigation zone."""
+        if self.zone is None:
+            raise ServiceValidationError("Must be called on a zone")
         await self.coordinator.api.suspend_zone(self.zone, until=until)
 
     async def resume(self) -> None:
         """Resume automatic watering in the irrigation zone."""
+        if self.zone is None:
+            raise ServiceValidationError("Must be called on a zone")
         await self.coordinator.api.resume_zone(self.zone)

--- a/homeassistant/components/hydrawise/const.py
+++ b/homeassistant/components/hydrawise/const.py
@@ -7,10 +7,6 @@ LOGGER = logging.getLogger(__package__)
 
 DOMAIN = "hydrawise"
 DEFAULT_WATERING_TIME = timedelta(minutes=15)
-# The API allows specifying a watering time larger than 90 minutes, but doing
-# so does not behave as expected. Likewise, the Hydrawise app has a maximum
-# allowed value of 90 minutes. So we stick with that.
-MAX_WATERING_TIME = timedelta(minutes=90)
 
 MANUFACTURER = "Hydrawise"
 

--- a/homeassistant/components/hydrawise/const.py
+++ b/homeassistant/components/hydrawise/const.py
@@ -5,14 +5,22 @@ import logging
 
 LOGGER = logging.getLogger(__package__)
 
-ALLOWED_WATERING_TIME = [5, 10, 15, 30, 45, 60]
-CONF_WATERING_TIME = "watering_minutes"
-
 DOMAIN = "hydrawise"
 DEFAULT_WATERING_TIME = timedelta(minutes=15)
+# The API allows specifying a watering time larger than 90 minutes, but doing
+# so does not behave as expected. Likewise, the Hydrawise app has a maximum
+# allowed value of 90 minutes. So we stick with that.
+MAX_WATERING_TIME = timedelta(minutes=90)
 
 MANUFACTURER = "Hydrawise"
 
 SCAN_INTERVAL = timedelta(seconds=30)
 
 SIGNAL_UPDATE_HYDRAWISE = "hydrawise_update"
+
+SERVICE_RESUME = "resume"
+SERVICE_START_WATERING = "start_watering"
+SERVICE_SUSPEND = "suspend"
+
+ATTR_DURATION = "duration"
+ATTR_UNTIL = "until"

--- a/homeassistant/components/hydrawise/icons.json
+++ b/homeassistant/components/hydrawise/icons.json
@@ -29,5 +29,10 @@
         }
       }
     }
+  },
+  "services": {
+    "start_watering": "mdi:sprinkler-variant",
+    "suspend": "mdi:pause-circle-outline",
+    "resume": "mdi:play"
   }
 }

--- a/homeassistant/components/hydrawise/services.yaml
+++ b/homeassistant/components/hydrawise/services.yaml
@@ -7,6 +7,12 @@ start_watering:
   fields:
     duration:
       required: false
+      selector:
+        number:
+          min: 0
+          max: 90
+          unit_of_measurement: min
+          mode: box
 suspend:
   target:
     entity:

--- a/homeassistant/components/hydrawise/services.yaml
+++ b/homeassistant/components/hydrawise/services.yaml
@@ -1,0 +1,26 @@
+start_watering:
+  target:
+    entity:
+      integration: hydrawise
+      domain: binary_sensor
+      device_class: running
+  fields:
+    duration:
+      required: false
+suspend:
+  target:
+    entity:
+      integration: hydrawise
+      domain: binary_sensor
+      device_class: running
+  fields:
+    until:
+      required: true
+      selector:
+        datetime:
+resume:
+  target:
+    entity:
+      integration: hydrawise
+      domain: binary_sensor
+      device_class: running

--- a/homeassistant/components/hydrawise/strings.json
+++ b/homeassistant/components/hydrawise/strings.json
@@ -57,5 +57,31 @@
         "name": "Manual watering"
       }
     }
+  },
+  "services": {
+    "start_watering": {
+      "name": "Start watering",
+      "description": "Starts a watering cycle in the selected irrigation zone.",
+      "fields": {
+        "duration": {
+          "name": "Duration",
+          "description": "Length of time to run the watering cycle. If not specified (or zero), the default watering duration set in the Hydrawise mobile or web app for the irrigation zone will be used."
+        }
+      }
+    },
+    "suspend": {
+      "name": "Suspend automatic watering",
+      "description": "Suspends an irrigation zone's automatic watering schedule until the given date and time.",
+      "fields": {
+        "until": {
+          "name": "Until",
+          "description": "Date and time to resume the automated watering schedule."
+        }
+      }
+    },
+    "resume": {
+      "name": "Resume automatic watering",
+      "description": "Resumes an irrigation zone's automatic watering schedule."
+    }
   }
 }

--- a/tests/components/hydrawise/test_services.py
+++ b/tests/components/hydrawise/test_services.py
@@ -40,27 +40,6 @@ async def test_start_watering(
     )
 
 
-async def test_start_watering_clamps_duration(
-    hass: HomeAssistant,
-    mock_added_config_entry: MockConfigEntry,
-    mock_pydrawise: AsyncMock,
-    zones: list[Zone],
-) -> None:
-    """Test that the start_watering service clamps the duration."""
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_START_WATERING,
-        {
-            ATTR_ENTITY_ID: "binary_sensor.zone_one_watering",
-            ATTR_DURATION: timedelta(hours=12),
-        },
-        blocking=True,
-    )
-    mock_pydrawise.start_zone.assert_called_once_with(
-        zones[0], custom_run_duration=90 * 60
-    )
-
-
 async def test_start_watering_no_duration(
     hass: HomeAssistant,
     mock_added_config_entry: MockConfigEntry,

--- a/tests/components/hydrawise/test_services.py
+++ b/tests/components/hydrawise/test_services.py
@@ -1,6 +1,6 @@
 """Test Hydrawise services."""
 
-from datetime import datetime, timedelta
+from datetime import datetime
 from unittest.mock import AsyncMock
 
 from pydrawise.schema import Zone
@@ -31,7 +31,7 @@ async def test_start_watering(
         SERVICE_START_WATERING,
         {
             ATTR_ENTITY_ID: "binary_sensor.zone_one_watering",
-            ATTR_DURATION: timedelta(minutes=20),
+            ATTR_DURATION: 20,
         },
         blocking=True,
     )

--- a/tests/components/hydrawise/test_services.py
+++ b/tests/components/hydrawise/test_services.py
@@ -1,0 +1,114 @@
+"""Test Hydrawise services."""
+
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock
+
+from pydrawise.schema import Zone
+
+from homeassistant.components.hydrawise.const import (
+    ATTR_DURATION,
+    ATTR_UNTIL,
+    DOMAIN,
+    SERVICE_RESUME,
+    SERVICE_START_WATERING,
+    SERVICE_SUSPEND,
+)
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_start_watering(
+    hass: HomeAssistant,
+    mock_added_config_entry: MockConfigEntry,
+    mock_pydrawise: AsyncMock,
+    zones: list[Zone],
+) -> None:
+    """Test that the start_watering service works as intended."""
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_START_WATERING,
+        {
+            ATTR_ENTITY_ID: "binary_sensor.zone_one_watering",
+            ATTR_DURATION: timedelta(minutes=20),
+        },
+        blocking=True,
+    )
+    mock_pydrawise.start_zone.assert_called_once_with(
+        zones[0], custom_run_duration=20 * 60
+    )
+
+
+async def test_start_watering_clamps_duration(
+    hass: HomeAssistant,
+    mock_added_config_entry: MockConfigEntry,
+    mock_pydrawise: AsyncMock,
+    zones: list[Zone],
+) -> None:
+    """Test that the start_watering service clamps the duration."""
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_START_WATERING,
+        {
+            ATTR_ENTITY_ID: "binary_sensor.zone_one_watering",
+            ATTR_DURATION: timedelta(hours=12),
+        },
+        blocking=True,
+    )
+    mock_pydrawise.start_zone.assert_called_once_with(
+        zones[0], custom_run_duration=90 * 60
+    )
+
+
+async def test_start_watering_no_duration(
+    hass: HomeAssistant,
+    mock_added_config_entry: MockConfigEntry,
+    mock_pydrawise: AsyncMock,
+    zones: list[Zone],
+) -> None:
+    """Test that the start_watering service works with no duration specified."""
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_START_WATERING,
+        {ATTR_ENTITY_ID: "binary_sensor.zone_one_watering"},
+        blocking=True,
+    )
+    mock_pydrawise.start_zone.assert_called_once_with(zones[0], custom_run_duration=0)
+
+
+async def test_resume(
+    hass: HomeAssistant,
+    mock_added_config_entry: MockConfigEntry,
+    mock_pydrawise: AsyncMock,
+    zones: list[Zone],
+) -> None:
+    """Test that the resume service works as intended."""
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_RESUME,
+        {ATTR_ENTITY_ID: "binary_sensor.zone_one_watering"},
+        blocking=True,
+    )
+    mock_pydrawise.resume_zone.assert_called_once_with(zones[0])
+
+
+async def test_suspend(
+    hass: HomeAssistant,
+    mock_added_config_entry: MockConfigEntry,
+    mock_pydrawise: AsyncMock,
+    zones: list[Zone],
+) -> None:
+    """Test that the suspend service works as intended."""
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SUSPEND,
+        {
+            ATTR_ENTITY_ID: "binary_sensor.zone_one_watering",
+            ATTR_UNTIL: datetime(2026, 1, 1, 0, 0, 0),
+        },
+        blocking=True,
+    )
+    mock_pydrawise.suspend_zone.assert_called_once_with(
+        zones[0], until=datetime(2026, 1, 1, 0, 0, 0)
+    )


### PR DESCRIPTION
## Proposed change
This adds the following services to the Hydrawise integration:

* `start_watering` - Starts a manual irrigation cycle for a given duration for an irrigation zone (e.g. a "watering" `binary_sensor`). This addresses #94649 which is a regression from when the duration could be specified with the old YAML configuration.
* `suspend` - Suspends the automated watering schedule that is controlled through the Hydrawise app
* `resume` - Resumes the automated watering schedule that is controlled through the Hydrawise app

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #94649
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33495

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
