### PR TITLE
Use service_calls fixture in zwave_js tests

### DIFF
--- a/tests/components/zwave_js/test_device_condition.py
+++ b/tests/components/zwave_js/test_device_condition.py
@@ -25,13 +25,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.setup import async_setup_component
 
-from tests.common import async_get_device_automations, async_mock_service
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
+from tests.common import async_get_device_automations
 
 
 async def test_get_conditions(
@@ -99,7 +93,7 @@ async def test_node_status_state(
     client,
     lock_schlage_be469,
     integration,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test for node_status conditions."""
@@ -206,8 +200,8 @@ async def test_node_status_state(
     hass.bus.async_fire("test_event3")
     hass.bus.async_fire("test_event4")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "alive - event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "alive - event - test_event1"
 
     event = Event(
         "wake up",
@@ -225,8 +219,8 @@ async def test_node_status_state(
     hass.bus.async_fire("test_event3")
     hass.bus.async_fire("test_event4")
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert calls[1].data["some"] == "awake - event - test_event2"
+    assert len(service_calls) == 2
+    assert service_calls[1].data["some"] == "awake - event - test_event2"
 
     event = Event(
         "sleep",
@@ -240,8 +234,8 @@ async def test_node_status_state(
     hass.bus.async_fire("test_event3")
     hass.bus.async_fire("test_event4")
     await hass.async_block_till_done()
-    assert len(calls) == 3
-    assert calls[2].data["some"] == "asleep - event - test_event3"
+    assert len(service_calls) == 3
+    assert service_calls[2].data["some"] == "asleep - event - test_event3"
 
     event = Event(
         "dead",
@@ -255,8 +249,8 @@ async def test_node_status_state(
     hass.bus.async_fire("test_event3")
     hass.bus.async_fire("test_event4")
     await hass.async_block_till_done()
-    assert len(calls) == 4
-    assert calls[3].data["some"] == "dead - event - test_event4"
+    assert len(service_calls) == 4
+    assert service_calls[3].data["some"] == "dead - event - test_event4"
 
 
 async def test_config_parameter_state(
@@ -264,7 +258,7 @@ async def test_config_parameter_state(
     client,
     lock_schlage_be469,
     integration,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test for config_parameter conditions."""
@@ -331,8 +325,8 @@ async def test_config_parameter_state(
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "Beeper - event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "Beeper - event - test_event1"
 
     # Flip Beeper state to not match condition
     event = Event(
@@ -375,8 +369,8 @@ async def test_config_parameter_state(
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert calls[1].data["some"] == "User Slot Status - event - test_event2"
+    assert len(service_calls) == 2
+    assert service_calls[1].data["some"] == "User Slot Status - event - test_event2"
 
 
 async def test_value_state(
@@ -384,7 +378,7 @@ async def test_value_state(
     client,
     lock_schlage_be469,
     integration,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test for value conditions."""
@@ -427,8 +421,8 @@ async def test_value_state(
 
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "value - event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "value - event - test_event1"
 
 
 async def test_get_condition_capabilities_node_status(

--- a/tests/components/zwave_js/test_device_trigger.py
+++ b/tests/components/zwave_js/test_device_trigger.py
@@ -28,13 +28,7 @@ from homeassistant.helpers import (
 )
 from homeassistant.setup import async_setup_component
 
-from tests.common import async_get_device_automations, async_mock_service
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
+from tests.common import async_get_device_automations
 
 
 async def test_no_controller_triggers(
@@ -85,7 +79,7 @@ async def test_if_notification_notification_fires(
     client,
     lock_schlage_be469,
     integration,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for event.notification.notification trigger firing."""
     node: Node = lock_schlage_be469
@@ -168,13 +162,13 @@ async def test_if_notification_notification_fires(
     )
     node.receive_event(event)
     await hass.async_block_till_done()
-    assert len(calls) == 2
+    assert len(service_calls) == 2
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"event.notification.notification - device - zwave_js_notification - {CommandClass.NOTIFICATION}"
     )
     assert (
-        calls[1].data["some"]
+        service_calls[1].data["some"]
         == f"event.notification.notification2 - device - zwave_js_notification - {CommandClass.NOTIFICATION}"
     )
 
@@ -221,7 +215,7 @@ async def test_if_entry_control_notification_fires(
     client,
     lock_schlage_be469,
     integration,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for notification.entry_control trigger firing."""
     node: Node = lock_schlage_be469
@@ -303,13 +297,13 @@ async def test_if_entry_control_notification_fires(
     )
     node.receive_event(event)
     await hass.async_block_till_done()
-    assert len(calls) == 2
+    assert len(service_calls) == 2
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"event.notification.notification - device - zwave_js_notification - {CommandClass.ENTRY_CONTROL}"
     )
     assert (
-        calls[1].data["some"]
+        service_calls[1].data["some"]
         == f"event.notification.notification2 - device - zwave_js_notification - {CommandClass.ENTRY_CONTROL}"
     )
 
@@ -389,7 +383,7 @@ async def test_if_node_status_change_fires(
     client,
     lock_schlage_be469,
     integration,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for node_status trigger firing."""
     node: Node = lock_schlage_be469
@@ -460,9 +454,9 @@ async def test_if_node_status_change_fires(
     )
     node.receive_event(event)
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert calls[0].data["some"] == "state.node_status - device - alive"
-    assert calls[1].data["some"] == "state.node_status2 - device - alive"
+    assert len(service_calls) == 2
+    assert service_calls[0].data["some"] == "state.node_status - device - alive"
+    assert service_calls[1].data["some"] == "state.node_status2 - device - alive"
 
 
 async def test_if_node_status_change_fires_legacy(
@@ -472,7 +466,7 @@ async def test_if_node_status_change_fires_legacy(
     client,
     lock_schlage_be469,
     integration,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for node_status trigger firing."""
     node: Node = lock_schlage_be469
@@ -543,9 +537,9 @@ async def test_if_node_status_change_fires_legacy(
     )
     node.receive_event(event)
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert calls[0].data["some"] == "state.node_status - device - alive"
-    assert calls[1].data["some"] == "state.node_status2 - device - alive"
+    assert len(service_calls) == 2
+    assert service_calls[0].data["some"] == "state.node_status - device - alive"
+    assert service_calls[1].data["some"] == "state.node_status2 - device - alive"
 
 
 async def test_get_trigger_capabilities_node_status(
@@ -645,7 +639,7 @@ async def test_if_basic_value_notification_fires(
     client,
     ge_in_wall_dimmer_switch,
     integration,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for event.value_notification.basic trigger firing."""
     node: Node = ge_in_wall_dimmer_switch
@@ -742,13 +736,13 @@ async def test_if_basic_value_notification_fires(
     )
     node.receive_event(event)
     await hass.async_block_till_done()
-    assert len(calls) == 2
+    assert len(service_calls) == 2
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"event.value_notification.basic - device - zwave_js_value_notification - {CommandClass.BASIC}"
     )
     assert (
-        calls[1].data["some"]
+        service_calls[1].data["some"]
         == f"event.value_notification.basic2 - device - zwave_js_value_notification - {CommandClass.BASIC}"
     )
 
@@ -830,7 +824,7 @@ async def test_if_central_scene_value_notification_fires(
     client,
     wallmote_central_scene,
     integration,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for event.value_notification.central_scene trigger firing."""
     node: Node = wallmote_central_scene
@@ -933,13 +927,13 @@ async def test_if_central_scene_value_notification_fires(
     )
     node.receive_event(event)
     await hass.async_block_till_done()
-    assert len(calls) == 2
+    assert len(service_calls) == 2
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"event.value_notification.central_scene - device - zwave_js_value_notification - {CommandClass.CENTRAL_SCENE}"
     )
     assert (
-        calls[1].data["some"]
+        service_calls[1].data["some"]
         == f"event.value_notification.central_scene2 - device - zwave_js_value_notification - {CommandClass.CENTRAL_SCENE}"
     )
 
@@ -1020,7 +1014,7 @@ async def test_if_scene_activation_value_notification_fires(
     client,
     hank_binary_switch,
     integration,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for event.value_notification.scene_activation trigger firing."""
     node: Node = hank_binary_switch
@@ -1117,13 +1111,13 @@ async def test_if_scene_activation_value_notification_fires(
     )
     node.receive_event(event)
     await hass.async_block_till_done()
-    assert len(calls) == 2
+    assert len(service_calls) == 2
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"event.value_notification.scene_activation - device - zwave_js_value_notification - {CommandClass.SCENE_ACTIVATION}"
     )
     assert (
-        calls[1].data["some"]
+        service_calls[1].data["some"]
         == f"event.value_notification.scene_activation2 - device - zwave_js_value_notification - {CommandClass.SCENE_ACTIVATION}"
     )
 
@@ -1200,7 +1194,7 @@ async def test_if_value_updated_value_fires(
     client,
     lock_schlage_be469,
     integration,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for zwave_js.value_updated.value trigger firing."""
     node: Node = lock_schlage_be469
@@ -1261,7 +1255,7 @@ async def test_if_value_updated_value_fires(
     )
     node.receive_event(event)
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     # Publish fake value update that should trigger
     event = Event(
@@ -1283,9 +1277,9 @@ async def test_if_value_updated_value_fires(
     )
     node.receive_event(event)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == "zwave_js.value_updated.value - zwave_js.value_updated - open"
     )
 
@@ -1296,7 +1290,7 @@ async def test_value_updated_value_no_driver(
     client,
     lock_schlage_be469,
     integration,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test zwave_js.value_updated.value trigger with missing driver."""
     node: Node = lock_schlage_be469
@@ -1362,7 +1356,7 @@ async def test_value_updated_value_no_driver(
     )
     node.receive_event(event)
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
 
 async def test_get_trigger_capabilities_value_updated_value(
@@ -1455,7 +1449,7 @@ async def test_if_value_updated_config_parameter_fires(
     client,
     lock_schlage_be469,
     integration,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for zwave_js.value_updated.config_parameter trigger firing."""
     node: Node = lock_schlage_be469
@@ -1517,9 +1511,9 @@ async def test_if_value_updated_config_parameter_fires(
     )
     node.receive_event(event)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == "zwave_js.value_updated.config_parameter - zwave_js.value_updated - 255"
     )
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #118356

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
