### PR TITLE
Use fixtures in deCONZ device trigger tests

### DIFF
--- a/tests/components/deconz/test_device_trigger.py
+++ b/tests/components/deconz/test_device_trigger.py
@@ -1,6 +1,6 @@
 """deCONZ device automation tests."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 from pytest_unordered import unordered
@@ -18,6 +18,7 @@ from homeassistant.components.deconz.const import DOMAIN as DECONZ_DOMAIN
 from homeassistant.components.deconz.device_trigger import CONF_SUBTYPE
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL,
     ATTR_ENTITY_ID,
@@ -32,10 +33,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.trigger import async_initialize_triggers
 from homeassistant.setup import async_setup_component
 
-from .test_gateway import DECONZ_WEB_REQUEST, setup_deconz_integration
-
 from tests.common import async_get_device_automations
-from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
@@ -43,15 +41,10 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
 
 
-async def test_get_triggers(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    entity_registry: er.EntityRegistry,
-    aioclient_mock: AiohttpClientMocker,
-) -> None:
-    """Test triggers work."""
-    data = {
-        "sensors": {
+@pytest.mark.parametrize(
+    "sensor_payload",
+    [
+        {
             "1": {
                 "config": {
                     "alert": "none",
@@ -72,10 +65,15 @@ async def test_get_triggers(
                 "uniqueid": "d0:cf:5e:ff:fe:71:a4:3a-01-1000",
             }
         }
-    }
-    with patch.dict(DECONZ_WEB_REQUEST, data):
-        await setup_deconz_integration(hass, aioclient_mock)
-
+    ],
+)
+@pytest.mark.usefixtures("config_entry_setup")
+async def test_get_triggers(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test triggers work."""
     device = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, "d0:cf:5e:ff:fe:71:a4:3a")}
     )
@@ -149,15 +147,10 @@ async def test_get_triggers(
     assert triggers == unordered(expected_triggers)
 
 
-async def test_get_triggers_for_alarm_event(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    entity_registry: er.EntityRegistry,
-    aioclient_mock: AiohttpClientMocker,
-) -> None:
-    """Test triggers work."""
-    data = {
-        "sensors": {
+@pytest.mark.parametrize(
+    "sensor_payload",
+    [
+        {
             "1": {
                 "config": {
                     "battery": 95,
@@ -185,10 +178,15 @@ async def test_get_triggers_for_alarm_event(
                 "uniqueid": "00:00:00:00:00:00:00:00-00",
             }
         }
-    }
-    with patch.dict(DECONZ_WEB_REQUEST, data):
-        await setup_deconz_integration(hass, aioclient_mock)
-
+    ],
+)
+@pytest.mark.usefixtures("config_entry_setup")
+async def test_get_triggers_for_alarm_event(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test triggers work."""
     device = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, "00:00:00:00:00:00:00:00")}
     )
@@ -246,14 +244,10 @@ async def test_get_triggers_for_alarm_event(
     assert triggers == unordered(expected_triggers)
 
 
-async def test_get_triggers_manage_unsupported_remotes(
-    hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
-    device_registry: dr.DeviceRegistry,
-) -> None:
-    """Verify no triggers for an unsupported remote."""
-    data = {
-        "sensors": {
+@pytest.mark.parametrize(
+    "sensor_payload",
+    [
+        {
             "1": {
                 "config": {
                     "alert": "none",
@@ -273,10 +267,13 @@ async def test_get_triggers_manage_unsupported_remotes(
                 "uniqueid": "d0:cf:5e:ff:fe:71:a4:3a-01-1000",
             }
         }
-    }
-    with patch.dict(DECONZ_WEB_REQUEST, data):
-        await setup_deconz_integration(hass, aioclient_mock)
-
+    ],
+)
+@pytest.mark.usefixtures("config_entry_setup")
+async def test_get_triggers_manage_unsupported_remotes(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Verify no triggers for an unsupported remote."""
     device = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, "d0:cf:5e:ff:fe:71:a4:3a")}
     )
@@ -290,17 +287,10 @@ async def test_get_triggers_manage_unsupported_remotes(
     assert triggers == unordered(expected_triggers)
 
 
-async def test_functional_device_trigger(
-    hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
-    mock_deconz_websocket,
-    service_calls: list[ServiceCall],
-    device_registry: dr.DeviceRegistry,
-) -> None:
-    """Test proper matching and attachment of device trigger automation."""
-
-    data = {
-        "sensors": {
+@pytest.mark.parametrize(
+    "sensor_payload",
+    [
+        {
             "1": {
                 "config": {
                     "alert": "none",
@@ -321,10 +311,16 @@ async def test_functional_device_trigger(
                 "uniqueid": "d0:cf:5e:ff:fe:71:a4:3a-01-1000",
             }
         }
-    }
-    with patch.dict(DECONZ_WEB_REQUEST, data):
-        await setup_deconz_integration(hass, aioclient_mock)
-
+    ],
+)
+@pytest.mark.usefixtures("config_entry_setup")
+async def test_functional_device_trigger(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    service_calls: list[ServiceCall],
+    mock_deconz_websocket,
+) -> None:
+    """Test proper matching and attachment of device trigger automation."""
     device = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, "d0:cf:5e:ff:fe:71:a4:3a")}
     )
@@ -368,12 +364,9 @@ async def test_functional_device_trigger(
 
 
 @pytest.mark.skip(reason="Temporarily disabled until automation validation is improved")
-async def test_validate_trigger_unknown_device(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
-) -> None:
+@pytest.mark.usefixtures("config_entry_setup")
+async def test_validate_trigger_unknown_device(hass: HomeAssistant) -> None:
     """Test unknown device does not return a trigger config."""
-    await setup_deconz_integration(hass, aioclient_mock)
-
     assert await async_setup_component(
         hass,
         AUTOMATION_DOMAIN,
@@ -402,14 +395,12 @@ async def test_validate_trigger_unknown_device(
 
 async def test_validate_trigger_unsupported_device(
     hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
     device_registry: dr.DeviceRegistry,
+    config_entry_setup: ConfigEntry,
 ) -> None:
     """Test unsupported device doesn't return a trigger config."""
-    config_entry = await setup_deconz_integration(hass, aioclient_mock)
-
     device = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id=config_entry_setup.entry_id,
         identifiers={(DECONZ_DOMAIN, "d0:cf:5e:ff:fe:71:a4:3a")},
         model="unsupported",
     )
@@ -444,14 +435,12 @@ async def test_validate_trigger_unsupported_device(
 
 async def test_validate_trigger_unsupported_trigger(
     hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
     device_registry: dr.DeviceRegistry,
+    config_entry_setup: ConfigEntry,
 ) -> None:
     """Test unsupported trigger does not return a trigger config."""
-    config_entry = await setup_deconz_integration(hass, aioclient_mock)
-
     device = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id=config_entry_setup.entry_id,
         identifiers={(DECONZ_DOMAIN, "d0:cf:5e:ff:fe:71:a4:3a")},
         model="TRADFRI on/off switch",
     )
@@ -488,14 +477,12 @@ async def test_validate_trigger_unsupported_trigger(
 
 async def test_attach_trigger_no_matching_event(
     hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
     device_registry: dr.DeviceRegistry,
+    config_entry_setup: ConfigEntry,
 ) -> None:
     """Test no matching event for device doesn't return a trigger config."""
-    config_entry = await setup_deconz_integration(hass, aioclient_mock)
-
     device = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id=config_entry_setup.entry_id,
         identifiers={(DECONZ_DOMAIN, "d0:cf:5e:ff:fe:71:a4:3a")},
         name="Tradfri switch",
         model="TRADFRI on/off switch",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

Related to https://github.com/home-assistant/core/pull/120863, https://github.com/home-assistant/core/pull/120936, https://github.com/home-assistant/core/pull/120938, https://github.com/home-assistant/core/pull/120943, https://github.com/home-assistant/core/pull/120944, https://github.com/home-assistant/core/pull/120947, https://github.com/home-assistant/core/pull/120948, https://github.com/home-assistant/core/pull/120953, https://github.com/home-assistant/core/pull/120954, https://github.com/home-assistant/core/pull/120966, https://github.com/home-assistant/core/pull/120967, https://github.com/home-assistant/core/pull/120968

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
