### PR TITLE
Fix locking/unlocking transition state in Matter lock platform

### DIFF
--- a/homeassistant/components/matter/lock.py
+++ b/homeassistant/components/matter/lock.py
@@ -123,7 +123,6 @@ class MatterLock(MatterEntity, LockEntity):
         # optimistically signal unlocking to state machine
         self._attr_is_unlocking = True
         self.async_write_ha_state()
-        self._attr_is_unlocking = None
         code: str | None = kwargs.get(ATTR_CODE)
         code_bytes = code.encode() if code else None
         await self.send_device_command(

--- a/homeassistant/components/matter/lock.py
+++ b/homeassistant/components/matter/lock.py
@@ -90,6 +90,9 @@ class MatterLock(MatterEntity, LockEntity):
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the lock with pin if needed."""
+        # optimistically signal locking to state machine
+        self._attr_is_locking = True
+        self.async_write_ha_state()
         code: str | None = kwargs.get(ATTR_CODE)
         code_bytes = code.encode() if code else None
         await self.send_device_command(
@@ -98,6 +101,9 @@ class MatterLock(MatterEntity, LockEntity):
 
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the lock with pin if needed."""
+        # optimistically signal unlocking to state machine
+        self._attr_is_unlocking = True
+        self.async_write_ha_state()
         code: str | None = kwargs.get(ATTR_CODE)
         code_bytes = code.encode() if code else None
         if self.supports_unbolt:
@@ -114,6 +120,10 @@ class MatterLock(MatterEntity, LockEntity):
 
     async def async_open(self, **kwargs: Any) -> None:
         """Open the door latch."""
+        # optimistically signal unlocking to state machine
+        self._attr_is_unlocking = True
+        self.async_write_ha_state()
+        self._attr_is_unlocking = None
         code: str | None = kwargs.get(ATTR_CODE)
         code_bytes = code.encode() if code else None
         await self.send_device_command(
@@ -135,29 +145,23 @@ class MatterLock(MatterEntity, LockEntity):
             clusters.DoorLock.Attributes.LockState
         )
 
+        # always reset the optimisically (un)locking state on state update
+        self._attr_is_locking = False
+        self._attr_is_unlocking = False
+
         LOGGER.debug("Lock state: %s for %s", lock_state, self.entity_id)
 
         if lock_state is clusters.DoorLock.Enums.DlLockState.kLocked:
             self._attr_is_locked = True
-            self._attr_is_locking = False
-            self._attr_is_unlocking = False
-        elif lock_state is clusters.DoorLock.Enums.DlLockState.kUnlocked:
-            self._attr_is_locked = False
-            self._attr_is_locking = False
-            self._attr_is_unlocking = False
-        elif lock_state is clusters.DoorLock.Enums.DlLockState.kNotFullyLocked:
-            if self.is_locked is True:
-                self._attr_is_unlocking = True
-            elif self.is_locked is False:
-                self._attr_is_locking = True
-            # always mark the lock as not locked because some locks (e.g. switchbot)
-            # use this state to indicate they are not locked.
+        elif lock_state in (
+            clusters.DoorLock.Enums.DlLockState.kUnlocked,
+            clusters.DoorLock.Enums.DlLockState.kUnlatched,
+            clusters.DoorLock.Enums.DlLockState.kNotFullyLocked,
+        ):
             self._attr_is_locked = False
         else:
             # According to the matter docs a null state can happen during device startup.
             self._attr_is_locked = None
-            self._attr_is_locking = None
-            self._attr_is_unlocking = None
 
         if self.supports_door_position_sensor:
             door_state = self.get_matter_attribute_value(

--- a/homeassistant/components/matter/lock.py
+++ b/homeassistant/components/matter/lock.py
@@ -150,6 +150,9 @@ class MatterLock(MatterEntity, LockEntity):
                 self._attr_is_unlocking = True
             elif self.is_locked is False:
                 self._attr_is_locking = True
+            # always mark the lock as not locked because some locks (e.g. switchbot)
+            # use this state to indicate they are not locked.
+            self._attr_is_locked = False
         else:
             # According to the matter docs a null state can happen during device startup.
             self._attr_is_locked = None

--- a/tests/components/matter/test_door_lock.py
+++ b/tests/components/matter/test_door_lock.py
@@ -8,13 +8,11 @@ import pytest
 
 from homeassistant.components.lock import (
     STATE_LOCKED,
-    STATE_LOCKING,
     STATE_OPEN,
     STATE_UNLOCKED,
-    STATE_UNLOCKING,
     LockEntityFeature,
 )
-from homeassistant.const import ATTR_CODE, STATE_UNKNOWN
+from homeassistant.const import ATTR_CODE, STATE_LOCKING, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 import homeassistant.helpers.entity_registry as er
@@ -68,14 +66,14 @@ async def test_lock(
 
     state = hass.states.get("lock.mock_door_lock_lock")
     assert state
-    assert state.state == STATE_LOCKED
+    assert state.state == STATE_LOCKING
 
     set_node_attribute(door_lock, 1, 257, 0, 0)
     await trigger_subscription_callback(hass, matter_client)
 
     state = hass.states.get("lock.mock_door_lock_lock")
     assert state
-    assert state.state == STATE_UNLOCKING
+    assert state.state == STATE_UNLOCKED
 
     set_node_attribute(door_lock, 1, 257, 0, 2)
     await trigger_subscription_callback(hass, matter_client)
@@ -89,7 +87,7 @@ async def test_lock(
 
     state = hass.states.get("lock.mock_door_lock_lock")
     assert state
-    assert state.state == STATE_LOCKING
+    assert state.state == STATE_UNLOCKED
 
     set_node_attribute(door_lock, 1, 257, 0, None)
     await trigger_subscription_callback(hass, matter_client)


### PR DESCRIPTION
## Proposed change

There was an incorrect assumption in the implementation of the Matter lock platform that the state 'NotFullyLocked' was to indicate the lock is transitioning to the next state but that is not true.

The specification says:

`The Not Fully Locked value is used by a lock to indicate that the state of the lock is somewhere between Locked and Unlocked so it is only partially secured. For example, a deadbolt could be par­tially extended and not in a dead latched state.`

In fact a lock may use this state (value 0) to indicate the lock is unlocked, as reported for at least SwitchBot in #120694 so the whole code was wrong. Fixed the code to treat NotFullyLocked as unlocked and use optimistic state for locking/unlocking instead (reset as soon as a state change comes in).

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #120694
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
