### PR TITLE
Improve type hints in home_connect tests

### DIFF
--- a/tests/components/home_connect/conftest.py
+++ b/tests/components/home_connect/conftest.py
@@ -94,7 +94,7 @@ async def bypass_throttle(hass: HomeAssistant, config_entry: MockConfigEntry):
 
 
 @pytest.fixture(name="bypass_throttle")
-def mock_bypass_throttle():
+def mock_bypass_throttle() -> Generator[None]:
     """Fixture to bypass the throttle decorator in __init__."""
     with patch(
         "homeassistant.components.home_connect.update_all_devices",
@@ -122,7 +122,7 @@ async def mock_integration_setup(
 
 
 @pytest.fixture(name="get_appliances")
-def mock_get_appliances() -> Generator[None, Any, None]:
+def mock_get_appliances() -> Generator[MagicMock]:
     """Mock ConfigEntryAuth parent (HomeAssistantAPI) method."""
     with patch(
         "homeassistant.components.home_connect.api.ConfigEntryAuth.get_appliances",

--- a/tests/components/home_connect/test_binary_sensor.py
+++ b/tests/components/home_connect/test_binary_sensor.py
@@ -1,7 +1,6 @@
 """Tests for home_connect binary_sensor entities."""
 
-from collections.abc import Awaitable, Callable, Generator
-from typing import Any
+from collections.abc import Awaitable, Callable
 from unittest.mock import MagicMock, Mock
 
 import pytest
@@ -26,9 +25,8 @@ def platforms() -> list[str]:
     return [Platform.BINARY_SENSOR]
 
 
+@pytest.mark.usefixtures("bypass_throttle")
 async def test_binary_sensors(
-    bypass_throttle: Generator[None, Any, None],
-    hass: HomeAssistant,
     config_entry: MockConfigEntry,
     integration_setup: Callable[[], Awaitable[bool]],
     setup_credentials: None,
@@ -51,10 +49,10 @@ async def test_binary_sensors(
         ("", "unavailable"),
     ],
 )
+@pytest.mark.usefixtures("bypass_throttle")
 async def test_binary_sensors_door_states(
     expected: str,
     state: str,
-    bypass_throttle: Generator[None, Any, None],
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     integration_setup: Callable[[], Awaitable[bool]],

--- a/tests/components/home_connect/test_init.py
+++ b/tests/components/home_connect/test_init.py
@@ -1,6 +1,6 @@
 """Test the integration init functionality."""
 
-from collections.abc import Awaitable, Callable, Generator
+from collections.abc import Awaitable, Callable
 from typing import Any
 from unittest.mock import MagicMock, Mock
 
@@ -117,8 +117,8 @@ SERVICE_APPLIANCE_METHOD_MAPPING = {
 }
 
 
+@pytest.mark.usefixtures("bypass_throttle")
 async def test_api_setup(
-    bypass_throttle: Generator[None, Any, None],
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     integration_setup: Callable[[], Awaitable[bool]],
@@ -137,9 +137,8 @@ async def test_api_setup(
     assert config_entry.state == ConfigEntryState.NOT_LOADED
 
 
+@pytest.mark.usefixtures("bypass_throttle")
 async def test_exception_handling(
-    bypass_throttle: Generator[None, Any, None],
-    hass: HomeAssistant,
     integration_setup: Callable[[], Awaitable[bool]],
     config_entry: MockConfigEntry,
     setup_credentials: None,
@@ -154,8 +153,8 @@ async def test_exception_handling(
 
 
 @pytest.mark.parametrize("token_expiration_time", [12345])
+@pytest.mark.usefixtures("bypass_throttle")
 async def test_token_refresh_success(
-    bypass_throttle: Generator[None, Any, None],
     integration_setup: Callable[[], Awaitable[bool]],
     config_entry: MockConfigEntry,
     aioclient_mock: AiohttpClientMocker,
@@ -227,9 +226,8 @@ async def test_update_throttle(
     assert get_appliances.call_count == 0
 
 
+@pytest.mark.usefixtures("bypass_throttle")
 async def test_http_error(
-    bypass_throttle: Generator[None, Any, None],
-    hass: HomeAssistant,
     config_entry: MockConfigEntry,
     integration_setup: Callable[[], Awaitable[bool]],
     setup_credentials: None,
@@ -247,9 +245,9 @@ async def test_http_error(
     "service_call",
     SERVICE_KV_CALL_PARAMS + SERVICE_COMMAND_CALL_PARAMS + SERVICE_PROGRAM_CALL_PARAMS,
 )
+@pytest.mark.usefixtures("bypass_throttle")
 async def test_services(
     service_call: list[dict[str, Any]],
-    bypass_throttle: Generator[None, Any, None],
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     config_entry: MockConfigEntry,
@@ -279,8 +277,8 @@ async def test_services(
     )
 
 
+@pytest.mark.usefixtures("bypass_throttle")
 async def test_services_exception(
-    bypass_throttle: Generator[None, Any, None],
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     integration_setup: Callable[[], Awaitable[bool]],

--- a/tests/components/home_connect/test_sensor.py
+++ b/tests/components/home_connect/test_sensor.py
@@ -1,7 +1,6 @@
 """Tests for home_connect sensor entities."""
 
-from collections.abc import Awaitable, Callable, Generator
-from typing import Any
+from collections.abc import Awaitable, Callable
 from unittest.mock import MagicMock, Mock
 
 from freezegun.api import FrozenDateTimeFactory
@@ -69,9 +68,8 @@ def platforms() -> list[str]:
     return [Platform.SENSOR]
 
 
+@pytest.mark.usefixtures("bypass_throttle")
 async def test_sensors(
-    bypass_throttle: Generator[None, Any, None],
-    hass: HomeAssistant,
     config_entry: MockConfigEntry,
     integration_setup: Callable[[], Awaitable[bool]],
     setup_credentials: None,
@@ -131,12 +129,12 @@ ENTITY_ID_STATES = {
         )
     ),
 )
+@pytest.mark.usefixtures("bypass_throttle")
 async def test_event_sensors(
     appliance: Mock,
     states: tuple,
     event_run: dict,
     freezer: FrozenDateTimeFactory,
-    bypass_throttle: Generator[None, Any, None],
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     integration_setup: Callable[[], Awaitable[bool]],
@@ -180,10 +178,10 @@ ENTITY_ID_EDGE_CASE_STATES = [
 
 
 @pytest.mark.parametrize("appliance", [TEST_HC_APP], indirect=True)
+@pytest.mark.usefixtures("bypass_throttle")
 async def test_remaining_prog_time_edge_cases(
     appliance: Mock,
     freezer: FrozenDateTimeFactory,
-    bypass_throttle: Generator[None, Any, None],
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     integration_setup: Callable[[], Awaitable[bool]],


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
