### PR TITLE
Use common registry fixtures in hue

### DIFF
--- a/tests/components/hue/conftest.py
+++ b/tests/components/hue/conftest.py
@@ -20,7 +20,7 @@ from homeassistant.setup import async_setup_component
 
 from .const import FAKE_BRIDGE, FAKE_BRIDGE_DEVICE
 
-from tests.common import MockConfigEntry, load_fixture, mock_device_registry
+from tests.common import MockConfigEntry, load_fixture
 
 
 @pytest.fixture(autouse=True)
@@ -276,9 +276,3 @@ async def setup_platform(
 
     # and make sure it completes before going further
     await hass.async_block_till_done()
-
-
-@pytest.fixture(name="device_reg")
-def get_device_reg(hass):
-    """Return an empty, loaded, registry."""
-    return mock_device_registry(hass)

--- a/tests/components/hue/test_device_trigger_v1.py
+++ b/tests/components/hue/test_device_trigger_v1.py
@@ -21,7 +21,7 @@ async def test_get_triggers(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_bridge_v1,
-    device_reg: dr.DeviceRegistry,
+    device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test we get the expected triggers from a hue remote."""
     mock_bridge_v1.mock_sensor_responses.append(REMOTES_RESPONSE)
@@ -32,7 +32,7 @@ async def test_get_triggers(
     assert len(hass.states.async_all()) == 1
 
     # Get triggers for specific tap switch
-    hue_tap_device = device_reg.async_get_device(
+    hue_tap_device = device_registry.async_get_device(
         identifiers={(hue.DOMAIN, "00:00:00:00:00:44:23:08")}
     )
     triggers = await async_get_device_automations(
@@ -53,7 +53,7 @@ async def test_get_triggers(
     assert triggers == unordered(expected_triggers)
 
     # Get triggers for specific dimmer switch
-    hue_dimmer_device = device_reg.async_get_device(
+    hue_dimmer_device = device_registry.async_get_device(
         identifiers={(hue.DOMAIN, "00:17:88:01:10:3e:3a:dc")}
     )
     hue_bat_sensor = entity_registry.async_get(
@@ -91,7 +91,7 @@ async def test_get_triggers(
 async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     mock_bridge_v1,
-    device_reg: dr.DeviceRegistry,
+    device_registry: dr.DeviceRegistry,
     service_calls: list[ServiceCall],
 ) -> None:
     """Test for button press trigger firing."""
@@ -101,7 +101,7 @@ async def test_if_fires_on_state_change(
     assert len(hass.states.async_all()) == 1
 
     # Set an automation with a specific tap switch trigger
-    hue_tap_device = device_reg.async_get_device(
+    hue_tap_device = device_registry.async_get_device(
         identifiers={(hue.DOMAIN, "00:00:00:00:00:44:23:08")}
     )
     assert await async_setup_component(

--- a/tests/components/hue/test_device_trigger_v2.py
+++ b/tests/components/hue/test_device_trigger_v2.py
@@ -8,7 +8,7 @@ from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.hue.v2.device import async_setup_devices
 from homeassistant.components.hue.v2.hue_event import async_setup_hue_events
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .conftest import setup_platform
 
@@ -50,14 +50,14 @@ async def test_get_triggers(
     entity_registry: er.EntityRegistry,
     mock_bridge_v2,
     v2_resources_test_data,
-    device_reg,
+    device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test we get the expected triggers from a hue remote."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
     await setup_platform(hass, mock_bridge_v2, ["binary_sensor", "sensor"])
 
     # Get triggers for `Wall switch with 2 controls`
-    hue_wall_switch_device = device_reg.async_get_device(
+    hue_wall_switch_device = device_registry.async_get_device(
         identifiers={(hue.DOMAIN, "3ff06175-29e8-44a8-8fe7-af591b0025da")}
     )
     hue_bat_sensor = entity_registry.async_get(

--- a/tests/components/hue/test_sensor_v1.py
+++ b/tests/components/hue/test_sensor_v1.py
@@ -10,7 +10,7 @@ from homeassistant.components.hue.const import ATTR_HUE_EVENT
 from homeassistant.components.hue.v1 import sensor_base
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .conftest import create_mock_bridge, setup_platform
 
@@ -452,7 +452,10 @@ async def test_update_unauthorized(hass: HomeAssistant, mock_bridge_v1) -> None:
 
 
 async def test_hue_events(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, mock_bridge_v1, device_reg
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_bridge_v1,
+    device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test that hue remotes fire events when pressed."""
     mock_bridge_v1.mock_sensor_responses.append(SENSOR_RESPONSE)
@@ -464,7 +467,7 @@ async def test_hue_events(
     assert len(hass.states.async_all()) == 7
     assert len(events) == 0
 
-    hue_tap_device = device_reg.async_get_device(
+    hue_tap_device = device_registry.async_get_device(
         identifiers={(hue.DOMAIN, "00:00:00:00:00:44:23:08")}
     )
 
@@ -495,7 +498,7 @@ async def test_hue_events(
         "last_updated": "2019-12-28T22:58:03",
     }
 
-    hue_dimmer_device = device_reg.async_get_device(
+    hue_dimmer_device = device_registry.async_get_device(
         identifiers={(hue.DOMAIN, "00:17:88:01:10:3e:3a:dc")}
     )
 
@@ -594,7 +597,7 @@ async def test_hue_events(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    hue_aurora_device = device_reg.async_get_device(
+    hue_aurora_device = device_registry.async_get_device(
         identifiers={(hue.DOMAIN, "ff:ff:00:0f:e7:fd:bc:b7")}
     )
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
