### PR TITLE
Use fixtures in deCONZ alarm control panel tests

### DIFF
--- a/tests/components/deconz/test_alarm_control_panel.py
+++ b/tests/components/deconz/test_alarm_control_panel.py
@@ -1,12 +1,14 @@
 """deCONZ alarm control panel platform tests."""
 
-from unittest.mock import patch
+from collections.abc import Callable
 
 from pydeconz.models.sensor.ancillary_control import AncillaryControlPanel
+import pytest
 
 from homeassistant.components.alarm_control_panel import (
     DOMAIN as ALARM_CONTROL_PANEL_DOMAIN,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_CODE,
     ATTR_ENTITY_ID,
@@ -26,29 +28,13 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from .test_gateway import (
-    DECONZ_WEB_REQUEST,
-    mock_deconz_put_request,
-    setup_deconz_integration,
-)
-
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_no_sensors(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
-) -> None:
-    """Test that no sensors in deconz results in no climate entities."""
-    await setup_deconz_integration(hass, aioclient_mock)
-    assert len(hass.states.async_all()) == 0
-
-
-async def test_alarm_control_panel(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
-) -> None:
-    """Test successful creation of alarm control panel entities."""
-    data = {
-        "alarmsystems": {
+@pytest.mark.parametrize(
+    "alarm_system_payload",
+    [
+        {
             "0": {
                 "name": "default",
                 "config": {
@@ -75,8 +61,13 @@ async def test_alarm_control_panel(
                     },
                 },
             }
-        },
-        "sensors": {
+        }
+    ],
+)
+@pytest.mark.parametrize(
+    "sensor_payload",
+    [
+        {
             "0": {
                 "config": {
                     "battery": 95,
@@ -103,11 +94,17 @@ async def test_alarm_control_panel(
                 "type": "ZHAAncillaryControl",
                 "uniqueid": "00:00:00:00:00:00:00:00-00",
             }
-        },
-    }
-    with patch.dict(DECONZ_WEB_REQUEST, data):
-        config_entry = await setup_deconz_integration(hass, aioclient_mock)
-
+        }
+    ],
+)
+async def test_alarm_control_panel(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    config_entry_setup: ConfigEntry,
+    mock_put_request: Callable[[str, str], AiohttpClientMocker],
+    mock_deconz_websocket,
+) -> None:
+    """Test successful creation of alarm control panel entities."""
     assert len(hass.states.async_all()) == 4
     assert hass.states.get("alarm_control_panel.keypad").state == STATE_UNKNOWN
 
@@ -240,9 +237,7 @@ async def test_alarm_control_panel(
 
     # Service set alarm to away mode
 
-    mock_deconz_put_request(
-        aioclient_mock, config_entry.data, "/alarmsystems/0/arm_away"
-    )
+    aioclient_mock = mock_put_request("/alarmsystems/0/arm_away")
 
     await hass.services.async_call(
         ALARM_CONTROL_PANEL_DOMAIN,
@@ -254,9 +249,7 @@ async def test_alarm_control_panel(
 
     # Service set alarm to home mode
 
-    mock_deconz_put_request(
-        aioclient_mock, config_entry.data, "/alarmsystems/0/arm_stay"
-    )
+    aioclient_mock = mock_put_request("/alarmsystems/0/arm_stay")
 
     await hass.services.async_call(
         ALARM_CONTROL_PANEL_DOMAIN,
@@ -268,9 +261,7 @@ async def test_alarm_control_panel(
 
     # Service set alarm to night mode
 
-    mock_deconz_put_request(
-        aioclient_mock, config_entry.data, "/alarmsystems/0/arm_night"
-    )
+    aioclient_mock = mock_put_request("/alarmsystems/0/arm_night")
 
     await hass.services.async_call(
         ALARM_CONTROL_PANEL_DOMAIN,
@@ -282,7 +273,7 @@ async def test_alarm_control_panel(
 
     # Service set alarm to disarmed
 
-    mock_deconz_put_request(aioclient_mock, config_entry.data, "/alarmsystems/0/disarm")
+    aioclient_mock = mock_put_request("/alarmsystems/0/disarm")
 
     await hass.services.async_call(
         ALARM_CONTROL_PANEL_DOMAIN,
@@ -292,13 +283,13 @@ async def test_alarm_control_panel(
     )
     assert aioclient_mock.mock_calls[4][2] == {"code0": "4567"}
 
-    await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.config_entries.async_unload(config_entry_setup.entry_id)
 
     states = hass.states.async_all()
     assert len(states) == 4
     for state in states:
         assert state.state == STATE_UNAVAILABLE
 
-    await hass.config_entries.async_remove(config_entry.entry_id)
+    await hass.config_entries.async_remove(config_entry_setup.entry_id)
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

Related to https://github.com/home-assistant/core/pull/120863, https://github.com/home-assistant/core/pull/120936, https://github.com/home-assistant/core/pull/120938, https://github.com/home-assistant/core/pull/120943, https://github.com/home-assistant/core/pull/120944, https://github.com/home-assistant/core/pull/120947, https://github.com/home-assistant/core/pull/120948, https://github.com/home-assistant/core/pull/120953, https://github.com/home-assistant/core/pull/120954, https://github.com/home-assistant/core/pull/120966

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
