### PR TITLE
Handle mains power for Matter appliances

### DIFF
--- a/homeassistant/components/matter/climate.py
+++ b/homeassistant/components/matter/climate.py
@@ -227,6 +227,13 @@ class MatterClimate(MatterEntity, ClimateEntity):
         self._attr_current_temperature = self._get_temperature_in_degrees(
             clusters.Thermostat.Attributes.LocalTemperature
         )
+        if self.get_matter_attribute_value(clusters.OnOff.Attributes.OnOff) is False:
+            # special case: the appliance has a dedicated Power switch on the OnOff cluster
+            # if the mains power is off - treat it as if the HVAC mode is off
+            self._attr_hvac_mode = HVACMode.OFF
+            self._attr_hvac_action = None
+            return
+
         # update hvac_mode from SystemMode
         system_mode_value = int(
             self.get_matter_attribute_value(clusters.Thermostat.Attributes.SystemMode)

--- a/tests/components/matter/test_climate.py
+++ b/tests/components/matter/test_climate.py
@@ -315,13 +315,18 @@ async def test_room_airconditioner(
     state = hass.states.get("climate.room_airconditioner_thermostat")
     assert state
     assert state.attributes["current_temperature"] == 20
-    assert state.attributes["min_temp"] == 16
-    assert state.attributes["max_temp"] == 32
+    # room airconditioner has mains power on OnOff cluster with value set to False
+    assert state.state == HVACMode.OFF
 
     # test supported features correctly parsed
     # WITHOUT temperature_range support
     mask = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.TURN_OFF
     assert state.attributes["supported_features"] & mask == mask
+
+    # set mains power to ON (OnOff cluster)
+    set_node_attribute(room_airconditioner, 1, 6, 0, True)
+    await trigger_subscription_callback(hass, matter_client)
+    state = hass.states.get("climate.room_airconditioner_thermostat")
 
     # test supported HVAC modes include fan and dry modes
     assert state.attributes["hvac_modes"] == [

--- a/tests/components/matter/test_fan.py
+++ b/tests/components/matter/test_fan.py
@@ -92,6 +92,12 @@ async def test_fan_base(
     await trigger_subscription_callback(hass, matter_client)
     state = hass.states.get(entity_id)
     assert state.attributes["preset_mode"] == "sleep_wind"
+    # set mains power to OFF (OnOff cluster)
+    set_node_attribute(air_purifier, 1, 6, 0, False)
+    await trigger_subscription_callback(hass, matter_client)
+    state = hass.states.get(entity_id)
+    assert state.attributes["preset_mode"] is None
+    assert state.attributes["percentage"] == 0
 
 
 async def test_fan_turn_on_with_percentage(


### PR DESCRIPTION
## Proposed change
Matter appliances, such as an Airconditioner or Air purifier, can have an (optional) mains power switch on the OnOff cluster. This mains power switch is exposed by us as an actual switched entity as well (named Power).

Currently when the mains power is turned off, the other control entities (for fan and climate) show still as if they're active in the HA UI while in fact they are not, that looks weird/funny. So this PR accounts for the fact that the OnOff cluster is present (on the same endpoint as the main control) to override the state if the mains power switch is OFF.

![Scherm­afbeelding 2024-07-02 om 16 58 35](https://github.com/home-assistant/core/assets/6389780/06408fdd-86ba-4416-a1ee-eb8689010bd2)


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
