### PR TITLE
Downgrade logging previously reported asyncio block to debug

### DIFF
--- a/homeassistant/util/loop.py
+++ b/homeassistant/util/loop.py
@@ -29,7 +29,7 @@ def _get_line_from_cache(filename: str, lineno: int) -> str:
 
 # Set of previously reported blocking calls
 # (integration, filename, lineno)
-_PREVIOUSLY_REPORTED: set[tuple[str | None, str, int]] = set()
+_PREVIOUSLY_REPORTED: set[tuple[str | None, str, int | Any]] = set()
 
 
 def raise_for_blocking_call(
@@ -48,6 +48,7 @@ def raise_for_blocking_call(
     offender_filename = offender_frame.f_code.co_filename
     offender_lineno = offender_frame.f_lineno
     offender_line = _get_line_from_cache(offender_filename, offender_lineno)
+    report_key: tuple[str | None, str, int | Any]
 
     try:
         integration_frame = get_integration_frame()

--- a/homeassistant/util/loop.py
+++ b/homeassistant/util/loop.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 import functools
+from functools import cache
 import linecache
 import logging
 import threading
@@ -26,6 +27,9 @@ def _get_line_from_cache(filename: str, lineno: int) -> str:
     return (linecache.getline(filename, lineno) or "?").strip()
 
 
+_PREVIOUSLY_REPORTED: set[tuple[str, int]] = set()
+
+
 def raise_for_blocking_call(
     func: Callable[..., Any],
     check_allowed: Callable[[dict[str, Any]], bool] | None = None,
@@ -43,27 +47,47 @@ def raise_for_blocking_call(
     offender_lineno = offender_frame.f_lineno
     offender_line = _get_line_from_cache(offender_filename, offender_lineno)
 
+    report_key = (offender_filename, offender_lineno)
+    was_reported = report_key in _PREVIOUSLY_REPORTED
+    _PREVIOUSLY_REPORTED.add(report_key)
+
     try:
         integration_frame = get_integration_frame()
     except MissingIntegrationFrame:
         # Did not source from integration? Hard error.
         if not strict_core:
-            _LOGGER.warning(
-                "Detected blocking call to %s with args %s in %s, "
-                "line %s: %s inside the event loop; "
-                "This is causing stability issues. "
-                "Please create a bug report at "
-                "https://github.com/home-assistant/core/issues?q=is%%3Aopen+is%%3Aissue\n"
-                "%s\n"
-                "Traceback (most recent call last):\n%s",
-                func.__name__,
-                mapped_args.get("args"),
-                offender_filename,
-                offender_lineno,
-                offender_line,
-                _dev_help_message(func.__name__),
-                "".join(traceback.format_stack(f=offender_frame)),
-            )
+            if was_reported:
+                _LOGGER.debug(
+                    "Detected blocking call to %s with args %s in %s, "
+                    "line %s: %s inside the event loop; "
+                    "This is causing stability issues. "
+                    "Please create a bug report at "
+                    "https://github.com/home-assistant/core/issues?q=is%%3Aopen+is%%3Aissue\n"
+                    "%s\n",
+                    func.__name__,
+                    mapped_args.get("args"),
+                    offender_filename,
+                    offender_lineno,
+                    offender_line,
+                    _dev_help_message(func.__name__),
+                )
+            else:
+                _LOGGER.warning(
+                    "Detected blocking call to %s with args %s in %s, "
+                    "line %s: %s inside the event loop; "
+                    "This is causing stability issues. "
+                    "Please create a bug report at "
+                    "https://github.com/home-assistant/core/issues?q=is%%3Aopen+is%%3Aissue\n"
+                    "%s\n"
+                    "Traceback (most recent call last):\n%s",
+                    func.__name__,
+                    mapped_args.get("args"),
+                    offender_filename,
+                    offender_lineno,
+                    offender_line,
+                    _dev_help_message(func.__name__),
+                    "".join(traceback.format_stack(f=offender_frame)),
+                )
             return
 
         if found_frame is None:
@@ -83,26 +107,46 @@ def raise_for_blocking_call(
         module=integration_frame.module,
     )
 
-    _LOGGER.warning(
-        "Detected blocking call to %s with args %s "
-        "inside the event loop by %sintegration '%s' "
-        "at %s, line %s: %s (offender: %s, line %s: %s), please %s\n"
-        "%s\n"
-        "Traceback (most recent call last):\n%s",
-        func.__name__,
-        mapped_args.get("args"),
-        "custom " if integration_frame.custom_integration else "",
-        integration_frame.integration,
-        integration_frame.relative_filename,
-        integration_frame.line_number,
-        integration_frame.line,
-        offender_filename,
-        offender_lineno,
-        offender_line,
-        report_issue,
-        _dev_help_message(func.__name__),
-        "".join(traceback.format_stack(f=integration_frame.frame)),
-    )
+    if was_reported:
+        _LOGGER.debug(
+            "Detected blocking call to %s with args %s "
+            "inside the event loop by %sintegration '%s' "
+            "at %s, line %s: %s (offender: %s, line %s: %s), please %s\n"
+            "%s\n",
+            func.__name__,
+            mapped_args.get("args"),
+            "custom " if integration_frame.custom_integration else "",
+            integration_frame.integration,
+            integration_frame.relative_filename,
+            integration_frame.line_number,
+            integration_frame.line,
+            offender_filename,
+            offender_lineno,
+            offender_line,
+            report_issue,
+            _dev_help_message(func.__name__),
+        )
+    else:
+        _LOGGER.warning(
+            "Detected blocking call to %s with args %s "
+            "inside the event loop by %sintegration '%s' "
+            "at %s, line %s: %s (offender: %s, line %s: %s), please %s\n"
+            "%s\n"
+            "Traceback (most recent call last):\n%s",
+            func.__name__,
+            mapped_args.get("args"),
+            "custom " if integration_frame.custom_integration else "",
+            integration_frame.integration,
+            integration_frame.relative_filename,
+            integration_frame.line_number,
+            integration_frame.line,
+            offender_filename,
+            offender_lineno,
+            offender_line,
+            report_issue,
+            _dev_help_message(func.__name__),
+            "".join(traceback.format_stack(f=integration_frame.frame)),
+        )
 
     if strict:
         raise RuntimeError(
@@ -117,6 +161,7 @@ def raise_for_blocking_call(
         )
 
 
+@cache
 def _dev_help_message(what: str) -> str:
     """Generate help message to guide developers."""
     return (

--- a/tests/util/test_loop.py
+++ b/tests/util/test_loop.py
@@ -1,5 +1,7 @@
 """Tests for async util methods from Python source."""
 
+from collections.abc import Generator
+import contextlib
 import threading
 from unittest.mock import Mock, patch
 
@@ -25,7 +27,25 @@ async def test_raise_for_blocking_call_async_non_strict_core(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test non_strict_core raise_for_blocking_call detects from event loop without integration context."""
-    haloop.raise_for_blocking_call(banned_function, strict_core=False)
+    stack = [
+        Mock(
+            filename="/home/paulus/homeassistant/core.py",
+            lineno="12",
+            line="do_something()",
+        ),
+        Mock(
+            filename="/home/paulus/homeassistant/core.py",
+            lineno="12",
+            line="self.light.is_on",
+        ),
+        Mock(
+            filename="/home/paulus/aiohue/lights.py",
+            lineno="2",
+            line="something()",
+        ),
+    ]
+    with patch_get_current_frame(stack):
+        haloop.raise_for_blocking_call(banned_function, strict_core=False)
     assert "Detected blocking call to banned_function" in caplog.text
     assert "Traceback (most recent call last)" in caplog.text
     assert (
@@ -37,35 +57,37 @@ async def test_raise_for_blocking_call_async_non_strict_core(
         "https://developers.home-assistant.io/docs/asyncio_blocking_operations/#banned_function"
     ) in caplog.text
 
+    warnings = [
+        record for record in caplog.get_records("call") if record.levelname == "WARNING"
+    ]
+    assert len(warnings) == 1
+    caplog.clear()
 
-async def test_raise_for_blocking_call_async_integration(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test raise_for_blocking_call detects and raises when called from event loop from integration context."""
-    frames = extract_stack_to_frame(
-        [
-            Mock(
-                filename="/home/paulus/homeassistant/core.py",
-                lineno="23",
-                line="do_something()",
-            ),
-            Mock(
-                filename="/home/paulus/homeassistant/components/hue/light.py",
-                lineno="23",
-                line="self.light.is_on",
-            ),
-            Mock(
-                filename="/home/paulus/aiohue/lights.py",
-                lineno="2",
-                line="something()",
-            ),
-        ]
-    )
+    # Second call should log at debug
+    with patch_get_current_frame(stack):
+        haloop.raise_for_blocking_call(banned_function, strict_core=False)
+
+    warnings = [
+        record for record in caplog.get_records("call") if record.levelname == "WARNING"
+    ]
+    assert len(warnings) == 0
+    assert (
+        "For developers, please see "
+        "https://developers.home-assistant.io/docs/asyncio_blocking_operations/#banned_function"
+    ) in caplog.text
+
+    # no expensive traceback on debug
+    assert "Traceback (most recent call last)" not in caplog.text
+
+
+@contextlib.contextmanager
+def patch_get_current_frame(stack: list[Mock]) -> Generator[None, None, None]:
+    """Patch get_current_frame."""
+    frames = extract_stack_to_frame(stack)
     with (
-        pytest.raises(RuntimeError),
         patch(
             "homeassistant.helpers.frame.linecache.getline",
-            return_value="self.light.is_on",
+            return_value=stack[1].line,
         ),
         patch(
             "homeassistant.util.loop._get_line_from_cache",
@@ -80,12 +102,40 @@ async def test_raise_for_blocking_call_async_integration(
             return_value=frames,
         ),
     ):
+        yield
+
+
+async def test_raise_for_blocking_call_async_integration(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test raise_for_blocking_call detects and raises when called from event loop from integration context."""
+    stack = [
+        Mock(
+            filename="/home/paulus/homeassistant/core.py",
+            lineno="18",
+            line="do_something()",
+        ),
+        Mock(
+            filename="/home/paulus/homeassistant/components/hue/light.py",
+            lineno="18",
+            line="self.light.is_on",
+        ),
+        Mock(
+            filename="/home/paulus/aiohue/lights.py",
+            lineno="8",
+            line="something()",
+        ),
+    ]
+    with (
+        pytest.raises(RuntimeError),
+        patch_get_current_frame(stack),
+    ):
         haloop.raise_for_blocking_call(banned_function)
     assert (
         "Detected blocking call to banned_function with args None"
         " inside the event loop by integration"
-        " 'hue' at homeassistant/components/hue/light.py, line 23: self.light.is_on "
-        "(offender: /home/paulus/aiohue/lights.py, line 2: mock_line), please create "
+        " 'hue' at homeassistant/components/hue/light.py, line 18: self.light.is_on "
+        "(offender: /home/paulus/aiohue/lights.py, line 8: mock_line), please create "
         "a bug report at https://github.com/home-assistant/core/issues?"
         "q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+hue%22" in caplog.text
     )
@@ -99,55 +149,37 @@ async def test_raise_for_blocking_call_async_integration_non_strict(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test raise_for_blocking_call detects when called from event loop from integration context."""
-    frames = extract_stack_to_frame(
-        [
-            Mock(
-                filename="/home/paulus/homeassistant/core.py",
-                lineno="23",
-                line="do_something()",
-            ),
-            Mock(
-                filename="/home/paulus/homeassistant/components/hue/light.py",
-                lineno="23",
-                line="self.light.is_on",
-            ),
-            Mock(
-                filename="/home/paulus/aiohue/lights.py",
-                lineno="2",
-                line="something()",
-            ),
-        ]
-    )
-    with (
-        patch(
-            "homeassistant.helpers.frame.linecache.getline",
-            return_value="self.light.is_on",
+    stack = [
+        Mock(
+            filename="/home/paulus/homeassistant/core.py",
+            lineno="15",
+            line="do_something()",
         ),
-        patch(
-            "homeassistant.util.loop._get_line_from_cache",
-            return_value="mock_line",
+        Mock(
+            filename="/home/paulus/homeassistant/components/hue/light.py",
+            lineno="15",
+            line="self.light.is_on",
         ),
-        patch(
-            "homeassistant.util.loop.get_current_frame",
-            return_value=frames,
+        Mock(
+            filename="/home/paulus/aiohue/lights.py",
+            lineno="1",
+            line="something()",
         ),
-        patch(
-            "homeassistant.helpers.frame.get_current_frame",
-            return_value=frames,
-        ),
-    ):
+    ]
+    with patch_get_current_frame(stack):
         haloop.raise_for_blocking_call(banned_function, strict=False)
+
     assert (
         "Detected blocking call to banned_function with args None"
         " inside the event loop by integration"
-        " 'hue' at homeassistant/components/hue/light.py, line 23: self.light.is_on "
-        "(offender: /home/paulus/aiohue/lights.py, line 2: mock_line), "
+        " 'hue' at homeassistant/components/hue/light.py, line 15: self.light.is_on "
+        "(offender: /home/paulus/aiohue/lights.py, line 1: mock_line), "
         "please create a bug report at https://github.com/home-assistant/core/issues?"
         "q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+hue%22" in caplog.text
     )
     assert "Traceback (most recent call last)" in caplog.text
     assert (
-        'File "/home/paulus/homeassistant/components/hue/light.py", line 23'
+        'File "/home/paulus/homeassistant/components/hue/light.py", line 15'
         in caplog.text
     )
     assert (
@@ -158,62 +190,62 @@ async def test_raise_for_blocking_call_async_integration_non_strict(
         "For developers, please see "
         "https://developers.home-assistant.io/docs/asyncio_blocking_operations/#banned_function"
     ) in caplog.text
+    warnings = [
+        record for record in caplog.get_records("call") if record.levelname == "WARNING"
+    ]
+    assert len(warnings) == 1
+    caplog.clear()
+
+    # Second call should log at debug
+    with patch_get_current_frame(stack):
+        haloop.raise_for_blocking_call(banned_function, strict=False)
+
+    warnings = [
+        record for record in caplog.get_records("call") if record.levelname == "WARNING"
+    ]
+    assert len(warnings) == 0
+    assert (
+        "For developers, please see "
+        "https://developers.home-assistant.io/docs/asyncio_blocking_operations/#banned_function"
+    ) in caplog.text
+    # no expensive traceback on debug
+    assert "Traceback (most recent call last)" not in caplog.text
 
 
 async def test_raise_for_blocking_call_async_custom(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test raise_for_blocking_call detects when called from event loop with custom component context."""
-    frames = extract_stack_to_frame(
-        [
-            Mock(
-                filename="/home/paulus/homeassistant/core.py",
-                lineno="23",
-                line="do_something()",
-            ),
-            Mock(
-                filename="/home/paulus/config/custom_components/hue/light.py",
-                lineno="23",
-                line="self.light.is_on",
-            ),
-            Mock(
-                filename="/home/paulus/aiohue/lights.py",
-                lineno="2",
-                line="something()",
-            ),
-        ]
-    )
-    with (
-        pytest.raises(RuntimeError),
-        patch(
-            "homeassistant.helpers.frame.linecache.getline",
-            return_value="self.light.is_on",
+    stack = [
+        Mock(
+            filename="/home/paulus/homeassistant/core.py",
+            lineno="12",
+            line="do_something()",
         ),
-        patch(
-            "homeassistant.util.loop._get_line_from_cache",
-            return_value="mock_line",
+        Mock(
+            filename="/home/paulus/config/custom_components/hue/light.py",
+            lineno="12",
+            line="self.light.is_on",
         ),
-        patch(
-            "homeassistant.util.loop.get_current_frame",
-            return_value=frames,
+        Mock(
+            filename="/home/paulus/aiohue/lights.py",
+            lineno="3",
+            line="something()",
         ),
-        patch(
-            "homeassistant.helpers.frame.get_current_frame",
-            return_value=frames,
-        ),
-    ):
+    ]
+    with pytest.raises(RuntimeError), patch_get_current_frame(stack):
         haloop.raise_for_blocking_call(banned_function)
     assert (
         "Detected blocking call to banned_function with args None"
         " inside the event loop by custom "
-        "integration 'hue' at custom_components/hue/light.py, line 23: self.light.is_on"
-        " (offender: /home/paulus/aiohue/lights.py, line 2: mock_line), "
+        "integration 'hue' at custom_components/hue/light.py, line 12: self.light.is_on"
+        " (offender: /home/paulus/aiohue/lights.py, line 3: mock_line), "
         "please create a bug report at https://github.com/home-assistant/core/issues?"
         "q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+hue%22"
     ) in caplog.text
     assert "Traceback (most recent call last)" in caplog.text
     assert (
-        'File "/home/paulus/config/custom_components/hue/light.py", line 23'
+        'File "/home/paulus/config/custom_components/hue/light.py", line 12'
         in caplog.text
     )
     assert (


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Downgrade logging previously reported asyncio blocking to debug. 

The traceback is also omitted once its already been reported since they are expensive and create a performance issue when hitting over and over.

Some users have older custom integrations that will never get fixed and will have pages and pages of reported blocking I/O in the log.  While its sad to see these integrations may never be fixed and the user's experience with HA will always be subpar as long as they choose to keep running these legacy custom components, at least we can solve the performance problem from generating all the tracebacks.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
