### PR TITLE
Adjust Generator type hints in tests

### DIFF
--- a/tests/components/drop_connect/test_sensor.py
+++ b/tests/components/drop_connect/test_sensor.py
@@ -47,7 +47,7 @@ from tests.typing import MqttMockHAClient
 
 
 @pytest.fixture(autouse=True)
-def only_sensor_platform() -> Generator[[], None]:
+def only_sensor_platform() -> Generator[None]:
     """Only setup the DROP sensor platform."""
     with patch("homeassistant.components.drop_connect.PLATFORMS", [Platform.SENSOR]):
         yield

--- a/tests/components/flume/conftest.py
+++ b/tests/components/flume/conftest.py
@@ -104,7 +104,7 @@ def encode_access_token() -> str:
 
 
 @pytest.fixture(name="access_token")
-def access_token_fixture(requests_mock: Mocker) -> Generator[None, None, None]:
+def access_token_fixture(requests_mock: Mocker) -> Generator[None]:
     """Fixture to setup the access token."""
     token_response = {
         "refresh_token": REFRESH_TOKEN,

--- a/tests/components/homekit/conftest.py
+++ b/tests/components/homekit/conftest.py
@@ -4,7 +4,6 @@ from asyncio import AbstractEventLoop
 from collections.abc import Generator
 from contextlib import suppress
 import os
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -19,7 +18,7 @@ from tests.common import async_capture_events
 
 
 @pytest.fixture
-def iid_storage(hass):
+def iid_storage(hass: HomeAssistant) -> Generator[AccessoryIIDStorage]:
     """Mock the iid storage."""
     with patch.object(AccessoryIIDStorage, "_async_schedule_save"):
         yield AccessoryIIDStorage(hass, "")
@@ -28,7 +27,7 @@ def iid_storage(hass):
 @pytest.fixture
 def run_driver(
     hass: HomeAssistant, event_loop: AbstractEventLoop, iid_storage: AccessoryIIDStorage
-) -> Generator[HomeDriver, Any, None]:
+) -> Generator[HomeDriver]:
     """Return a custom AccessoryDriver instance for HomeKit accessory init.
 
     This mock does not mock async_stop, so the driver will not be stopped
@@ -57,7 +56,7 @@ def run_driver(
 @pytest.fixture
 def hk_driver(
     hass: HomeAssistant, event_loop: AbstractEventLoop, iid_storage: AccessoryIIDStorage
-) -> Generator[HomeDriver, Any, None]:
+) -> Generator[HomeDriver]:
     """Return a custom AccessoryDriver instance for HomeKit accessory init."""
     with (
         patch("pyhap.accessory_driver.AsyncZeroconf"),
@@ -89,7 +88,7 @@ def mock_hap(
     event_loop: AbstractEventLoop,
     iid_storage: AccessoryIIDStorage,
     mock_zeroconf: MagicMock,
-) -> Generator[HomeDriver, Any, None]:
+) -> Generator[HomeDriver]:
     """Return a custom AccessoryDriver instance for HomeKit accessory init."""
     with (
         patch("pyhap.accessory_driver.AsyncZeroconf"),
@@ -128,7 +127,7 @@ def events(hass):
 
 
 @pytest.fixture
-def demo_cleanup(hass):
+def demo_cleanup(hass: HomeAssistant) -> Generator[None]:
     """Clean up device tracker demo file."""
     yield
     with suppress(FileNotFoundError):

--- a/tests/components/incomfort/conftest.py
+++ b/tests/components/incomfort/conftest.py
@@ -77,10 +77,9 @@ def mock_room_status() -> dict[str, Any]:
 
 @pytest.fixture
 def mock_incomfort(
-    hass: HomeAssistant,
     mock_heater_status: dict[str, Any],
     mock_room_status: dict[str, Any],
-) -> Generator[MagicMock, None]:
+) -> Generator[MagicMock]:
     """Mock the InComfort gateway client."""
 
     class MockRoom:

--- a/tests/components/tibber/conftest.py
+++ b/tests/components/tibber/conftest.py
@@ -27,7 +27,7 @@ def config_entry(hass: HomeAssistant) -> MockConfigEntry:
 @pytest.fixture
 async def mock_tibber_setup(
     config_entry: MockConfigEntry, hass: HomeAssistant
-) -> AsyncGenerator[None, MagicMock]:
+) -> AsyncGenerator[MagicMock]:
     """Mock tibber entry setup."""
     unique_user_id = "unique_user_id"
     title = "title"

--- a/tests/util/test_loop.py
+++ b/tests/util/test_loop.py
@@ -18,7 +18,7 @@ def banned_function():
 
 
 @contextlib.contextmanager
-def patch_get_current_frame(stack: list[Mock]) -> Generator[None, None, None]:
+def patch_get_current_frame(stack: list[Mock]) -> Generator[None]:
     """Patch get_current_frame."""
     frames = extract_stack_to_frame(stack)
     with (


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA
cc @cdce8p

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
