### PR TITLE
Use service_calls fixture in webostv tests

### DIFF
--- a/tests/components/webostv/conftest.py
+++ b/tests/components/webostv/conftest.py
@@ -6,11 +6,8 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from homeassistant.components.webostv.const import LIVE_TV_APP_ID
-from homeassistant.core import HomeAssistant, ServiceCall
 
 from .const import CHANNEL_1, CHANNEL_2, CLIENT_KEY, FAKE_UUID, MOCK_APPS, MOCK_INPUTS
-
-from tests.common import async_mock_service
 
 
 @pytest.fixture
@@ -20,12 +17,6 @@ def mock_setup_entry() -> Generator[AsyncMock]:
         "homeassistant.components.webostv.async_setup_entry", return_value=True
     ) as mock_setup_entry:
         yield mock_setup_entry
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 @pytest.fixture(name="client")

--- a/tests/components/webostv/test_device_trigger.py
+++ b/tests/components/webostv/test_device_trigger.py
@@ -44,7 +44,7 @@ async def test_get_triggers(
 
 async def test_if_fires_on_turn_on_request(
     hass: HomeAssistant,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     device_registry: dr.DeviceRegistry,
     client,
 ) -> None:
@@ -97,11 +97,11 @@ async def test_if_fires_on_turn_on_request(
         blocking=True,
     )
 
-    assert len(calls) == 2
-    assert calls[0].data["some"] == device.id
-    assert calls[0].data["id"] == 0
-    assert calls[1].data["some"] == ENTITY_ID
-    assert calls[1].data["id"] == 0
+    assert len(service_calls) == 3
+    assert service_calls[1].data["some"] == device.id
+    assert service_calls[1].data["id"] == 0
+    assert service_calls[2].data["some"] == ENTITY_ID
+    assert service_calls[2].data["id"] == 0
 
 
 async def test_failure_scenarios(

--- a/tests/components/webostv/test_trigger.py
+++ b/tests/components/webostv/test_trigger.py
@@ -20,7 +20,7 @@ from tests.common import MockEntity, MockEntityPlatform
 
 async def test_webostv_turn_on_trigger_device_id(
     hass: HomeAssistant,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     device_registry: dr.DeviceRegistry,
     client,
 ) -> None:
@@ -58,14 +58,14 @@ async def test_webostv_turn_on_trigger_device_id(
         blocking=True,
     )
 
-    assert len(calls) == 1
-    assert calls[0].data["some"] == device.id
-    assert calls[0].data["id"] == 0
+    assert len(service_calls) == 2
+    assert service_calls[1].data["some"] == device.id
+    assert service_calls[1].data["id"] == 0
 
     with patch("homeassistant.config.load_yaml_dict", return_value={}):
         await hass.services.async_call(automation.DOMAIN, SERVICE_RELOAD, blocking=True)
 
-    calls.clear()
+    service_calls.clear()
 
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
@@ -75,11 +75,11 @@ async def test_webostv_turn_on_trigger_device_id(
             blocking=True,
         )
 
-    assert len(calls) == 0
+    assert len(service_calls) == 1
 
 
 async def test_webostv_turn_on_trigger_entity_id(
-    hass: HomeAssistant, calls: list[ServiceCall], client
+    hass: HomeAssistant, service_calls: list[ServiceCall], client
 ) -> None:
     """Test for turn_on triggers by entity_id firing."""
     await setup_webostv(hass)
@@ -113,9 +113,9 @@ async def test_webostv_turn_on_trigger_entity_id(
         blocking=True,
     )
 
-    assert len(calls) == 1
-    assert calls[0].data["some"] == ENTITY_ID
-    assert calls[0].data["id"] == 0
+    assert len(service_calls) == 2
+    assert service_calls[1].data["some"] == ENTITY_ID
+    assert service_calls[1].data["id"] == 0
 
 
 async def test_wrong_trigger_platform_type(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #118356

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
