### PR TITLE
Use service_calls fixture in media_extractor tests

### DIFF
--- a/tests/components/media_extractor/conftest.py
+++ b/tests/components/media_extractor/conftest.py
@@ -7,13 +7,11 @@ import pytest
 from typing_extensions import Generator
 
 from homeassistant.components.media_extractor import DOMAIN
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from . import MockYoutubeDL
 from .const import AUDIO_QUERY
-
-from tests.common import async_mock_service
 
 
 @pytest.fixture(autouse=True)
@@ -29,12 +27,6 @@ async def setup_media_player(hass: HomeAssistant) -> None:
         hass, "media_player", {"media_player": {"platform": "demo"}}
     )
     await hass.async_block_till_done()
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "media_player", "play_media")
 
 
 @pytest.fixture(name="mock_youtube_dl")

--- a/tests/components/media_extractor/test_init.py
+++ b/tests/components/media_extractor/test_init.py
@@ -100,7 +100,7 @@ async def test_extracting_playlist_no_entries(
 async def test_play_media_service(
     hass: HomeAssistant,
     mock_youtube_dl: MockYoutubeDL,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     snapshot: SnapshotAssertion,
     request: pytest.FixtureRequest,
     config_fixture: str,
@@ -123,13 +123,14 @@ async def test_play_media_service(
     )
     await hass.async_block_till_done()
 
-    assert calls[0].data == snapshot
+    assert len(service_calls) == 2
+    assert service_calls[1].data == snapshot
 
 
 async def test_download_error(
     hass: HomeAssistant,
     empty_media_extractor_config: dict[str, Any],
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test handling DownloadError."""
@@ -152,7 +153,7 @@ async def test_download_error(
         )
         await hass.async_block_till_done()
 
-    assert len(calls) == 0
+    assert len(service_calls) == 1
     assert f"Could not retrieve data for the URL: {YOUTUBE_VIDEO}" in caplog.text
 
 
@@ -160,7 +161,7 @@ async def test_no_target_entity(
     hass: HomeAssistant,
     mock_youtube_dl: MockYoutubeDL,
     empty_media_extractor_config: dict[str, Any],
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test having no target entity."""
@@ -179,14 +180,15 @@ async def test_no_target_entity(
     )
     await hass.async_block_till_done()
 
-    assert calls[0].data == snapshot
+    assert len(service_calls) == 2
+    assert service_calls[1].data == snapshot
 
 
 async def test_playlist(
     hass: HomeAssistant,
     mock_youtube_dl: MockYoutubeDL,
     empty_media_extractor_config: dict[str, Any],
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test extracting a playlist."""
@@ -205,14 +207,15 @@ async def test_playlist(
     )
     await hass.async_block_till_done()
 
-    assert calls[0].data == snapshot
+    assert len(service_calls) == 2
+    assert service_calls[1].data == snapshot
 
 
 async def test_playlist_no_entries(
     hass: HomeAssistant,
     mock_youtube_dl: MockYoutubeDL,
     empty_media_extractor_config: dict[str, Any],
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test extracting a playlist without entries."""
@@ -231,7 +234,7 @@ async def test_playlist_no_entries(
     )
     await hass.async_block_till_done()
 
-    assert len(calls) == 0
+    assert len(service_calls) == 1
     assert (
         f"Could not retrieve data for the URL: {YOUTUBE_EMPTY_PLAYLIST}" in caplog.text
     )
@@ -240,7 +243,7 @@ async def test_playlist_no_entries(
 async def test_query_error(
     hass: HomeAssistant,
     empty_media_extractor_config: dict[str, Any],
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test handling error with query."""
 
@@ -270,15 +273,13 @@ async def test_query_error(
         )
         await hass.async_block_till_done()
 
-    assert len(calls) == 0
+    assert len(service_calls) == 1
 
 
 async def test_cookiefile_detection(
     hass: HomeAssistant,
     mock_youtube_dl: MockYoutubeDL,
     empty_media_extractor_config: dict[str, Any],
-    calls: list[ServiceCall],
-    snapshot: SnapshotAssertion,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test cookie file detection."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #118356

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
