### PR TITLE
Use service_calls fixture in core platform tests [m-z]

### DIFF
--- a/tests/components/media_player/test_device_condition.py
+++ b/tests/components/media_player/test_device_condition.py
@@ -20,22 +20,12 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
-from tests.common import (
-    MockConfigEntry,
-    async_get_device_automations,
-    async_mock_service,
-)
+from tests.common import MockConfigEntry, async_get_device_automations
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 async def test_get_conditions(
@@ -136,7 +126,7 @@ async def test_if_state(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -274,8 +264,8 @@ async def test_if_state(
     hass.bus.async_fire("test_event5")
     hass.bus.async_fire("test_event6")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "is_on - event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "is_on - event - test_event1"
 
     hass.states.async_set(entry.entity_id, STATE_OFF)
     hass.bus.async_fire("test_event1")
@@ -285,8 +275,8 @@ async def test_if_state(
     hass.bus.async_fire("test_event5")
     hass.bus.async_fire("test_event6")
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert calls[1].data["some"] == "is_off - event - test_event2"
+    assert len(service_calls) == 2
+    assert service_calls[1].data["some"] == "is_off - event - test_event2"
 
     hass.states.async_set(entry.entity_id, STATE_IDLE)
     hass.bus.async_fire("test_event1")
@@ -296,8 +286,8 @@ async def test_if_state(
     hass.bus.async_fire("test_event5")
     hass.bus.async_fire("test_event6")
     await hass.async_block_till_done()
-    assert len(calls) == 3
-    assert calls[2].data["some"] == "is_idle - event - test_event3"
+    assert len(service_calls) == 3
+    assert service_calls[2].data["some"] == "is_idle - event - test_event3"
 
     hass.states.async_set(entry.entity_id, STATE_PAUSED)
     hass.bus.async_fire("test_event1")
@@ -307,8 +297,8 @@ async def test_if_state(
     hass.bus.async_fire("test_event5")
     hass.bus.async_fire("test_event6")
     await hass.async_block_till_done()
-    assert len(calls) == 4
-    assert calls[3].data["some"] == "is_paused - event - test_event4"
+    assert len(service_calls) == 4
+    assert service_calls[3].data["some"] == "is_paused - event - test_event4"
 
     hass.states.async_set(entry.entity_id, STATE_PLAYING)
     hass.bus.async_fire("test_event1")
@@ -318,8 +308,8 @@ async def test_if_state(
     hass.bus.async_fire("test_event5")
     hass.bus.async_fire("test_event6")
     await hass.async_block_till_done()
-    assert len(calls) == 5
-    assert calls[4].data["some"] == "is_playing - event - test_event5"
+    assert len(service_calls) == 5
+    assert service_calls[4].data["some"] == "is_playing - event - test_event5"
 
     hass.states.async_set(entry.entity_id, STATE_BUFFERING)
     hass.bus.async_fire("test_event1")
@@ -329,15 +319,15 @@ async def test_if_state(
     hass.bus.async_fire("test_event5")
     hass.bus.async_fire("test_event6")
     await hass.async_block_till_done()
-    assert len(calls) == 6
-    assert calls[5].data["some"] == "is_buffering - event - test_event6"
+    assert len(service_calls) == 6
+    assert service_calls[5].data["some"] == "is_buffering - event - test_event6"
 
 
 async def test_if_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -380,5 +370,5 @@ async def test_if_state_legacy(
     )
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "is_on - event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "is_on - event - test_event1"

--- a/tests/components/media_player/test_device_trigger.py
+++ b/tests/components/media_player/test_device_trigger.py
@@ -28,19 +28,12 @@ from tests.common import (
     async_fire_time_changed,
     async_get_device_automation_capabilities,
     async_get_device_automations,
-    async_mock_service,
 )
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 async def test_get_triggers(
@@ -209,7 +202,7 @@ async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -265,8 +258,8 @@ async def test_if_fires_on_state_change(
     # Fake that the entity is turning on.
     hass.states.async_set(entry.entity_id, STATE_ON)
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert {calls[0].data["some"], calls[1].data["some"]} == {
+    assert len(service_calls) == 2
+    assert {service_calls[0].data["some"], service_calls[1].data["some"]} == {
         "turned_on - device - media_player.test_5678 - off - on - None",
         "changed_states - device - media_player.test_5678 - off - on - None",
     }
@@ -274,8 +267,8 @@ async def test_if_fires_on_state_change(
     # Fake that the entity is turning off.
     hass.states.async_set(entry.entity_id, STATE_OFF)
     await hass.async_block_till_done()
-    assert len(calls) == 4
-    assert {calls[2].data["some"], calls[3].data["some"]} == {
+    assert len(service_calls) == 4
+    assert {service_calls[2].data["some"], service_calls[3].data["some"]} == {
         "turned_off - device - media_player.test_5678 - on - off - None",
         "changed_states - device - media_player.test_5678 - on - off - None",
     }
@@ -283,8 +276,8 @@ async def test_if_fires_on_state_change(
     # Fake that the entity becomes idle.
     hass.states.async_set(entry.entity_id, STATE_IDLE)
     await hass.async_block_till_done()
-    assert len(calls) == 6
-    assert {calls[4].data["some"], calls[5].data["some"]} == {
+    assert len(service_calls) == 6
+    assert {service_calls[4].data["some"], service_calls[5].data["some"]} == {
         "idle - device - media_player.test_5678 - off - idle - None",
         "changed_states - device - media_player.test_5678 - off - idle - None",
     }
@@ -292,8 +285,8 @@ async def test_if_fires_on_state_change(
     # Fake that the entity starts playing.
     hass.states.async_set(entry.entity_id, STATE_PLAYING)
     await hass.async_block_till_done()
-    assert len(calls) == 8
-    assert {calls[6].data["some"], calls[7].data["some"]} == {
+    assert len(service_calls) == 8
+    assert {service_calls[6].data["some"], service_calls[7].data["some"]} == {
         "playing - device - media_player.test_5678 - idle - playing - None",
         "changed_states - device - media_player.test_5678 - idle - playing - None",
     }
@@ -301,8 +294,8 @@ async def test_if_fires_on_state_change(
     # Fake that the entity is paused.
     hass.states.async_set(entry.entity_id, STATE_PAUSED)
     await hass.async_block_till_done()
-    assert len(calls) == 10
-    assert {calls[8].data["some"], calls[9].data["some"]} == {
+    assert len(service_calls) == 10
+    assert {service_calls[8].data["some"], service_calls[9].data["some"]} == {
         "paused - device - media_player.test_5678 - playing - paused - None",
         "changed_states - device - media_player.test_5678 - playing - paused - None",
     }
@@ -310,8 +303,8 @@ async def test_if_fires_on_state_change(
     # Fake that the entity is buffering.
     hass.states.async_set(entry.entity_id, STATE_BUFFERING)
     await hass.async_block_till_done()
-    assert len(calls) == 12
-    assert {calls[10].data["some"], calls[11].data["some"]} == {
+    assert len(service_calls) == 12
+    assert {service_calls[10].data["some"], service_calls[11].data["some"]} == {
         "buffering - device - media_player.test_5678 - paused - buffering - None",
         "changed_states - device - media_player.test_5678 - paused - buffering - None",
     }
@@ -321,7 +314,7 @@ async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -369,9 +362,9 @@ async def test_if_fires_on_state_change_legacy(
     # Fake that the entity is turning on.
     hass.states.async_set(entry.entity_id, STATE_ON)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == "turned_on - device - media_player.test_5678 - off - on - None"
     )
 
@@ -380,7 +373,7 @@ async def test_if_fires_on_state_change_with_for(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for triggers firing with delay."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -426,16 +419,16 @@ async def test_if_fires_on_state_change_with_for(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, STATE_ON)
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     await hass.async_block_till_done()
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"turn_off device - {entry.entity_id} - off - on - 0:00:05"
     )

--- a/tests/components/remote/test_device_action.py
+++ b/tests/components/remote/test_device_action.py
@@ -7,7 +7,7 @@ from homeassistant.components import automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.remote import DOMAIN
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
@@ -22,12 +22,6 @@ from tests.common import (
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 async def test_get_actions(
@@ -114,7 +108,6 @@ async def test_action(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off actions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -189,7 +182,6 @@ async def test_action_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off actions."""
     config_entry = MockConfigEntry(domain="test", data={})

--- a/tests/components/remote/test_device_condition.py
+++ b/tests/components/remote/test_device_condition.py
@@ -20,19 +20,12 @@ from tests.common import (
     MockConfigEntry,
     async_get_device_automation_capabilities,
     async_get_device_automations,
-    async_mock_service,
 )
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 async def test_get_conditions(
@@ -183,7 +176,7 @@ async def test_if_state(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -249,20 +242,20 @@ async def test_if_state(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "is_on event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "is_on event - test_event1"
 
     hass.states.async_set(entry.entity_id, STATE_OFF)
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert calls[1].data["some"] == "is_off event - test_event2"
+    assert len(service_calls) == 2
+    assert service_calls[1].data["some"] == "is_off event - test_event2"
 
 
 @pytest.mark.usefixtures("enable_custom_integrations")
@@ -270,7 +263,7 @@ async def test_if_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -315,13 +308,13 @@ async def test_if_state_legacy(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "is_on event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "is_on event - test_event1"
 
 
 @pytest.mark.usefixtures("enable_custom_integrations")
@@ -329,7 +322,7 @@ async def test_if_fires_on_for_condition(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for firing if condition is on with delay."""
     point1 = dt_util.utcnow()
@@ -378,26 +371,26 @@ async def test_if_fires_on_for_condition(
             },
         )
         await hass.async_block_till_done()
-        assert len(calls) == 0
+        assert len(service_calls) == 0
 
         hass.bus.async_fire("test_event1")
         await hass.async_block_till_done()
-        assert len(calls) == 0
+        assert len(service_calls) == 0
 
         # Time travel 10 secs into the future
         freezer.move_to(point2)
         hass.bus.async_fire("test_event1")
         await hass.async_block_till_done()
-        assert len(calls) == 0
+        assert len(service_calls) == 0
 
         hass.states.async_set(entry.entity_id, STATE_OFF)
         hass.bus.async_fire("test_event1")
         await hass.async_block_till_done()
-        assert len(calls) == 0
+        assert len(service_calls) == 0
 
         # Time travel 20 secs into the future
         freezer.move_to(point3)
         hass.bus.async_fire("test_event1")
         await hass.async_block_till_done()
-        assert len(calls) == 1
-        assert calls[0].data["some"] == "is_off event - test_event1"
+        assert len(service_calls) == 1
+        assert service_calls[0].data["some"] == "is_off event - test_event1"

--- a/tests/components/remote/test_device_trigger.py
+++ b/tests/components/remote/test_device_trigger.py
@@ -20,19 +20,12 @@ from tests.common import (
     async_fire_time_changed,
     async_get_device_automation_capabilities,
     async_get_device_automations,
-    async_mock_service,
 )
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 async def test_get_triggers(
@@ -181,7 +174,7 @@ async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -267,20 +260,20 @@ async def test_if_fires_on_state_change(
             ]
         },
     )
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, STATE_OFF)
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert {calls[0].data["some"], calls[1].data["some"]} == {
+    assert len(service_calls) == 2
+    assert {service_calls[0].data["some"], service_calls[1].data["some"]} == {
         f"turn_off device - {entry.entity_id} - on - off - None",
         f"turn_on_or_off device - {entry.entity_id} - on - off - None",
     }
 
     hass.states.async_set(entry.entity_id, STATE_ON)
     await hass.async_block_till_done()
-    assert len(calls) == 4
-    assert {calls[2].data["some"], calls[3].data["some"]} == {
+    assert len(service_calls) == 4
+    assert {service_calls[2].data["some"], service_calls[3].data["some"]} == {
         f"turn_on device - {entry.entity_id} - off - on - None",
         f"turn_on_or_off device - {entry.entity_id} - off - on - None",
     }
@@ -291,7 +284,7 @@ async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -335,13 +328,13 @@ async def test_if_fires_on_state_change_legacy(
             ]
         },
     )
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, STATE_OFF)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"turn_off device - {entry.entity_id} - on - off - None"
     )
 
@@ -351,7 +344,7 @@ async def test_if_fires_on_state_change_with_for(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for triggers firing with delay."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -397,16 +390,16 @@ async def test_if_fires_on_state_change_with_for(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, STATE_OFF)
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     await hass.async_block_till_done()
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"turn_off device - {entry.entity_id} - on - off - 0:00:05"
     )

--- a/tests/components/select/test_device_condition.py
+++ b/tests/components/select/test_device_condition.py
@@ -21,17 +21,7 @@ from homeassistant.helpers import (
 )
 from homeassistant.setup import async_setup_component
 
-from tests.common import (
-    MockConfigEntry,
-    async_get_device_automations,
-    async_mock_service,
-)
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
+from tests.common import MockConfigEntry, async_get_device_automations
 
 
 async def test_get_conditions(
@@ -115,7 +105,7 @@ async def test_get_conditions_hidden_auxiliary(
 
 async def test_if_selected_option(
     hass: HomeAssistant,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
@@ -181,7 +171,7 @@ async def test_if_selected_option(
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(
         entry.entity_id, "option1", {"options": ["option1", "option2"]}
@@ -189,8 +179,8 @@ async def test_if_selected_option(
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["result"] == "option1 - event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["result"] == "option1 - event - test_event1"
 
     hass.states.async_set(
         entry.entity_id, "option2", {"options": ["option1", "option2"]}
@@ -198,13 +188,13 @@ async def test_if_selected_option(
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert calls[1].data["result"] == "option2 - event - test_event2"
+    assert len(service_calls) == 2
+    assert service_calls[1].data["result"] == "option2 - event - test_event2"
 
 
 async def test_if_selected_option_legacy(
     hass: HomeAssistant,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
@@ -252,8 +242,8 @@ async def test_if_selected_option_legacy(
     )
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["result"] == "option1 - event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["result"] == "option1 - event - test_event1"
 
 
 async def test_get_condition_capabilities(

--- a/tests/components/select/test_device_trigger.py
+++ b/tests/components/select/test_device_trigger.py
@@ -21,17 +21,7 @@ from homeassistant.helpers import (
 )
 from homeassistant.setup import async_setup_component
 
-from tests.common import (
-    MockConfigEntry,
-    async_get_device_automations,
-    async_mock_service,
-)
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
+from tests.common import MockConfigEntry, async_get_device_automations
 
 
 async def test_get_triggers(
@@ -117,7 +107,7 @@ async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -210,27 +200,27 @@ async def test_if_fires_on_state_change(
     # Test triggering device trigger with a to state
     hass.states.async_set(entry.entity_id, "option2")
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"to - device - {entry.entity_id} - option1 - option2 - None - 0"
     )
 
     # Test triggering device trigger with a from state
     hass.states.async_set(entry.entity_id, "option3")
     await hass.async_block_till_done()
-    assert len(calls) == 2
+    assert len(service_calls) == 2
     assert (
-        calls[1].data["some"]
+        service_calls[1].data["some"]
         == f"from - device - {entry.entity_id} - option2 - option3 - None - 0"
     )
 
     # Test triggering device trigger with both a from and to state
     hass.states.async_set(entry.entity_id, "option1")
     await hass.async_block_till_done()
-    assert len(calls) == 3
+    assert len(service_calls) == 3
     assert (
-        calls[2].data["some"]
+        service_calls[2].data["some"]
         == f"from-to - device - {entry.entity_id} - option3 - option1 - None - 0"
     )
 
@@ -239,7 +229,7 @@ async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -289,9 +279,9 @@ async def test_if_fires_on_state_change_legacy(
     # Test triggering device trigger with a to state
     hass.states.async_set(entry.entity_id, "option2")
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"to - device - {entry.entity_id} - option1 - option2 - None - 0"
     )
 

--- a/tests/components/sensor/test_device_condition.py
+++ b/tests/components/sensor/test_device_condition.py
@@ -27,7 +27,6 @@ from tests.common import (
     MockConfigEntry,
     async_get_device_automation_capabilities,
     async_get_device_automations,
-    async_mock_service,
     setup_test_component_platform,
 )
 
@@ -35,12 +34,6 @@ from tests.common import (
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 @pytest.mark.parametrize(
@@ -470,7 +463,6 @@ async def test_if_state_not_above_below(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test for bad value conditions."""
@@ -513,7 +505,7 @@ async def test_if_state_above(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for value conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -559,22 +551,22 @@ async def test_if_state_above(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, 9)
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, 11)
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "event - test_event1"
 
 
 @pytest.mark.usefixtures("enable_custom_integrations")
@@ -582,7 +574,7 @@ async def test_if_state_above_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for value conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -628,22 +620,22 @@ async def test_if_state_above_legacy(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, 9)
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, 11)
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "event - test_event1"
 
 
 @pytest.mark.usefixtures("enable_custom_integrations")
@@ -651,7 +643,7 @@ async def test_if_state_below(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for value conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -697,22 +689,22 @@ async def test_if_state_below(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, 11)
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, 9)
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "event - test_event1"
 
 
 @pytest.mark.usefixtures("enable_custom_integrations")
@@ -720,7 +712,7 @@ async def test_if_state_between(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for value conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -767,30 +759,30 @@ async def test_if_state_between(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, 9)
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, 11)
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "event - test_event1"
 
     hass.states.async_set(entry.entity_id, 21)
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
 
     hass.states.async_set(entry.entity_id, 19)
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert calls[1].data["some"] == "event - test_event1"
+    assert len(service_calls) == 2
+    assert service_calls[1].data["some"] == "event - test_event1"

--- a/tests/components/sensor/test_device_trigger.py
+++ b/tests/components/sensor/test_device_trigger.py
@@ -31,7 +31,6 @@ from tests.common import (
     async_fire_time_changed,
     async_get_device_automation_capabilities,
     async_get_device_automations,
-    async_mock_service,
     setup_test_component_platform,
 )
 
@@ -39,12 +38,6 @@ from tests.common import (
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 @pytest.mark.parametrize(
@@ -427,7 +420,6 @@ async def test_if_fires_not_on_above_below(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test for value triggers firing."""
@@ -467,7 +459,7 @@ async def test_if_fires_on_state_above(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for value triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -513,17 +505,18 @@ async def test_if_fires_on_state_above(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, 9)
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, 11)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     assert (
-        calls[0].data["some"] == f"bat_low device - {entry.entity_id} - 9 - 11 - None"
+        service_calls[0].data["some"]
+        == f"bat_low device - {entry.entity_id} - 9 - 11 - None"
     )
 
 
@@ -532,7 +525,7 @@ async def test_if_fires_on_state_below(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for value triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -578,17 +571,18 @@ async def test_if_fires_on_state_below(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, 11)
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, 9)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     assert (
-        calls[0].data["some"] == f"bat_low device - {entry.entity_id} - 11 - 9 - None"
+        service_calls[0].data["some"]
+        == f"bat_low device - {entry.entity_id} - 11 - 9 - None"
     )
 
 
@@ -597,7 +591,7 @@ async def test_if_fires_on_state_between(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for value triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -644,28 +638,30 @@ async def test_if_fires_on_state_between(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, 9)
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, 11)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     assert (
-        calls[0].data["some"] == f"bat_low device - {entry.entity_id} - 9 - 11 - None"
+        service_calls[0].data["some"]
+        == f"bat_low device - {entry.entity_id} - 9 - 11 - None"
     )
 
     hass.states.async_set(entry.entity_id, 21)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
 
     hass.states.async_set(entry.entity_id, 19)
     await hass.async_block_till_done()
-    assert len(calls) == 2
+    assert len(service_calls) == 2
     assert (
-        calls[1].data["some"] == f"bat_low device - {entry.entity_id} - 21 - 19 - None"
+        service_calls[1].data["some"]
+        == f"bat_low device - {entry.entity_id} - 21 - 19 - None"
     )
 
 
@@ -674,7 +670,7 @@ async def test_if_fires_on_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for value triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -720,17 +716,18 @@ async def test_if_fires_on_state_legacy(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, 9)
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, 11)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     assert (
-        calls[0].data["some"] == f"bat_low device - {entry.entity_id} - 9 - 11 - None"
+        service_calls[0].data["some"]
+        == f"bat_low device - {entry.entity_id} - 9 - 11 - None"
     )
 
 
@@ -739,7 +736,7 @@ async def test_if_fires_on_state_change_with_for(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for triggers firing with delay."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -786,17 +783,17 @@ async def test_if_fires_on_state_change_with_for(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, 10)
     hass.states.async_set(entry.entity_id, 11)
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     await hass.async_block_till_done()
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"turn_off device - {entry.entity_id} - 10 - 11 - 0:00:05"
     )

--- a/tests/components/switch/test_device_action.py
+++ b/tests/components/switch/test_device_action.py
@@ -7,7 +7,7 @@ from homeassistant.components import automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.switch import DOMAIN
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
@@ -22,12 +22,6 @@ from tests.common import (
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 async def test_get_actions(
@@ -115,7 +109,6 @@ async def test_action(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off actions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -190,7 +183,6 @@ async def test_action_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off actions."""
     config_entry = MockConfigEntry(domain="test", data={})

--- a/tests/components/switch/test_device_condition.py
+++ b/tests/components/switch/test_device_condition.py
@@ -20,19 +20,12 @@ from tests.common import (
     MockConfigEntry,
     async_get_device_automation_capabilities,
     async_get_device_automations,
-    async_mock_service,
 )
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 async def test_get_conditions(
@@ -183,7 +176,7 @@ async def test_if_state(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -249,20 +242,20 @@ async def test_if_state(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "is_on event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "is_on event - test_event1"
 
     hass.states.async_set(entry.entity_id, STATE_OFF)
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert calls[1].data["some"] == "is_off event - test_event2"
+    assert len(service_calls) == 2
+    assert service_calls[1].data["some"] == "is_off event - test_event2"
 
 
 @pytest.mark.usefixtures("enable_custom_integrations")
@@ -270,7 +263,7 @@ async def test_if_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -315,12 +308,12 @@ async def test_if_state_legacy(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "is_on event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "is_on event - test_event1"
 
 
 @pytest.mark.usefixtures("enable_custom_integrations")
@@ -328,7 +321,7 @@ async def test_if_fires_on_for_condition(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for firing if condition is on with delay."""
     point1 = dt_util.utcnow()
@@ -377,26 +370,26 @@ async def test_if_fires_on_for_condition(
             },
         )
         await hass.async_block_till_done()
-        assert len(calls) == 0
+        assert len(service_calls) == 0
 
         hass.bus.async_fire("test_event1")
         await hass.async_block_till_done()
-        assert len(calls) == 0
+        assert len(service_calls) == 0
 
         # Time travel 10 secs into the future
         freezer.move_to(point2)
         hass.bus.async_fire("test_event1")
         await hass.async_block_till_done()
-        assert len(calls) == 0
+        assert len(service_calls) == 0
 
         hass.states.async_set(entry.entity_id, STATE_OFF)
         hass.bus.async_fire("test_event1")
         await hass.async_block_till_done()
-        assert len(calls) == 0
+        assert len(service_calls) == 0
 
         # Time travel 20 secs into the future
         freezer.move_to(point3)
         hass.bus.async_fire("test_event1")
         await hass.async_block_till_done()
-        assert len(calls) == 1
-        assert calls[0].data["some"] == "is_off event - test_event1"
+        assert len(service_calls) == 1
+        assert service_calls[0].data["some"] == "is_off event - test_event1"

--- a/tests/components/switch/test_device_trigger.py
+++ b/tests/components/switch/test_device_trigger.py
@@ -20,19 +20,12 @@ from tests.common import (
     async_fire_time_changed,
     async_get_device_automation_capabilities,
     async_get_device_automations,
-    async_mock_service,
 )
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 async def test_get_triggers(
@@ -181,7 +174,7 @@ async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -268,20 +261,20 @@ async def test_if_fires_on_state_change(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, STATE_OFF)
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert {calls[0].data["some"], calls[1].data["some"]} == {
+    assert len(service_calls) == 2
+    assert {service_calls[0].data["some"], service_calls[1].data["some"]} == {
         f"turn_off device - {entry.entity_id} - on - off - None",
         f"turn_on_or_off device - {entry.entity_id} - on - off - None",
     }
 
     hass.states.async_set(entry.entity_id, STATE_ON)
     await hass.async_block_till_done()
-    assert len(calls) == 4
-    assert {calls[2].data["some"], calls[3].data["some"]} == {
+    assert len(service_calls) == 4
+    assert {service_calls[2].data["some"], service_calls[3].data["some"]} == {
         f"turn_on device - {entry.entity_id} - off - on - None",
         f"turn_on_or_off device - {entry.entity_id} - off - on - None",
     }
@@ -292,7 +285,7 @@ async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -337,13 +330,13 @@ async def test_if_fires_on_state_change_legacy(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, STATE_OFF)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"turn_off device - {entry.entity_id} - on - off - None"
     )
 
@@ -353,7 +346,7 @@ async def test_if_fires_on_state_change_with_for(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for triggers firing with delay."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -399,16 +392,16 @@ async def test_if_fires_on_state_change_with_for(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, STATE_OFF)
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     await hass.async_block_till_done()
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"turn_off device - {entry.entity_id} - on - off - 0:00:05"
     )

--- a/tests/components/update/test_device_trigger.py
+++ b/tests/components/update/test_device_trigger.py
@@ -21,7 +21,6 @@ from tests.common import (
     async_fire_time_changed,
     async_get_device_automation_capabilities,
     async_get_device_automations,
-    async_mock_service,
     setup_test_component_platform,
 )
 
@@ -29,12 +28,6 @@ from tests.common import (
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 async def test_get_triggers(
@@ -182,7 +175,7 @@ async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     mock_update_entities: list[MockUpdateEntity],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
@@ -253,21 +246,21 @@ async def test_if_fires_on_state_change(
     state = hass.states.get("update.update_available")
     assert state
     assert state.state == STATE_ON
-    assert not calls
+    assert not service_calls
 
     hass.states.async_set("update.update_available", STATE_OFF)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == "no_update device - update.update_available - on - off - None"
     )
 
     hass.states.async_set("update.update_available", STATE_ON)
     await hass.async_block_till_done()
-    assert len(calls) == 2
+    assert len(service_calls) == 2
     assert (
-        calls[1].data["some"]
+        service_calls[1].data["some"]
         == "update_available device - update.update_available - off - on - None"
     )
 
@@ -276,7 +269,7 @@ async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     mock_update_entities: list[MockUpdateEntity],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
@@ -326,13 +319,13 @@ async def test_if_fires_on_state_change_legacy(
     state = hass.states.get("update.update_available")
     assert state
     assert state.state == STATE_ON
-    assert not calls
+    assert not service_calls
 
     hass.states.async_set("update.update_available", STATE_OFF)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == "no_update device - update.update_available - on - off - None"
     )
 
@@ -341,7 +334,7 @@ async def test_if_fires_on_state_change_with_for(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
     mock_update_entities: list[MockUpdateEntity],
 ) -> None:
     """Test for triggers firing with delay."""
@@ -392,16 +385,16 @@ async def test_if_fires_on_state_change_with_for(
     state = hass.states.get("update.update_available")
     assert state
     assert state.state == STATE_ON
-    assert not calls
+    assert not service_calls
 
     hass.states.async_set("update.update_available", STATE_OFF)
     await hass.async_block_till_done()
-    assert not calls
+    assert not service_calls
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     await hass.async_block_till_done()
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == "turn_off device - update.update_available - on - off - 0:00:05"
     )

--- a/tests/components/vacuum/test_device_condition.py
+++ b/tests/components/vacuum/test_device_condition.py
@@ -17,22 +17,12 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
 
-from tests.common import (
-    MockConfigEntry,
-    async_get_device_automations,
-    async_mock_service,
-)
+from tests.common import MockConfigEntry, async_get_device_automations
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 async def test_get_conditions(
@@ -119,7 +109,7 @@ async def test_if_state(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -181,30 +171,30 @@ async def test_if_state(
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "is_docked - event - test_event2"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "is_docked - event - test_event2"
 
     hass.states.async_set(entry.entity_id, STATE_CLEANING)
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert calls[1].data["some"] == "is_cleaning - event - test_event1"
+    assert len(service_calls) == 2
+    assert service_calls[1].data["some"] == "is_cleaning - event - test_event1"
 
     # Returning means it's still cleaning
     hass.states.async_set(entry.entity_id, STATE_RETURNING)
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
-    assert len(calls) == 3
-    assert calls[2].data["some"] == "is_cleaning - event - test_event1"
+    assert len(service_calls) == 3
+    assert service_calls[2].data["some"] == "is_cleaning - event - test_event1"
 
 
 async def test_if_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -247,5 +237,5 @@ async def test_if_state_legacy(
     )
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].data["some"] == "is_cleaning - event - test_event1"
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "is_cleaning - event - test_event1"

--- a/tests/components/vacuum/test_device_trigger.py
+++ b/tests/components/vacuum/test_device_trigger.py
@@ -20,19 +20,12 @@ from tests.common import (
     async_fire_time_changed,
     async_get_device_automation_capabilities,
     async_get_device_automations,
-    async_mock_service,
 )
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
 def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
-
-
-@pytest.fixture
-def calls(hass: HomeAssistant) -> list[ServiceCall]:
-    """Track calls to a mock service."""
-    return async_mock_service(hass, "test", "automation")
 
 
 async def test_get_triggers(
@@ -182,7 +175,7 @@ async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -247,18 +240,18 @@ async def test_if_fires_on_state_change(
     # Fake that the entity is cleaning
     hass.states.async_set(entry.entity_id, STATE_CLEANING)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"cleaning - device - {entry.entity_id} - docked - cleaning"
     )
 
     # Fake that the entity is docked
     hass.states.async_set(entry.entity_id, STATE_DOCKED)
     await hass.async_block_till_done()
-    assert len(calls) == 2
+    assert len(service_calls) == 2
     assert (
-        calls[1].data["some"]
+        service_calls[1].data["some"]
         == f"docked - device - {entry.entity_id} - cleaning - docked"
     )
 
@@ -267,7 +260,7 @@ async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -313,9 +306,9 @@ async def test_if_fires_on_state_change_legacy(
     # Fake that the entity is cleaning
     hass.states.async_set(entry.entity_id, STATE_CLEANING)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"cleaning - device - {entry.entity_id} - docked - cleaning"
     )
 
@@ -324,7 +317,7 @@ async def test_if_fires_on_state_change_with_for(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls: list[ServiceCall],
+    service_calls: list[ServiceCall],
 ) -> None:
     """Test for triggers firing with delay."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -370,16 +363,16 @@ async def test_if_fires_on_state_change_with_for(
         },
     )
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
 
     hass.states.async_set(entry.entity_id, STATE_CLEANING)
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(service_calls) == 0
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(service_calls) == 1
     await hass.async_block_till_done()
     assert (
-        calls[0].data["some"]
+        service_calls[0].data["some"]
         == f"turn_off device - {entry.entity_id} - docked - cleaning - 0:00:05"
     )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #118356

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
