### PR TITLE
Use common fixtures in tasmota tests

### DIFF
--- a/tests/components/tasmota/conftest.py
+++ b/tests/components/tasmota/conftest.py
@@ -11,20 +11,8 @@ from homeassistant.components.tasmota.const import (
     DOMAIN,
 )
 
-from tests.common import MockConfigEntry, mock_device_registry, mock_registry
+from tests.common import MockConfigEntry
 from tests.components.light.conftest import mock_light_profiles  # noqa: F401
-
-
-@pytest.fixture
-def device_reg(hass):
-    """Return an empty, loaded, registry."""
-    return mock_device_registry(hass)
-
-
-@pytest.fixture
-def entity_reg(hass):
-    """Return an empty, loaded, registry."""
-    return mock_registry(hass)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/tasmota/conftest.py
+++ b/tests/components/tasmota/conftest.py
@@ -10,14 +10,8 @@ from homeassistant.components.tasmota.const import (
     DEFAULT_PREFIX,
     DOMAIN,
 )
-from homeassistant.core import HomeAssistant, ServiceCall
 
-from tests.common import (
-    MockConfigEntry,
-    async_mock_service,
-    mock_device_registry,
-    mock_registry,
-)
+from tests.common import MockConfigEntry, mock_device_registry, mock_registry
 from tests.components.light.conftest import mock_light_profiles  # noqa: F401
 
 
@@ -31,12 +25,6 @@ def device_reg(hass):
 def entity_reg(hass):
     """Return an empty, loaded, registry."""
     return mock_registry(hass)
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/tasmota/test_device_trigger.py
+++ b/tests/components/tasmota/test_device_trigger.py
@@ -30,8 +30,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 async def test_get_triggers_btn(
     hass: HomeAssistant,
-    device_reg,
-    entity_reg,
+    device_registry: dr.DeviceRegistry,
     mqtt_mock: MqttMockHAClient,
     setup_tasmota,
 ) -> None:
@@ -46,7 +45,7 @@ async def test_get_triggers_btn(
     async_fire_mqtt_message(hass, f"{DEFAULT_PREFIX}/{mac}/config", json.dumps(config))
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     expected_triggers = [
@@ -77,8 +76,7 @@ async def test_get_triggers_btn(
 
 async def test_get_triggers_swc(
     hass: HomeAssistant,
-    device_reg,
-    entity_reg,
+    device_registry: dr.DeviceRegistry,
     mqtt_mock: MqttMockHAClient,
     setup_tasmota,
 ) -> None:
@@ -90,7 +88,7 @@ async def test_get_triggers_swc(
     async_fire_mqtt_message(hass, f"{DEFAULT_PREFIX}/{mac}/config", json.dumps(config))
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     expected_triggers = [
@@ -112,8 +110,7 @@ async def test_get_triggers_swc(
 
 async def test_get_unknown_triggers(
     hass: HomeAssistant,
-    device_reg,
-    entity_reg,
+    device_registry: dr.DeviceRegistry,
     mqtt_mock: MqttMockHAClient,
     setup_tasmota,
 ) -> None:
@@ -126,7 +123,7 @@ async def test_get_unknown_triggers(
     async_fire_mqtt_message(hass, f"{DEFAULT_PREFIX}/{mac}/config", json.dumps(config))
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
@@ -161,8 +158,7 @@ async def test_get_unknown_triggers(
 
 async def test_get_non_existing_triggers(
     hass: HomeAssistant,
-    device_reg,
-    entity_reg,
+    device_registry: dr.DeviceRegistry,
     mqtt_mock: MqttMockHAClient,
     setup_tasmota,
 ) -> None:
@@ -175,7 +171,7 @@ async def test_get_non_existing_triggers(
     async_fire_mqtt_message(hass, f"{DEFAULT_PREFIX}/{mac}/config", json.dumps(config1))
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     triggers = await async_get_device_automations(
@@ -187,8 +183,7 @@ async def test_get_non_existing_triggers(
 @pytest.mark.no_fail_on_log_exception
 async def test_discover_bad_triggers(
     hass: HomeAssistant,
-    device_reg,
-    entity_reg,
+    device_registry: dr.DeviceRegistry,
     mqtt_mock: MqttMockHAClient,
     setup_tasmota,
 ) -> None:
@@ -207,7 +202,7 @@ async def test_discover_bad_triggers(
         )
         await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     triggers = await async_get_device_automations(
@@ -243,7 +238,7 @@ async def test_discover_bad_triggers(
         )
         await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     triggers = await async_get_device_automations(
@@ -274,8 +269,7 @@ async def test_discover_bad_triggers(
 
 async def test_update_remove_triggers(
     hass: HomeAssistant,
-    device_reg,
-    entity_reg,
+    device_registry: dr.DeviceRegistry,
     mqtt_mock: MqttMockHAClient,
     setup_tasmota,
 ) -> None:
@@ -296,7 +290,7 @@ async def test_update_remove_triggers(
     async_fire_mqtt_message(hass, f"{DEFAULT_PREFIX}/{mac}/config", json.dumps(config1))
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
@@ -351,7 +345,7 @@ async def test_update_remove_triggers(
 
 async def test_if_fires_on_mqtt_message_btn(
     hass: HomeAssistant,
-    device_reg,
+    device_registry: dr.DeviceRegistry,
     service_calls: list[ServiceCall],
     mqtt_mock: MqttMockHAClient,
     setup_tasmota,
@@ -366,7 +360,7 @@ async def test_if_fires_on_mqtt_message_btn(
 
     async_fire_mqtt_message(hass, f"{DEFAULT_PREFIX}/{mac}/config", json.dumps(config))
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
@@ -426,7 +420,7 @@ async def test_if_fires_on_mqtt_message_btn(
 
 async def test_if_fires_on_mqtt_message_swc(
     hass: HomeAssistant,
-    device_reg,
+    device_registry: dr.DeviceRegistry,
     service_calls: list[ServiceCall],
     mqtt_mock: MqttMockHAClient,
     setup_tasmota,
@@ -442,7 +436,7 @@ async def test_if_fires_on_mqtt_message_swc(
 
     async_fire_mqtt_message(hass, f"{DEFAULT_PREFIX}/{mac}/config", json.dumps(config))
     await hass.async_block_till_done()
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
@@ -524,7 +518,7 @@ async def test_if_fires_on_mqtt_message_swc(
 
 async def test_if_fires_on_mqtt_message_late_discover(
     hass: HomeAssistant,
-    device_reg,
+    device_registry: dr.DeviceRegistry,
     service_calls: list[ServiceCall],
     mqtt_mock: MqttMockHAClient,
     setup_tasmota,
@@ -544,7 +538,7 @@ async def test_if_fires_on_mqtt_message_late_discover(
     async_fire_mqtt_message(hass, f"{DEFAULT_PREFIX}/{mac}/config", json.dumps(config1))
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
@@ -607,7 +601,7 @@ async def test_if_fires_on_mqtt_message_late_discover(
 
 async def test_if_fires_on_mqtt_message_after_update(
     hass: HomeAssistant,
-    device_reg,
+    device_registry: dr.DeviceRegistry,
     service_calls: list[ServiceCall],
     mqtt_mock: MqttMockHAClient,
     setup_tasmota,
@@ -624,7 +618,7 @@ async def test_if_fires_on_mqtt_message_after_update(
     async_fire_mqtt_message(hass, f"{DEFAULT_PREFIX}/{mac}/config", json.dumps(config1))
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
@@ -692,7 +686,10 @@ async def test_if_fires_on_mqtt_message_after_update(
 
 
 async def test_no_resubscribe_same_topic(
-    hass: HomeAssistant, device_reg, mqtt_mock: MqttMockHAClient, setup_tasmota
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
 ) -> None:
     """Test subscription to topics without change."""
     # Discover a device with device trigger
@@ -705,7 +702,7 @@ async def test_no_resubscribe_same_topic(
     async_fire_mqtt_message(hass, f"{DEFAULT_PREFIX}/{mac}/config", json.dumps(config))
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
@@ -741,7 +738,7 @@ async def test_no_resubscribe_same_topic(
 
 async def test_not_fires_on_mqtt_message_after_remove_by_mqtt(
     hass: HomeAssistant,
-    device_reg,
+    device_registry: dr.DeviceRegistry,
     service_calls: list[ServiceCall],
     mqtt_mock: MqttMockHAClient,
     setup_tasmota,
@@ -757,7 +754,7 @@ async def test_not_fires_on_mqtt_message_after_remove_by_mqtt(
     async_fire_mqtt_message(hass, f"{DEFAULT_PREFIX}/{mac}/config", json.dumps(config))
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
@@ -817,7 +814,7 @@ async def test_not_fires_on_mqtt_message_after_remove_by_mqtt(
 async def test_not_fires_on_mqtt_message_after_remove_from_registry(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
-    device_reg,
+    device_registry: dr.DeviceRegistry,
     service_calls: list[ServiceCall],
     mqtt_mock: MqttMockHAClient,
     setup_tasmota,
@@ -834,7 +831,7 @@ async def test_not_fires_on_mqtt_message_after_remove_from_registry(
     async_fire_mqtt_message(hass, f"{DEFAULT_PREFIX}/{mac}/config", json.dumps(config))
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
@@ -880,7 +877,10 @@ async def test_not_fires_on_mqtt_message_after_remove_from_registry(
 
 
 async def test_attach_remove(
-    hass: HomeAssistant, device_reg, mqtt_mock: MqttMockHAClient, setup_tasmota
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
 ) -> None:
     """Test attach and removal of trigger."""
     # Discover a device with device trigger
@@ -893,7 +893,7 @@ async def test_attach_remove(
     async_fire_mqtt_message(hass, f"{DEFAULT_PREFIX}/{mac}/config", json.dumps(config))
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
@@ -941,7 +941,10 @@ async def test_attach_remove(
 
 
 async def test_attach_remove_late(
-    hass: HomeAssistant, device_reg, mqtt_mock: MqttMockHAClient, setup_tasmota
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
 ) -> None:
     """Test attach and removal of trigger."""
     # Discover a device without device triggers
@@ -956,7 +959,7 @@ async def test_attach_remove_late(
     async_fire_mqtt_message(hass, f"{DEFAULT_PREFIX}/{mac}/config", json.dumps(config1))
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
@@ -1014,7 +1017,10 @@ async def test_attach_remove_late(
 
 
 async def test_attach_remove_late2(
-    hass: HomeAssistant, device_reg, mqtt_mock: MqttMockHAClient, setup_tasmota
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
 ) -> None:
     """Test attach and removal of trigger."""
     # Discover a device without device triggers
@@ -1029,7 +1035,7 @@ async def test_attach_remove_late2(
     async_fire_mqtt_message(hass, f"{DEFAULT_PREFIX}/{mac}/config", json.dumps(config1))
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
@@ -1072,7 +1078,10 @@ async def test_attach_remove_late2(
 
 
 async def test_attach_remove_unknown1(
-    hass: HomeAssistant, device_reg, mqtt_mock: MqttMockHAClient, setup_tasmota
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
 ) -> None:
     """Test attach and removal of unknown trigger."""
     # Discover a device without device triggers
@@ -1083,7 +1092,7 @@ async def test_attach_remove_unknown1(
     async_fire_mqtt_message(hass, f"{DEFAULT_PREFIX}/{mac}/config", json.dumps(config1))
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
@@ -1113,7 +1122,7 @@ async def test_attach_remove_unknown1(
 async def test_attach_unknown_remove_device_from_registry(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
-    device_reg,
+    device_registry: dr.DeviceRegistry,
     mqtt_mock: MqttMockHAClient,
     setup_tasmota,
 ) -> None:
@@ -1136,7 +1145,7 @@ async def test_attach_unknown_remove_device_from_registry(
     async_fire_mqtt_message(hass, f"{DEFAULT_PREFIX}/{mac}/config", json.dumps(config1))
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
@@ -1164,7 +1173,10 @@ async def test_attach_unknown_remove_device_from_registry(
 
 
 async def test_attach_remove_config_entry(
-    hass: HomeAssistant, device_reg, mqtt_mock: MqttMockHAClient, setup_tasmota
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
 ) -> None:
     """Test trigger cleanup when removing a Tasmota config entry."""
     # Discover a device with device trigger
@@ -1177,7 +1189,7 @@ async def test_attach_remove_config_entry(
     async_fire_mqtt_message(hass, f"{DEFAULT_PREFIX}/{mac}/config", json.dumps(config))
     await hass.async_block_till_done()
 
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 

--- a/tests/components/tasmota/test_device_trigger.py
+++ b/tests/components/tasmota/test_device_trigger.py
@@ -352,7 +352,7 @@ async def test_update_remove_triggers(
 async def test_if_fires_on_mqtt_message_btn(
     hass: HomeAssistant,
     device_reg,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     mqtt_mock: MqttMockHAClient,
     setup_tasmota,
 ) -> None:
@@ -412,22 +412,22 @@ async def test_if_fires_on_mqtt_message_btn(
         hass, "tasmota_49A3BC/stat/RESULT", '{"Button1":{"Action":"SINGLE"}}'
     )
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "short_press_1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "short_press_1"
 
     # Fake button 3 single press.
     async_fire_mqtt_message(
         hass, "tasmota_49A3BC/stat/RESULT", '{"Button3":{"Action":"SINGLE"}}'
     )
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert calls[1].data["some"] == "short_press_3"
+    assert len(service_calls) == 2
+    assert service_calls[1].data["some"] == "short_press_3"
 
 
 async def test_if_fires_on_mqtt_message_swc(
     hass: HomeAssistant,
     device_reg,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     mqtt_mock: MqttMockHAClient,
     setup_tasmota,
 ) -> None:
@@ -502,30 +502,30 @@ async def test_if_fires_on_mqtt_message_swc(
         hass, "tasmota_49A3BC/stat/RESULT", '{"Switch1":{"Action":"TOGGLE"}}'
     )
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "short_press_1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "short_press_1"
 
     # Fake switch 2 short press.
     async_fire_mqtt_message(
         hass, "tasmota_49A3BC/stat/RESULT", '{"Switch2":{"Action":"TOGGLE"}}'
     )
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert calls[1].data["some"] == "short_press_2"
+    assert len(service_calls) == 2
+    assert service_calls[1].data["some"] == "short_press_2"
 
     # Fake switch 3 long press.
     async_fire_mqtt_message(
         hass, "tasmota_49A3BC/stat/RESULT", '{"custom_switch":{"Action":"HOLD"}}'
     )
     await hass.async_block_till_done()
-    assert len(calls) == 3
-    assert calls[2].data["some"] == "long_press_3"
+    assert len(service_calls) == 3
+    assert service_calls[2].data["some"] == "long_press_3"
 
 
 async def test_if_fires_on_mqtt_message_late_discover(
     hass: HomeAssistant,
     device_reg,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     mqtt_mock: MqttMockHAClient,
     setup_tasmota,
 ) -> None:
@@ -593,22 +593,22 @@ async def test_if_fires_on_mqtt_message_late_discover(
         hass, "tasmota_49A3BC/stat/RESULT", '{"Switch1":{"Action":"TOGGLE"}}'
     )
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "short_press"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "short_press"
 
     # Fake long press.
     async_fire_mqtt_message(
         hass, "tasmota_49A3BC/stat/RESULT", '{"custom_switch":{"Action":"HOLD"}}'
     )
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert calls[1].data["some"] == "double_press"
+    assert len(service_calls) == 2
+    assert service_calls[1].data["some"] == "double_press"
 
 
 async def test_if_fires_on_mqtt_message_after_update(
     hass: HomeAssistant,
     device_reg,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     mqtt_mock: MqttMockHAClient,
     setup_tasmota,
 ) -> None:
@@ -656,7 +656,7 @@ async def test_if_fires_on_mqtt_message_after_update(
         hass, "tasmota_49A3BC/stat/RESULT", '{"Switch1":{"Action":"TOGGLE"}}'
     )
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
 
     # Update the trigger with different topic
     async_fire_mqtt_message(hass, f"{DEFAULT_PREFIX}/{mac}/config", json.dumps(config2))
@@ -666,13 +666,13 @@ async def test_if_fires_on_mqtt_message_after_update(
         hass, "tasmota_49A3BC/stat/RESULT", '{"Switch1":{"Action":"TOGGLE"}}'
     )
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
 
     async_fire_mqtt_message(
         hass, "tasmota_49A3BC/status/RESULT", '{"Switch1":{"Action":"TOGGLE"}}'
     )
     await hass.async_block_till_done()
-    assert len(calls) == 2
+    assert len(service_calls) == 2
 
     # Update the trigger with same topic
     async_fire_mqtt_message(hass, f"{DEFAULT_PREFIX}/{mac}/config", json.dumps(config2))
@@ -682,13 +682,13 @@ async def test_if_fires_on_mqtt_message_after_update(
         hass, "tasmota_49A3BC/stat/RESULT", '{"Switch1":{"Action":"TOGGLE"}}'
     )
     await hass.async_block_till_done()
-    assert len(calls) == 2
+    assert len(service_calls) == 2
 
     async_fire_mqtt_message(
         hass, "tasmota_49A3BC/status/RESULT", '{"Switch1":{"Action":"TOGGLE"}}'
     )
     await hass.async_block_till_done()
-    assert len(calls) == 3
+    assert len(service_calls) == 3
 
 
 async def test_no_resubscribe_same_topic(
@@ -742,7 +742,7 @@ async def test_no_resubscribe_same_topic(
 async def test_not_fires_on_mqtt_message_after_remove_by_mqtt(
     hass: HomeAssistant,
     device_reg,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     mqtt_mock: MqttMockHAClient,
     setup_tasmota,
 ) -> None:
@@ -789,7 +789,7 @@ async def test_not_fires_on_mqtt_message_after_remove_by_mqtt(
         hass, "tasmota_49A3BC/stat/RESULT", '{"Switch1":{"Action":"TOGGLE"}}'
     )
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
 
     # Remove the trigger
     config["swc"][0] = -1
@@ -800,7 +800,7 @@ async def test_not_fires_on_mqtt_message_after_remove_by_mqtt(
         hass, "tasmota_49A3BC/stat/RESULT", '{"Switch1":{"Action":"TOGGLE"}}'
     )
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
 
     # Rediscover the trigger
     config["swc"][0] = 0
@@ -811,14 +811,14 @@ async def test_not_fires_on_mqtt_message_after_remove_by_mqtt(
         hass, "tasmota_49A3BC/stat/RESULT", '{"Switch1":{"Action":"TOGGLE"}}'
     )
     await hass.async_block_till_done()
-    assert len(calls) == 2
+    assert len(service_calls) == 2
 
 
 async def test_not_fires_on_mqtt_message_after_remove_from_registry(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     device_reg,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     mqtt_mock: MqttMockHAClient,
     setup_tasmota,
 ) -> None:
@@ -866,7 +866,7 @@ async def test_not_fires_on_mqtt_message_after_remove_from_registry(
         hass, "tasmota_49A3BC/stat/RESULT", '{"Switch1":{"Action":"TOGGLE"}}'
     )
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
 
     # Remove the device
     await remove_device(hass, hass_ws_client, device_entry.id)
@@ -876,7 +876,7 @@ async def test_not_fires_on_mqtt_message_after_remove_from_registry(
         hass, "tasmota_49A3BC/stat/RESULT", '{"Switch1":{"Action":"TOGGLE"}}'
     )
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
 
 
 async def test_attach_remove(
@@ -897,10 +897,10 @@ async def test_attach_remove(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
-    calls = []
+    service_calls = []
 
     def callback(trigger, context):
-        calls.append(trigger["trigger"]["description"])
+        service_calls.append(trigger["trigger"]["description"])
 
     remove = await async_initialize_triggers(
         hass,
@@ -925,8 +925,8 @@ async def test_attach_remove(
         hass, "tasmota_49A3BC/stat/RESULT", '{"Switch1":{"Action":"TOGGLE"}}'
     )
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0] == "event 'tasmota_event'"
+    assert len(service_calls) == 1
+    assert service_calls[0] == "event 'tasmota_event'"
 
     # Remove the trigger
     remove()
@@ -937,7 +937,7 @@ async def test_attach_remove(
         hass, "tasmota_49A3BC/stat/RESULT", '{"Switch1":{"Action":"TOGGLE"}}'
     )
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
 
 
 async def test_attach_remove_late(
@@ -960,10 +960,10 @@ async def test_attach_remove_late(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
-    calls = []
+    service_calls = []
 
     def callback(trigger, context):
-        calls.append(trigger["trigger"]["description"])
+        service_calls.append(trigger["trigger"]["description"])
 
     remove = await async_initialize_triggers(
         hass,
@@ -988,7 +988,7 @@ async def test_attach_remove_late(
         hass, "tasmota_49A3BC/stat/RESULT", '{"Switch1":{"Action":"TOGGLE"}}'
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     async_fire_mqtt_message(hass, f"{DEFAULT_PREFIX}/{mac}/config", json.dumps(config2))
     await hass.async_block_till_done()
@@ -998,8 +998,8 @@ async def test_attach_remove_late(
         hass, "tasmota_49A3BC/stat/RESULT", '{"Switch1":{"Action":"TOGGLE"}}'
     )
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0] == "event 'tasmota_event'"
+    assert len(service_calls) == 1
+    assert service_calls[0] == "event 'tasmota_event'"
 
     # Remove the trigger
     remove()
@@ -1010,7 +1010,7 @@ async def test_attach_remove_late(
         hass, "tasmota_49A3BC/stat/RESULT", '{"Switch1":{"Action":"TOGGLE"}}'
     )
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
 
 
 async def test_attach_remove_late2(
@@ -1033,10 +1033,10 @@ async def test_attach_remove_late2(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
-    calls = []
+    service_calls = []
 
     def callback(trigger, context):
-        calls.append(trigger["trigger"]["description"])
+        service_calls.append(trigger["trigger"]["description"])
 
     remove = await async_initialize_triggers(
         hass,
@@ -1068,7 +1068,7 @@ async def test_attach_remove_late2(
         hass, "tasmota_49A3BC/stat/RESULT", '{"Switch1":{"Action":"TOGGLE"}}'
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
 
 async def test_attach_remove_unknown1(
@@ -1181,10 +1181,10 @@ async def test_attach_remove_config_entry(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
 
-    calls = []
+    service_calls = []
 
     def callback(trigger, context):
-        calls.append(trigger["trigger"]["description"])
+        service_calls.append(trigger["trigger"]["description"])
 
     await async_initialize_triggers(
         hass,
@@ -1209,8 +1209,8 @@ async def test_attach_remove_config_entry(
         hass, "tasmota_49A3BC/stat/RESULT", '{"Switch1":{"Action":"TOGGLE"}}'
     )
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0] == "event 'tasmota_event'"
+    assert len(service_calls) == 1
+    assert service_calls[0] == "event 'tasmota_event'"
 
     # Remove the Tasmota config entry
     config_entries = hass.config_entries.async_entries("tasmota")
@@ -1222,4 +1222,4 @@ async def test_attach_remove_config_entry(
         hass, "tasmota_49A3BC/stat/RESULT", '{"Switch1":{"Action":"TOGGLE"}}'
     )
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1

--- a/tests/components/tasmota/test_discovery.py
+++ b/tests/components/tasmota/test_discovery.py
@@ -124,9 +124,8 @@ async def test_invalid_mac(
 async def test_correct_config_discovery(
     hass: HomeAssistant,
     mqtt_mock: MqttMockHAClient,
-    caplog: pytest.LogCaptureFixture,
-    device_reg,
-    entity_reg,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     setup_tasmota,
 ) -> None:
     """Test receiving valid discovery message."""
@@ -142,11 +141,11 @@ async def test_correct_config_discovery(
     await hass.async_block_till_done()
 
     # Verify device and registry entries are created
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is not None
-    entity_entry = entity_reg.async_get("switch.tasmota_test")
+    entity_entry = entity_registry.async_get("switch.tasmota_test")
     assert entity_entry is not None
 
     state = hass.states.get("switch.tasmota_test")
@@ -159,9 +158,7 @@ async def test_correct_config_discovery(
 async def test_device_discover(
     hass: HomeAssistant,
     mqtt_mock: MqttMockHAClient,
-    caplog: pytest.LogCaptureFixture,
-    device_reg,
-    entity_reg,
+    device_registry: dr.DeviceRegistry,
     setup_tasmota,
 ) -> None:
     """Test setting up a device."""
@@ -176,7 +173,7 @@ async def test_device_discover(
     await hass.async_block_till_done()
 
     # Verify device and registry entries are created
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is not None
@@ -190,9 +187,7 @@ async def test_device_discover(
 async def test_device_discover_deprecated(
     hass: HomeAssistant,
     mqtt_mock: MqttMockHAClient,
-    caplog: pytest.LogCaptureFixture,
-    device_reg,
-    entity_reg,
+    device_registry: dr.DeviceRegistry,
     setup_tasmota,
 ) -> None:
     """Test setting up a device with deprecated discovery message."""
@@ -207,7 +202,7 @@ async def test_device_discover_deprecated(
     await hass.async_block_till_done()
 
     # Verify device and registry entries are created
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is not None
@@ -220,9 +215,7 @@ async def test_device_discover_deprecated(
 async def test_device_update(
     hass: HomeAssistant,
     mqtt_mock: MqttMockHAClient,
-    caplog: pytest.LogCaptureFixture,
-    device_reg,
-    entity_reg,
+    device_registry: dr.DeviceRegistry,
     setup_tasmota,
 ) -> None:
     """Test updating a device."""
@@ -240,7 +233,7 @@ async def test_device_update(
     await hass.async_block_till_done()
 
     # Verify device entry is created
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is not None
@@ -258,7 +251,7 @@ async def test_device_update(
     await hass.async_block_till_done()
 
     # Verify device entry is updated
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is not None
@@ -270,9 +263,7 @@ async def test_device_update(
 async def test_device_remove(
     hass: HomeAssistant,
     mqtt_mock: MqttMockHAClient,
-    caplog: pytest.LogCaptureFixture,
-    device_reg,
-    entity_reg,
+    device_registry: dr.DeviceRegistry,
     setup_tasmota,
 ) -> None:
     """Test removing a discovered device."""
@@ -287,7 +278,7 @@ async def test_device_remove(
     await hass.async_block_till_done()
 
     # Verify device entry is created
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is not None
@@ -300,7 +291,7 @@ async def test_device_remove(
     await hass.async_block_till_done()
 
     # Verify device entry is removed
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is None
@@ -309,9 +300,7 @@ async def test_device_remove(
 async def test_device_remove_multiple_config_entries_1(
     hass: HomeAssistant,
     mqtt_mock: MqttMockHAClient,
-    caplog: pytest.LogCaptureFixture,
-    device_reg,
-    entity_reg,
+    device_registry: dr.DeviceRegistry,
     setup_tasmota,
 ) -> None:
     """Test removing a discovered device."""
@@ -321,7 +310,7 @@ async def test_device_remove_multiple_config_entries_1(
     mock_entry = MockConfigEntry(domain="test")
     mock_entry.add_to_hass(hass)
 
-    device_reg.async_get_or_create(
+    device_registry.async_get_or_create(
         config_entry_id=mock_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, mac)},
     )
@@ -336,7 +325,7 @@ async def test_device_remove_multiple_config_entries_1(
     await hass.async_block_till_done()
 
     # Verify device entry is created
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is not None
@@ -350,7 +339,7 @@ async def test_device_remove_multiple_config_entries_1(
     await hass.async_block_till_done()
 
     # Verify device entry is not removed
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is not None
@@ -360,9 +349,7 @@ async def test_device_remove_multiple_config_entries_1(
 async def test_device_remove_multiple_config_entries_2(
     hass: HomeAssistant,
     mqtt_mock: MqttMockHAClient,
-    caplog: pytest.LogCaptureFixture,
-    device_reg,
-    entity_reg,
+    device_registry: dr.DeviceRegistry,
     setup_tasmota,
 ) -> None:
     """Test removing a discovered device."""
@@ -372,12 +359,12 @@ async def test_device_remove_multiple_config_entries_2(
     mock_entry = MockConfigEntry(domain="test")
     mock_entry.add_to_hass(hass)
 
-    device_reg.async_get_or_create(
+    device_registry.async_get_or_create(
         config_entry_id=mock_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, mac)},
     )
 
-    other_device_entry = device_reg.async_get_or_create(
+    other_device_entry = device_registry.async_get_or_create(
         config_entry_id=mock_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "other_device")},
     )
@@ -392,7 +379,7 @@ async def test_device_remove_multiple_config_entries_2(
     await hass.async_block_till_done()
 
     # Verify device entry is created
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is not None
@@ -400,13 +387,13 @@ async def test_device_remove_multiple_config_entries_2(
     assert other_device_entry.id != device_entry.id
 
     # Remove other config entry from the device
-    device_reg.async_update_device(
+    device_registry.async_update_device(
         device_entry.id, remove_config_entry_id=mock_entry.entry_id
     )
     await hass.async_block_till_done()
 
     # Verify device entry is not removed
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is not None
@@ -414,7 +401,7 @@ async def test_device_remove_multiple_config_entries_2(
     mqtt_mock.async_publish.assert_not_called()
 
     # Remove other config entry from the other device - Tasmota should not do any cleanup
-    device_reg.async_update_device(
+    device_registry.async_update_device(
         other_device_entry.id, remove_config_entry_id=mock_entry.entry_id
     )
     await hass.async_block_till_done()
@@ -425,8 +412,7 @@ async def test_device_remove_stale(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     mqtt_mock: MqttMockHAClient,
-    caplog: pytest.LogCaptureFixture,
-    device_reg,
+    device_registry: dr.DeviceRegistry,
     setup_tasmota,
 ) -> None:
     """Test removing a stale (undiscovered) device does not throw."""
@@ -436,13 +422,13 @@ async def test_device_remove_stale(
     config_entry = hass.config_entries.async_entries("tasmota")[0]
 
     # Create a device
-    device_reg.async_get_or_create(
+    device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, mac)},
     )
 
     # Verify device entry was created
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is not None
@@ -451,7 +437,7 @@ async def test_device_remove_stale(
     await remove_device(hass, hass_ws_client, device_entry.id)
 
     # Verify device entry is removed
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is None
@@ -460,9 +446,7 @@ async def test_device_remove_stale(
 async def test_device_rediscover(
     hass: HomeAssistant,
     mqtt_mock: MqttMockHAClient,
-    caplog: pytest.LogCaptureFixture,
-    device_reg,
-    entity_reg,
+    device_registry: dr.DeviceRegistry,
     setup_tasmota,
 ) -> None:
     """Test removing a device."""
@@ -477,7 +461,7 @@ async def test_device_rediscover(
     await hass.async_block_till_done()
 
     # Verify device entry is created
-    device_entry1 = device_reg.async_get_device(
+    device_entry1 = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry1 is not None
@@ -490,7 +474,7 @@ async def test_device_rediscover(
     await hass.async_block_till_done()
 
     # Verify device entry is removed
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is None
@@ -503,7 +487,7 @@ async def test_device_rediscover(
     await hass.async_block_till_done()
 
     # Verify device entry is created, and id is reused
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is not None
@@ -576,9 +560,8 @@ async def test_entity_duplicate_removal(
 async def test_same_topic(
     hass: HomeAssistant,
     mqtt_mock: MqttMockHAClient,
-    caplog: pytest.LogCaptureFixture,
-    device_reg,
-    entity_reg,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     setup_tasmota,
     issue_registry: ir.IssueRegistry,
 ) -> None:
@@ -605,7 +588,7 @@ async def test_same_topic(
 
     # Verify device registry entries are created for both devices
     for config in configs[0:2]:
-        device_entry = device_reg.async_get_device(
+        device_entry = device_registry.async_get_device(
             connections={(dr.CONNECTION_NETWORK_MAC, config["mac"])}
         )
         assert device_entry is not None
@@ -616,14 +599,14 @@ async def test_same_topic(
         assert device_entry.sw_version == config["sw"]
 
     # Verify entities are created only for the first device
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, configs[0]["mac"])}
     )
-    assert len(er.async_entries_for_device(entity_reg, device_entry.id, True)) == 1
-    device_entry = device_reg.async_get_device(
+    assert len(er.async_entries_for_device(entity_registry, device_entry.id, True)) == 1
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, configs[1]["mac"])}
     )
-    assert len(er.async_entries_for_device(entity_reg, device_entry.id, True)) == 0
+    assert len(er.async_entries_for_device(entity_registry, device_entry.id, True)) == 0
 
     # Verify a repairs issue was created
     issue_id = "topic_duplicated_tasmota_49A3BC/cmnd/"
@@ -639,7 +622,7 @@ async def test_same_topic(
     await hass.async_block_till_done()
 
     # Verify device registry entries was created
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, configs[2]["mac"])}
     )
     assert device_entry is not None
@@ -650,10 +633,10 @@ async def test_same_topic(
     assert device_entry.sw_version == configs[2]["sw"]
 
     # Verify no entities were created
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, configs[2]["mac"])}
     )
-    assert len(er.async_entries_for_device(entity_reg, device_entry.id, True)) == 0
+    assert len(er.async_entries_for_device(entity_registry, device_entry.id, True)) == 0
 
     # Verify the repairs issue has been updated
     issue = issue_registry.async_get_issue("tasmota", issue_id)
@@ -669,10 +652,10 @@ async def test_same_topic(
     await hass.async_block_till_done()
 
     # Verify entities are created also for the third device
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, configs[2]["mac"])}
     )
-    assert len(er.async_entries_for_device(entity_reg, device_entry.id, True)) == 1
+    assert len(er.async_entries_for_device(entity_registry, device_entry.id, True)) == 1
 
     # Verify the repairs issue has been updated
     issue = issue_registry.async_get_issue("tasmota", issue_id)
@@ -688,10 +671,10 @@ async def test_same_topic(
     await hass.async_block_till_done()
 
     # Verify entities are created also for the second device
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, configs[1]["mac"])}
     )
-    assert len(er.async_entries_for_device(entity_reg, device_entry.id, True)) == 1
+    assert len(er.async_entries_for_device(entity_registry, device_entry.id, True)) == 1
 
     # Verify the repairs issue has been removed
     assert issue_registry.async_get_issue("tasmota", issue_id) is None
@@ -700,9 +683,8 @@ async def test_same_topic(
 async def test_topic_no_prefix(
     hass: HomeAssistant,
     mqtt_mock: MqttMockHAClient,
-    caplog: pytest.LogCaptureFixture,
-    device_reg,
-    entity_reg,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
     setup_tasmota,
     issue_registry: ir.IssueRegistry,
 ) -> None:
@@ -719,7 +701,7 @@ async def test_topic_no_prefix(
     await hass.async_block_till_done()
 
     # Verify device registry entry is created
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, config["mac"])}
     )
     assert device_entry is not None
@@ -730,10 +712,10 @@ async def test_topic_no_prefix(
     assert device_entry.sw_version == config["sw"]
 
     # Verify entities are not created
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, config["mac"])}
     )
-    assert len(er.async_entries_for_device(entity_reg, device_entry.id, True)) == 0
+    assert len(er.async_entries_for_device(entity_registry, device_entry.id, True)) == 0
 
     # Verify a repairs issue was created
     issue_id = "topic_no_prefix_00000049A3BC"
@@ -749,10 +731,10 @@ async def test_topic_no_prefix(
     await hass.async_block_till_done()
 
     # Verify entities are created
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, config["mac"])}
     )
-    assert len(er.async_entries_for_device(entity_reg, device_entry.id, True)) == 1
+    assert len(er.async_entries_for_device(entity_registry, device_entry.id, True)) == 1
 
     # Verify the repairs issue has been removed
     assert ("tasmota", issue_id) not in issue_registry.issues

--- a/tests/components/tasmota/test_init.py
+++ b/tests/components/tasmota/test_init.py
@@ -4,8 +4,6 @@ import copy
 import json
 from unittest.mock import call
 
-import pytest
-
 from homeassistant.components.tasmota.const import DEFAULT_PREFIX, DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
@@ -26,9 +24,7 @@ async def test_device_remove(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     mqtt_mock: MqttMockHAClient,
-    caplog: pytest.LogCaptureFixture,
-    device_reg,
-    entity_reg,
+    device_registry: dr.DeviceRegistry,
     setup_tasmota,
 ) -> None:
     """Test removing a discovered device through device registry."""
@@ -44,7 +40,7 @@ async def test_device_remove(
     await hass.async_block_till_done()
 
     # Verify device entry is created
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is not None
@@ -53,7 +49,7 @@ async def test_device_remove(
     await hass.async_block_till_done()
 
     # Verify device entry is removed
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is None
@@ -70,7 +66,7 @@ async def test_device_remove(
 
 async def test_device_remove_non_tasmota_device(
     hass: HomeAssistant,
-    device_reg,
+    device_registry: dr.DeviceRegistry,
     hass_ws_client: WebSocketGenerator,
     mqtt_mock: MqttMockHAClient,
     setup_tasmota,
@@ -92,7 +88,7 @@ async def test_device_remove_non_tasmota_device(
     config_entry.add_to_hass(hass)
 
     mac = "12:34:56:AB:CD:EF"
-    device_entry = device_reg.async_get_or_create(
+    device_entry = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, mac)},
     )
@@ -102,7 +98,7 @@ async def test_device_remove_non_tasmota_device(
     await hass.async_block_till_done()
 
     # Verify device entry is removed
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is None
@@ -113,7 +109,7 @@ async def test_device_remove_non_tasmota_device(
 
 async def test_device_remove_stale_tasmota_device(
     hass: HomeAssistant,
-    device_reg,
+    device_registry: dr.DeviceRegistry,
     hass_ws_client: WebSocketGenerator,
     mqtt_mock: MqttMockHAClient,
     setup_tasmota,
@@ -123,7 +119,7 @@ async def test_device_remove_stale_tasmota_device(
     config_entry = hass.config_entries.async_entries("tasmota")[0]
 
     mac = "12:34:56:AB:CD:EF"
-    device_entry = device_reg.async_get_or_create(
+    device_entry = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, mac)},
     )
@@ -133,7 +129,7 @@ async def test_device_remove_stale_tasmota_device(
     await hass.async_block_till_done()
 
     # Verify device entry is removed
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is None
@@ -144,8 +140,7 @@ async def test_device_remove_stale_tasmota_device(
 
 async def test_tasmota_ws_remove_discovered_device(
     hass: HomeAssistant,
-    device_reg,
-    entity_reg,
+    device_registry: dr.DeviceRegistry,
     hass_ws_client: WebSocketGenerator,
     mqtt_mock: MqttMockHAClient,
     setup_tasmota,
@@ -159,7 +154,7 @@ async def test_tasmota_ws_remove_discovered_device(
     await hass.async_block_till_done()
 
     # Verify device entry is created
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is not None
@@ -170,7 +165,7 @@ async def test_tasmota_ws_remove_discovered_device(
     )
 
     # Verify device entry is cleared
-    device_entry = device_reg.async_get_device(
+    device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)}
     )
     assert device_entry is None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #118356

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
