### PR TITLE
Use fixtures in deCONZ button tests

### DIFF
--- a/tests/components/deconz/conftest.py
+++ b/tests/components/deconz/conftest.py
@@ -85,6 +85,11 @@ def fixture_put_request(
 def fixture_get_request(
     aioclient_mock: AiohttpClientMocker,
     config_entry_data: MappingProxyType[str, Any],
+    config_payload: dict[str, Any],
+    alarm_system_payload: dict[str, Any],
+    group_payload: dict[str, Any],
+    light_payload: dict[str, Any],
+    sensor_payload: dict[str, Any],
     deconz_payload: dict[str, Any],
 ) -> Callable[[str], None]:
     """Mock default deCONZ requests responses."""
@@ -92,10 +97,21 @@ def fixture_get_request(
     _port = config_entry_data[CONF_PORT]
     _api_key = config_entry_data[CONF_API_KEY]
 
+    data = deconz_payload
+    data.setdefault("alarmsystems", alarm_system_payload)
+    data.setdefault("config", config_payload)
+    data.setdefault("groups", group_payload)
+    data.setdefault("lights", light_payload)
+    data.setdefault("sensors", sensor_payload)
+
     def __mock_requests(host: str = "") -> None:
         url = f"http://{host or _host}:{_port}/api/{_api_key}"
         aioclient_mock.get(
-            url, json=deconz_payload, headers={"content-type": CONTENT_TYPE_JSON}
+            url,
+            json=deconz_payload | {"config": config_payload},
+            headers={
+                "content-type": CONTENT_TYPE_JSON,
+            },
         )
 
     return __mock_requests
@@ -105,21 +121,9 @@ def fixture_get_request(
 
 
 @pytest.fixture(name="deconz_payload")
-def fixture_data(
-    alarm_system_payload: dict[str, Any],
-    config_payload: dict[str, Any],
-    group_payload: dict[str, Any],
-    light_payload: dict[str, Any],
-    sensor_payload: dict[str, Any],
-) -> dict[str, Any]:
-    """DeCONZ data."""
-    return {
-        "alarmsystems": alarm_system_payload,
-        "config": config_payload,
-        "groups": group_payload,
-        "lights": light_payload,
-        "sensors": sensor_payload,
-    }
+def fixture_data() -> dict[str, Any]:
+    """Combine multiple payloads with one fixture."""
+    return {}
 
 
 @pytest.fixture(name="alarm_system_payload")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

Related to https://github.com/home-assistant/core/pull/120863, https://github.com/home-assistant/core/pull/120936, https://github.com/home-assistant/core/pull/120938, https://github.com/home-assistant/core/pull/120943, https://github.com/home-assistant/core/pull/120944, https://github.com/home-assistant/core/pull/120947, https://github.com/home-assistant/core/pull/120948, https://github.com/home-assistant/core/pull/120953, https://github.com/home-assistant/core/pull/120954

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
