### PR TITLE
Fix setting target temperature for single setpoint Matter thermostat

### DIFF
--- a/homeassistant/components/matter/climate.py
+++ b/homeassistant/components/matter/climate.py
@@ -267,19 +267,16 @@ class MatterClimate(MatterEntity, ClimateEntity):
                     self._attr_hvac_action = HVACAction.FAN
                 case _:
                     self._attr_hvac_action = HVACAction.OFF
-        # update target_temperature
-        if self._attr_hvac_mode == HVACMode.HEAT_COOL:
-            self._attr_target_temperature = None
-        elif self._attr_hvac_mode == HVACMode.COOL:
-            self._attr_target_temperature = self._get_temperature_in_degrees(
-                clusters.Thermostat.Attributes.OccupiedCoolingSetpoint
-            )
-        else:
-            self._attr_target_temperature = self._get_temperature_in_degrees(
-                clusters.Thermostat.Attributes.OccupiedHeatingSetpoint
-            )
         # update target temperature high/low
-        if self._attr_hvac_mode == HVACMode.HEAT_COOL:
+        supports_range = (
+            self._attr_supported_features
+            & ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+        )
+        if supports_range and self._attr_hvac_mode in (
+            HVACMode.HEAT_COOL,
+            HVACMode.AUTO,
+        ):
+            self._attr_target_temperature = None
             self._attr_target_temperature_high = self._get_temperature_in_degrees(
                 clusters.Thermostat.Attributes.OccupiedCoolingSetpoint
             )
@@ -289,6 +286,16 @@ class MatterClimate(MatterEntity, ClimateEntity):
         else:
             self._attr_target_temperature_high = None
             self._attr_target_temperature_low = None
+            # update target_temperature
+            if self._attr_hvac_mode == HVACMode.COOL:
+                self._attr_target_temperature = self._get_temperature_in_degrees(
+                    clusters.Thermostat.Attributes.OccupiedCoolingSetpoint
+                )
+            else:
+                self._attr_target_temperature = self._get_temperature_in_degrees(
+                    clusters.Thermostat.Attributes.OccupiedHeatingSetpoint
+                )
+
         # update min_temp
         if self._attr_hvac_mode == HVACMode.COOL:
             attribute = clusters.Thermostat.Attributes.AbsMinCoolSetpointLimit

--- a/homeassistant/components/matter/climate.py
+++ b/homeassistant/components/matter/climate.py
@@ -272,10 +272,7 @@ class MatterClimate(MatterEntity, ClimateEntity):
             self._attr_supported_features
             & ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
         )
-        if supports_range and self._attr_hvac_mode in (
-            HVACMode.HEAT_COOL,
-            HVACMode.HEAT_COOL,
-        ):
+        if supports_range and self._attr_hvac_mode == HVACMode.HEAT_COOL:
             self._attr_target_temperature = None
             self._attr_target_temperature_high = self._get_temperature_in_degrees(
                 clusters.Thermostat.Attributes.OccupiedCoolingSetpoint

--- a/homeassistant/components/matter/climate.py
+++ b/homeassistant/components/matter/climate.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
 TEMPERATURE_SCALING_FACTOR = 100
 HVAC_SYSTEM_MODE_MAP = {
     HVACMode.OFF: 0,
-    HVACMode.HEAT_COOL: 1,
+    HVACMode.AUTO: 1,
     HVACMode.COOL: 3,
     HVACMode.HEAT: 4,
     HVACMode.DRY: 8,
@@ -135,7 +135,7 @@ class MatterClimate(MatterEntity, ClimateEntity):
         if (vendor_id, product_id) in SUPPORT_FAN_MODE_DEVICES:
             self._attr_hvac_modes.append(HVACMode.FAN_ONLY)
         if feature_map & ThermostatFeature.kAutoMode:
-            self._attr_hvac_modes.append(HVACMode.HEAT_COOL)
+            self._attr_hvac_modes.append(HVACMode.AUTO)
             # only enable temperature_range feature if the device actually supports that
 
             if (vendor_id, product_id) not in SINGLE_SETPOINT_DEVICES:
@@ -233,7 +233,7 @@ class MatterClimate(MatterEntity, ClimateEntity):
         )
         match system_mode_value:
             case SystemModeEnum.kAuto:
-                self._attr_hvac_mode = HVACMode.HEAT_COOL
+                self._attr_hvac_mode = HVACMode.AUTO
             case SystemModeEnum.kDry:
                 self._attr_hvac_mode = HVACMode.DRY
             case SystemModeEnum.kFanOnly:

--- a/homeassistant/components/matter/climate.py
+++ b/homeassistant/components/matter/climate.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
 TEMPERATURE_SCALING_FACTOR = 100
 HVAC_SYSTEM_MODE_MAP = {
     HVACMode.OFF: 0,
-    HVACMode.AUTO: 1,
+    HVACMode.HEAT_COOL: 1,
     HVACMode.COOL: 3,
     HVACMode.HEAT: 4,
     HVACMode.DRY: 8,
@@ -135,7 +135,7 @@ class MatterClimate(MatterEntity, ClimateEntity):
         if (vendor_id, product_id) in SUPPORT_FAN_MODE_DEVICES:
             self._attr_hvac_modes.append(HVACMode.FAN_ONLY)
         if feature_map & ThermostatFeature.kAutoMode:
-            self._attr_hvac_modes.append(HVACMode.AUTO)
+            self._attr_hvac_modes.append(HVACMode.HEAT_COOL)
             # only enable temperature_range feature if the device actually supports that
 
             if (vendor_id, product_id) not in SINGLE_SETPOINT_DEVICES:
@@ -233,7 +233,7 @@ class MatterClimate(MatterEntity, ClimateEntity):
         )
         match system_mode_value:
             case SystemModeEnum.kAuto:
-                self._attr_hvac_mode = HVACMode.AUTO
+                self._attr_hvac_mode = HVACMode.HEAT_COOL
             case SystemModeEnum.kDry:
                 self._attr_hvac_mode = HVACMode.DRY
             case SystemModeEnum.kFanOnly:
@@ -274,7 +274,7 @@ class MatterClimate(MatterEntity, ClimateEntity):
         )
         if supports_range and self._attr_hvac_mode in (
             HVACMode.HEAT_COOL,
-            HVACMode.AUTO,
+            HVACMode.HEAT_COOL,
         ):
             self._attr_target_temperature = None
             self._attr_target_temperature_high = self._get_temperature_in_degrees(

--- a/tests/components/matter/test_climate.py
+++ b/tests/components/matter/test_climate.py
@@ -74,7 +74,7 @@ async def test_thermostat_base(
         HVACMode.OFF,
         HVACMode.HEAT,
         HVACMode.COOL,
-        HVACMode.HEAT_COOL,
+        HVACMode.AUTO,
     ]
 
     # test system mode update from device
@@ -221,12 +221,12 @@ async def test_thermostat_service_calls(
     )
     matter_client.write_attribute.reset_mock()
 
-    # test dual setpoint temperature adjustments when heat_cool mode is active
+    # test dual setpoint temperature adjustments when AUTO mode is active
     set_node_attribute(thermostat, 1, 513, 28, 1)
     await trigger_subscription_callback(hass, matter_client)
     state = hass.states.get("climate.longan_link_hvac_thermostat")
     assert state
-    assert state.state == HVACMode.HEAT_COOL
+    assert state.state == HVACMode.AUTO
 
     await hass.services.async_call(
         "climate",
@@ -330,7 +330,7 @@ async def test_room_airconditioner(
         HVACMode.COOL,
         HVACMode.DRY,
         HVACMode.FAN_ONLY,
-        HVACMode.HEAT_COOL,
+        HVACMode.AUTO,
     ]
     # test fan-only hvac mode
     set_node_attribute(room_airconditioner, 1, 513, 28, 7)

--- a/tests/components/matter/test_climate.py
+++ b/tests/components/matter/test_climate.py
@@ -74,7 +74,7 @@ async def test_thermostat_base(
         HVACMode.OFF,
         HVACMode.HEAT,
         HVACMode.COOL,
-        HVACMode.AUTO,
+        HVACMode.HEAT_COOL,
     ]
 
     # test system mode update from device
@@ -221,12 +221,12 @@ async def test_thermostat_service_calls(
     )
     matter_client.write_attribute.reset_mock()
 
-    # test dual setpoint temperature adjustments when AUTO mode is active
+    # test dual setpoint temperature adjustments when HEAT_COOL mode is active
     set_node_attribute(thermostat, 1, 513, 28, 1)
     await trigger_subscription_callback(hass, matter_client)
     state = hass.states.get("climate.longan_link_hvac_thermostat")
     assert state
-    assert state.state == HVACMode.AUTO
+    assert state.state == HVACMode.HEAT_COOL
 
     await hass.services.async_call(
         "climate",
@@ -330,7 +330,7 @@ async def test_room_airconditioner(
         HVACMode.COOL,
         HVACMode.DRY,
         HVACMode.FAN_ONLY,
-        HVACMode.AUTO,
+        HVACMode.HEAT_COOL,
     ]
     # test fan-only hvac mode
     set_node_attribute(room_airconditioner, 1, 513, 28, 7)

--- a/tests/components/matter/test_climate.py
+++ b/tests/components/matter/test_climate.py
@@ -221,7 +221,7 @@ async def test_thermostat_service_calls(
     )
     matter_client.write_attribute.reset_mock()
 
-    # test dual setpoint temperature adjustments when HEAT_COOL mode is active
+    # test dual setpoint temperature adjustments when heat_cool mode is active
     set_node_attribute(thermostat, 1, 513, 28, 1)
     await trigger_subscription_callback(hass, matter_client)
     state = hass.states.get("climate.longan_link_hvac_thermostat")


### PR DESCRIPTION
## Proposed change
While testing with a device vendor we found a (remaining) issue in the Matter climate platform.

- Fix target temperature control when device in auto (= HA heat/cool) mode and support single setpoint only.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
