### PR TITLE
Use service_calls fixture in mqtt tests

### DIFF
--- a/tests/components/mqtt/test_trigger.py
+++ b/tests/components/mqtt/test_trigger.py
@@ -9,19 +9,13 @@ from homeassistant.const import ATTR_ENTITY_ID, ENTITY_MATCH_ALL, SERVICE_TURN_O
 from homeassistant.core import HassJobType, HomeAssistant, ServiceCall
 from homeassistant.setup import async_setup_component
 
-from tests.common import async_fire_mqtt_message, async_mock_service, mock_component
+from tests.common import async_fire_mqtt_message, mock_component
 from tests.typing import MqttMockHAClient, MqttMockHAClientGenerator
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 @pytest.fixture(autouse=True)
@@ -34,7 +28,7 @@ async def setup_comp(
 
 
 async def test_if_fires_on_topic_match(
-    hass: HomeAssistant, calls: list[ServiceCall]
+    hass: HomeAssistant, service_calls: list[ServiceCall]
 ) -> None:
     """Test if message is fired on topic match."""
     assert await async_setup_component(
@@ -57,9 +51,10 @@ async def test_if_fires_on_topic_match(
 
     async_fire_mqtt_message(hass, "test-topic", '{ "hello": "world" }')
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     assert (
-        calls[0].data["some"] == 'mqtt - test-topic - { "hello": "world" } - world - 0'
+        service_calls[0].data["some"]
+        == 'mqtt - test-topic - { "hello": "world" } - world - 0'
     )
 
     await hass.services.async_call(
@@ -68,13 +63,15 @@ async def test_if_fires_on_topic_match(
         {ATTR_ENTITY_ID: ENTITY_MATCH_ALL},
         blocking=True,
     )
+    assert len(service_calls) == 2
+
     async_fire_mqtt_message(hass, "test-topic", "test_payload")
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 2
 
 
 async def test_if_fires_on_topic_and_payload_match(
-    hass: HomeAssistant, calls: list[ServiceCall]
+    hass: HomeAssistant, service_calls: list[ServiceCall]
 ) -> None:
     """Test if message is fired on topic and payload match."""
     assert await async_setup_component(
@@ -94,11 +91,11 @@ async def test_if_fires_on_topic_and_payload_match(
 
     async_fire_mqtt_message(hass, "test-topic", "hello")
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
 
 
 async def test_if_fires_on_topic_and_payload_match2(
-    hass: HomeAssistant, calls: list[ServiceCall]
+    hass: HomeAssistant, service_calls: list[ServiceCall]
 ) -> None:
     """Test if message is fired on topic and payload match.
 
@@ -121,11 +118,11 @@ async def test_if_fires_on_topic_and_payload_match2(
 
     async_fire_mqtt_message(hass, "test-topic", "0")
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
 
 
 async def test_if_fires_on_templated_topic_and_payload_match(
-    hass: HomeAssistant, calls: list[ServiceCall]
+    hass: HomeAssistant, service_calls: list[ServiceCall]
 ) -> None:
     """Test if message is fired on templated topic and payload match."""
     assert await async_setup_component(
@@ -145,19 +142,19 @@ async def test_if_fires_on_templated_topic_and_payload_match(
 
     async_fire_mqtt_message(hass, "test-topic-", "foo")
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     async_fire_mqtt_message(hass, "test-topic-4", "foo")
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     async_fire_mqtt_message(hass, "test-topic-4", "bar")
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
 
 
 async def test_if_fires_on_payload_template(
-    hass: HomeAssistant, calls: list[ServiceCall]
+    hass: HomeAssistant, service_calls: list[ServiceCall]
 ) -> None:
     """Test if message is fired on templated topic and payload match."""
     assert await async_setup_component(
@@ -178,19 +175,21 @@ async def test_if_fires_on_payload_template(
 
     async_fire_mqtt_message(hass, "test-topic", "hello")
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     async_fire_mqtt_message(hass, "test-topic", '{"unwanted_key":"hello"}')
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     async_fire_mqtt_message(hass, "test-topic", '{"wanted_key":"hello"}')
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
 
 
 async def test_non_allowed_templates(
-    hass: HomeAssistant, calls: list[ServiceCall], caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    service_calls: list[ServiceCall],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test non allowed function in template."""
     assert await async_setup_component(
@@ -214,7 +213,7 @@ async def test_non_allowed_templates(
 
 
 async def test_if_not_fires_on_topic_but_no_payload_match(
-    hass: HomeAssistant, calls: list[ServiceCall]
+    hass: HomeAssistant, service_calls: list[ServiceCall]
 ) -> None:
     """Test if message is not fired on topic but no payload."""
     assert await async_setup_component(
@@ -234,11 +233,11 @@ async def test_if_not_fires_on_topic_but_no_payload_match(
 
     async_fire_mqtt_message(hass, "test-topic", "no-hello")
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
 
 async def test_encoding_default(
-    hass: HomeAssistant, calls: list[ServiceCall], setup_comp
+    hass: HomeAssistant, service_calls: list[ServiceCall], setup_comp
 ) -> None:
     """Test default encoding."""
     assert await async_setup_component(
@@ -258,7 +257,7 @@ async def test_encoding_default(
 
 
 async def test_encoding_custom(
-    hass: HomeAssistant, calls: list[ServiceCall], setup_comp
+    hass: HomeAssistant, service_calls: list[ServiceCall], setup_comp
 ) -> None:
     """Test default encoding."""
     assert await async_setup_component(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #118356

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
