### PR TITLE
Use service_calls fixture in homekit_controller tests

### DIFF
--- a/tests/components/homekit_controller/test_device_trigger.py
+++ b/tests/components/homekit_controller/test_device_trigger.py
@@ -15,18 +15,12 @@ from homeassistant.setup import async_setup_component
 
 from .common import setup_test_component
 
-from tests.common import async_get_device_automations, async_mock_service
+from tests.common import async_get_device_automations
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 def create_remote(accessory):
@@ -239,7 +233,7 @@ async def test_handle_events(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test that events are handled."""
     helper = await setup_test_component(hass, create_remote)
@@ -303,8 +297,8 @@ async def test_handle_events(
     )
 
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "device - button1 - single_press - 0"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "device - button1 - single_press - 0"
 
     # Make sure automation doesn't trigger for long press
     helper.pairing.testing.update_named_service(
@@ -312,7 +306,7 @@ async def test_handle_events(
     )
 
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
 
     # Make sure automation doesn't trigger for double press
     helper.pairing.testing.update_named_service(
@@ -320,7 +314,7 @@ async def test_handle_events(
     )
 
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
 
     # Make sure second automation fires for long press
     helper.pairing.testing.update_named_service(
@@ -328,8 +322,8 @@ async def test_handle_events(
     )
 
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert calls[1].data["some"] == "device - button2 - long_press - 0"
+    assert len(service_calls) == 2
+    assert service_calls[1].data["some"] == "device - button2 - long_press - 0"
 
     # Turn the automations off
     await hass.services.async_call(
@@ -338,6 +332,7 @@ async def test_handle_events(
         {"entity_id": "automation.long_press"},
         blocking=True,
     )
+    assert len(service_calls) == 3
 
     await hass.services.async_call(
         "automation",
@@ -345,6 +340,7 @@ async def test_handle_events(
         {"entity_id": "automation.single_press"},
         blocking=True,
     )
+    assert len(service_calls) == 4
 
     # Make sure event no longer fires
     helper.pairing.testing.update_named_service(
@@ -352,14 +348,14 @@ async def test_handle_events(
     )
 
     await hass.async_block_till_done()
-    assert len(calls) == 2
+    assert len(service_calls) == 4
 
 
 async def test_handle_events_late_setup(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test that events are handled when setup happens after startup."""
     helper = await setup_test_component(hass, create_remote)
@@ -432,8 +428,8 @@ async def test_handle_events_late_setup(
     )
 
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "device - button1 - single_press - 0"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "device - button1 - single_press - 0"
 
     # Make sure automation doesn't trigger for a polled None
     helper.pairing.testing.update_named_service(
@@ -441,7 +437,7 @@ async def test_handle_events_late_setup(
     )
 
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
 
     # Make sure automation doesn't trigger for long press
     helper.pairing.testing.update_named_service(
@@ -449,7 +445,7 @@ async def test_handle_events_late_setup(
     )
 
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
 
     # Make sure automation doesn't trigger for double press
     helper.pairing.testing.update_named_service(
@@ -457,7 +453,7 @@ async def test_handle_events_late_setup(
     )
 
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
 
     # Make sure second automation fires for long press
     helper.pairing.testing.update_named_service(
@@ -465,8 +461,8 @@ async def test_handle_events_late_setup(
     )
 
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert calls[1].data["some"] == "device - button2 - long_press - 0"
+    assert len(service_calls) == 2
+    assert service_calls[1].data["some"] == "device - button2 - long_press - 0"
 
     # Turn the automations off
     await hass.services.async_call(
@@ -475,6 +471,7 @@ async def test_handle_events_late_setup(
         {"entity_id": "automation.long_press"},
         blocking=True,
     )
+    assert len(service_calls) == 3
 
     await hass.services.async_call(
         "automation",
@@ -482,6 +479,7 @@ async def test_handle_events_late_setup(
         {"entity_id": "automation.single_press"},
         blocking=True,
     )
+    assert len(service_calls) == 4
 
     # Make sure event no longer fires
     helper.pairing.testing.update_named_service(
@@ -489,4 +487,4 @@ async def test_handle_events_late_setup(
     )
 
     await hass.async_block_till_done()
-    assert len(calls) == 2
+    assert len(service_calls) == 4


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #118356

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
