### PR TITLE
Remove schema option for mqtt vacuum configs

### DIFF
--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -1,9 +1,5 @@
 {
   "issues": {
-    "deprecation_mqtt_schema_vacuum_yaml": {
-      "title": "MQTT vacuum entities with deprecated `schema` config settings found in your configuration.yaml",
-      "description": "The `schema` setting for MQTT vacuum entities is deprecated and should be removed. Please adjust your configuration.yaml and restart Home Assistant to fix this issue."
-    },
     "deprecated_color_handling": {
       "title": "Deprecated color handling used for MQTT light",
       "description": "An MQTT light config (with `json` schema) found in `configuration.yaml` uses deprecated color handling flags.\n\nConfiguration found:\n```yaml\n{config}\n```\nDeprecated flags: **{deprecated_flags}**.\n\nUse the `supported_color_modes` option instead and [reload](/developer-tools/yaml) the manually configured MQTT items or restart Home Assistant to fix this issue."

--- a/tests/components/mqtt/test_legacy_vacuum.py
+++ b/tests/components/mqtt/test_legacy_vacuum.py
@@ -23,7 +23,7 @@ DEFAULT_CONFIG = {mqtt.DOMAIN: {vacuum.DOMAIN: {"name": "test"}}}
     [
         ({mqtt.DOMAIN: {vacuum.DOMAIN: {"name": "test", "schema": "legacy"}}}, True),
         ({mqtt.DOMAIN: {vacuum.DOMAIN: {"name": "test"}}}, False),
-        ({mqtt.DOMAIN: {vacuum.DOMAIN: {"name": "test", "schema": "state"}}}, False),
+        ({mqtt.DOMAIN: {vacuum.DOMAIN: {"name": "test", "schema": "state"}}}, True),
     ],
 )
 async def test_removed_support_yaml(
@@ -39,8 +39,8 @@ async def test_removed_support_yaml(
     if removed:
         assert entity is None
         assert (
-            "The support for the `legacy` MQTT "
-            "vacuum schema has been removed" in caplog.text
+            "The 'schema' option has been removed, "
+            "please remove it from your configuration" in caplog.text
         )
     else:
         assert entity is not None
@@ -51,7 +51,7 @@ async def test_removed_support_yaml(
     [
         ({"name": "test", "schema": "legacy"}, True),
         ({"name": "test"}, False),
-        ({"name": "test", "schema": "state"}, False),
+        ({"name": "test", "schema": "state"}, True),
     ],
 )
 async def test_removed_support_discovery(
@@ -69,12 +69,15 @@ async def test_removed_support_discovery(
     await hass.async_block_till_done()
 
     entity = hass.states.get("vacuum.test")
+    assert entity is not None
 
     if removed:
-        assert entity is None
         assert (
-            "The support for the `legacy` MQTT "
-            "vacuum schema has been removed" in caplog.text
+            "The 'schema' option has been removed, "
+            "please remove it from your configuration" in caplog.text
         )
     else:
-        assert entity is not None
+        assert (
+            "The 'schema' option has been removed, "
+            "please remove it from your configuration" not in caplog.text
+        )

--- a/tests/components/mqtt/test_vacuum.py
+++ b/tests/components/mqtt/test_vacuum.py
@@ -119,16 +119,13 @@ async def test_warning_schema_option(
     await hass.async_block_till_done(wait_background_tasks=True)
 
     state = hass.states.get("vacuum.test")
+    # We do not fail if the schema option is still in the payload, but we log an error
     assert state is not None
     with caplog.at_level(logging.WARNING):
         assert (
-            "The `schema` option is deprecated for MQTT vacuum, but it was used in a "
-            "discovery payload. Please contact the maintainer of the integration or "
-            "service that supplies the config, and suggest to remove the option."
-            in caplog.text
+            "The 'schema' option has been removed, "
+            "please remove it from your configuration" in caplog.text
         )
-        assert "https://example.com/support" in caplog.text
-        assert "at discovery topic homeassistant/vacuum/bla/config" in caplog.text
 
 
 @pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `schema` option has been removed from the mqtt vacuum schema. YAML configs still containing this option will break after 6 months of deprecation. Users have been warned with with a repair. Discovery configs will not break if the schema options is still in the config, but it will simple be ignored and an error message will be logged to notice.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The `schema` option has been removed from the mqtt vacuum schema. Loag an error and break YAML based configs that still have the `schema` option. Cleanup the code for registering a deprecation issue.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
