### PR TITLE
Add monkeypatch type hints to webostv tests

### DIFF
--- a/tests/components/webostv/test_config_flow.py
+++ b/tests/components/webostv/test_config_flow.py
@@ -295,7 +295,9 @@ async def test_form_abort_uuid_configured(hass: HomeAssistant, client) -> None:
     assert entry.data[CONF_HOST] == "new_host"
 
 
-async def test_reauth_successful(hass: HomeAssistant, client, monkeypatch) -> None:
+async def test_reauth_successful(
+    hass: HomeAssistant, client, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test that the reauthorization is successful."""
     entry = await setup_webostv(hass)
     assert client
@@ -331,7 +333,7 @@ async def test_reauth_successful(hass: HomeAssistant, client, monkeypatch) -> No
     ],
 )
 async def test_reauth_errors(
-    hass: HomeAssistant, client, monkeypatch, side_effect, reason
+    hass: HomeAssistant, client, monkeypatch: pytest.MonkeyPatch, side_effect, reason
 ) -> None:
     """Test reauthorization errors."""
     entry = await setup_webostv(hass)

--- a/tests/components/webostv/test_init.py
+++ b/tests/components/webostv/test_init.py
@@ -3,6 +3,7 @@
 from unittest.mock import Mock
 
 from aiowebostv import WebOsTvPairError
+import pytest
 
 from homeassistant.components.webostv.const import DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
@@ -12,7 +13,9 @@ from homeassistant.core import HomeAssistant
 from . import setup_webostv
 
 
-async def test_reauth_setup_entry(hass: HomeAssistant, client, monkeypatch) -> None:
+async def test_reauth_setup_entry(
+    hass: HomeAssistant, client, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test reauth flow triggered by setup entry."""
     monkeypatch.setattr(client, "is_connected", Mock(return_value=False))
     monkeypatch.setattr(client, "connect", Mock(side_effect=WebOsTvPairError))
@@ -32,7 +35,9 @@ async def test_reauth_setup_entry(hass: HomeAssistant, client, monkeypatch) -> N
     assert flow["context"].get("entry_id") == entry.entry_id
 
 
-async def test_key_update_setup_entry(hass: HomeAssistant, client, monkeypatch) -> None:
+async def test_key_update_setup_entry(
+    hass: HomeAssistant, client, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test key update from setup entry."""
     monkeypatch.setattr(client, "client_key", "new_key")
     entry = await setup_webostv(hass)

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -144,7 +144,7 @@ async def test_media_play_pause(hass: HomeAssistant, client) -> None:
     ],
 )
 async def test_media_next_previous_track(
-    hass: HomeAssistant, client, service, client_call, monkeypatch
+    hass: HomeAssistant, client, service, client_call, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test media next/previous track services."""
     await setup_webostv(hass)
@@ -389,7 +389,7 @@ async def test_play_media(hass: HomeAssistant, client, media_id, ch_id) -> None:
 
 
 async def test_update_sources_live_tv_find(
-    hass: HomeAssistant, client, monkeypatch
+    hass: HomeAssistant, client, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test finding live TV app id in update sources."""
     await setup_webostv(hass)
@@ -485,7 +485,10 @@ async def test_client_disconnected(
 
 
 async def test_control_error_handling(
-    hass: HomeAssistant, client, caplog: pytest.LogCaptureFixture, monkeypatch
+    hass: HomeAssistant,
+    client,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test control errors handling."""
     await setup_webostv(hass)
@@ -575,7 +578,7 @@ async def test_supported_features(
 
 
 async def test_cached_supported_features(
-    hass: HomeAssistant, client, monkeypatch
+    hass: HomeAssistant, client, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test test supported features."""
     monkeypatch.setattr(client, "is_on", False)
@@ -682,7 +685,7 @@ async def test_cached_supported_features(
 
 
 async def test_supported_features_no_cache(
-    hass: HomeAssistant, client, monkeypatch
+    hass: HomeAssistant, client, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test supported features if device is off and no cache."""
     monkeypatch.setattr(client, "is_on", False)

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -270,7 +270,10 @@ async def test_select_sound_output(hass: HomeAssistant, client) -> None:
 
 
 async def test_device_info_startup_off(
-    hass: HomeAssistant, client, monkeypatch, device_registry: dr.DeviceRegistry
+    hass: HomeAssistant,
+    client,
+    monkeypatch: pytest.MonkeyPatch,
+    device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test device info when device is off at startup."""
     monkeypatch.setattr(client, "system_info", None)
@@ -291,7 +294,10 @@ async def test_device_info_startup_off(
 
 
 async def test_entity_attributes(
-    hass: HomeAssistant, client, monkeypatch, device_registry: dr.DeviceRegistry
+    hass: HomeAssistant,
+    client,
+    monkeypatch: pytest.MonkeyPatch,
+    device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test entity attributes."""
     entry = await setup_webostv(hass)
@@ -466,7 +472,9 @@ async def test_update_sources_live_tv_find(
     assert len(sources) == 1
 
 
-async def test_client_disconnected(hass: HomeAssistant, client, monkeypatch) -> None:
+async def test_client_disconnected(
+    hass: HomeAssistant, client, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test error not raised when client is disconnected."""
     await setup_webostv(hass)
     monkeypatch.setattr(client, "is_connected", Mock(return_value=False))
@@ -507,7 +515,9 @@ async def test_control_error_handling(
     )
 
 
-async def test_supported_features(hass: HomeAssistant, client, monkeypatch) -> None:
+async def test_supported_features(
+    hass: HomeAssistant, client, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test test supported features."""
     monkeypatch.setattr(client, "sound_output", "lineout")
     await setup_webostv(hass)
@@ -716,7 +726,7 @@ async def test_get_image_http(
     client,
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test get image via http."""
     url = "http://something/valid_icon"
@@ -742,7 +752,7 @@ async def test_get_image_http_error(
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
     caplog: pytest.LogCaptureFixture,
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test get image via http error."""
     url = "http://something/icon_error"
@@ -769,7 +779,7 @@ async def test_get_image_https(
     client,
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test get image via http."""
     url = "https://something/valid_icon_https"
@@ -789,7 +799,9 @@ async def test_get_image_https(
     assert content == b"https_image"
 
 
-async def test_reauth_reconnect(hass: HomeAssistant, client, monkeypatch) -> None:
+async def test_reauth_reconnect(
+    hass: HomeAssistant, client, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test reauth flow triggered by reconnect."""
     entry = await setup_webostv(hass)
     monkeypatch.setattr(client, "is_connected", Mock(return_value=False))
@@ -814,7 +826,9 @@ async def test_reauth_reconnect(hass: HomeAssistant, client, monkeypatch) -> Non
     assert flow["context"].get("entry_id") == entry.entry_id
 
 
-async def test_update_media_state(hass: HomeAssistant, client, monkeypatch) -> None:
+async def test_update_media_state(
+    hass: HomeAssistant, client, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test updating media state."""
     await setup_webostv(hass)
 

--- a/tests/components/webostv/test_notify.py
+++ b/tests/components/webostv/test_notify.py
@@ -97,7 +97,10 @@ async def test_notify_not_connected(
 
 
 async def test_icon_not_found(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, client, monkeypatch
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    client,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test notify icon not found error."""
     await setup_webostv(hass)

--- a/tests/components/webostv/test_notify.py
+++ b/tests/components/webostv/test_notify.py
@@ -72,7 +72,9 @@ async def test_notify(hass: HomeAssistant, client) -> None:
     )
 
 
-async def test_notify_not_connected(hass: HomeAssistant, client, monkeypatch) -> None:
+async def test_notify_not_connected(
+    hass: HomeAssistant, client, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test sending a message when client is not connected."""
     await setup_webostv(hass)
     assert hass.services.has_service(NOTIFY_DOMAIN, TV_NAME)
@@ -130,7 +132,7 @@ async def test_connection_errors(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
     client,
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
     side_effect,
     error,
 ) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #121051

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
