### PR TITLE
Bump reolink-aio to 0.9.4

### DIFF
--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -18,5 +18,5 @@
   "documentation": "https://www.home-assistant.io/integrations/reolink",
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
-  "requirements": ["reolink-aio==0.9.3"]
+  "requirements": ["reolink-aio==0.9.4"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2460,7 +2460,7 @@ renault-api==0.2.4
 renson-endura-delta==1.7.1
 
 # homeassistant.components.reolink
-reolink-aio==0.9.3
+reolink-aio==0.9.4
 
 # homeassistant.components.idteck_prox
 rfk101py==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1924,7 +1924,7 @@ renault-api==0.2.4
 renson-endura-delta==1.7.1
 
 # homeassistant.components.reolink
-reolink-aio==0.9.3
+reolink-aio==0.9.4
 
 # homeassistant.components.rflink
 rflink==0.0.66


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This fixes a fairly serious issue introduced in the reolink integration in HA 2024.7.0.b0:
For a NVR that does not provide UIDs of the connected camera's the UID of channel 0 would be set to "Unknown" as is expected.
However for channels 1,2,3.. it would be wrongfully set to "Unknown_1", "Unknown_2", "Unknown_3".......
This would cause the integration to think those cams have a UID and the unique_ids of those camera's would wrongfully be migrated to use the "UID", "Unknown_1" in the unique_id. That will cause a mess in the integration.

Bump reolink-aio to 0.9.4:
**Additions:**
- [Add camera_online method](https://github.com/starkillerOG/reolink_aio/commit/58f8ae0b63c10f7622d6882b92f306891f49eab7)

**Bug fixes:**
- [Fix camera_uid for NVRs that do not have a UID](https://github.com/starkillerOG/reolink_aio/commit/89865e26ae3799da36b9f751632141ff84013b8d)
- [prevent errors when "name" not present in GetPtzPatrol](https://github.com/starkillerOG/reolink_aio/commit/7067868053dc7df704be22a7cdc3cfe2e5f9343d)

**Optimizations:**
- [Minimum firmware for Reolink Home Hub](https://github.com/starkillerOG/reolink_aio/commit/d9f7dabd504dfad8e9d00162c1e4f37ada081f2e)
- [Minimum firmware for Argus Eco Ultra, Argus Track and Reolink Doorbell Battery](https://github.com/starkillerOG/reolink_aio/commit/cd9fed73c26121797e674757d5dcd4af7932726b)
- [Base SpotlightModeEnum.auto support on supportFLIntelligent](https://github.com/starkillerOG/reolink_aio/commit/e9829ea28d266ff13995b3d9eb33c1779f55331f)
- [Recognize "Login has been locked" as a credential issue](https://github.com/starkillerOG/reolink_aio/commit/85a1e4fe9aea1b63ee569d7fe1681b74b1fd624a)
- [improve Login/Credential Error message](https://github.com/starkillerOG/reolink_aio/commit/db2b7ea501cd5a6c245de43adba9ca28fbfa4b94)

**Full Changelog**: https://github.com/starkillerOG/reolink_aio/compare/0.9.3...0.9.4

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: https://github.com/home-assistant/core/issues/120961
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
