### PR TITLE
Improve type hints in analytics tests

### DIFF
--- a/tests/components/analytics/test_analytics.py
+++ b/tests/components/analytics/test_analytics.py
@@ -19,7 +19,6 @@ from homeassistant.components.analytics.const import (
     ATTR_STATISTICS,
     ATTR_USAGE,
 )
-from homeassistant.components.recorder import Recorder
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -36,7 +35,7 @@ MOCK_VERSION_NIGHTLY = "1970.1.0.dev19700101"
 
 
 @pytest.fixture(autouse=True)
-def uuid_mock() -> Generator[Any, Any, None]:
+def uuid_mock() -> Generator[None]:
     """Mock the UUID."""
     with patch("uuid.UUID.hex", new_callable=PropertyMock) as hex_mock:
         hex_mock.return_value = MOCK_UUID
@@ -44,7 +43,7 @@ def uuid_mock() -> Generator[Any, Any, None]:
 
 
 @pytest.fixture(autouse=True)
-def ha_version_mock() -> Generator[Any, Any, None]:
+def ha_version_mock() -> Generator[None]:
     """Mock the core version."""
     with patch(
         "homeassistant.components.analytics.analytics.HA_VERSION",
@@ -54,7 +53,7 @@ def ha_version_mock() -> Generator[Any, Any, None]:
 
 
 @pytest.fixture
-def installation_type_mock() -> Generator[Any, Any, None]:
+def installation_type_mock() -> Generator[None]:
     """Mock the async_get_system_info."""
     with patch(
         "homeassistant.components.analytics.analytics.async_get_system_info",
@@ -160,11 +159,11 @@ async def test_failed_to_send_raises(
     assert "Error sending analytics" in caplog.text
 
 
+@pytest.mark.usefixtures("installation_type_mock")
 async def test_send_base(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
     aioclient_mock: AiohttpClientMocker,
-    installation_type_mock: Generator[Any, Any, None],
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test send base preferences are defined."""
@@ -231,11 +230,11 @@ async def test_send_base_with_supervisor(
     assert snapshot == submitted_data
 
 
+@pytest.mark.usefixtures("installation_type_mock")
 async def test_send_usage(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
     aioclient_mock: AiohttpClientMocker,
-    installation_type_mock: Generator[Any, Any, None],
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test send usage preferences are defined."""
@@ -331,11 +330,11 @@ async def test_send_usage_with_supervisor(
     assert snapshot == submitted_data
 
 
+@pytest.mark.usefixtures("installation_type_mock")
 async def test_send_statistics(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
     aioclient_mock: AiohttpClientMocker,
-    installation_type_mock: Generator[Any, Any, None],
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test send statistics preferences are defined."""
@@ -382,12 +381,11 @@ async def test_send_statistics_one_integration_fails(
     assert post_call[2]["integration_count"] == 0
 
 
-@pytest.mark.usefixtures("mock_hass_config")
+@pytest.mark.usefixtures("installation_type_mock", "mock_hass_config")
 async def test_send_statistics_disabled_integration(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
     aioclient_mock: AiohttpClientMocker,
-    installation_type_mock: Generator[Any, Any, None],
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test send statistics with disabled integration."""
@@ -420,12 +418,11 @@ async def test_send_statistics_disabled_integration(
     assert snapshot == submitted_data
 
 
-@pytest.mark.usefixtures("mock_hass_config")
+@pytest.mark.usefixtures("installation_type_mock", "mock_hass_config")
 async def test_send_statistics_ignored_integration(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
     aioclient_mock: AiohttpClientMocker,
-    installation_type_mock: Generator[Any, Any, None],
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test send statistics with ignored integration."""
@@ -566,12 +563,11 @@ async def test_reusing_uuid(
     assert analytics.uuid == "NOT_MOCK_UUID"
 
 
-@pytest.mark.usefixtures("enable_custom_integrations")
+@pytest.mark.usefixtures("enable_custom_integrations", "installation_type_mock")
 async def test_custom_integrations(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     caplog: pytest.LogCaptureFixture,
-    installation_type_mock: Generator[Any, Any, None],
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test sending custom integrations."""
@@ -651,12 +647,11 @@ async def test_nightly_endpoint(
     assert str(payload[1]) == ANALYTICS_ENDPOINT_URL
 
 
-@pytest.mark.usefixtures("mock_hass_config")
+@pytest.mark.usefixtures("installation_type_mock", "mock_hass_config")
 async def test_send_with_no_energy(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     caplog: pytest.LogCaptureFixture,
-    installation_type_mock: Generator[Any, Any, None],
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test send base preferences are defined."""
@@ -688,12 +683,11 @@ async def test_send_with_no_energy(
     assert snapshot == submitted_data
 
 
-@pytest.mark.usefixtures("recorder_mock", "mock_hass_config")
+@pytest.mark.usefixtures("recorder_mock", "installation_type_mock", "mock_hass_config")
 async def test_send_with_no_energy_config(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     caplog: pytest.LogCaptureFixture,
-    installation_type_mock: Generator[Any, Any, None],
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test send base preferences are defined."""
@@ -720,12 +714,11 @@ async def test_send_with_no_energy_config(
     )
 
 
-@pytest.mark.usefixtures("recorder_mock", "mock_hass_config")
+@pytest.mark.usefixtures("recorder_mock", "installation_type_mock", "mock_hass_config")
 async def test_send_with_energy_config(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     caplog: pytest.LogCaptureFixture,
-    installation_type_mock: Generator[Any, Any, None],
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test send base preferences are defined."""
@@ -752,12 +745,11 @@ async def test_send_with_energy_config(
     )
 
 
-@pytest.mark.usefixtures("mock_hass_config")
+@pytest.mark.usefixtures("installation_type_mock", "mock_hass_config")
 async def test_send_usage_with_certificate(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
     aioclient_mock: AiohttpClientMocker,
-    installation_type_mock: Generator[Any, Any, None],
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test send usage preferences with certificate."""
@@ -779,12 +771,11 @@ async def test_send_usage_with_certificate(
     assert snapshot == submitted_data
 
 
+@pytest.mark.usefixtures("recorder_mock", "installation_type_mock")
 async def test_send_with_recorder(
-    recorder_mock: Recorder,
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     caplog: pytest.LogCaptureFixture,
-    installation_type_mock: Generator[Any, Any, None],
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test recorder information."""
@@ -849,11 +840,11 @@ async def test_timeout_while_sending(
     assert "Timeout sending analytics" in caplog.text
 
 
+@pytest.mark.usefixtures("installation_type_mock")
 async def test_not_check_config_entries_if_yaml(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
     aioclient_mock: AiohttpClientMocker,
-    installation_type_mock: Generator[Any, Any, None],
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test skip config entry check if defined in yaml."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
