### PR TITLE
Use service_calls fixture in xiaomi_ble tests

### DIFF
--- a/tests/components/xiaomi_ble/test_device_trigger.py
+++ b/tests/components/xiaomi_ble/test_device_trigger.py
@@ -18,7 +18,6 @@ from tests.common import (
     MockConfigEntry,
     async_capture_events,
     async_get_device_automations,
-    async_mock_service,
 )
 from tests.components.bluetooth import inject_bluetooth_service_info_bleak
 
@@ -27,12 +26,6 @@ from tests.components.bluetooth import inject_bluetooth_service_info_bleak
 def get_device_id(mac: str) -> tuple[str, str]:
     """Get device registry identifier for xiaomi_ble."""
     return (BLUETOOTH_DOMAIN, mac)
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 async def _async_setup_xiaomi_device(
@@ -399,7 +392,9 @@ async def test_get_triggers_for_invalid_device_id(
 
 
 async def test_if_fires_on_button_press(
-    hass: HomeAssistant, device_registry: dr.DeviceRegistry, calls: list[ServiceCall]
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for button press event trigger firing."""
     mac = "54:EF:44:E3:9C:BC"
@@ -452,15 +447,17 @@ async def test_if_fires_on_button_press(
     )
     await hass.async_block_till_done()
 
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "test_trigger_button_press"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "test_trigger_button_press"
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
 
 async def test_if_fires_on_double_button_long_press(
-    hass: HomeAssistant, device_registry: dr.DeviceRegistry, calls: list[ServiceCall]
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for button press event trigger firing."""
     mac = "DC:ED:83:87:12:73"
@@ -513,15 +510,17 @@ async def test_if_fires_on_double_button_long_press(
     )
     await hass.async_block_till_done()
 
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "test_trigger_right_button_press"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "test_trigger_right_button_press"
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
 
 async def test_if_fires_on_motion_detected(
-    hass: HomeAssistant, device_registry: dr.DeviceRegistry, calls: list[ServiceCall]
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for motion event trigger firing."""
     mac = "DE:70:E8:B2:39:0C"
@@ -567,8 +566,8 @@ async def test_if_fires_on_motion_detected(
     )
     await hass.async_block_till_done()
 
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "test_trigger_motion_detected"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "test_trigger_motion_detected"
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
@@ -676,7 +675,9 @@ async def test_automation_with_invalid_trigger_event_property(
 
 
 async def test_triggers_for_invalid__model(
-    hass: HomeAssistant, device_registry: dr.DeviceRegistry, calls: list[ServiceCall]
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test invalid model doesn't return triggers."""
     mac = "DE:70:E8:B2:39:0C"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #118356

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
