### PR TITLE
Add monkeypatch type hints to rflink tests

### DIFF
--- a/tests/components/rflink/test_binary_sensor.py
+++ b/tests/components/rflink/test_binary_sensor.py
@@ -7,6 +7,7 @@ automatic sensor creation.
 from datetime import timedelta
 
 from freezegun import freeze_time
+import pytest
 
 from homeassistant.components.rflink import CONF_RECONNECT_INTERVAL
 from homeassistant.const import (
@@ -45,7 +46,9 @@ CONFIG = {
 }
 
 
-async def test_default_setup(hass: HomeAssistant, monkeypatch) -> None:
+async def test_default_setup(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test all basic functionality of the rflink sensor component."""
     # setup mocking rflink module
     event_callback, create, _, _ = await mock_rflink(hass, CONFIG, DOMAIN, monkeypatch)
@@ -84,7 +87,9 @@ async def test_default_setup(hass: HomeAssistant, monkeypatch) -> None:
     assert hass.states.get("binary_sensor.test").state == STATE_OFF
 
 
-async def test_entity_availability(hass: HomeAssistant, monkeypatch) -> None:
+async def test_entity_availability(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """If Rflink device is disconnected, entities should become unavailable."""
     # Make sure Rflink mock does not 'recover' to quickly from the
     # disconnect or else the unavailability cannot be measured
@@ -125,7 +130,7 @@ async def test_entity_availability(hass: HomeAssistant, monkeypatch) -> None:
     assert hass.states.get("binary_sensor.test").state == STATE_ON
 
 
-async def test_off_delay(hass: HomeAssistant, monkeypatch) -> None:
+async def test_off_delay(hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test off_delay option."""
     # setup mocking rflink module
     event_callback, create, _, _ = await mock_rflink(hass, CONFIG, DOMAIN, monkeypatch)
@@ -188,7 +193,9 @@ async def test_off_delay(hass: HomeAssistant, monkeypatch) -> None:
     assert len(events) == 3
 
 
-async def test_restore_state(hass: HomeAssistant, monkeypatch) -> None:
+async def test_restore_state(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Ensure states are restored on startup."""
     mock_restore_cache(
         hass, (State(f"{DOMAIN}.test", STATE_ON), State(f"{DOMAIN}.test2", STATE_ON))

--- a/tests/components/rflink/test_cover.py
+++ b/tests/components/rflink/test_cover.py
@@ -5,6 +5,8 @@ control of RFLink cover devices.
 
 """
 
+import pytest
+
 from homeassistant.components.rflink import EVENT_BUTTON_PRESSED
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -37,7 +39,9 @@ CONFIG = {
 }
 
 
-async def test_default_setup(hass: HomeAssistant, monkeypatch) -> None:
+async def test_default_setup(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test all basic functionality of the RFLink cover component."""
     # setup mocking rflink module
     event_callback, create, protocol, _ = await mock_rflink(
@@ -107,7 +111,9 @@ async def test_default_setup(hass: HomeAssistant, monkeypatch) -> None:
     assert protocol.send_command_ack.call_args_list[1][0][1] == "UP"
 
 
-async def test_firing_bus_event(hass: HomeAssistant, monkeypatch) -> None:
+async def test_firing_bus_event(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Incoming RFLink command events should be put on the HA event bus."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -142,7 +148,9 @@ async def test_firing_bus_event(hass: HomeAssistant, monkeypatch) -> None:
     assert calls[0].data == {"state": "down", "entity_id": f"{DOMAIN}.test"}
 
 
-async def test_signal_repetitions(hass: HomeAssistant, monkeypatch) -> None:
+async def test_signal_repetitions(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Command should be sent amount of configured repetitions."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -180,7 +188,9 @@ async def test_signal_repetitions(hass: HomeAssistant, monkeypatch) -> None:
     assert protocol.send_command_ack.call_count == 5
 
 
-async def test_signal_repetitions_alternation(hass: HomeAssistant, monkeypatch) -> None:
+async def test_signal_repetitions_alternation(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Simultaneously switching entities must alternate repetitions."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -211,7 +221,9 @@ async def test_signal_repetitions_alternation(hass: HomeAssistant, monkeypatch) 
     assert protocol.send_command_ack.call_args_list[3][0][0] == "protocol_0_1"
 
 
-async def test_signal_repetitions_cancelling(hass: HomeAssistant, monkeypatch) -> None:
+async def test_signal_repetitions_cancelling(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Cancel outstanding repetitions when state changed."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -240,7 +252,9 @@ async def test_signal_repetitions_cancelling(hass: HomeAssistant, monkeypatch) -
     assert protocol.send_command_ack.call_args_list[3][0][1] == "UP"
 
 
-async def test_group_alias(hass: HomeAssistant, monkeypatch) -> None:
+async def test_group_alias(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Group aliases should only respond to group commands (allon/alloff)."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -270,7 +284,9 @@ async def test_group_alias(hass: HomeAssistant, monkeypatch) -> None:
     assert hass.states.get(f"{DOMAIN}.test").state == STATE_OPEN
 
 
-async def test_nogroup_alias(hass: HomeAssistant, monkeypatch) -> None:
+async def test_nogroup_alias(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Non group aliases should not respond to group commands."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -303,7 +319,9 @@ async def test_nogroup_alias(hass: HomeAssistant, monkeypatch) -> None:
     assert hass.states.get(f"{DOMAIN}.test").state == STATE_OPEN
 
 
-async def test_nogroup_device_id(hass: HomeAssistant, monkeypatch) -> None:
+async def test_nogroup_device_id(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Device id that do not respond to group commands (allon/alloff)."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -331,7 +349,9 @@ async def test_nogroup_device_id(hass: HomeAssistant, monkeypatch) -> None:
     assert hass.states.get(f"{DOMAIN}.test").state == STATE_OPEN
 
 
-async def test_restore_state(hass: HomeAssistant, monkeypatch) -> None:
+async def test_restore_state(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Ensure states are restored on startup."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -377,7 +397,9 @@ async def test_restore_state(hass: HomeAssistant, monkeypatch) -> None:
 # The code checks the ID, it will use the
 # 'inverted' class when the name starts with
 # 'newkaku'
-async def test_inverted_cover(hass: HomeAssistant, monkeypatch) -> None:
+async def test_inverted_cover(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Ensure states are restored on startup."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},

--- a/tests/components/rflink/test_init.py
+++ b/tests/components/rflink/test_init.py
@@ -520,7 +520,9 @@ async def test_default_keepalive(
 
 
 async def test_unique_id(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, monkeypatch
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Validate the device unique_id."""
 

--- a/tests/components/rflink/test_init.py
+++ b/tests/components/rflink/test_init.py
@@ -31,7 +31,12 @@ from homeassistant.helpers import entity_registry as er
 
 
 async def mock_rflink(
-    hass, config, domain, monkeypatch, failures=None, failcommand=False
+    hass: HomeAssistant,
+    config,
+    domain,
+    monkeypatch: pytest.MonkeyPatch,
+    failures=None,
+    failcommand=False,
 ):
     """Create mock RFLink asyncio protocol, test component setup."""
     transport, protocol = (Mock(), Mock())
@@ -77,7 +82,9 @@ async def mock_rflink(
     return event_callback, mock_create, protocol, disconnect_callback
 
 
-async def test_version_banner(hass: HomeAssistant, monkeypatch) -> None:
+async def test_version_banner(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test sending unknown commands doesn't cause issues."""
     # use sensor domain during testing main platform
     domain = "sensor"
@@ -102,7 +109,9 @@ async def test_version_banner(hass: HomeAssistant, monkeypatch) -> None:
     )
 
 
-async def test_send_no_wait(hass: HomeAssistant, monkeypatch) -> None:
+async def test_send_no_wait(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test command sending without ack."""
     domain = "switch"
     config = {
@@ -126,7 +135,9 @@ async def test_send_no_wait(hass: HomeAssistant, monkeypatch) -> None:
     assert protocol.send_command.call_args_list[0][0][1] == "off"
 
 
-async def test_cover_send_no_wait(hass: HomeAssistant, monkeypatch) -> None:
+async def test_cover_send_no_wait(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test command sending to a cover device without ack."""
     domain = "cover"
     config = {
@@ -150,7 +161,9 @@ async def test_cover_send_no_wait(hass: HomeAssistant, monkeypatch) -> None:
     assert protocol.send_command.call_args_list[0][0][1] == "STOP"
 
 
-async def test_send_command(hass: HomeAssistant, monkeypatch) -> None:
+async def test_send_command(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test send_command service."""
     domain = "rflink"
     config = {"rflink": {"port": "/dev/ttyABC0"}}
@@ -168,7 +181,9 @@ async def test_send_command(hass: HomeAssistant, monkeypatch) -> None:
     assert protocol.send_command_ack.call_args_list[0][0][1] == "on"
 
 
-async def test_send_command_invalid_arguments(hass: HomeAssistant, monkeypatch) -> None:
+async def test_send_command_invalid_arguments(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test send_command service."""
     domain = "rflink"
     config = {"rflink": {"port": "/dev/ttyABC0"}}
@@ -201,7 +216,9 @@ async def test_send_command_invalid_arguments(hass: HomeAssistant, monkeypatch) 
     assert not success, "send command should not succeed for unknown command"
 
 
-async def test_send_command_event_propagation(hass: HomeAssistant, monkeypatch) -> None:
+async def test_send_command_event_propagation(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test event propagation for send_command service."""
     domain = "light"
     config = {
@@ -243,7 +260,9 @@ async def test_send_command_event_propagation(hass: HomeAssistant, monkeypatch) 
     assert hass.states.get(f"{domain}.test1").state == "off"
 
 
-async def test_reconnecting_after_disconnect(hass: HomeAssistant, monkeypatch) -> None:
+async def test_reconnecting_after_disconnect(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """An unexpected disconnect should cause a reconnect."""
     domain = "sensor"
     config = {
@@ -267,7 +286,9 @@ async def test_reconnecting_after_disconnect(hass: HomeAssistant, monkeypatch) -
     assert mock_create.call_count == 2
 
 
-async def test_reconnecting_after_failure(hass: HomeAssistant, monkeypatch) -> None:
+async def test_reconnecting_after_failure(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """A failure to reconnect should be retried."""
     domain = "sensor"
     config = {
@@ -294,7 +315,9 @@ async def test_reconnecting_after_failure(hass: HomeAssistant, monkeypatch) -> N
     assert mock_create.call_count == 3
 
 
-async def test_error_when_not_connected(hass: HomeAssistant, monkeypatch) -> None:
+async def test_error_when_not_connected(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Sending command should error when not connected."""
     domain = "switch"
     config = {
@@ -324,7 +347,9 @@ async def test_error_when_not_connected(hass: HomeAssistant, monkeypatch) -> Non
     assert not success, "changing state should not succeed when disconnected"
 
 
-async def test_async_send_command_error(hass: HomeAssistant, monkeypatch) -> None:
+async def test_async_send_command_error(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Sending command should error when protocol fails."""
     domain = "rflink"
     config = {"rflink": {"port": "/dev/ttyABC0"}}
@@ -345,7 +370,9 @@ async def test_async_send_command_error(hass: HomeAssistant, monkeypatch) -> Non
     assert protocol.send_command_ack.call_args_list[0][0][1] == SERVICE_TURN_OFF
 
 
-async def test_race_condition(hass: HomeAssistant, monkeypatch) -> None:
+async def test_race_condition(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test race condition for unknown components."""
     domain = "light"
     config = {"rflink": {"port": "/dev/ttyABC0"}, domain: {"platform": "rflink"}}
@@ -381,7 +408,7 @@ async def test_race_condition(hass: HomeAssistant, monkeypatch) -> None:
     assert new_sensor.state == "on"
 
 
-async def test_not_connected(hass: HomeAssistant, monkeypatch) -> None:
+async def test_not_connected() -> None:
     """Test Error when sending commands to a disconnected device."""
     test_device = RflinkCommand("DUMMY_DEVICE")
     RflinkCommand.set_rflink_protocol(None)
@@ -390,7 +417,9 @@ async def test_not_connected(hass: HomeAssistant, monkeypatch) -> None:
 
 
 async def test_keepalive(
-    hass: HomeAssistant, monkeypatch, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Validate negative keepalive values."""
     keepalive_value = -3
@@ -418,7 +447,9 @@ async def test_keepalive(
 
 
 async def test_keepalive_2(
-    hass: HomeAssistant, monkeypatch, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Validate very short keepalive values."""
     keepalive_value = 30
@@ -446,7 +477,9 @@ async def test_keepalive_2(
 
 
 async def test_keepalive_3(
-    hass: HomeAssistant, monkeypatch, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Validate keepalive=0 value."""
     domain = RFLINK_DOMAIN
@@ -466,7 +499,9 @@ async def test_keepalive_3(
 
 
 async def test_default_keepalive(
-    hass: HomeAssistant, monkeypatch, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Validate keepalive=0 value."""
     domain = RFLINK_DOMAIN

--- a/tests/components/rflink/test_light.py
+++ b/tests/components/rflink/test_light.py
@@ -5,6 +5,8 @@ control of RFLink switch devices.
 
 """
 
+import pytest
+
 from homeassistant.components.light import ATTR_BRIGHTNESS
 from homeassistant.components.rflink import EVENT_BUTTON_PRESSED
 from homeassistant.const import (
@@ -38,7 +40,9 @@ CONFIG = {
 }
 
 
-async def test_default_setup(hass: HomeAssistant, monkeypatch) -> None:
+async def test_default_setup(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test all basic functionality of the RFLink switch component."""
     # setup mocking rflink module
     event_callback, create, protocol, _ = await mock_rflink(
@@ -146,7 +150,9 @@ async def test_default_setup(hass: HomeAssistant, monkeypatch) -> None:
     assert protocol.send_command_ack.call_args_list[5][0][1] == "7"
 
 
-async def test_firing_bus_event(hass: HomeAssistant, monkeypatch) -> None:
+async def test_firing_bus_event(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Incoming RFLink command events should be put on the HA event bus."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -181,7 +187,9 @@ async def test_firing_bus_event(hass: HomeAssistant, monkeypatch) -> None:
     assert calls[0].data == {"state": "off", "entity_id": f"{DOMAIN}.test"}
 
 
-async def test_signal_repetitions(hass: HomeAssistant, monkeypatch) -> None:
+async def test_signal_repetitions(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Command should be sent amount of configured repetitions."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -237,7 +245,9 @@ async def test_signal_repetitions(hass: HomeAssistant, monkeypatch) -> None:
     assert protocol.send_command_ack.call_count == 8
 
 
-async def test_signal_repetitions_alternation(hass: HomeAssistant, monkeypatch) -> None:
+async def test_signal_repetitions_alternation(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Simultaneously switching entities must alternate repetitions."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -268,7 +278,9 @@ async def test_signal_repetitions_alternation(hass: HomeAssistant, monkeypatch) 
     assert protocol.send_command_ack.call_args_list[3][0][0] == "protocol_0_1"
 
 
-async def test_signal_repetitions_cancelling(hass: HomeAssistant, monkeypatch) -> None:
+async def test_signal_repetitions_cancelling(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Cancel outstanding repetitions when state changed."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -302,7 +314,9 @@ async def test_signal_repetitions_cancelling(hass: HomeAssistant, monkeypatch) -
     ]
 
 
-async def test_type_toggle(hass: HomeAssistant, monkeypatch) -> None:
+async def test_type_toggle(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test toggle type lights (on/on)."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -347,7 +361,9 @@ async def test_type_toggle(hass: HomeAssistant, monkeypatch) -> None:
     assert hass.states.get(f"{DOMAIN}.toggle_test").state == "off"
 
 
-async def test_set_level_command(hass: HomeAssistant, monkeypatch) -> None:
+async def test_set_level_command(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test 'set_level=XX' events."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -434,7 +450,9 @@ async def test_set_level_command(hass: HomeAssistant, monkeypatch) -> None:
     assert state.attributes[ATTR_BRIGHTNESS] == 0
 
 
-async def test_group_alias(hass: HomeAssistant, monkeypatch) -> None:
+async def test_group_alias(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Group aliases should only respond to group commands (allon/alloff)."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -471,7 +489,9 @@ async def test_group_alias(hass: HomeAssistant, monkeypatch) -> None:
     assert hass.states.get(f"{DOMAIN}.test2").state == "on"
 
 
-async def test_nogroup_alias(hass: HomeAssistant, monkeypatch) -> None:
+async def test_nogroup_alias(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Non group aliases should not respond to group commands."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -504,7 +524,9 @@ async def test_nogroup_alias(hass: HomeAssistant, monkeypatch) -> None:
     assert hass.states.get(f"{DOMAIN}.test").state == "on"
 
 
-async def test_nogroup_device_id(hass: HomeAssistant, monkeypatch) -> None:
+async def test_nogroup_device_id(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Device id that do not respond to group commands (allon/alloff)."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -532,7 +554,9 @@ async def test_nogroup_device_id(hass: HomeAssistant, monkeypatch) -> None:
     assert hass.states.get(f"{DOMAIN}.test").state == "on"
 
 
-async def test_disable_automatic_add(hass: HomeAssistant, monkeypatch) -> None:
+async def test_disable_automatic_add(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """If disabled new devices should not be automatically added."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -550,7 +574,9 @@ async def test_disable_automatic_add(hass: HomeAssistant, monkeypatch) -> None:
     assert not hass.states.get(f"{DOMAIN}.protocol_0_0")
 
 
-async def test_restore_state(hass: HomeAssistant, monkeypatch) -> None:
+async def test_restore_state(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Ensure states are restored on startup."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},

--- a/tests/components/rflink/test_sensor.py
+++ b/tests/components/rflink/test_sensor.py
@@ -5,6 +5,8 @@ automatic sensor creation.
 
 """
 
+import pytest
+
 from homeassistant.components.rflink import (
     CONF_RECONNECT_INTERVAL,
     DATA_ENTITY_LOOKUP,
@@ -39,7 +41,9 @@ CONFIG = {
 }
 
 
-async def test_default_setup(hass: HomeAssistant, monkeypatch) -> None:
+async def test_default_setup(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test all basic functionality of the rflink sensor component."""
     # setup mocking rflink module
     event_callback, create, _, _ = await mock_rflink(hass, CONFIG, DOMAIN, monkeypatch)
@@ -100,7 +104,9 @@ async def test_default_setup(hass: HomeAssistant, monkeypatch) -> None:
     assert bat_sensor.attributes[ATTR_ICON] == "mdi:battery"
 
 
-async def test_disable_automatic_add(hass: HomeAssistant, monkeypatch) -> None:
+async def test_disable_automatic_add(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """If disabled new devices should not be automatically added."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -125,7 +131,9 @@ async def test_disable_automatic_add(hass: HomeAssistant, monkeypatch) -> None:
     assert not hass.states.get("sensor.test2")
 
 
-async def test_entity_availability(hass: HomeAssistant, monkeypatch) -> None:
+async def test_entity_availability(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """If Rflink device is disconnected, entities should become unavailable."""
     # Make sure Rflink mock does not 'recover' to quickly from the
     # disconnect or else the unavailability cannot be measured
@@ -160,7 +168,7 @@ async def test_entity_availability(hass: HomeAssistant, monkeypatch) -> None:
     assert hass.states.get("sensor.test").state == STATE_UNKNOWN
 
 
-async def test_aliases(hass: HomeAssistant, monkeypatch) -> None:
+async def test_aliases(hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch) -> None:
     """Validate the response to sensor's alias (with aliases)."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -202,7 +210,9 @@ async def test_aliases(hass: HomeAssistant, monkeypatch) -> None:
     assert updated_sensor.attributes[ATTR_UNIT_OF_MEASUREMENT] == PERCENTAGE
 
 
-async def test_race_condition(hass: HomeAssistant, monkeypatch) -> None:
+async def test_race_condition(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test race condition for unknown components."""
     config = {"rflink": {"port": "/dev/ttyABC0"}, DOMAIN: {"platform": "rflink"}}
     tmp_entity = TMP_ENTITY.format("test3")
@@ -241,7 +251,9 @@ async def test_race_condition(hass: HomeAssistant, monkeypatch) -> None:
     assert new_sensor.state == "ko"
 
 
-async def test_sensor_attributes(hass: HomeAssistant, monkeypatch) -> None:
+async def test_sensor_attributes(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Validate the sensor attributes."""
 
     config = {

--- a/tests/components/rflink/test_switch.py
+++ b/tests/components/rflink/test_switch.py
@@ -5,6 +5,8 @@ control of Rflink switch devices.
 
 """
 
+import pytest
+
 from homeassistant.components.rflink import EVENT_BUTTON_PRESSED
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -33,7 +35,9 @@ CONFIG = {
 }
 
 
-async def test_default_setup(hass: HomeAssistant, monkeypatch) -> None:
+async def test_default_setup(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test all basic functionality of the rflink switch component."""
     # setup mocking rflink module
     event_callback, create, protocol, _ = await mock_rflink(
@@ -93,7 +97,9 @@ async def test_default_setup(hass: HomeAssistant, monkeypatch) -> None:
     assert protocol.send_command_ack.call_args_list[1][0][1] == "on"
 
 
-async def test_group_alias(hass: HomeAssistant, monkeypatch) -> None:
+async def test_group_alias(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Group aliases should only respond to group commands (allon/alloff)."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -123,7 +129,9 @@ async def test_group_alias(hass: HomeAssistant, monkeypatch) -> None:
     assert hass.states.get(f"{DOMAIN}.test").state == "on"
 
 
-async def test_nogroup_alias(hass: HomeAssistant, monkeypatch) -> None:
+async def test_nogroup_alias(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Non group aliases should not respond to group commands."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -156,7 +164,9 @@ async def test_nogroup_alias(hass: HomeAssistant, monkeypatch) -> None:
     assert hass.states.get(f"{DOMAIN}.test").state == "on"
 
 
-async def test_nogroup_device_id(hass: HomeAssistant, monkeypatch) -> None:
+async def test_nogroup_device_id(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Device id that do not respond to group commands (allon/alloff)."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -184,7 +194,9 @@ async def test_nogroup_device_id(hass: HomeAssistant, monkeypatch) -> None:
     assert hass.states.get(f"{DOMAIN}.test").state == "on"
 
 
-async def test_device_defaults(hass: HomeAssistant, monkeypatch) -> None:
+async def test_device_defaults(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Event should fire if device_defaults config says so."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -216,7 +228,9 @@ async def test_device_defaults(hass: HomeAssistant, monkeypatch) -> None:
     assert calls[0].data == {"state": "off", "entity_id": f"{DOMAIN}.test"}
 
 
-async def test_not_firing_default(hass: HomeAssistant, monkeypatch) -> None:
+async def test_not_firing_default(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """By default no bus events should be fired."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},
@@ -246,7 +260,9 @@ async def test_not_firing_default(hass: HomeAssistant, monkeypatch) -> None:
     assert not calls, "an event has been fired"
 
 
-async def test_restore_state(hass: HomeAssistant, monkeypatch) -> None:
+async def test_restore_state(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Ensure states are restored on startup."""
     config = {
         "rflink": {"port": "/dev/ttyABC0"},

--- a/tests/components/rflink/test_utils.py
+++ b/tests/components/rflink/test_utils.py
@@ -4,10 +4,9 @@ from homeassistant.components.rflink.utils import (
     brightness_to_rflink,
     rflink_to_brightness,
 )
-from homeassistant.core import HomeAssistant
 
 
-async def test_utils(hass: HomeAssistant, monkeypatch) -> None:
+async def test_utils() -> None:
     """Test all utils methods."""
     # test brightness_to_rflink
     assert brightness_to_rflink(0) == 0


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #121051

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
