### PR TITLE
Cleanup deprecated json utils

### DIFF
--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-import json
 import logging
 from os import PathLike
 from typing import Any
@@ -11,8 +9,6 @@ from typing import Any
 import orjson
 
 from homeassistant.exceptions import HomeAssistantError
-
-from .file import WriteError  # noqa: F401
 
 _SENTINEL = object()
 _LOGGER = logging.getLogger(__name__)
@@ -129,63 +125,9 @@ def load_json_object(
     raise HomeAssistantError(f"Expected JSON to be parsed as a dict got {type(value)}")
 
 
-def save_json(
-    filename: str,
-    data: list | dict,
-    private: bool = False,
-    *,
-    encoder: type[json.JSONEncoder] | None = None,
-    atomic_writes: bool = False,
-) -> None:
-    """Save JSON data to a file."""
-    # pylint: disable-next=import-outside-toplevel
-    from homeassistant.helpers.frame import report
-
-    report(
-        (
-            "uses save_json from homeassistant.util.json module."
-            " This is deprecated and will stop working in Home Assistant 2022.4, it"
-            " should be updated to use homeassistant.helpers.json module instead"
-        ),
-        error_if_core=False,
-    )
-
-    # pylint: disable-next=import-outside-toplevel
-    import homeassistant.helpers.json as json_helper
-
-    json_helper.save_json(
-        filename, data, private, encoder=encoder, atomic_writes=atomic_writes
-    )
-
-
 def format_unserializable_data(data: dict[str, Any]) -> str:
     """Format output of find_paths in a friendly way.
 
     Format is comma separated: <path>=<value>(<type>)
     """
     return ", ".join(f"{path}={value}({type(value)}" for path, value in data.items())
-
-
-def find_paths_unserializable_data(
-    bad_data: Any, *, dump: Callable[[Any], str] = json.dumps
-) -> dict[str, Any]:
-    """Find the paths to unserializable data.
-
-    This method is slow! Only use for error handling.
-    """
-    # pylint: disable-next=import-outside-toplevel
-    from homeassistant.helpers.frame import report
-
-    report(
-        (
-            "uses find_paths_unserializable_data from homeassistant.util.json module."
-            " This is deprecated and will stop working in Home Assistant 2022.4, it"
-            " should be updated to use homeassistant.helpers.json module instead"
-        ),
-        error_if_core=False,
-    )
-
-    # pylint: disable-next=import-outside-toplevel
-    import homeassistant.helpers.json as json_helper
-
-    return json_helper.find_paths_unserializable_data(bad_data, dump=dump)

--- a/pylint/plugins/hass_imports.py
+++ b/pylint/plugins/hass_imports.py
@@ -392,12 +392,6 @@ _OBSOLETE_IMPORT: dict[str, list[ObsoleteImportMatch]] = {
             constant=re.compile(r"^IMPERIAL_SYSTEM$"),
         ),
     ],
-    "homeassistant.util.json": [
-        ObsoleteImportMatch(
-            reason="moved to homeassistant.helpers.json",
-            constant=re.compile(r"^save_json|find_paths_unserializable_data$"),
-        ),
-    ],
 }
 
 

--- a/tests/util/test_json.py
+++ b/tests/util/test_json.py
@@ -131,34 +131,6 @@ def test_json_loads_object() -> None:
         json_loads_object("null")
 
 
-async def test_deprecated_test_find_unserializable_data(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test deprecated test_find_unserializable_data logs a warning."""
-    # pylint: disable-next=hass-deprecated-import,import-outside-toplevel
-    from homeassistant.util.json import find_paths_unserializable_data
-
-    find_paths_unserializable_data(1)
-    assert (
-        "uses find_paths_unserializable_data from homeassistant.util.json"
-        in caplog.text
-    )
-    assert "should be updated to use homeassistant.helpers.json module" in caplog.text
-
-
-async def test_deprecated_save_json(
-    caplog: pytest.LogCaptureFixture, tmp_path: Path
-) -> None:
-    """Test deprecated save_json logs a warning."""
-    # pylint: disable-next=hass-deprecated-import,import-outside-toplevel
-    from homeassistant.util.json import save_json
-
-    fname = tmp_path / "test1.json"
-    save_json(fname, TEST_JSON_A)
-    assert "uses save_json from homeassistant.util.json" in caplog.text
-    assert "should be updated to use homeassistant.helpers.json module" in caplog.text
-
-
 async def test_loading_derived_class() -> None:
     """Test loading data from classes derived from str."""
 


### PR DESCRIPTION
## Breaking change
FOR DEVELOPERS ONLY:
- `save_json` and `find_paths_unserializable_data` functions have been moved from `homeassistant.util.json` to `homeassistant.helpers.json`

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, due for removal in 2022.4 (before merge of Feb 16, 2023 ???? - was probably meant to be 2024.2)
#88099

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
