### PR TITLE
Use fixtures in deCONZ fan tests

### DIFF
--- a/tests/components/deconz/test_fan.py
+++ b/tests/components/deconz/test_fan.py
@@ -1,9 +1,8 @@
 """deCONZ fan platform tests."""
 
-from unittest.mock import patch
+from collections.abc import Callable
 
 import pytest
-from voluptuous.error import MultipleInvalid
 
 from homeassistant.components.fan import (
     ATTR_PERCENTAGE,
@@ -12,14 +11,11 @@ from homeassistant.components.fan import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 
-from .test_gateway import (
-    DECONZ_WEB_REQUEST,
-    mock_deconz_put_request,
-    setup_deconz_integration,
-)
+from .test_gateway import setup_deconz_integration
 
 from tests.test_util.aiohttp import AiohttpClientMocker
 
@@ -32,12 +28,10 @@ async def test_no_fans(
     assert len(hass.states.async_all()) == 0
 
 
-async def test_fans(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
-) -> None:
-    """Test that all supported fan entities are created."""
-    data = {
-        "lights": {
+@pytest.mark.parametrize(
+    "light_payload",
+    [
+        {
             "1": {
                 "etag": "432f3de28965052961a99e3c5494daf4",
                 "hascolor": False,
@@ -56,11 +50,16 @@ async def test_fans(
                 "uniqueid": "00:22:a3:00:00:27:8b:81-01",
             }
         }
-    }
-
-    with patch.dict(DECONZ_WEB_REQUEST, data):
-        config_entry = await setup_deconz_integration(hass, aioclient_mock)
-
+    ],
+)
+async def test_fans(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    config_entry_setup: ConfigEntry,
+    mock_put_request: Callable[[str, str], AiohttpClientMocker],
+    mock_deconz_websocket,
+) -> None:
+    """Test that all supported fan entities are created."""
     assert len(hass.states.async_all()) == 2  # Light and fan
     assert hass.states.get("fan.ceiling_fan").state == STATE_ON
     assert hass.states.get("fan.ceiling_fan").attributes[ATTR_PERCENTAGE] == 100
@@ -134,7 +133,7 @@ async def test_fans(
 
     # Test service calls
 
-    mock_deconz_put_request(aioclient_mock, config_entry.data, "/lights/1/state")
+    aioclient_mock = mock_put_request("/lights/1/state")
 
     # Service turn on fan using saved default_on_speed
 
@@ -231,258 +230,13 @@ async def test_fans(
     assert hass.states.get("fan.ceiling_fan").state == STATE_ON
     assert not hass.states.get("fan.ceiling_fan").attributes[ATTR_PERCENTAGE]
 
-    await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.config_entries.async_unload(config_entry_setup.entry_id)
 
     states = hass.states.async_all()
     assert len(states) == 2
     for state in states:
         assert state.state == STATE_UNAVAILABLE
 
-    await hass.config_entries.async_remove(config_entry.entry_id)
-    await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 0
-
-
-async def test_fans_legacy_speed_modes(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
-) -> None:
-    """Test that all supported fan entities are created.
-
-    Legacy fan support.
-    """
-    data = {
-        "lights": {
-            "1": {
-                "etag": "432f3de28965052961a99e3c5494daf4",
-                "hascolor": False,
-                "manufacturername": "King Of Fans,  Inc.",
-                "modelid": "HDC52EastwindFan",
-                "name": "Ceiling fan",
-                "state": {
-                    "alert": "none",
-                    "bri": 254,
-                    "on": False,
-                    "reachable": True,
-                    "speed": 4,
-                },
-                "swversion": "0000000F",
-                "type": "Fan",
-                "uniqueid": "00:22:a3:00:00:27:8b:81-01",
-            }
-        }
-    }
-
-    with patch.dict(DECONZ_WEB_REQUEST, data):
-        config_entry = await setup_deconz_integration(hass, aioclient_mock)
-
-    assert len(hass.states.async_all()) == 2  # Light and fan
-    assert hass.states.get("fan.ceiling_fan").state == STATE_ON
-
-    # Test states
-
-    event_changed_light = {
-        "t": "event",
-        "e": "changed",
-        "r": "lights",
-        "id": "1",
-        "state": {"speed": 1},
-    }
-    await mock_deconz_websocket(data=event_changed_light)
-    await hass.async_block_till_done()
-
-    assert hass.states.get("fan.ceiling_fan").state == STATE_ON
-    assert hass.states.get("fan.ceiling_fan").attributes[ATTR_PERCENTAGE] == 25
-
-    event_changed_light = {
-        "t": "event",
-        "e": "changed",
-        "r": "lights",
-        "id": "1",
-        "state": {"speed": 2},
-    }
-    await mock_deconz_websocket(data=event_changed_light)
-    await hass.async_block_till_done()
-
-    assert hass.states.get("fan.ceiling_fan").state == STATE_ON
-    assert hass.states.get("fan.ceiling_fan").attributes[ATTR_PERCENTAGE] == 50
-
-    event_changed_light = {
-        "t": "event",
-        "e": "changed",
-        "r": "lights",
-        "id": "1",
-        "state": {"speed": 3},
-    }
-    await mock_deconz_websocket(data=event_changed_light)
-    await hass.async_block_till_done()
-
-    assert hass.states.get("fan.ceiling_fan").state == STATE_ON
-    assert hass.states.get("fan.ceiling_fan").attributes[ATTR_PERCENTAGE] == 75
-
-    event_changed_light = {
-        "t": "event",
-        "e": "changed",
-        "r": "lights",
-        "id": "1",
-        "state": {"speed": 4},
-    }
-    await mock_deconz_websocket(data=event_changed_light)
-    await hass.async_block_till_done()
-
-    assert hass.states.get("fan.ceiling_fan").state == STATE_ON
-    assert hass.states.get("fan.ceiling_fan").attributes[ATTR_PERCENTAGE] == 100
-
-    event_changed_light = {
-        "t": "event",
-        "e": "changed",
-        "r": "lights",
-        "id": "1",
-        "state": {"speed": 0},
-    }
-    await mock_deconz_websocket(data=event_changed_light)
-    await hass.async_block_till_done()
-
-    assert hass.states.get("fan.ceiling_fan").state == STATE_OFF
-    assert hass.states.get("fan.ceiling_fan").attributes[ATTR_PERCENTAGE] == 0
-
-    # Test service calls
-
-    mock_deconz_put_request(aioclient_mock, config_entry.data, "/lights/1/state")
-
-    # Service turn on fan using saved default_on_speed
-
-    await hass.services.async_call(
-        FAN_DOMAIN,
-        SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "fan.ceiling_fan"},
-        blocking=True,
-    )
-    assert aioclient_mock.mock_calls[1][2] == {"speed": 4}
-
-    # Service turn on fan with speed_off
-    # async_turn_on_compat use speed_to_percentage which will return 0
-
-    await hass.services.async_call(
-        FAN_DOMAIN,
-        SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "fan.ceiling_fan", ATTR_PERCENTAGE: 0},
-        blocking=True,
-    )
-    assert aioclient_mock.mock_calls[2][2] == {"speed": 0}
-
-    # Service turn on fan with bad speed
-    # async_turn_on_compat use speed_to_percentage which will convert to SPEED_MEDIUM -> 2
-
-    with pytest.raises(MultipleInvalid):
-        await hass.services.async_call(
-            FAN_DOMAIN,
-            SERVICE_TURN_ON,
-            {ATTR_ENTITY_ID: "fan.ceiling_fan", ATTR_PERCENTAGE: "bad"},
-            blocking=True,
-        )
-
-    # Service turn on fan to low speed
-
-    await hass.services.async_call(
-        FAN_DOMAIN,
-        SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "fan.ceiling_fan", ATTR_PERCENTAGE: 25},
-        blocking=True,
-    )
-    assert aioclient_mock.mock_calls[3][2] == {"speed": 1}
-
-    # Service turn on fan to medium speed
-
-    await hass.services.async_call(
-        FAN_DOMAIN,
-        SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "fan.ceiling_fan", ATTR_PERCENTAGE: 50},
-        blocking=True,
-    )
-    assert aioclient_mock.mock_calls[4][2] == {"speed": 2}
-
-    # Service turn on fan to high speed
-
-    await hass.services.async_call(
-        FAN_DOMAIN,
-        SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "fan.ceiling_fan", ATTR_PERCENTAGE: 100},
-        blocking=True,
-    )
-    assert aioclient_mock.mock_calls[5][2] == {"speed": 4}
-
-    # Service set fan speed to low
-
-    await hass.services.async_call(
-        FAN_DOMAIN,
-        SERVICE_SET_PERCENTAGE,
-        {ATTR_ENTITY_ID: "fan.ceiling_fan", ATTR_PERCENTAGE: 25},
-        blocking=True,
-    )
-    assert aioclient_mock.mock_calls[6][2] == {"speed": 1}
-
-    # Service set fan speed to medium
-
-    await hass.services.async_call(
-        FAN_DOMAIN,
-        SERVICE_SET_PERCENTAGE,
-        {ATTR_ENTITY_ID: "fan.ceiling_fan", ATTR_PERCENTAGE: 50},
-        blocking=True,
-    )
-    assert aioclient_mock.mock_calls[7][2] == {"speed": 2}
-
-    # Service set fan speed to high
-
-    await hass.services.async_call(
-        FAN_DOMAIN,
-        SERVICE_SET_PERCENTAGE,
-        {ATTR_ENTITY_ID: "fan.ceiling_fan", ATTR_PERCENTAGE: 100},
-        blocking=True,
-    )
-    assert aioclient_mock.mock_calls[8][2] == {"speed": 4}
-
-    # Service set fan speed to off
-
-    await hass.services.async_call(
-        FAN_DOMAIN,
-        SERVICE_SET_PERCENTAGE,
-        {ATTR_ENTITY_ID: "fan.ceiling_fan", ATTR_PERCENTAGE: 0},
-        blocking=True,
-    )
-    assert aioclient_mock.mock_calls[9][2] == {"speed": 0}
-
-    # Service set fan speed to unsupported value
-
-    with pytest.raises(MultipleInvalid):
-        await hass.services.async_call(
-            FAN_DOMAIN,
-            SERVICE_SET_PERCENTAGE,
-            {ATTR_ENTITY_ID: "fan.ceiling_fan", ATTR_PERCENTAGE: "bad value"},
-            blocking=True,
-        )
-
-    # Events with an unsupported speed gets converted to default speed "medium"
-
-    event_changed_light = {
-        "t": "event",
-        "e": "changed",
-        "r": "lights",
-        "id": "1",
-        "state": {"speed": 3},
-    }
-    await mock_deconz_websocket(data=event_changed_light)
-    await hass.async_block_till_done()
-
-    assert hass.states.get("fan.ceiling_fan").state == STATE_ON
-    assert hass.states.get("fan.ceiling_fan").attributes[ATTR_PERCENTAGE] == 75
-
-    await hass.config_entries.async_unload(config_entry.entry_id)
-
-    states = hass.states.async_all()
-    assert len(states) == 2
-    for state in states:
-        assert state.state == STATE_UNAVAILABLE
-
-    await hass.config_entries.async_remove(config_entry.entry_id)
+    await hass.config_entries.async_remove(config_entry_setup.entry_id)
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

Related to https://github.com/home-assistant/core/pull/120863, https://github.com/home-assistant/core/pull/120936, https://github.com/home-assistant/core/pull/120938, https://github.com/home-assistant/core/pull/120943, https://github.com/home-assistant/core/pull/120944, https://github.com/home-assistant/core/pull/120947, https://github.com/home-assistant/core/pull/120948

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
