### PR TITLE
Add entity matching to intent_script

### DIFF
--- a/homeassistant/components/intent_script/__init__.py
+++ b/homeassistant/components/intent_script/__init__.py
@@ -144,6 +144,12 @@ class _IntentCardData(TypedDict):
 class ScriptIntentHandler(intent.IntentHandler):
     """Respond to an intent with a script."""
 
+    slot_schema = {
+        vol.Any("name", "area", "floor"): cv.string,
+        vol.Optional("domain"): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional("device_class"): vol.All(cv.ensure_list, [cv.string]),
+    }
+
     def __init__(self, intent_type: str, config: ConfigType) -> None:
         """Initialize the script intent handler."""
         self.intent_type = intent_type
@@ -158,8 +164,10 @@ class ScriptIntentHandler(intent.IntentHandler):
         card: _IntentCardData | None = self.config.get(CONF_CARD)
         action: script.Script | None = self.config.get(CONF_ACTION)
         is_async_action: bool = self.config[CONF_ASYNC_ACTION]
+        hass: HomeAssistant = intent_obj.hass
+        intent_slots = self.async_validate_slots(intent_obj.slots)
         slots: dict[str, Any] = {
-            key: value["value"] for key, value in intent_obj.slots.items()
+            key: value["value"] for key, value in intent_slots.items()
         }
 
         _LOGGER.debug(
@@ -171,6 +179,51 @@ class ScriptIntentHandler(intent.IntentHandler):
                 if not key.startswith("_") and not key.endswith("_raw_value")
             },
         )
+
+        entity_name = slots.get("name")
+        area_name = slots.get("area")
+        floor_name = slots.get("floor")
+
+        # Optional domain/device class filters.
+        # Convert to sets for speed.
+        domains: set[str] | None = None
+        device_classes: set[str] | None = None
+
+        if "domain" in slots:
+            domains = set(slots["domain"])
+
+        if "device_class" in slots:
+            device_classes = set(slots["device_class"])
+
+        match_constraints = intent.MatchTargetsConstraints(
+            name=entity_name,
+            area_name=area_name,
+            floor_name=floor_name,
+            domains=domains,
+            device_classes=device_classes,
+            assistant=intent_obj.assistant,
+        )
+
+        if match_constraints.has_constraints:
+            match_result = intent.async_match_targets(hass, match_constraints)
+            if match_result.is_match:
+                targets = {}
+
+                if match_result.states:
+                    targets["entities"] = [
+                        state.entity_id for state in match_result.states
+                    ]
+
+                if match_result.areas:
+                    targets["areas"] = [area.id for area in match_result.areas]
+
+                if match_result.floors:
+                    targets["floors"] = [
+                        floor.floor_id for floor in match_result.floors
+                    ]
+
+                if targets:
+                    slots["targets"] = targets
 
         if action is not None:
             if is_async_action:

--- a/tests/components/intent_script/test_init.py
+++ b/tests/components/intent_script/test_init.py
@@ -6,7 +6,12 @@ from homeassistant import config as hass_config
 from homeassistant.components.intent_script import DOMAIN
 from homeassistant.const import SERVICE_RELOAD
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import intent
+from homeassistant.helpers import (
+    area_registry as ar,
+    entity_registry as er,
+    floor_registry as fr,
+    intent,
+)
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_mock_service, get_fixture_path
@@ -195,6 +200,84 @@ async def test_intent_script_falsy_reprompt(hass: HomeAssistant) -> None:
 
     assert response.card["simple"]["title"] == "Hello Paulus"
     assert response.card["simple"]["content"] == "Content for Paulus"
+
+
+async def test_intent_script_targets(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    entity_registry: er.EntityRegistry,
+    floor_registry: fr.FloorRegistry,
+) -> None:
+    """Test intent scripts work."""
+    calls = async_mock_service(hass, "test", "service")
+
+    await async_setup_component(
+        hass,
+        "intent_script",
+        {
+            "intent_script": {
+                "Targets": {
+                    "description": "Intent to control a test service.",
+                    "action": {
+                        "service": "test.service",
+                        "data_template": {
+                            "targets": "{{ targets if targets is defined }}",
+                        },
+                    },
+                    "speech": {
+                        "text": "{{ targets.entities[0] if targets is defined }}"
+                    },
+                }
+            }
+        },
+    )
+
+    floor_1 = floor_registry.async_create("first floor")
+    kitchen = area_registry.async_get_or_create("kitchen")
+    area_registry.async_update(kitchen.id, floor_id=floor_1.floor_id)
+    entity_registry.async_get_or_create(
+        "light", "demo", "1234", suggested_object_id="kitchen"
+    )
+    entity_registry.async_update_entity("light.kitchen", area_id=kitchen.id)
+    hass.states.async_set("light.kitchen", "off")
+
+    response = await intent.async_handle(
+        hass,
+        "test",
+        "Targets",
+        {"name": {"value": "kitchen"}, "domain": {"value": "light"}},
+    )
+    assert len(calls) == 1
+    assert calls[0].data["targets"] == {"entities": ["light.kitchen"]}
+    assert response.speech["plain"]["speech"] == "light.kitchen"
+    calls.clear()
+
+    response = await intent.async_handle(
+        hass,
+        "test",
+        "Targets",
+        {
+            "area": {"value": "kitchen"},
+            "floor": {"value": "first floor"},
+        },
+    )
+    assert len(calls) == 1
+    assert calls[0].data["targets"] == {
+        "entities": ["light.kitchen"],
+        "areas": ["kitchen"],
+        "floors": ["first_floor"],
+    }
+    calls.clear()
+
+    response = await intent.async_handle(
+        hass,
+        "test",
+        "Targets",
+        {"device_class": {"value": "door"}},
+    )
+    assert len(calls) == 1
+    assert calls[0].data["targets"] == ""
+    calls.clear()
 
 
 async def test_reload(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add entity matching to intent_script.

This allows us to do the following:
```yaml
# custom_sentences.yaml
intents:
  HassPress:
    data:
      - sentences:
          - "press <name>"
        requires_context:
          domain: button
```
```yaml
# configuration.yaml
intent_script:
  HassPress:
    action:
      - service: button.press
        target:
          entity_id: "{{ targets.entities }}"
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
