### PR TITLE
Use fixtures in deCONZ cover tests

### DIFF
--- a/tests/components/deconz/test_cover.py
+++ b/tests/components/deconz/test_cover.py
@@ -1,6 +1,8 @@
 """deCONZ cover platform tests."""
 
-from unittest.mock import patch
+from collections.abc import Callable
+
+import pytest
 
 from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
@@ -17,6 +19,7 @@ from homeassistant.components.cover import (
     SERVICE_STOP_COVER,
     SERVICE_STOP_COVER_TILT,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     STATE_CLOSED,
@@ -25,29 +28,13 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from .test_gateway import (
-    DECONZ_WEB_REQUEST,
-    mock_deconz_put_request,
-    setup_deconz_integration,
-)
-
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_no_covers(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
-) -> None:
-    """Test that no cover entities are created."""
-    await setup_deconz_integration(hass, aioclient_mock)
-    assert len(hass.states.async_all()) == 0
-
-
-async def test_cover(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
-) -> None:
-    """Test that all supported cover entities are created."""
-    data = {
-        "lights": {
+@pytest.mark.parametrize(
+    "light_payload",
+    [
+        {
             "1": {
                 "name": "Window covering device",
                 "type": "Window covering device",
@@ -62,10 +49,15 @@ async def test_cover(
                 "uniqueid": "00:00:00:00:00:00:00:02-00",
             },
         }
-    }
-    with patch.dict(DECONZ_WEB_REQUEST, data):
-        config_entry = await setup_deconz_integration(hass, aioclient_mock)
-
+    ],
+)
+async def test_cover(
+    hass: HomeAssistant,
+    config_entry_setup: ConfigEntry,
+    mock_put_request: Callable[[str, str], AiohttpClientMocker],
+    mock_deconz_websocket,
+) -> None:
+    """Test that all supported cover entities are created."""
     assert len(hass.states.async_all()) == 2
     cover = hass.states.get("cover.window_covering_device")
     assert cover.state == STATE_CLOSED
@@ -90,7 +82,7 @@ async def test_cover(
 
     # Verify service calls for cover
 
-    mock_deconz_put_request(aioclient_mock, config_entry.data, "/lights/1/state")
+    aioclient_mock = mock_put_request("/lights/1/state")
 
     # Service open cover
 
@@ -132,24 +124,22 @@ async def test_cover(
     )
     assert aioclient_mock.mock_calls[4][2] == {"stop": True}
 
-    await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.config_entries.async_unload(config_entry_setup.entry_id)
 
     states = hass.states.async_all()
     assert len(states) == 2
     for state in states:
         assert state.state == STATE_UNAVAILABLE
 
-    await hass.config_entries.async_remove(config_entry.entry_id)
+    await hass.config_entries.async_remove(config_entry_setup.entry_id)
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 0
 
 
-async def test_tilt_cover(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
-) -> None:
-    """Test that tilting a cover works."""
-    data = {
-        "lights": {
+@pytest.mark.parametrize(
+    "light_payload",
+    [
+        {
             "0": {
                 "etag": "87269755b9b3a046485fdae8d96b252c",
                 "lastannounced": None,
@@ -170,10 +160,13 @@ async def test_tilt_cover(
                 "uniqueid": "00:24:46:00:00:12:34:56-01",
             }
         }
-    }
-    with patch.dict(DECONZ_WEB_REQUEST, data):
-        config_entry = await setup_deconz_integration(hass, aioclient_mock)
-
+    ],
+)
+@pytest.mark.usefixtures("config_entry_setup")
+async def test_tilt_cover(
+    hass: HomeAssistant, mock_put_request: Callable[[str, str], AiohttpClientMocker]
+) -> None:
+    """Test that tilting a cover works."""
     assert len(hass.states.async_all()) == 1
     covering_device = hass.states.get("cover.covering_device")
     assert covering_device.state == STATE_OPEN
@@ -181,7 +174,7 @@ async def test_tilt_cover(
 
     # Verify service calls for tilting cover
 
-    mock_deconz_put_request(aioclient_mock, config_entry.data, "/lights/0/state")
+    aioclient_mock = mock_put_request("/lights/0/state")
 
     # Service set tilt cover
 
@@ -224,12 +217,10 @@ async def test_tilt_cover(
     assert aioclient_mock.mock_calls[4][2] == {"stop": True}
 
 
-async def test_level_controllable_output_cover(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
-) -> None:
-    """Test that tilting a cover works."""
-    data = {
-        "lights": {
+@pytest.mark.parametrize(
+    "light_payload",
+    [
+        {
             "0": {
                 "etag": "4cefc909134c8e99086b55273c2bde67",
                 "hascolor": False,
@@ -250,10 +241,13 @@ async def test_level_controllable_output_cover(
                 "uniqueid": "00:22:a3:00:00:00:00:00-01",
             }
         }
-    }
-    with patch.dict(DECONZ_WEB_REQUEST, data):
-        config_entry = await setup_deconz_integration(hass, aioclient_mock)
-
+    ],
+)
+@pytest.mark.usefixtures("config_entry_setup")
+async def test_level_controllable_output_cover(
+    hass: HomeAssistant, mock_put_request: Callable[[str, str], AiohttpClientMocker]
+) -> None:
+    """Test that tilting a cover works."""
     assert len(hass.states.async_all()) == 1
     covering_device = hass.states.get("cover.vent")
     assert covering_device.state == STATE_OPEN
@@ -261,7 +255,7 @@ async def test_level_controllable_output_cover(
 
     # Verify service calls for tilting cover
 
-    mock_deconz_put_request(aioclient_mock, config_entry.data, "/lights/0/state")
+    aioclient_mock = mock_put_request("/lights/0/state")
 
     # Service open cover
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

Related to https://github.com/home-assistant/core/pull/120863, https://github.com/home-assistant/core/pull/120936, https://github.com/home-assistant/core/pull/120938, https://github.com/home-assistant/core/pull/120943, https://github.com/home-assistant/core/pull/120944, https://github.com/home-assistant/core/pull/120947, https://github.com/home-assistant/core/pull/120948, https://github.com/home-assistant/core/pull/120953

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
