### PR TITLE
Use TypeVar defaults for Generator

### DIFF
--- a/tests/components/apsystems/conftest.py
+++ b/tests/components/apsystems/conftest.py
@@ -23,7 +23,7 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_apsystems() -> Generator[AsyncMock, None, None]:
+def mock_apsystems() -> Generator[AsyncMock]:
     """Mock APSystems lib."""
     with (
         patch(

--- a/tests/components/apsystems/conftest.py
+++ b/tests/components/apsystems/conftest.py
@@ -1,7 +1,7 @@
 """Common fixtures for the APsystems Local API tests."""
 
 from collections.abc import Generator
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from APsystemsEZ1 import ReturnDeviceInfo, ReturnOutputData
 import pytest
@@ -23,7 +23,7 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_apsystems() -> Generator[AsyncMock]:
+def mock_apsystems() -> Generator[MagicMock]:
     """Mock APSystems lib."""
     with (
         patch(

--- a/tests/components/aquacell/conftest.py
+++ b/tests/components/aquacell/conftest.py
@@ -19,7 +19,7 @@ from tests.common import MockConfigEntry, load_json_array_fixture
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.aquacell.async_setup_entry", return_value=True
@@ -28,7 +28,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_aquacell_api() -> Generator[AsyncMock, None, None]:
+def mock_aquacell_api() -> Generator[AsyncMock]:
     """Build a fixture for the Aquacell API that authenticates successfully and returns a single softener."""
     with (
         patch(

--- a/tests/components/aquacell/conftest.py
+++ b/tests/components/aquacell/conftest.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Generator
 from datetime import datetime
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from aioaquacell import AquacellApi, Softener
 import pytest
@@ -28,7 +28,7 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_aquacell_api() -> Generator[AsyncMock]:
+def mock_aquacell_api() -> Generator[MagicMock]:
     """Build a fixture for the Aquacell API that authenticates successfully and returns a single softener."""
     with (
         patch(

--- a/tests/components/brother/conftest.py
+++ b/tests/components/brother/conftest.py
@@ -87,7 +87,7 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_unload_entry() -> Generator[AsyncMock, None, None]:
+def mock_unload_entry() -> Generator[AsyncMock]:
     """Override async_unload_entry."""
     with patch(
         "homeassistant.components.brother.async_unload_entry", return_value=True
@@ -96,7 +96,7 @@ def mock_unload_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_brother_client() -> Generator[AsyncMock, None, None]:
+def mock_brother_client() -> Generator[AsyncMock]:
     """Mock Brother client."""
     with (
         patch("homeassistant.components.brother.Brother", autospec=True) as mock_client,

--- a/tests/components/brother/conftest.py
+++ b/tests/components/brother/conftest.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Generator
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from brother import BrotherSensors
 import pytest
@@ -96,7 +96,7 @@ def mock_unload_entry() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_brother_client() -> Generator[AsyncMock]:
+def mock_brother_client() -> Generator[MagicMock]:
     """Mock Brother client."""
     with (
         patch("homeassistant.components.brother.Brother", autospec=True) as mock_client,

--- a/tests/components/ecovacs/test_services.py
+++ b/tests/components/ecovacs/test_services.py
@@ -16,9 +16,7 @@ pytestmark = [pytest.mark.usefixtures("init_integration")]
 
 
 @pytest.fixture
-def mock_device_execute_response(
-    data: dict[str, Any],
-) -> Generator[dict[str, Any], None, None]:
+def mock_device_execute_response(data: dict[str, Any]) -> Generator[dict[str, Any]]:
     """Mock the device execute function response."""
 
     response = {

--- a/tests/components/kitchen_sink/test_config_flow.py
+++ b/tests/components/kitchen_sink/test_config_flow.py
@@ -1,6 +1,6 @@
 """Test the Everything but the Kitchen Sink config flow."""
 
-from collections.abc import AsyncGenerator
+from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
@@ -15,7 +15,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-async def no_platforms() -> AsyncGenerator[None]:
+def no_platforms() -> Generator[None]:
     """Don't enable any platforms."""
     with patch(
         "homeassistant.components.kitchen_sink.COMPONENTS_WITH_DEMO_PLATFORM",

--- a/tests/components/kitchen_sink/test_config_flow.py
+++ b/tests/components/kitchen_sink/test_config_flow.py
@@ -15,7 +15,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-async def no_platforms() -> AsyncGenerator[None, None]:
+async def no_platforms() -> AsyncGenerator[None]:
     """Don't enable any platforms."""
     with patch(
         "homeassistant.components.kitchen_sink.COMPONENTS_WITH_DEMO_PLATFORM",

--- a/tests/components/mpd/conftest.py
+++ b/tests/components/mpd/conftest.py
@@ -1,7 +1,7 @@
 """Fixtures for Music Player Daemon integration tests."""
 
 from collections.abc import Generator
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -31,7 +31,7 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_mpd_client() -> Generator[AsyncMock]:
+def mock_mpd_client() -> Generator[MagicMock]:
     """Return a mock for Music Player Daemon client."""
 
     with patch(

--- a/tests/components/mpd/conftest.py
+++ b/tests/components/mpd/conftest.py
@@ -22,7 +22,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.mpd.async_setup_entry", return_value=True
@@ -31,7 +31,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_mpd_client() -> Generator[AsyncMock, None, None]:
+def mock_mpd_client() -> Generator[AsyncMock]:
     """Return a mock for Music Player Daemon client."""
 
     with patch(

--- a/tests/components/otp/conftest.py
+++ b/tests/components/otp/conftest.py
@@ -14,7 +14,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.otp.async_setup_entry", return_value=True
@@ -23,7 +23,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_pyotp() -> Generator[MagicMock, None, None]:
+def mock_pyotp() -> Generator[MagicMock]:
     """Mock a pyotp."""
     with (
         patch(

--- a/tests/components/pyload/conftest.py
+++ b/tests/components/pyload/conftest.py
@@ -1,7 +1,7 @@
 """Fixtures for pyLoad integration tests."""
 
 from collections.abc import Generator
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from pyloadapi.types import LoginResponse, StatusServerResponse
 import pytest
@@ -72,7 +72,7 @@ def pyload_config() -> ConfigType:
 
 
 @pytest.fixture
-def mock_pyloadapi() -> Generator[AsyncMock]:
+def mock_pyloadapi() -> Generator[MagicMock]:
     """Mock PyLoadAPI."""
     with (
         patch(

--- a/tests/components/pyload/conftest.py
+++ b/tests/components/pyload/conftest.py
@@ -72,7 +72,7 @@ def pyload_config() -> ConfigType:
 
 
 @pytest.fixture
-def mock_pyloadapi() -> Generator[AsyncMock, None, None]:
+def mock_pyloadapi() -> Generator[AsyncMock]:
     """Mock PyLoadAPI."""
     with (
         patch(

--- a/tests/components/pyload/test_button.py
+++ b/tests/components/pyload/test_button.py
@@ -1,6 +1,6 @@
 """The tests for the button component."""
 
-from collections.abc import AsyncGenerator
+from collections.abc import Generator
 from unittest.mock import AsyncMock, call, patch
 
 from pyloadapi import CannotConnect, InvalidAuth
@@ -26,7 +26,7 @@ API_CALL = {
 
 
 @pytest.fixture(autouse=True)
-async def button_only() -> AsyncGenerator[None]:
+def button_only() -> Generator[None]:
     """Enable only the button platform."""
     with patch(
         "homeassistant.components.pyload.PLATFORMS",

--- a/tests/components/pyload/test_button.py
+++ b/tests/components/pyload/test_button.py
@@ -26,7 +26,7 @@ API_CALL = {
 
 
 @pytest.fixture(autouse=True)
-async def button_only() -> AsyncGenerator[None, None]:
+async def button_only() -> AsyncGenerator[None]:
     """Enable only the button platform."""
     with patch(
         "homeassistant.components.pyload.PLATFORMS",

--- a/tests/components/pyload/test_sensor.py
+++ b/tests/components/pyload/test_sensor.py
@@ -1,6 +1,6 @@
 """Tests for the pyLoad Sensors."""
 
-from collections.abc import AsyncGenerator
+from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
@@ -22,7 +22,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_plat
 
 
 @pytest.fixture(autouse=True)
-async def sensor_only() -> AsyncGenerator[None]:
+def sensor_only() -> Generator[None]:
     """Enable only the sensor platform."""
     with patch(
         "homeassistant.components.pyload.PLATFORMS",

--- a/tests/components/pyload/test_sensor.py
+++ b/tests/components/pyload/test_sensor.py
@@ -22,7 +22,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_plat
 
 
 @pytest.fixture(autouse=True)
-async def sensor_only() -> AsyncGenerator[None, None]:
+async def sensor_only() -> AsyncGenerator[None]:
     """Enable only the sensor platform."""
     with patch(
         "homeassistant.components.pyload.PLATFORMS",

--- a/tests/components/pyload/test_switch.py
+++ b/tests/components/pyload/test_switch.py
@@ -1,6 +1,6 @@
 """Tests for the pyLoad Switches."""
 
-from collections.abc import AsyncGenerator
+from collections.abc import Generator
 from unittest.mock import AsyncMock, call, patch
 
 from pyloadapi import CannotConnect, InvalidAuth
@@ -38,7 +38,7 @@ API_CALL = {
 
 
 @pytest.fixture(autouse=True)
-async def switch_only() -> AsyncGenerator[None]:
+def switch_only() -> Generator[None]:
     """Enable only the switch platform."""
     with patch(
         "homeassistant.components.pyload.PLATFORMS",

--- a/tests/components/pyload/test_switch.py
+++ b/tests/components/pyload/test_switch.py
@@ -38,7 +38,7 @@ API_CALL = {
 
 
 @pytest.fixture(autouse=True)
-async def switch_only() -> AsyncGenerator[None, None]:
+async def switch_only() -> AsyncGenerator[None]:
     """Enable only the switch platform."""
     with patch(
         "homeassistant.components.pyload.PLATFORMS",

--- a/tests/components/solarlog/conftest.py
+++ b/tests/components/solarlog/conftest.py
@@ -60,7 +60,7 @@ def mock_solarlog_connector():
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.solarlog.async_setup_entry", return_value=True


### PR DESCRIPTION
## Proposed change
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
