### PR TITLE
Add monkeypatch type hints to switcher_kis tests

### DIFF
--- a/tests/components/switcher_kis/test_button.py
+++ b/tests/components/switcher_kis/test_button.py
@@ -63,7 +63,12 @@ async def test_assume_button(
 )
 @pytest.mark.parametrize("mock_bridge", [[DEVICE]], indirect=True)
 async def test_swing_button(
-    hass: HomeAssistant, entity, swing, mock_bridge, mock_api, monkeypatch
+    hass: HomeAssistant,
+    entity,
+    swing,
+    mock_bridge,
+    mock_api,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test vertical swing on/off button."""
     monkeypatch.setattr(DEVICE, "remote_id", "ELEC7022")
@@ -88,7 +93,7 @@ async def test_swing_button(
 
 @pytest.mark.parametrize("mock_bridge", [[DEVICE]], indirect=True)
 async def test_control_device_fail(
-    hass: HomeAssistant, mock_bridge, mock_api, monkeypatch
+    hass: HomeAssistant, mock_bridge, mock_api, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test control device fail."""
     await init_integration(hass)

--- a/tests/components/switcher_kis/test_climate.py
+++ b/tests/components/switcher_kis/test_climate.py
@@ -37,7 +37,7 @@ ENTITY_ID = f"{CLIMATE_DOMAIN}.{slugify(DEVICE.name)}"
 
 @pytest.mark.parametrize("mock_bridge", [[DEVICE]], indirect=True)
 async def test_climate_hvac_mode(
-    hass: HomeAssistant, mock_bridge, mock_api, monkeypatch
+    hass: HomeAssistant, mock_bridge, mock_api, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test climate hvac mode service."""
     await init_integration(hass)
@@ -92,7 +92,7 @@ async def test_climate_hvac_mode(
 
 @pytest.mark.parametrize("mock_bridge", [[DEVICE]], indirect=True)
 async def test_climate_temperature(
-    hass: HomeAssistant, mock_bridge, mock_api, monkeypatch
+    hass: HomeAssistant, mock_bridge, mock_api, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test climate temperature service."""
     await init_integration(hass)
@@ -144,7 +144,7 @@ async def test_climate_temperature(
 
 @pytest.mark.parametrize("mock_bridge", [[DEVICE]], indirect=True)
 async def test_climate_fan_level(
-    hass: HomeAssistant, mock_bridge, mock_api, monkeypatch
+    hass: HomeAssistant, mock_bridge, mock_api, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test climate fan level service."""
     await init_integration(hass)
@@ -179,7 +179,7 @@ async def test_climate_fan_level(
 
 @pytest.mark.parametrize("mock_bridge", [[DEVICE]], indirect=True)
 async def test_climate_swing(
-    hass: HomeAssistant, mock_bridge, mock_api, monkeypatch
+    hass: HomeAssistant, mock_bridge, mock_api, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test climate swing service."""
     await init_integration(hass)
@@ -234,9 +234,7 @@ async def test_climate_swing(
 
 
 @pytest.mark.parametrize("mock_bridge", [[DEVICE]], indirect=True)
-async def test_control_device_fail(
-    hass: HomeAssistant, mock_bridge, mock_api, monkeypatch
-) -> None:
+async def test_control_device_fail(hass: HomeAssistant, mock_bridge, mock_api) -> None:
     """Test control device fail."""
     await init_integration(hass)
     assert mock_bridge
@@ -295,7 +293,7 @@ async def test_control_device_fail(
 
 @pytest.mark.parametrize("mock_bridge", [[DEVICE]], indirect=True)
 async def test_bad_update_discard(
-    hass: HomeAssistant, mock_bridge, mock_api, monkeypatch
+    hass: HomeAssistant, mock_bridge, mock_api, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test that a bad update from device is discarded."""
     await init_integration(hass)
@@ -318,7 +316,7 @@ async def test_bad_update_discard(
 
 @pytest.mark.parametrize("mock_bridge", [[DEVICE]], indirect=True)
 async def test_climate_control_errors(
-    hass: HomeAssistant, mock_bridge, mock_api, monkeypatch
+    hass: HomeAssistant, mock_bridge, mock_api, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test control with settings not supported by device."""
     await init_integration(hass)

--- a/tests/components/switcher_kis/test_cover.py
+++ b/tests/components/switcher_kis/test_cover.py
@@ -31,7 +31,9 @@ ENTITY_ID = f"{COVER_DOMAIN}.{slugify(DEVICE.name)}"
 
 
 @pytest.mark.parametrize("mock_bridge", [[DEVICE]], indirect=True)
-async def test_cover(hass: HomeAssistant, mock_bridge, mock_api, monkeypatch) -> None:
+async def test_cover(
+    hass: HomeAssistant, mock_bridge, mock_api, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test cover services."""
     await init_integration(hass)
     assert mock_bridge

--- a/tests/components/switcher_kis/test_diagnostics.py
+++ b/tests/components/switcher_kis/test_diagnostics.py
@@ -1,5 +1,7 @@
 """Tests for the diagnostics data provided by Switcher."""
 
+import pytest
+
 from homeassistant.components.diagnostics import REDACTED
 from homeassistant.core import HomeAssistant
 
@@ -11,7 +13,10 @@ from tests.typing import ClientSessionGenerator
 
 
 async def test_diagnostics(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator, mock_bridge, monkeypatch
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_bridge,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test diagnostics."""
     entry = await init_integration(hass)

--- a/tests/components/switcher_kis/test_sensor.py
+++ b/tests/components/switcher_kis/test_sensor.py
@@ -74,7 +74,9 @@ async def test_sensor_disabled(
 
 
 @pytest.mark.parametrize("mock_bridge", [[DUMMY_WATER_HEATER_DEVICE]], indirect=True)
-async def test_sensor_update(hass: HomeAssistant, mock_bridge, monkeypatch) -> None:
+async def test_sensor_update(
+    hass: HomeAssistant, mock_bridge, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test sensor update."""
     await init_integration(hass)
     assert mock_bridge

--- a/tests/components/switcher_kis/test_services.py
+++ b/tests/components/switcher_kis/test_services.py
@@ -30,7 +30,7 @@ from .consts import (
 
 @pytest.mark.parametrize("mock_bridge", [[DUMMY_WATER_HEATER_DEVICE]], indirect=True)
 async def test_turn_on_with_timer_service(
-    hass: HomeAssistant, mock_bridge, mock_api, monkeypatch
+    hass: HomeAssistant, mock_bridge, mock_api, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test the turn on with timer service."""
     await init_integration(hass)

--- a/tests/components/switcher_kis/test_switch.py
+++ b/tests/components/switcher_kis/test_switch.py
@@ -23,7 +23,9 @@ from .consts import DUMMY_PLUG_DEVICE, DUMMY_WATER_HEATER_DEVICE
 
 
 @pytest.mark.parametrize("mock_bridge", [[DUMMY_WATER_HEATER_DEVICE]], indirect=True)
-async def test_switch(hass: HomeAssistant, mock_bridge, mock_api, monkeypatch) -> None:
+async def test_switch(
+    hass: HomeAssistant, mock_bridge, mock_api, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test the switch."""
     await init_integration(hass)
     assert mock_bridge
@@ -75,7 +77,7 @@ async def test_switch_control_fail(
     hass: HomeAssistant,
     mock_bridge,
     mock_api,
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test switch control fail."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #121051

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
