### PR TITLE
Device change test improvements in Template

### DIFF
--- a/tests/components/template/test_init.py
+++ b/tests/components/template/test_init.py
@@ -1,4 +1,4 @@
-"""The test for the Template sensor platform."""
+"""Test for Template helper."""
 
 from datetime import timedelta
 from unittest.mock import patch
@@ -271,13 +271,48 @@ async def async_yaml_patch_helper(hass, filename):
         await hass.async_block_till_done()
 
 
+@pytest.mark.parametrize(
+    (
+        "config_entry_options",
+        "config_user_input",
+    ),
+    [
+        (
+            {
+                "name": "My template",
+                "state": "{{10}}",
+                "template_type": "sensor",
+            },
+            {
+                "state": "{{12}}",
+            },
+        ),
+        (
+            {
+                "template_type": "binary_sensor",
+                "name": "My template",
+                "state": "{{1 == 1}}",
+            },
+            {
+                "state": "{{1 == 2}}",
+            },
+        ),
+    ],
+)
 async def test_change_device(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
+    config_entry_options: dict[str, str],
+    config_user_input: dict[str, str],
 ) -> None:
-    """Test remove the device registry configuration entry when the device changes."""
+    """Test the link between the device and the config entry.
 
-    # Configure a device registry
+    Test, for each platform, that the device was linked to the
+    config entry and the link was removed when the device is
+    changed in the integration options.
+    """
+
+    # Configure devices registry
     entry_device1 = MockConfigEntry()
     entry_device1.add_to_hass(hass)
     device1 = device_registry.async_get_or_create(
@@ -300,60 +335,57 @@ async def test_change_device(
     device_id2 = device2.id
     assert device_id2 is not None
 
-    # Setup the config entry (binary_sensor)
-    sensor_config_entry = MockConfigEntry(
+    # Setup the config entry
+    template_config_entry = MockConfigEntry(
         data={},
         domain=DOMAIN,
-        options={
-            "template_type": "binary_sensor",
-            "name": "Teste",
-            "state": "{{15}}",
-            "device_id": device_id1,
-        },
-        title="Binary sensor template",
+        options=config_entry_options | {"device_id": device_id1},
+        title="Template",
     )
-    sensor_config_entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(sensor_config_entry.entry_id)
+    template_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(template_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    # Confirm that the configuration entry has been added to the device 1 registry (current)
+    # Confirm that the config entry has been added to the device 1 registry (current)
     current_device = device_registry.async_get(device_id=device_id1)
-    assert sensor_config_entry.entry_id in current_device.config_entries
+    assert template_config_entry.entry_id in current_device.config_entries
 
-    # Change configuration options to use device 2 and reload the integration
-    result = await hass.config_entries.options.async_init(sensor_config_entry.entry_id)
+    # Change config options to use device 2 and reload the integration
+    result = await hass.config_entries.options.async_init(
+        template_config_entry.entry_id
+    )
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input={
-            "state": "{{15}}",
-            "device_id": device_id2,
-        },
+        user_input=config_user_input | {"device_id": device_id2},
     )
     await hass.async_block_till_done()
 
-    # Confirm that the configuration entry has been removed from the device 1 registry (previous)
+    # Confirm that the config entry has been removed from the device 1 registry
     previous_device = device_registry.async_get(device_id=device_id1)
-    assert sensor_config_entry.entry_id not in previous_device.config_entries
+    assert template_config_entry.entry_id not in previous_device.config_entries
 
-    # Confirm that the configuration entry has been added to the device 2 registry (current)
+    # Confirm that the config entry has been added to the device 2 registry (current)
     current_device = device_registry.async_get(device_id=device_id2)
-    assert sensor_config_entry.entry_id in current_device.config_entries
+    assert template_config_entry.entry_id in current_device.config_entries
 
-    result = await hass.config_entries.options.async_init(sensor_config_entry.entry_id)
+    # Change the config options to remove the device and reload the integration
+    result = await hass.config_entries.options.async_init(
+        template_config_entry.entry_id
+    )
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input={
-            "state": "{{15}}",
-        },
+        user_input=config_user_input,
     )
     await hass.async_block_till_done()
 
-    # Confirm that the configuration entry has been removed from the device 2 registry (previous)
+    # Confirm that the config entry has been removed from the device 2 registry
     previous_device = device_registry.async_get(device_id=device_id2)
-    assert sensor_config_entry.entry_id not in previous_device.config_entries
+    assert template_config_entry.entry_id not in previous_device.config_entries
 
-    # Confirm that there is no device with the helper configuration entry
+    # Confirm that there is no device with the helper config entry
     assert (
-        dr.async_entries_for_config_entry(device_registry, sensor_config_entry.entry_id)
+        dr.async_entries_for_config_entry(
+            device_registry, template_config_entry.entry_id
+        )
         == []
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Updated the `test_change_device` test to improve the code including:
* Changed the test structure to allow testing all platforms that implement config entries.
* Improvement of test docstrings and comments (limiting the length to 72 characters for docstring and 88 characters for comments).

I am implementing the config flow for other platforms, and this allows platforms that do not use the `state` option to use this same test. This then prepares the code for implementing new platforms via the UI.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
