### PR TITLE
Use fixtures in deCONZ logbook tests

### DIFF
--- a/tests/components/deconz/test_logbook.py
+++ b/tests/components/deconz/test_logbook.py
@@ -1,6 +1,8 @@
 """The tests for deCONZ logbook."""
 
-from unittest.mock import patch
+from typing import Any
+
+import pytest
 
 from homeassistant.components.deconz.const import CONF_GESTURE, DOMAIN as DECONZ_DOMAIN
 from homeassistant.components.deconz.deconz_event import (
@@ -21,20 +23,13 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 from homeassistant.util import slugify
 
-from .test_gateway import DECONZ_WEB_REQUEST, setup_deconz_integration
-
 from tests.components.logbook.common import MockRow, mock_humanify
-from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_humanifying_deconz_alarm_event(
-    hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
-    device_registry: dr.DeviceRegistry,
-) -> None:
-    """Test humanifying deCONZ event."""
-    data = {
-        "sensors": {
+@pytest.mark.parametrize(
+    "sensor_payload",
+    [
+        {
             "1": {
                 "config": {
                     "armed": "disarmed",
@@ -60,12 +55,17 @@ async def test_humanifying_deconz_alarm_event(
                 "uniqueid": "00:0d:6f:00:13:4f:61:39-01-0501",
             }
         }
-    }
-    with patch.dict(DECONZ_WEB_REQUEST, data):
-        await setup_deconz_integration(hass, aioclient_mock)
-
-    keypad_event_id = slugify(data["sensors"]["1"]["name"])
-    keypad_serial = serial_from_unique_id(data["sensors"]["1"]["uniqueid"])
+    ],
+)
+@pytest.mark.usefixtures("config_entry_setup")
+async def test_humanifying_deconz_alarm_event(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    sensor_payload: dict[str, Any],
+) -> None:
+    """Test humanifying deCONZ alarm event."""
+    keypad_event_id = slugify(sensor_payload["1"]["name"])
+    keypad_serial = serial_from_unique_id(sensor_payload["1"]["uniqueid"])
     keypad_entry = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, keypad_serial)}
     )
@@ -113,14 +113,10 @@ async def test_humanifying_deconz_alarm_event(
     assert events[1]["message"] == "fired event 'armed_away'"
 
 
-async def test_humanifying_deconz_event(
-    hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
-    device_registry: dr.DeviceRegistry,
-) -> None:
-    """Test humanifying deCONZ event."""
-    data = {
-        "sensors": {
+@pytest.mark.parametrize(
+    "sensor_payload",
+    [
+        {
             "1": {
                 "name": "Switch 1",
                 "type": "ZHASwitch",
@@ -152,30 +148,35 @@ async def test_humanifying_deconz_event(
                 "uniqueid": "00:00:00:00:00:00:00:04-00",
             },
         }
-    }
-    with patch.dict(DECONZ_WEB_REQUEST, data):
-        await setup_deconz_integration(hass, aioclient_mock)
-
-    switch_event_id = slugify(data["sensors"]["1"]["name"])
-    switch_serial = serial_from_unique_id(data["sensors"]["1"]["uniqueid"])
+    ],
+)
+@pytest.mark.usefixtures("config_entry_setup")
+async def test_humanifying_deconz_event(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    sensor_payload: dict[str, Any],
+) -> None:
+    """Test humanifying deCONZ event."""
+    switch_event_id = slugify(sensor_payload["1"]["name"])
+    switch_serial = serial_from_unique_id(sensor_payload["1"]["uniqueid"])
     switch_entry = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, switch_serial)}
     )
 
-    hue_remote_event_id = slugify(data["sensors"]["2"]["name"])
-    hue_remote_serial = serial_from_unique_id(data["sensors"]["2"]["uniqueid"])
+    hue_remote_event_id = slugify(sensor_payload["2"]["name"])
+    hue_remote_serial = serial_from_unique_id(sensor_payload["2"]["uniqueid"])
     hue_remote_entry = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, hue_remote_serial)}
     )
 
-    xiaomi_cube_event_id = slugify(data["sensors"]["3"]["name"])
-    xiaomi_cube_serial = serial_from_unique_id(data["sensors"]["3"]["uniqueid"])
+    xiaomi_cube_event_id = slugify(sensor_payload["3"]["name"])
+    xiaomi_cube_serial = serial_from_unique_id(sensor_payload["3"]["uniqueid"])
     xiaomi_cube_entry = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, xiaomi_cube_serial)}
     )
 
-    faulty_event_id = slugify(data["sensors"]["4"]["name"])
-    faulty_serial = serial_from_unique_id(data["sensors"]["4"]["uniqueid"])
+    faulty_event_id = slugify(sensor_payload["4"]["name"])
+    faulty_serial = serial_from_unique_id(sensor_payload["4"]["uniqueid"])
     faulty_entry = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, faulty_serial)}
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

Related to https://github.com/home-assistant/core/pull/120863, https://github.com/home-assistant/core/pull/120936, https://github.com/home-assistant/core/pull/120938, https://github.com/home-assistant/core/pull/120943, https://github.com/home-assistant/core/pull/120944

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
