### PR TITLE
Allow video stream preview in generic camera config flow

### DIFF
--- a/homeassistant/components/generic/strings.json
+++ b/homeassistant/components/generic/strings.json
@@ -38,10 +38,17 @@
         }
       },
       "user_confirm_still": {
-        "title": "Preview",
+        "title": "Image Preview",
         "description": "![Camera Still Image Preview]({preview_url})",
         "data": {
           "confirmed_ok": "This image looks good."
+        }
+      },
+      "user_confirm_stream": {
+        "title": "Stream Preview",
+        "description": "Please wait a few seconds for the stream to load\b{video_html}",
+        "data": {
+          "confirmed_ok": "This stream looks good"
         }
       }
     }

--- a/tests/components/generic/conftest.py
+++ b/tests/components/generic/conftest.py
@@ -13,8 +13,8 @@ from homeassistant import config_entries
 from homeassistant.components.generic.const import DOMAIN
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.core import HomeAssistant
-
 from homeassistant.setup import async_setup_component
+
 from tests.common import MockConfigEntry
 
 
@@ -64,7 +64,7 @@ def fakeimg_gif(fakeimgbytes_gif: bytes) -> None:
 
 
 @pytest.fixture
-async def mock_create_stream(hass:HomeAssistant) -> _patch[MagicMock]:
+async def mock_create_stream(hass: HomeAssistant) -> _patch[MagicMock]:
     """Mock create stream."""
     assert await async_setup_component(hass, "stream", {})
     assert "stream" in hass.config.components

--- a/tests/components/generic/conftest.py
+++ b/tests/components/generic/conftest.py
@@ -14,6 +14,7 @@ from homeassistant.components.generic.const import DOMAIN
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.core import HomeAssistant
 
+from homeassistant.setup import async_setup_component
 from tests.common import MockConfigEntry
 
 
@@ -62,9 +63,12 @@ def fakeimg_gif(fakeimgbytes_gif: bytes) -> None:
     respx.get("http://127.0.0.1/testurl/1").respond(stream=fakeimgbytes_gif)
 
 
-@pytest.fixture(scope="package")
-def mock_create_stream() -> _patch[MagicMock]:
+@pytest.fixture
+async def mock_create_stream(hass:HomeAssistant) -> _patch[MagicMock]:
     """Mock create stream."""
+    assert await async_setup_component(hass, "stream", {})
+    assert "stream" in hass.config.components
+
     mock_stream = Mock()
     mock_provider = Mock()
     mock_provider.part_recv = AsyncMock()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add preview of video stream during config flow to allow user to verify stream settings when configuring.
![stream_preview](https://github.com/home-assistant/core/assets/17680170/bf0fb2cf-159f-4dc8-9bea-d9e215d80d6b)

The generic camera config flow was updated some time ago to show a preview of the still image before the config flow was complete, the aim was to help users get username/passwords correct without having to add a camera, then delete it if it didn't work. But so far that was only implemented on still images. 

The real problem and most of the remaining questions that still occur on the forums are from users trying to set up cameras, and confusing rtsp settings, passwords, or simply not knowing how to find a valid stream URL for their camera.

This feature has been a goal of mine for some time but finally got round to it last weekend!

Attention points for reviewer (feedback wanted):
- The aim is to set up a camera stream during one of the config flow steps without actually adding it to the hass object. This is done by creating the GenericCamera object, then immediately creating a stream URL for it. But I'm not sure if this is an ok thing to do... 
  - We could possibly be left with a left over stream at the end (I can't see a big problem with this - it should disappear on restart), 
  - I'm not fully sure of the consequences of creating a Camera but not adding it to the hass object properly.

_Note that the above only concerns the stream preview. The final configured camera is unchanged by this PR._

I've tested it manually and added pytests.

A [related frontend PR](https://github.com/home-assistant/frontend/pull/21246) was needed to enable `<ha-hls-player>` to be shown during the config flow.

Once this is merged, I'll do a separate PR to add the same functionality to the options flow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/frontend/pull/21246
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
