### PR TITLE
Use service_calls fixture in core platform tests [a-l]

### DIFF
--- a/tests/components/binary_sensor/test_device_condition.py
+++ b/tests/components/binary_sensor/test_device_condition.py
@@ -22,7 +22,6 @@ from tests.common import (
     MockConfigEntry,
     async_get_device_automation_capabilities,
     async_get_device_automations,
-    async_mock_service,
     setup_test_component_platform,
 )
 
@@ -30,12 +29,6 @@ from tests.common import (
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 async def test_get_conditions(
@@ -239,7 +232,7 @@ async def test_if_state(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     mock_binary_sensor_entities: dict[str, MockBinarySensor],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
@@ -308,26 +301,26 @@ async def test_if_state(
     )
     await hass.async_block_till_done()
     assert hass.states.get(entry.entity_id).state == STATE_ON
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "is_on event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "is_on event - test_event1"
 
     hass.states.async_set(entry.entity_id, STATE_OFF)
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert calls[1].data["some"] == "is_off event - test_event2"
+    assert len(service_calls) == 2
+    assert service_calls[1].data["some"] == "is_off event - test_event2"
 
 
 async def test_if_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     mock_binary_sensor_entities: dict[str, MockBinarySensor],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
@@ -375,19 +368,19 @@ async def test_if_state_legacy(
     )
     await hass.async_block_till_done()
     assert hass.states.get(entry.entity_id).state == STATE_ON
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "is_on event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "is_on event - test_event1"
 
 
 async def test_if_fires_on_for_condition(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     mock_binary_sensor_entities: dict[str, MockBinarySensor],
 ) -> None:
     """Test for firing if condition is on with delay."""
@@ -439,26 +432,26 @@ async def test_if_fires_on_for_condition(
         )
         await hass.async_block_till_done()
         assert hass.states.get(entry.entity_id).state == STATE_ON
-        assert len(calls) == 0
+        assert len(service_calls) == 0
 
         hass.bus.async_fire("test_event1")
         await hass.async_block_till_done()
-        assert len(calls) == 0
+        assert len(service_calls) == 0
 
         # Time travel 10 secs into the future
         time_freeze.move_to(point2)
         hass.bus.async_fire("test_event1")
         await hass.async_block_till_done()
-        assert len(calls) == 0
+        assert len(service_calls) == 0
 
         hass.states.async_set(entry.entity_id, STATE_OFF)
         hass.bus.async_fire("test_event1")
         await hass.async_block_till_done()
-        assert len(calls) == 0
+        assert len(service_calls) == 0
 
         # Time travel 20 secs into the future
         time_freeze.move_to(point3)
         hass.bus.async_fire("test_event1")
         await hass.async_block_till_done()
-        assert len(calls) == 1
-        assert calls[0].data["some"] == "is_off event - test_event1"
+        assert len(service_calls) == 1
+        assert service_calls[0].data["some"] == "is_off event - test_event1"

--- a/tests/components/binary_sensor/test_device_trigger.py
+++ b/tests/components/binary_sensor/test_device_trigger.py
@@ -22,7 +22,6 @@ from tests.common import (
     async_fire_time_changed,
     async_get_device_automation_capabilities,
     async_get_device_automations,
-    async_mock_service,
     setup_test_component_platform,
 )
 
@@ -30,12 +29,6 @@ from tests.common import (
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 async def test_get_triggers(
@@ -240,7 +233,7 @@ async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     mock_binary_sensor_entities: dict[str, MockBinarySensor],
 ) -> None:
     """Test for on and off triggers firing."""
@@ -313,21 +306,22 @@ async def test_if_fires_on_state_change(
     )
     await hass.async_block_till_done()
     assert hass.states.get(entry.entity_id).state == STATE_ON
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, STATE_OFF)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"not_bat_low device - {entry.entity_id} - on - off - None"
     )
 
     hass.states.async_set(entry.entity_id, STATE_ON)
     await hass.async_block_till_done()
-    assert len(calls) == 2
+    assert len(service_calls) == 2
     assert (
-        calls[1].data["some"] == f"bat_low device - {entry.entity_id} - off - on - None"
+        service_calls[1].data["some"]
+        == f"bat_low device - {entry.entity_id} - off - on - None"
     )
 
 
@@ -335,7 +329,7 @@ async def test_if_fires_on_state_change_with_for(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     mock_binary_sensor_entities: dict[str, MockBinarySensor],
 ) -> None:
     """Test for triggers firing with delay."""
@@ -388,17 +382,17 @@ async def test_if_fires_on_state_change_with_for(
     )
     await hass.async_block_till_done()
     assert hass.states.get(entry.entity_id).state == STATE_ON
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, STATE_OFF)
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     await hass.async_block_till_done()
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"turn_off device - {entry.entity_id} - on - off - 0:00:05"
     )
 
@@ -407,7 +401,7 @@ async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     mock_binary_sensor_entities: dict[str, MockBinarySensor],
 ) -> None:
     """Test for triggers firing."""
@@ -459,12 +453,12 @@ async def test_if_fires_on_state_change_legacy(
     )
     await hass.async_block_till_done()
     assert hass.states.get(entry.entity_id).state == STATE_ON
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, STATE_OFF)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"turn_off device - {entry.entity_id} - on - off - None"
     )

--- a/tests/components/button/test_device_trigger.py
+++ b/tests/components/button/test_device_trigger.py
@@ -13,17 +13,7 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
-from tests.common import (
-    MockConfigEntry,
-    async_get_device_automations,
-    async_mock_service,
-)
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
+from tests.common import MockConfigEntry, async_get_device_automations
 
 
 async def test_get_triggers(
@@ -109,7 +99,7 @@ async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -158,9 +148,9 @@ async def test_if_fires_on_state_change(
     # Test triggering device trigger with a to state
     hass.states.async_set(entry.entity_id, "2021-01-01T23:59:59+00:00")
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"to - device - {entry.entity_id} - unknown - 2021-01-01T23:59:59+00:00 - None - 0"
     )
 
@@ -169,7 +159,7 @@ async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -218,8 +208,8 @@ async def test_if_fires_on_state_change_legacy(
     # Test triggering device trigger with a to state
     hass.states.async_set(entry.entity_id, "2021-01-01T23:59:59+00:00")
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"to - device - {entry.entity_id} - unknown - 2021-01-01T23:59:59+00:00 - None - 0"
     )

--- a/tests/components/climate/test_device_condition.py
+++ b/tests/components/climate/test_device_condition.py
@@ -17,22 +17,12 @@ from homeassistant.helpers import (
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
-from tests.common import (
-    MockConfigEntry,
-    async_get_device_automations,
-    async_mock_service,
-)
+from tests.common import MockConfigEntry, async_get_device_automations
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 @pytest.mark.parametrize(
@@ -151,7 +141,7 @@ async def test_if_state(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -220,7 +210,7 @@ async def test_if_state(
     # Should not fire, entity doesn't exist yet
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(
         entry.entity_id,
@@ -232,8 +222,8 @@ async def test_if_state(
 
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "is_hvac_mode - event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "is_hvac_mode - event - test_event1"
 
     hass.states.async_set(
         entry.entity_id,
@@ -246,13 +236,13 @@ async def test_if_state(
     # Should not fire
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
 
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
 
-    assert len(calls) == 2
-    assert calls[1].data["some"] == "is_preset_mode - event - test_event2"
+    assert len(service_calls) == 2
+    assert service_calls[1].data["some"] == "is_preset_mode - event - test_event2"
 
     hass.states.async_set(
         entry.entity_id,
@@ -265,14 +255,14 @@ async def test_if_state(
     # Should not fire
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 2
+    assert len(service_calls) == 2
 
 
 async def test_if_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -323,8 +313,8 @@ async def test_if_state_legacy(
 
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "is_hvac_mode - event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "is_hvac_mode - event - test_event1"
 
 
 @pytest.mark.parametrize(

--- a/tests/components/climate/test_device_trigger.py
+++ b/tests/components/climate/test_device_trigger.py
@@ -23,22 +23,12 @@ from homeassistant.helpers import (
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
-from tests.common import (
-    MockConfigEntry,
-    async_get_device_automations,
-    async_mock_service,
-)
+from tests.common import MockConfigEntry, async_get_device_automations
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 async def test_get_triggers(
@@ -151,7 +141,7 @@ async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -236,8 +226,8 @@ async def test_if_fires_on_state_change(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "hvac_mode_changed"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "hvac_mode_changed"
 
     # Fake that the temperature is changing
     hass.states.async_set(
@@ -250,8 +240,8 @@ async def test_if_fires_on_state_change(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert calls[1].data["some"] == "current_temperature_changed"
+    assert len(service_calls) == 2
+    assert service_calls[1].data["some"] == "current_temperature_changed"
 
     # Fake that the humidity is changing
     hass.states.async_set(
@@ -264,15 +254,15 @@ async def test_if_fires_on_state_change(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 3
-    assert calls[2].data["some"] == "current_humidity_changed"
+    assert len(service_calls) == 3
+    assert service_calls[2].data["some"] == "current_humidity_changed"
 
 
 async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -329,8 +319,8 @@ async def test_if_fires_on_state_change_legacy(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "hvac_mode_changed"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "hvac_mode_changed"
 
 
 async def test_get_trigger_capabilities_hvac_mode(hass: HomeAssistant) -> None:

--- a/tests/components/cover/test_device_condition.py
+++ b/tests/components/cover/test_device_condition.py
@@ -26,7 +26,6 @@ from tests.common import (
     MockConfigEntry,
     async_get_device_automation_capabilities,
     async_get_device_automations,
-    async_mock_service,
     setup_test_component_platform,
 )
 
@@ -34,12 +33,6 @@ from tests.common import (
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 @pytest.mark.parametrize(
@@ -359,7 +352,7 @@ async def test_if_state(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -473,36 +466,36 @@ async def test_if_state(
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "is_open - event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "is_open - event - test_event1"
 
     hass.states.async_set(entry.entity_id, STATE_CLOSED)
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert calls[1].data["some"] == "is_closed - event - test_event2"
+    assert len(service_calls) == 2
+    assert service_calls[1].data["some"] == "is_closed - event - test_event2"
 
     hass.states.async_set(entry.entity_id, STATE_OPENING)
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event3")
     await hass.async_block_till_done()
-    assert len(calls) == 3
-    assert calls[2].data["some"] == "is_opening - event - test_event3"
+    assert len(service_calls) == 3
+    assert service_calls[2].data["some"] == "is_opening - event - test_event3"
 
     hass.states.async_set(entry.entity_id, STATE_CLOSING)
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event4")
     await hass.async_block_till_done()
-    assert len(calls) == 4
-    assert calls[3].data["some"] == "is_closing - event - test_event4"
+    assert len(service_calls) == 4
+    assert service_calls[3].data["some"] == "is_closing - event - test_event4"
 
 
 async def test_if_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -550,15 +543,15 @@ async def test_if_state_legacy(
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "is_open - event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "is_open - event - test_event1"
 
 
 async def test_if_position(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     caplog: pytest.LogCaptureFixture,
     mock_cover_entities: list[MockCover],
 ) -> None:
@@ -676,10 +669,10 @@ async def test_if_position(
     await hass.async_block_till_done()
     hass.bus.async_fire("test_event3")
     await hass.async_block_till_done()
-    assert len(calls) == 3
-    assert calls[0].data["some"] == "is_pos_gt_45 - event - test_event1"
-    assert calls[1].data["some"] == "is_pos_lt_90 - event - test_event2"
-    assert calls[2].data["some"] == "is_pos_gt_45_lt_90 - event - test_event3"
+    assert len(service_calls) == 3
+    assert service_calls[0].data["some"] == "is_pos_gt_45 - event - test_event1"
+    assert service_calls[1].data["some"] == "is_pos_lt_90 - event - test_event2"
+    assert service_calls[2].data["some"] == "is_pos_gt_45_lt_90 - event - test_event3"
 
     hass.states.async_set(
         ent.entity_id, STATE_CLOSED, attributes={"current_position": 45}
@@ -690,9 +683,9 @@ async def test_if_position(
     await hass.async_block_till_done()
     hass.bus.async_fire("test_event3")
     await hass.async_block_till_done()
-    assert len(calls) == 5
-    assert calls[3].data["some"] == "is_pos_not_gt_45 - event - test_event1"
-    assert calls[4].data["some"] == "is_pos_lt_90 - event - test_event2"
+    assert len(service_calls) == 5
+    assert service_calls[3].data["some"] == "is_pos_not_gt_45 - event - test_event1"
+    assert service_calls[4].data["some"] == "is_pos_lt_90 - event - test_event2"
 
     hass.states.async_set(
         ent.entity_id, STATE_CLOSED, attributes={"current_position": 90}
@@ -701,14 +694,14 @@ async def test_if_position(
     hass.bus.async_fire("test_event2")
     hass.bus.async_fire("test_event3")
     await hass.async_block_till_done()
-    assert len(calls) == 6
-    assert calls[5].data["some"] == "is_pos_gt_45 - event - test_event1"
+    assert len(service_calls) == 6
+    assert service_calls[5].data["some"] == "is_pos_gt_45 - event - test_event1"
 
     hass.states.async_set(ent.entity_id, STATE_UNAVAILABLE, attributes={})
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 7
-    assert calls[6].data["some"] == "is_pos_not_gt_45 - event - test_event1"
+    assert len(service_calls) == 7
+    assert service_calls[6].data["some"] == "is_pos_not_gt_45 - event - test_event1"
 
     for record in caplog.records:
         assert record.levelname in ("DEBUG", "INFO")
@@ -718,7 +711,7 @@ async def test_if_tilt_position(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     caplog: pytest.LogCaptureFixture,
     mock_cover_entities: list[MockCover],
 ) -> None:
@@ -836,10 +829,10 @@ async def test_if_tilt_position(
     await hass.async_block_till_done()
     hass.bus.async_fire("test_event3")
     await hass.async_block_till_done()
-    assert len(calls) == 3
-    assert calls[0].data["some"] == "is_pos_gt_45 - event - test_event1"
-    assert calls[1].data["some"] == "is_pos_lt_90 - event - test_event2"
-    assert calls[2].data["some"] == "is_pos_gt_45_lt_90 - event - test_event3"
+    assert len(service_calls) == 3
+    assert service_calls[0].data["some"] == "is_pos_gt_45 - event - test_event1"
+    assert service_calls[1].data["some"] == "is_pos_lt_90 - event - test_event2"
+    assert service_calls[2].data["some"] == "is_pos_gt_45_lt_90 - event - test_event3"
 
     hass.states.async_set(
         ent.entity_id, STATE_CLOSED, attributes={"current_tilt_position": 45}
@@ -850,9 +843,9 @@ async def test_if_tilt_position(
     await hass.async_block_till_done()
     hass.bus.async_fire("test_event3")
     await hass.async_block_till_done()
-    assert len(calls) == 5
-    assert calls[3].data["some"] == "is_pos_not_gt_45 - event - test_event1"
-    assert calls[4].data["some"] == "is_pos_lt_90 - event - test_event2"
+    assert len(service_calls) == 5
+    assert service_calls[3].data["some"] == "is_pos_not_gt_45 - event - test_event1"
+    assert service_calls[4].data["some"] == "is_pos_lt_90 - event - test_event2"
 
     hass.states.async_set(
         ent.entity_id, STATE_CLOSED, attributes={"current_tilt_position": 90}
@@ -863,14 +856,14 @@ async def test_if_tilt_position(
     await hass.async_block_till_done()
     hass.bus.async_fire("test_event3")
     await hass.async_block_till_done()
-    assert len(calls) == 6
-    assert calls[5].data["some"] == "is_pos_gt_45 - event - test_event1"
+    assert len(service_calls) == 6
+    assert service_calls[5].data["some"] == "is_pos_gt_45 - event - test_event1"
 
     hass.states.async_set(ent.entity_id, STATE_UNAVAILABLE, attributes={})
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 7
-    assert calls[6].data["some"] == "is_pos_not_gt_45 - event - test_event1"
+    assert len(service_calls) == 7
+    assert service_calls[6].data["some"] == "is_pos_not_gt_45 - event - test_event1"
 
     for record in caplog.records:
         assert record.levelname in ("DEBUG", "INFO")

--- a/tests/components/cover/test_device_trigger.py
+++ b/tests/components/cover/test_device_trigger.py
@@ -29,7 +29,6 @@ from tests.common import (
     async_fire_time_changed,
     async_get_device_automation_capabilities,
     async_get_device_automations,
-    async_mock_service,
     setup_test_component_platform,
 )
 
@@ -37,12 +36,6 @@ from tests.common import (
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 @pytest.mark.parametrize(
@@ -381,7 +374,7 @@ async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for state triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -496,36 +489,36 @@ async def test_if_fires_on_state_change(
     # Fake that the entity is opened.
     hass.states.async_set(entry.entity_id, STATE_OPEN)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"opened - device - {entry.entity_id} - closed - open - None"
     )
 
     # Fake that the entity is closed.
     hass.states.async_set(entry.entity_id, STATE_CLOSED)
     await hass.async_block_till_done()
-    assert len(calls) == 2
+    assert len(service_calls) == 2
     assert (
-        calls[1].data["some"]
+        service_calls[1].data["some"]
         == f"closed - device - {entry.entity_id} - open - closed - None"
     )
 
     # Fake that the entity is opening.
     hass.states.async_set(entry.entity_id, STATE_OPENING)
     await hass.async_block_till_done()
-    assert len(calls) == 3
+    assert len(service_calls) == 3
     assert (
-        calls[2].data["some"]
+        service_calls[2].data["some"]
         == f"opening - device - {entry.entity_id} - closed - opening - None"
     )
 
     # Fake that the entity is closing.
     hass.states.async_set(entry.entity_id, STATE_CLOSING)
     await hass.async_block_till_done()
-    assert len(calls) == 4
+    assert len(service_calls) == 4
     assert (
-        calls[3].data["some"]
+        service_calls[3].data["some"]
         == f"closing - device - {entry.entity_id} - opening - closing - None"
     )
 
@@ -534,7 +527,7 @@ async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for state triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -583,9 +576,9 @@ async def test_if_fires_on_state_change_legacy(
     # Fake that the entity is opened.
     hass.states.async_set(entry.entity_id, STATE_OPEN)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"opened - device - {entry.entity_id} - closed - open - None"
     )
 
@@ -594,7 +587,7 @@ async def test_if_fires_on_state_change_with_for(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for triggers firing with delay."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -640,17 +633,17 @@ async def test_if_fires_on_state_change_with_for(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, STATE_OPEN)
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     await hass.async_block_till_done()
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"turn_off device - {entry.entity_id} - closed - open - 0:00:05"
     )
 
@@ -660,7 +653,7 @@ async def test_if_fires_on_position(
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     mock_cover_entities: list[MockCover],
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for position triggers."""
     setup_test_component_platform(hass, DOMAIN, mock_cover_entities)
@@ -769,9 +762,13 @@ async def test_if_fires_on_position(
         ent.entity_id, STATE_OPEN, attributes={"current_position": 50}
     )
     await hass.async_block_till_done()
-    assert len(calls) == 3
+    assert len(service_calls) == 3
     assert sorted(
-        [calls[0].data["some"], calls[1].data["some"], calls[2].data["some"]]
+        [
+            service_calls[0].data["some"],
+            service_calls[1].data["some"],
+            service_calls[2].data["some"],
+        ]
     ) == sorted(
         [
             (
@@ -791,9 +788,9 @@ async def test_if_fires_on_position(
         ent.entity_id, STATE_CLOSED, attributes={"current_position": 45}
     )
     await hass.async_block_till_done()
-    assert len(calls) == 4
+    assert len(service_calls) == 4
     assert (
-        calls[3].data["some"]
+        service_calls[3].data["some"]
         == f"is_pos_lt_90 - device - {entry.entity_id} - closed - closed - None"
     )
 
@@ -801,9 +798,9 @@ async def test_if_fires_on_position(
         ent.entity_id, STATE_CLOSED, attributes={"current_position": 90}
     )
     await hass.async_block_till_done()
-    assert len(calls) == 5
+    assert len(service_calls) == 5
     assert (
-        calls[4].data["some"]
+        service_calls[4].data["some"]
         == f"is_pos_gt_45 - device - {entry.entity_id} - closed - closed - None"
     )
 
@@ -812,7 +809,7 @@ async def test_if_fires_on_tilt_position(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     mock_cover_entities: list[MockCover],
 ) -> None:
     """Test for tilt position triggers."""
@@ -924,9 +921,13 @@ async def test_if_fires_on_tilt_position(
         ent.entity_id, STATE_OPEN, attributes={"current_tilt_position": 50}
     )
     await hass.async_block_till_done()
-    assert len(calls) == 3
+    assert len(service_calls) == 3
     assert sorted(
-        [calls[0].data["some"], calls[1].data["some"], calls[2].data["some"]]
+        [
+            service_calls[0].data["some"],
+            service_calls[1].data["some"],
+            service_calls[2].data["some"],
+        ]
     ) == sorted(
         [
             (
@@ -946,9 +947,9 @@ async def test_if_fires_on_tilt_position(
         ent.entity_id, STATE_CLOSED, attributes={"current_tilt_position": 45}
     )
     await hass.async_block_till_done()
-    assert len(calls) == 4
+    assert len(service_calls) == 4
     assert (
-        calls[3].data["some"]
+        service_calls[3].data["some"]
         == f"is_pos_lt_90 - device - {entry.entity_id} - closed - closed - None"
     )
 
@@ -956,8 +957,8 @@ async def test_if_fires_on_tilt_position(
         ent.entity_id, STATE_CLOSED, attributes={"current_tilt_position": 90}
     )
     await hass.async_block_till_done()
-    assert len(calls) == 5
+    assert len(service_calls) == 5
     assert (
-        calls[4].data["some"]
+        service_calls[4].data["some"]
         == f"is_pos_gt_45 - device - {entry.entity_id} - closed - closed - None"
     )

--- a/tests/components/device_automation/test_init.py
+++ b/tests/components/device_automation/test_init.py
@@ -23,13 +23,7 @@ from homeassistant.loader import IntegrationNotFound
 from homeassistant.requirements import RequirementsNotFound
 from homeassistant.setup import async_setup_component
 
-from tests.common import (
-    MockConfigEntry,
-    MockModule,
-    async_mock_service,
-    mock_integration,
-    mock_platform,
-)
+from tests.common import MockConfigEntry, MockModule, mock_integration, mock_platform
 from tests.typing import WebSocketGenerator
 
 
@@ -1384,15 +1378,9 @@ async def test_automation_with_bad_condition(
     assert expected_error.format(path="['condition'][0]") in caplog.text
 
 
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
-
-
 async def test_automation_with_sub_condition(
     hass: HomeAssistant,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
@@ -1492,29 +1480,29 @@ async def test_automation_with_sub_condition(
     await hass.async_block_till_done()
     assert hass.states.get(entity_entry1.entity_id).state == STATE_ON
     assert hass.states.get(entity_entry2.entity_id).state == STATE_OFF
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "or event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "or event - test_event1"
 
     hass.states.async_set(entity_entry1.entity_id, STATE_OFF)
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
 
     hass.states.async_set(entity_entry2.entity_id, STATE_ON)
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert calls[1].data["some"] == "or event - test_event1"
+    assert len(service_calls) == 2
+    assert service_calls[1].data["some"] == "or event - test_event1"
 
     hass.states.async_set(entity_entry1.entity_id, STATE_ON)
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 4
-    assert [calls[2].data["some"], calls[3].data["some"]] == unordered(
+    assert len(service_calls) == 4
+    assert [service_calls[2].data["some"], service_calls[3].data["some"]] == unordered(
         ["or event - test_event1", "and event - test_event1"]
     )
 

--- a/tests/components/device_tracker/test_device_condition.py
+++ b/tests/components/device_tracker/test_device_condition.py
@@ -12,22 +12,12 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
-from tests.common import (
-    MockConfigEntry,
-    async_get_device_automations,
-    async_mock_service,
-)
+from tests.common import MockConfigEntry, async_get_device_automations
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 async def test_get_conditions(
@@ -114,7 +104,7 @@ async def test_if_state(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -184,22 +174,22 @@ async def test_if_state(
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "is_home - event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "is_home - event - test_event1"
 
     hass.states.async_set(entry.entity_id, "school")
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert calls[1].data["some"] == "is_not_home - event - test_event2"
+    assert len(service_calls) == 2
+    assert service_calls[1].data["some"] == "is_not_home - event - test_event2"
 
 
 async def test_if_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -247,5 +237,5 @@ async def test_if_state_legacy(
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "is_home - event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "is_home - event - test_event1"

--- a/tests/components/device_tracker/test_device_trigger.py
+++ b/tests/components/device_tracker/test_device_trigger.py
@@ -17,11 +17,7 @@ from homeassistant.helpers import (
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
-from tests.common import (
-    MockConfigEntry,
-    async_get_device_automations,
-    async_mock_service,
-)
+from tests.common import MockConfigEntry, async_get_device_automations
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
@@ -34,12 +30,6 @@ AWAY_LONGITUDE = -117.234758
 
 HOME_LATITUDE = 32.880837
 HOME_LONGITUDE = -117.237561
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 @pytest.fixture(autouse=True)
@@ -145,7 +135,7 @@ async def test_if_fires_on_zone_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for enter and leave triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -228,9 +218,9 @@ async def test_if_fires_on_zone_change(
         {"latitude": HOME_LATITUDE, "longitude": HOME_LONGITUDE},
     )
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"enter - device - {entry.entity_id} - -117.235 - -117.238"
     )
 
@@ -241,9 +231,9 @@ async def test_if_fires_on_zone_change(
         {"latitude": AWAY_LATITUDE, "longitude": AWAY_LONGITUDE},
     )
     await hass.async_block_till_done()
-    assert len(calls) == 2
+    assert len(service_calls) == 2
     assert (
-        calls[1].data["some"]
+        service_calls[1].data["some"]
         == f"leave - device - {entry.entity_id} - -117.238 - -117.235"
     )
 
@@ -252,7 +242,7 @@ async def test_if_fires_on_zone_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for enter and leave triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -311,9 +301,9 @@ async def test_if_fires_on_zone_change_legacy(
         {"latitude": HOME_LATITUDE, "longitude": HOME_LONGITUDE},
     )
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"enter - device - {entry.entity_id} - -117.235 - -117.238"
     )
 

--- a/tests/components/fan/test_device_condition.py
+++ b/tests/components/fan/test_device_condition.py
@@ -12,22 +12,12 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
-from tests.common import (
-    MockConfigEntry,
-    async_get_device_automations,
-    async_mock_service,
-)
+from tests.common import MockConfigEntry, async_get_device_automations
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 async def test_get_conditions(
@@ -114,7 +104,7 @@ async def test_if_state(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -184,22 +174,22 @@ async def test_if_state(
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "is_on - event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "is_on - event - test_event1"
 
     hass.states.async_set(entry.entity_id, STATE_OFF)
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert calls[1].data["some"] == "is_off - event - test_event2"
+    assert len(service_calls) == 2
+    assert service_calls[1].data["some"] == "is_off - event - test_event2"
 
 
 async def test_if_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -246,5 +236,5 @@ async def test_if_state_legacy(
     )
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "is_on - event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "is_on - event - test_event1"

--- a/tests/components/fan/test_device_trigger.py
+++ b/tests/components/fan/test_device_trigger.py
@@ -20,19 +20,12 @@ from tests.common import (
     async_fire_time_changed,
     async_get_device_automation_capabilities,
     async_get_device_automations,
-    async_mock_service,
 )
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 async def test_get_triggers(
@@ -180,7 +173,7 @@ async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -273,8 +266,8 @@ async def test_if_fires_on_state_change(
     # Fake that the entity is turning on.
     hass.states.async_set(entry.entity_id, STATE_ON)
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert {calls[0].data["some"], calls[1].data["some"]} == {
+    assert len(service_calls) == 2
+    assert {service_calls[0].data["some"], service_calls[1].data["some"]} == {
         f"turn_on - device - {entry.entity_id} - off - on - None",
         f"turn_on_or_off - device - {entry.entity_id} - off - on - None",
     }
@@ -282,8 +275,8 @@ async def test_if_fires_on_state_change(
     # Fake that the entity is turning off.
     hass.states.async_set(entry.entity_id, STATE_OFF)
     await hass.async_block_till_done()
-    assert len(calls) == 4
-    assert {calls[2].data["some"], calls[3].data["some"]} == {
+    assert len(service_calls) == 4
+    assert {service_calls[2].data["some"], service_calls[3].data["some"]} == {
         f"turn_off - device - {entry.entity_id} - on - off - None",
         f"turn_on_or_off - device - {entry.entity_id} - on - off - None",
     }
@@ -293,7 +286,7 @@ async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -342,9 +335,9 @@ async def test_if_fires_on_state_change_legacy(
     # Fake that the entity is turning on.
     hass.states.async_set(entry.entity_id, STATE_ON)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"turn_on - device - {entry.entity_id} - off - on - None"
     )
 
@@ -353,7 +346,7 @@ async def test_if_fires_on_state_change_with_for(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for triggers firing with delay."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -399,16 +392,16 @@ async def test_if_fires_on_state_change_with_for(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, STATE_OFF)
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     await hass.async_block_till_done()
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"turn_off device - {entry.entity_id} - on - off - 0:00:05"
     )

--- a/tests/components/humidifier/test_device_condition.py
+++ b/tests/components/humidifier/test_device_condition.py
@@ -17,22 +17,12 @@ from homeassistant.helpers import (
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
-from tests.common import (
-    MockConfigEntry,
-    async_get_device_automations,
-    async_mock_service,
-)
+from tests.common import MockConfigEntry, async_get_device_automations
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 @pytest.mark.parametrize(
@@ -153,7 +143,7 @@ async def test_if_state(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -238,42 +228,42 @@ async def test_if_state(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "is_on event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "is_on event - test_event1"
 
     hass.states.async_set(entry.entity_id, STATE_OFF)
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert calls[1].data["some"] == "is_off event - test_event2"
+    assert len(service_calls) == 2
+    assert service_calls[1].data["some"] == "is_off event - test_event2"
 
     hass.states.async_set(entry.entity_id, STATE_ON, {ATTR_MODE: const.MODE_AWAY})
 
     hass.bus.async_fire("test_event3")
     await hass.async_block_till_done()
 
-    assert len(calls) == 3
-    assert calls[2].data["some"] == "is_mode - event - test_event3"
+    assert len(service_calls) == 3
+    assert service_calls[2].data["some"] == "is_mode - event - test_event3"
 
     hass.states.async_set(entry.entity_id, STATE_ON, {ATTR_MODE: const.MODE_HOME})
 
     # Should not fire
     hass.bus.async_fire("test_event3")
     await hass.async_block_till_done()
-    assert len(calls) == 3
+    assert len(service_calls) == 3
 
 
 async def test_if_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -316,15 +306,15 @@ async def test_if_state_legacy(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, STATE_ON, {ATTR_MODE: const.MODE_AWAY})
 
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
 
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "is_mode - event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "is_mode - event - test_event1"
 
 
 @pytest.mark.parametrize(

--- a/tests/components/humidifier/test_device_trigger.py
+++ b/tests/components/humidifier/test_device_trigger.py
@@ -30,19 +30,12 @@ from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
     async_get_device_automations,
-    async_mock_service,
 )
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 async def test_get_triggers(
@@ -166,7 +159,7 @@ async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -356,8 +349,8 @@ async def test_if_fires_on_state_change(
         {const.ATTR_HUMIDITY: 7, const.ATTR_CURRENT_HUMIDITY: 35},
     )
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "target_humidity_changed_below"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "target_humidity_changed_below"
 
     # Fake that the current humidity is changing
     hass.states.async_set(
@@ -366,8 +359,8 @@ async def test_if_fires_on_state_change(
         {const.ATTR_HUMIDITY: 7, const.ATTR_CURRENT_HUMIDITY: 18},
     )
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert calls[1].data["some"] == "current_humidity_changed_below"
+    assert len(service_calls) == 2
+    assert service_calls[1].data["some"] == "current_humidity_changed_below"
 
     # Fake that the humidity target is changing
     hass.states.async_set(
@@ -376,8 +369,8 @@ async def test_if_fires_on_state_change(
         {const.ATTR_HUMIDITY: 37, const.ATTR_CURRENT_HUMIDITY: 18},
     )
     await hass.async_block_till_done()
-    assert len(calls) == 3
-    assert calls[2].data["some"] == "target_humidity_changed_above"
+    assert len(service_calls) == 3
+    assert service_calls[2].data["some"] == "target_humidity_changed_above"
 
     # Fake that the current humidity is changing
     hass.states.async_set(
@@ -386,14 +379,14 @@ async def test_if_fires_on_state_change(
         {const.ATTR_HUMIDITY: 37, const.ATTR_CURRENT_HUMIDITY: 41},
     )
     await hass.async_block_till_done()
-    assert len(calls) == 4
-    assert calls[3].data["some"] == "current_humidity_changed_above"
+    assert len(service_calls) == 4
+    assert service_calls[3].data["some"] == "current_humidity_changed_above"
 
     # Wait 6 minutes
     async_fire_time_changed(hass, dt_util.utcnow() + datetime.timedelta(minutes=6))
     await hass.async_block_till_done()
-    assert len(calls) == 6
-    assert {calls[4].data["some"], calls[5].data["some"]} == {
+    assert len(service_calls) == 6
+    assert {service_calls[4].data["some"], service_calls[5].data["some"]} == {
         "current_humidity_changed_above_for",
         "target_humidity_changed_above_for",
     }
@@ -405,8 +398,8 @@ async def test_if_fires_on_state_change(
         {const.ATTR_HUMIDITY: 37, const.ATTR_CURRENT_HUMIDITY: 41},
     )
     await hass.async_block_till_done()
-    assert len(calls) == 8
-    assert {calls[6].data["some"], calls[7].data["some"]} == {
+    assert len(service_calls) == 8
+    assert {service_calls[6].data["some"], service_calls[7].data["some"]} == {
         "turn_off device - humidifier.test_5678 - on - off - None",
         "turn_on_or_off device - humidifier.test_5678 - on - off - None",
     }
@@ -418,8 +411,8 @@ async def test_if_fires_on_state_change(
         {const.ATTR_HUMIDITY: 37, const.ATTR_CURRENT_HUMIDITY: 41},
     )
     await hass.async_block_till_done()
-    assert len(calls) == 10
-    assert {calls[8].data["some"], calls[9].data["some"]} == {
+    assert len(service_calls) == 10
+    assert {service_calls[8].data["some"], service_calls[9].data["some"]} == {
         "turn_on device - humidifier.test_5678 - off - on - None",
         "turn_on_or_off device - humidifier.test_5678 - off - on - None",
     }
@@ -429,7 +422,7 @@ async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -479,12 +472,14 @@ async def test_if_fires_on_state_change_legacy(
     # Fake that the humidity is changing
     hass.states.async_set(entry.entity_id, STATE_ON, {const.ATTR_HUMIDITY: 7})
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "target_humidity_changed_below"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "target_humidity_changed_below"
 
 
 async def test_invalid_config(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, calls: list[ServiceCall]
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")
@@ -528,7 +523,7 @@ async def test_invalid_config(
     hass.states.async_set(entry.entity_id, STATE_ON, {const.ATTR_HUMIDITY: 7})
     await hass.async_block_till_done()
     # Should not trigger for invalid config
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
 
 async def test_get_trigger_capabilities_on(hass: HomeAssistant) -> None:

--- a/tests/components/light/test_device_action.py
+++ b/tests/components/light/test_device_action.py
@@ -14,7 +14,7 @@ from homeassistant.components.light import (
     LightEntityFeature,
 )
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
@@ -30,12 +30,6 @@ from tests.common import (
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 async def test_get_actions(
@@ -471,7 +465,6 @@ async def test_action(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off actions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -636,7 +629,6 @@ async def test_action_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off actions."""
     config_entry = MockConfigEntry(domain="test", data={})

--- a/tests/components/light/test_device_condition.py
+++ b/tests/components/light/test_device_condition.py
@@ -22,7 +22,6 @@ from tests.common import (
     MockConfigEntry,
     async_get_device_automation_capabilities,
     async_get_device_automations,
-    async_mock_service,
     setup_test_component_platform,
 )
 
@@ -30,12 +29,6 @@ from tests.common import (
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 async def test_get_conditions(
@@ -186,7 +179,7 @@ async def test_if_state(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -252,20 +245,20 @@ async def test_if_state(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "is_on event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "is_on event - test_event1"
 
     hass.states.async_set(entry.entity_id, STATE_OFF)
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert calls[1].data["some"] == "is_off event - test_event2"
+    assert len(service_calls) == 2
+    assert service_calls[1].data["some"] == "is_off event - test_event2"
 
 
 @pytest.mark.usefixtures("enable_custom_integrations")
@@ -273,7 +266,7 @@ async def test_if_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -318,20 +311,20 @@ async def test_if_state_legacy(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "is_on event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "is_on event - test_event1"
 
 
 async def test_if_fires_on_for_condition(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test for firing if condition is on with delay."""
@@ -385,26 +378,26 @@ async def test_if_fires_on_for_condition(
             },
         )
         await hass.async_block_till_done()
-        assert len(calls) == 0
+        assert len(service_calls) == 0
 
         hass.bus.async_fire("test_event1")
         await hass.async_block_till_done()
-        assert len(calls) == 0
+        assert len(service_calls) == 0
 
         # Time travel 10 secs into the future
         freezer.move_to(point2)
         hass.bus.async_fire("test_event1")
         await hass.async_block_till_done()
-        assert len(calls) == 0
+        assert len(service_calls) == 0
 
         hass.states.async_set(entry.entity_id, STATE_OFF)
         hass.bus.async_fire("test_event1")
         await hass.async_block_till_done()
-        assert len(calls) == 0
+        assert len(service_calls) == 0
 
         # Time travel 20 secs into the future
         freezer.move_to(point3)
         hass.bus.async_fire("test_event1")
         await hass.async_block_till_done()
-        assert len(calls) == 1
-        assert calls[0].data["some"] == "is_off event - test_event1"
+        assert len(service_calls) == 1
+        assert service_calls[0].data["some"] == "is_off event - test_event1"

--- a/tests/components/light/test_device_trigger.py
+++ b/tests/components/light/test_device_trigger.py
@@ -20,7 +20,6 @@ from tests.common import (
     async_fire_time_changed,
     async_get_device_automation_capabilities,
     async_get_device_automations,
-    async_mock_service,
 )
 
 DATA_TEMPLATE_ATTRIBUTES = (
@@ -35,12 +34,6 @@ DATA_TEMPLATE_ATTRIBUTES = (
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 async def test_get_triggers(
@@ -189,7 +182,7 @@ async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -258,20 +251,20 @@ async def test_if_fires_on_state_change(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, STATE_OFF)
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert {calls[0].data["some"], calls[1].data["some"]} == {
+    assert len(service_calls) == 2
+    assert {service_calls[0].data["some"], service_calls[1].data["some"]} == {
         f"turn_off device - {entry.entity_id} - on - off - None",
         f"turn_on_or_off device - {entry.entity_id} - on - off - None",
     }
 
     hass.states.async_set(entry.entity_id, STATE_ON)
     await hass.async_block_till_done()
-    assert len(calls) == 4
-    assert {calls[2].data["some"], calls[3].data["some"]} == {
+    assert len(service_calls) == 4
+    assert {service_calls[2].data["some"], service_calls[3].data["some"]} == {
         f"turn_on device - {entry.entity_id} - off - on - None",
         f"turn_on_or_off device - {entry.entity_id} - off - on - None",
     }
@@ -282,7 +275,7 @@ async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -321,13 +314,14 @@ async def test_if_fires_on_state_change_legacy(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, STATE_OFF)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     assert (
-        calls[0].data["some"] == f"turn_on device - {entry.entity_id} - on - off - None"
+        service_calls[0].data["some"]
+        == f"turn_on device - {entry.entity_id} - on - off - None"
     )
 
 
@@ -336,7 +330,7 @@ async def test_if_fires_on_state_change_with_for(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for triggers firing with delay."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -376,16 +370,16 @@ async def test_if_fires_on_state_change_with_for(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, STATE_OFF)
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     await hass.async_block_till_done()
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"turn_off device - {entry.entity_id} - on - off - 0:00:05"
     )

--- a/tests/components/lock/test_device_condition.py
+++ b/tests/components/lock/test_device_condition.py
@@ -21,22 +21,12 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
-from tests.common import (
-    MockConfigEntry,
-    async_get_device_automations,
-    async_mock_service,
-)
+from tests.common import MockConfigEntry, async_get_device_automations
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 async def test_get_conditions(
@@ -139,7 +129,7 @@ async def test_if_state(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -291,52 +281,52 @@ async def test_if_state(
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "is_locked - event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "is_locked - event - test_event1"
 
     hass.states.async_set(entry.entity_id, STATE_UNLOCKED)
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert calls[1].data["some"] == "is_unlocked - event - test_event2"
+    assert len(service_calls) == 2
+    assert service_calls[1].data["some"] == "is_unlocked - event - test_event2"
 
     hass.states.async_set(entry.entity_id, STATE_UNLOCKING)
     hass.bus.async_fire("test_event3")
     await hass.async_block_till_done()
-    assert len(calls) == 3
-    assert calls[2].data["some"] == "is_unlocking - event - test_event3"
+    assert len(service_calls) == 3
+    assert service_calls[2].data["some"] == "is_unlocking - event - test_event3"
 
     hass.states.async_set(entry.entity_id, STATE_LOCKING)
     hass.bus.async_fire("test_event4")
     await hass.async_block_till_done()
-    assert len(calls) == 4
-    assert calls[3].data["some"] == "is_locking - event - test_event4"
+    assert len(service_calls) == 4
+    assert service_calls[3].data["some"] == "is_locking - event - test_event4"
 
     hass.states.async_set(entry.entity_id, STATE_JAMMED)
     hass.bus.async_fire("test_event5")
     await hass.async_block_till_done()
-    assert len(calls) == 5
-    assert calls[4].data["some"] == "is_jammed - event - test_event5"
+    assert len(service_calls) == 5
+    assert service_calls[4].data["some"] == "is_jammed - event - test_event5"
 
     hass.states.async_set(entry.entity_id, STATE_OPENING)
     hass.bus.async_fire("test_event6")
     await hass.async_block_till_done()
-    assert len(calls) == 6
-    assert calls[5].data["some"] == "is_opening - event - test_event6"
+    assert len(service_calls) == 6
+    assert service_calls[5].data["some"] == "is_opening - event - test_event6"
 
     hass.states.async_set(entry.entity_id, STATE_OPEN)
     hass.bus.async_fire("test_event7")
     await hass.async_block_till_done()
-    assert len(calls) == 7
-    assert calls[6].data["some"] == "is_open - event - test_event7"
+    assert len(service_calls) == 7
+    assert service_calls[6].data["some"] == "is_open - event - test_event7"
 
 
 async def test_if_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -380,5 +370,5 @@ async def test_if_state_legacy(
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "is_locked - event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "is_locked - event - test_event1"

--- a/tests/components/lock/test_device_trigger.py
+++ b/tests/components/lock/test_device_trigger.py
@@ -29,19 +29,12 @@ from tests.common import (
     async_fire_time_changed,
     async_get_device_automation_capabilities,
     async_get_device_automations,
-    async_mock_service,
 )
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 async def test_get_triggers(
@@ -212,7 +205,7 @@ async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -296,27 +289,27 @@ async def test_if_fires_on_state_change(
     # Fake that the entity is turning on.
     hass.states.async_set(entry.entity_id, STATE_LOCKED)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"locked - device - {entry.entity_id} - unlocked - locked - None"
     )
 
     # Fake that the entity is turning off.
     hass.states.async_set(entry.entity_id, STATE_UNLOCKED)
     await hass.async_block_till_done()
-    assert len(calls) == 2
+    assert len(service_calls) == 2
     assert (
-        calls[1].data["some"]
+        service_calls[1].data["some"]
         == f"unlocked - device - {entry.entity_id} - locked - unlocked - None"
     )
 
     # Fake that the entity is opens.
     hass.states.async_set(entry.entity_id, STATE_OPEN)
     await hass.async_block_till_done()
-    assert len(calls) == 3
+    assert len(service_calls) == 3
     assert (
-        calls[2].data["some"]
+        service_calls[2].data["some"]
         == f"open - device - {entry.entity_id} - unlocked - open - None"
     )
 
@@ -325,7 +318,7 @@ async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -371,9 +364,9 @@ async def test_if_fires_on_state_change_legacy(
     # Fake that the entity is turning on.
     hass.states.async_set(entry.entity_id, STATE_LOCKED)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"locked - device - {entry.entity_id} - unlocked - locked - None"
     )
 
@@ -382,7 +375,7 @@ async def test_if_fires_on_state_change_with_for(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for triggers firing with delay."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -516,64 +509,64 @@ async def test_if_fires_on_state_change_with_for(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, STATE_LOCKED)
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     await hass.async_block_till_done()
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"turn_off device - {entry.entity_id} - unlocked - locked - 0:00:05"
     )
 
     hass.states.async_set(entry.entity_id, STATE_UNLOCKING)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=16))
     await hass.async_block_till_done()
-    assert len(calls) == 2
+    assert len(service_calls) == 2
     await hass.async_block_till_done()
     assert (
-        calls[1].data["some"]
+        service_calls[1].data["some"]
         == f"turn_on device - {entry.entity_id} - locked - unlocking - 0:00:05"
     )
 
     hass.states.async_set(entry.entity_id, STATE_JAMMED)
     await hass.async_block_till_done()
-    assert len(calls) == 2
+    assert len(service_calls) == 2
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=21))
     await hass.async_block_till_done()
-    assert len(calls) == 3
+    assert len(service_calls) == 3
     await hass.async_block_till_done()
     assert (
-        calls[2].data["some"]
+        service_calls[2].data["some"]
         == f"turn_off device - {entry.entity_id} - unlocking - jammed - 0:00:05"
     )
 
     hass.states.async_set(entry.entity_id, STATE_LOCKING)
     await hass.async_block_till_done()
-    assert len(calls) == 3
+    assert len(service_calls) == 3
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=27))
     await hass.async_block_till_done()
-    assert len(calls) == 4
+    assert len(service_calls) == 4
     await hass.async_block_till_done()
     assert (
-        calls[3].data["some"]
+        service_calls[3].data["some"]
         == f"turn_on device - {entry.entity_id} - jammed - locking - 0:00:05"
     )
 
     hass.states.async_set(entry.entity_id, STATE_OPENING)
     await hass.async_block_till_done()
-    assert len(calls) == 4
+    assert len(service_calls) == 4
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=27))
     await hass.async_block_till_done()
-    assert len(calls) == 5
+    assert len(service_calls) == 5
     await hass.async_block_till_done()
     assert (
-        calls[4].data["some"]
+        service_calls[4].data["some"]
         == f"turn_on device - {entry.entity_id} - locking - opening - 0:00:05"
     )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #118356

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
