### PR TITLE
Use service_calls fixture in litejet tests

### DIFF
--- a/tests/components/litejet/test_trigger.py
+++ b/tests/components/litejet/test_trigger.py
@@ -14,7 +14,7 @@ import homeassistant.util.dt as dt_util
 
 from . import async_init_integration
 
-from tests.common import async_fire_time_changed_exact, async_mock_service
+from tests.common import async_fire_time_changed_exact
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
@@ -28,12 +28,6 @@ ENTITY_SWITCH = "switch.mock_switch_1"
 ENTITY_SWITCH_NUMBER = 1
 ENTITY_OTHER_SWITCH = "switch.mock_switch_2"
 ENTITY_OTHER_SWITCH_NUMBER = 2
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 async def simulate_press(hass, mock_litejet, number):
@@ -101,7 +95,7 @@ async def setup_automation(hass, trigger):
 
 
 async def test_simple(
-    hass: HomeAssistant, calls: list[ServiceCall], mock_litejet
+    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet
 ) -> None:
     """Test the simplest form of a LiteJet trigger."""
     await setup_automation(
@@ -111,12 +105,12 @@ async def test_simple(
     await simulate_press(hass, mock_litejet, ENTITY_OTHER_SWITCH_NUMBER)
     await simulate_release(hass, mock_litejet, ENTITY_OTHER_SWITCH_NUMBER)
 
-    assert len(calls) == 1
-    assert calls[0].data["id"] == 0
+    assert len(service_calls) == 1
+    assert service_calls[0].data["id"] == 0
 
 
 async def test_only_release(
-    hass: HomeAssistant, calls: list[ServiceCall], mock_litejet
+    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet
 ) -> None:
     """Test the simplest form of a LiteJet trigger."""
     await setup_automation(
@@ -125,11 +119,11 @@ async def test_only_release(
 
     await simulate_release(hass, mock_litejet, ENTITY_OTHER_SWITCH_NUMBER)
 
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
 
 async def test_held_more_than_short(
-    hass: HomeAssistant, calls: list[ServiceCall], mock_litejet
+    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet
 ) -> None:
     """Test a too short hold."""
     await setup_automation(
@@ -144,11 +138,11 @@ async def test_held_more_than_short(
     await simulate_press(hass, mock_litejet, ENTITY_OTHER_SWITCH_NUMBER)
     await simulate_time(hass, mock_litejet, timedelta(seconds=1))
     await simulate_release(hass, mock_litejet, ENTITY_OTHER_SWITCH_NUMBER)
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
 
 async def test_held_more_than_long(
-    hass: HomeAssistant, calls: list[ServiceCall], mock_litejet
+    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet
 ) -> None:
     """Test a hold that is long enough."""
     await setup_automation(
@@ -161,16 +155,16 @@ async def test_held_more_than_long(
     )
 
     await simulate_press(hass, mock_litejet, ENTITY_OTHER_SWITCH_NUMBER)
-    assert len(calls) == 0
+    assert len(service_calls) == 0
     await simulate_time(hass, mock_litejet, timedelta(seconds=3))
-    assert len(calls) == 1
-    assert calls[0].data["id"] == 0
+    assert len(service_calls) == 1
+    assert service_calls[0].data["id"] == 0
     await simulate_release(hass, mock_litejet, ENTITY_OTHER_SWITCH_NUMBER)
-    assert len(calls) == 1
+    assert len(service_calls) == 1
 
 
 async def test_held_less_than_short(
-    hass: HomeAssistant, calls: list[ServiceCall], mock_litejet
+    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet
 ) -> None:
     """Test a hold that is short enough."""
     await setup_automation(
@@ -184,14 +178,14 @@ async def test_held_less_than_short(
 
     await simulate_press(hass, mock_litejet, ENTITY_OTHER_SWITCH_NUMBER)
     await simulate_time(hass, mock_litejet, timedelta(seconds=1))
-    assert len(calls) == 0
+    assert len(service_calls) == 0
     await simulate_release(hass, mock_litejet, ENTITY_OTHER_SWITCH_NUMBER)
-    assert len(calls) == 1
-    assert calls[0].data["id"] == 0
+    assert len(service_calls) == 1
+    assert service_calls[0].data["id"] == 0
 
 
 async def test_held_less_than_long(
-    hass: HomeAssistant, calls: list[ServiceCall], mock_litejet
+    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet
 ) -> None:
     """Test a hold that is too long."""
     await setup_automation(
@@ -204,15 +198,15 @@ async def test_held_less_than_long(
     )
 
     await simulate_press(hass, mock_litejet, ENTITY_OTHER_SWITCH_NUMBER)
-    assert len(calls) == 0
+    assert len(service_calls) == 0
     await simulate_time(hass, mock_litejet, timedelta(seconds=3))
-    assert len(calls) == 0
+    assert len(service_calls) == 0
     await simulate_release(hass, mock_litejet, ENTITY_OTHER_SWITCH_NUMBER)
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
 
 async def test_held_in_range_short(
-    hass: HomeAssistant, calls: list[ServiceCall], mock_litejet
+    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet
 ) -> None:
     """Test an in-range trigger with a too short hold."""
     await setup_automation(
@@ -228,11 +222,11 @@ async def test_held_in_range_short(
     await simulate_press(hass, mock_litejet, ENTITY_OTHER_SWITCH_NUMBER)
     await simulate_time(hass, mock_litejet, timedelta(seconds=0.5))
     await simulate_release(hass, mock_litejet, ENTITY_OTHER_SWITCH_NUMBER)
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
 
 async def test_held_in_range_just_right(
-    hass: HomeAssistant, calls: list[ServiceCall], mock_litejet
+    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet
 ) -> None:
     """Test an in-range trigger with a just right hold."""
     await setup_automation(
@@ -246,16 +240,16 @@ async def test_held_in_range_just_right(
     )
 
     await simulate_press(hass, mock_litejet, ENTITY_OTHER_SWITCH_NUMBER)
-    assert len(calls) == 0
+    assert len(service_calls) == 0
     await simulate_time(hass, mock_litejet, timedelta(seconds=2))
-    assert len(calls) == 0
+    assert len(service_calls) == 0
     await simulate_release(hass, mock_litejet, ENTITY_OTHER_SWITCH_NUMBER)
-    assert len(calls) == 1
-    assert calls[0].data["id"] == 0
+    assert len(service_calls) == 1
+    assert service_calls[0].data["id"] == 0
 
 
 async def test_held_in_range_long(
-    hass: HomeAssistant, calls: list[ServiceCall], mock_litejet
+    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet
 ) -> None:
     """Test an in-range trigger with a too long hold."""
     await setup_automation(
@@ -269,15 +263,15 @@ async def test_held_in_range_long(
     )
 
     await simulate_press(hass, mock_litejet, ENTITY_OTHER_SWITCH_NUMBER)
-    assert len(calls) == 0
+    assert len(service_calls) == 0
     await simulate_time(hass, mock_litejet, timedelta(seconds=4))
-    assert len(calls) == 0
+    assert len(service_calls) == 0
     await simulate_release(hass, mock_litejet, ENTITY_OTHER_SWITCH_NUMBER)
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
 
 async def test_reload(
-    hass: HomeAssistant, calls: list[ServiceCall], mock_litejet
+    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet
 ) -> None:
     """Test reloading automation."""
     await setup_automation(
@@ -312,8 +306,8 @@ async def test_reload(
         await hass.async_block_till_done()
 
     await simulate_press(hass, mock_litejet, ENTITY_OTHER_SWITCH_NUMBER)
-    assert len(calls) == 0
+    assert len(service_calls) == 1
     await simulate_time(hass, mock_litejet, timedelta(seconds=5))
-    assert len(calls) == 0
+    assert len(service_calls) == 1
     await simulate_time(hass, mock_litejet, timedelta(seconds=12.5))
-    assert len(calls) == 1
+    assert len(service_calls) == 2


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #118356

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
