### PR TITLE
Use service_calls fixture in knx tests

### DIFF
--- a/tests/components/knx/test_device_trigger.py
+++ b/tests/components/knx/test_device_trigger.py
@@ -18,18 +18,12 @@ from homeassistant.setup import async_setup_component
 
 from .conftest import KNXTestKit
 
-from tests.common import async_get_device_automations, async_mock_service
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
+from tests.common import async_get_device_automations
 
 
 async def test_if_fires_on_telegram(
     hass: HomeAssistant,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     device_registry: dr.DeviceRegistry,
     knx: KNXTestKit,
 ) -> None:
@@ -98,31 +92,31 @@ async def test_if_fires_on_telegram(
 
     # "specific" shall ignore destination address
     await knx.receive_write("0/0/1", (0x03, 0x2F))
-    assert len(calls) == 1
-    test_call = calls.pop()
+    assert len(service_calls) == 1
+    test_call = service_calls.pop()
     assert test_call.data["catch_all"] == "telegram - 0/0/1"
     assert test_call.data["id"] == 0
 
     await knx.receive_write("1/2/4", (0x03, 0x2F))
-    assert len(calls) == 2
-    test_call = calls.pop()
+    assert len(service_calls) == 2
+    test_call = service_calls.pop()
     assert test_call.data["specific"] == "telegram - 1/2/4"
     assert test_call.data["id"] == "test-id"
-    test_call = calls.pop()
+    test_call = service_calls.pop()
     assert test_call.data["catch_all"] == "telegram - 1/2/4"
     assert test_call.data["id"] == 0
 
     # "specific" shall ignore GroupValueRead
     await knx.receive_read("1/2/4")
-    assert len(calls) == 1
-    test_call = calls.pop()
+    assert len(service_calls) == 1
+    test_call = service_calls.pop()
     assert test_call.data["catch_all"] == "telegram - 1/2/4"
     assert test_call.data["id"] == 0
 
 
 async def test_default_if_fires_on_telegram(
     hass: HomeAssistant,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     device_registry: dr.DeviceRegistry,
     knx: KNXTestKit,
 ) -> None:
@@ -179,34 +173,34 @@ async def test_default_if_fires_on_telegram(
     )
 
     await knx.receive_write("0/0/1", (0x03, 0x2F))
-    assert len(calls) == 1
-    test_call = calls.pop()
+    assert len(service_calls) == 1
+    test_call = service_calls.pop()
     assert test_call.data["catch_all"] == "telegram - 0/0/1"
     assert test_call.data["id"] == 0
 
     await knx.receive_write("1/2/4", (0x03, 0x2F))
-    assert len(calls) == 2
-    test_call = calls.pop()
+    assert len(service_calls) == 2
+    test_call = service_calls.pop()
     assert test_call.data["specific"] == "telegram - 1/2/4"
     assert test_call.data["id"] == "test-id"
-    test_call = calls.pop()
+    test_call = service_calls.pop()
     assert test_call.data["catch_all"] == "telegram - 1/2/4"
     assert test_call.data["id"] == 0
 
     # "specific" shall catch GroupValueRead as it is not set explicitly
     await knx.receive_read("1/2/4")
-    assert len(calls) == 2
-    test_call = calls.pop()
+    assert len(service_calls) == 2
+    test_call = service_calls.pop()
     assert test_call.data["specific"] == "telegram - 1/2/4"
     assert test_call.data["id"] == "test-id"
-    test_call = calls.pop()
+    test_call = service_calls.pop()
     assert test_call.data["catch_all"] == "telegram - 1/2/4"
     assert test_call.data["id"] == 0
 
 
 async def test_remove_device_trigger(
     hass: HomeAssistant,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     device_registry: dr.DeviceRegistry,
     knx: KNXTestKit,
 ) -> None:
@@ -241,8 +235,8 @@ async def test_remove_device_trigger(
     )
 
     await knx.receive_write("0/0/1", (0x03, 0x2F))
-    assert len(calls) == 1
-    assert calls.pop().data["catch_all"] == "telegram - 0/0/1"
+    assert len(service_calls) == 1
+    assert service_calls.pop().data["catch_all"] == "telegram - 0/0/1"
 
     await hass.services.async_call(
         automation.DOMAIN,
@@ -250,8 +244,10 @@ async def test_remove_device_trigger(
         {ATTR_ENTITY_ID: f"automation.{automation_name}"},
         blocking=True,
     )
+    assert len(service_calls) == 1
+
     await knx.receive_write("0/0/1", (0x03, 0x2F))
-    assert len(calls) == 0
+    assert len(service_calls) == 1
 
 
 async def test_get_triggers(

--- a/tests/components/knx/test_trigger.py
+++ b/tests/components/knx/test_trigger.py
@@ -11,18 +11,10 @@ from homeassistant.setup import async_setup_component
 
 from .conftest import KNXTestKit
 
-from tests.common import async_mock_service
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
-
 
 async def test_telegram_trigger(
     hass: HomeAssistant,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     knx: KNXTestKit,
 ) -> None:
     """Test telegram triggers firing."""
@@ -73,24 +65,24 @@ async def test_telegram_trigger(
 
     # "specific" shall ignore destination address
     await knx.receive_write("0/0/1", (0x03, 0x2F))
-    assert len(calls) == 1
-    test_call = calls.pop()
+    assert len(service_calls) == 1
+    test_call = service_calls.pop()
     assert test_call.data["catch_all"] == "telegram - 0/0/1"
     assert test_call.data["id"] == 0
 
     await knx.receive_write("1/2/4", (0x03, 0x2F))
-    assert len(calls) == 2
-    test_call = calls.pop()
+    assert len(service_calls) == 2
+    test_call = service_calls.pop()
     assert test_call.data["specific"] == "telegram - 1/2/4"
     assert test_call.data["id"] == "test-id"
-    test_call = calls.pop()
+    test_call = service_calls.pop()
     assert test_call.data["catch_all"] == "telegram - 1/2/4"
     assert test_call.data["id"] == 0
 
     # "specific" shall ignore GroupValueRead
     await knx.receive_read("1/2/4")
-    assert len(calls) == 1
-    test_call = calls.pop()
+    assert len(service_calls) == 1
+    test_call = service_calls.pop()
     assert test_call.data["catch_all"] == "telegram - 1/2/4"
     assert test_call.data["id"] == 0
 
@@ -105,7 +97,7 @@ async def test_telegram_trigger(
 )
 async def test_telegram_trigger_dpt_option(
     hass: HomeAssistant,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     knx: KNXTestKit,
     payload: tuple[int, ...],
     type_option: dict[str, bool],
@@ -138,16 +130,16 @@ async def test_telegram_trigger_dpt_option(
     )
     await knx.receive_write("0/0/1", payload)
 
-    assert len(calls) == 1
-    test_call = calls.pop()
+    assert len(service_calls) == 1
+    test_call = service_calls.pop()
     assert test_call.data["catch_all"] == "telegram - 0/0/1"
     assert test_call.data["trigger"]["value"] == expected_value
     assert test_call.data["trigger"]["unit"] == expected_unit
 
     await knx.receive_read("0/0/1")
 
-    assert len(calls) == 1
-    test_call = calls.pop()
+    assert len(service_calls) == 1
+    test_call = service_calls.pop()
     assert test_call.data["catch_all"] == "telegram - 0/0/1"
     assert test_call.data["trigger"]["value"] is None
     assert test_call.data["trigger"]["unit"] is None
@@ -192,7 +184,7 @@ async def test_telegram_trigger_dpt_option(
 )
 async def test_telegram_trigger_options(
     hass: HomeAssistant,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     knx: KNXTestKit,
     group_value_options: dict[str, bool],
     direction_options: dict[str, bool],
@@ -225,28 +217,28 @@ async def test_telegram_trigger_options(
     if group_value_options.get("group_value_write", True) and direction_options.get(
         "incoming", True
     ):
-        assert len(calls) == 1
-        assert calls.pop().data["catch_all"] == "telegram - 0/0/1"
+        assert len(service_calls) == 1
+        assert service_calls.pop().data["catch_all"] == "telegram - 0/0/1"
     else:
-        assert len(calls) == 0
+        assert len(service_calls) == 0
 
     await knx.receive_response("0/0/1", 1)
     if group_value_options["group_value_response"] and direction_options.get(
         "incoming", True
     ):
-        assert len(calls) == 1
-        assert calls.pop().data["catch_all"] == "telegram - 0/0/1"
+        assert len(service_calls) == 1
+        assert service_calls.pop().data["catch_all"] == "telegram - 0/0/1"
     else:
-        assert len(calls) == 0
+        assert len(service_calls) == 0
 
     await knx.receive_read("0/0/1")
     if group_value_options["group_value_read"] and direction_options.get(
         "incoming", True
     ):
-        assert len(calls) == 1
-        assert calls.pop().data["catch_all"] == "telegram - 0/0/1"
+        assert len(service_calls) == 1
+        assert service_calls.pop().data["catch_all"] == "telegram - 0/0/1"
     else:
-        assert len(calls) == 0
+        assert len(service_calls) == 0
 
     await hass.services.async_call(
         "knx",
@@ -254,20 +246,22 @@ async def test_telegram_trigger_options(
         {"address": "0/0/1", "payload": True},
         blocking=True,
     )
+    assert len(service_calls) == 1
+
     await knx.assert_write("0/0/1", True)
     if (
         group_value_options.get("group_value_write", True)
         and direction_options["outgoing"]
     ):
-        assert len(calls) == 1
-        assert calls.pop().data["catch_all"] == "telegram - 0/0/1"
+        assert len(service_calls) == 2
+        assert service_calls.pop().data["catch_all"] == "telegram - 0/0/1"
     else:
-        assert len(calls) == 0
+        assert len(service_calls) == 1
 
 
 async def test_remove_telegram_trigger(
     hass: HomeAssistant,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     knx: KNXTestKit,
 ) -> None:
     """Test for removed callback when telegram trigger not used."""
@@ -296,8 +290,8 @@ async def test_remove_telegram_trigger(
     )
 
     await knx.receive_write("0/0/1", (0x03, 0x2F))
-    assert len(calls) == 1
-    assert calls.pop().data["catch_all"] == "telegram - 0/0/1"
+    assert len(service_calls) == 1
+    assert service_calls.pop().data["catch_all"] == "telegram - 0/0/1"
 
     await hass.services.async_call(
         automation.DOMAIN,
@@ -305,8 +299,10 @@ async def test_remove_telegram_trigger(
         {ATTR_ENTITY_ID: f"automation.{automation_name}"},
         blocking=True,
     )
+    assert len(service_calls) == 1
+
     await knx.receive_write("0/0/1", (0x03, 0x2F))
-    assert len(calls) == 0
+    assert len(service_calls) == 1
 
 
 async def test_invalid_trigger(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #118356

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
