### PR TITLE
Use service_calls fixture in lcn tests

### DIFF
--- a/tests/components/lcn/conftest.py
+++ b/tests/components/lcn/conftest.py
@@ -12,11 +12,10 @@ import pytest
 from homeassistant.components.lcn.const import DOMAIN
 from homeassistant.components.lcn.helpers import generate_unique_id
 from homeassistant.const import CONF_HOST
-from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockConfigEntry, async_mock_service, load_fixture
+from tests.common import MockConfigEntry, load_fixture
 
 
 class MockModuleConnection(ModuleConnection):
@@ -76,12 +75,6 @@ def create_config_entry(name):
         data=entry_data,
         options=options,
     )
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 @pytest.fixture(name="entry")

--- a/tests/components/lcn/test_device_trigger.py
+++ b/tests/components/lcn/test_device_trigger.py
@@ -72,7 +72,7 @@ async def test_get_triggers_non_module_device(
 
 
 async def test_if_fires_on_transponder_event(
-    hass: HomeAssistant, calls: list[ServiceCall], entry, lcn_connection
+    hass: HomeAssistant, service_calls: list[ServiceCall], entry, lcn_connection
 ) -> None:
     """Test for transponder event triggers firing."""
     address = (0, 7, False)
@@ -111,15 +111,15 @@ async def test_if_fires_on_transponder_event(
     await lcn_connection.async_process_input(inp)
     await hass.async_block_till_done()
 
-    assert len(calls) == 1
-    assert calls[0].data == {
+    assert len(service_calls) == 1
+    assert service_calls[0].data == {
         "test": "test_trigger_transponder",
         "code": "aabbcc",
     }
 
 
 async def test_if_fires_on_fingerprint_event(
-    hass: HomeAssistant, calls: list[ServiceCall], entry, lcn_connection
+    hass: HomeAssistant, service_calls: list[ServiceCall], entry, lcn_connection
 ) -> None:
     """Test for fingerprint event triggers firing."""
     address = (0, 7, False)
@@ -158,15 +158,15 @@ async def test_if_fires_on_fingerprint_event(
     await lcn_connection.async_process_input(inp)
     await hass.async_block_till_done()
 
-    assert len(calls) == 1
-    assert calls[0].data == {
+    assert len(service_calls) == 1
+    assert service_calls[0].data == {
         "test": "test_trigger_fingerprint",
         "code": "aabbcc",
     }
 
 
 async def test_if_fires_on_codelock_event(
-    hass: HomeAssistant, calls: list[ServiceCall], entry, lcn_connection
+    hass: HomeAssistant, service_calls: list[ServiceCall], entry, lcn_connection
 ) -> None:
     """Test for codelock event triggers firing."""
     address = (0, 7, False)
@@ -205,15 +205,15 @@ async def test_if_fires_on_codelock_event(
     await lcn_connection.async_process_input(inp)
     await hass.async_block_till_done()
 
-    assert len(calls) == 1
-    assert calls[0].data == {
+    assert len(service_calls) == 1
+    assert service_calls[0].data == {
         "test": "test_trigger_codelock",
         "code": "aabbcc",
     }
 
 
 async def test_if_fires_on_transmitter_event(
-    hass: HomeAssistant, calls: list[ServiceCall], entry, lcn_connection
+    hass: HomeAssistant, service_calls: list[ServiceCall], entry, lcn_connection
 ) -> None:
     """Test for transmitter event triggers firing."""
     address = (0, 7, False)
@@ -258,8 +258,8 @@ async def test_if_fires_on_transmitter_event(
     await lcn_connection.async_process_input(inp)
     await hass.async_block_till_done()
 
-    assert len(calls) == 1
-    assert calls[0].data == {
+    assert len(service_calls) == 1
+    assert service_calls[0].data == {
         "test": "test_trigger_transmitter",
         "code": "aabbcc",
         "level": 0,
@@ -269,7 +269,7 @@ async def test_if_fires_on_transmitter_event(
 
 
 async def test_if_fires_on_send_keys_event(
-    hass: HomeAssistant, calls: list[ServiceCall], entry, lcn_connection
+    hass: HomeAssistant, service_calls: list[ServiceCall], entry, lcn_connection
 ) -> None:
     """Test for send_keys event triggers firing."""
     address = (0, 7, False)
@@ -309,8 +309,8 @@ async def test_if_fires_on_send_keys_event(
     await lcn_connection.async_process_input(inp)
     await hass.async_block_till_done()
 
-    assert len(calls) == 1
-    assert calls[0].data == {
+    assert len(service_calls) == 1
+    assert service_calls[0].data == {
         "test": "test_trigger_send_keys",
         "key": "a1",
         "action": "hit",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #118356

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
