### PR TITLE
Use fixtures in deCONZ service tests

### DIFF
--- a/tests/components/deconz/test_services.py
+++ b/tests/components/deconz/test_services.py
@@ -1,6 +1,7 @@
 """deCONZ service tests."""
 
-from unittest.mock import patch
+from collections.abc import Callable
+from typing import Any
 
 import pytest
 import voluptuous as vol
@@ -20,34 +21,29 @@ from homeassistant.components.deconz.services import (
     SERVICE_REMOVE_ORPHANED_ENTRIES,
 )
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from .test_gateway import (
-    BRIDGEID,
-    DECONZ_WEB_REQUEST,
-    mock_deconz_put_request,
-    mock_deconz_request,
-    setup_deconz_integration,
-)
+from .test_gateway import BRIDGEID
 
 from tests.common import async_capture_events
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
+@pytest.mark.usefixtures("config_entry_setup")
 async def test_configure_service_with_field(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant,
+    mock_put_request: Callable[[str, str], AiohttpClientMocker],
 ) -> None:
     """Test that service invokes pydeconz with the correct path and data."""
-    config_entry = await setup_deconz_integration(hass, aioclient_mock)
-
     data = {
         SERVICE_FIELD: "/lights/2",
         CONF_BRIDGE_ID: BRIDGEID,
         SERVICE_DATA: {"on": True, "attr1": 10, "attr2": 20},
     }
 
-    mock_deconz_put_request(aioclient_mock, config_entry.data, "/lights/2")
+    aioclient_mock = mock_put_request("/lights/2")
 
     await hass.services.async_call(
         DECONZ_DOMAIN, SERVICE_CONFIGURE_DEVICE, service_data=data, blocking=True
@@ -55,12 +51,10 @@ async def test_configure_service_with_field(
     assert aioclient_mock.mock_calls[1][2] == {"on": True, "attr1": 10, "attr2": 20}
 
 
-async def test_configure_service_with_entity(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
-) -> None:
-    """Test that service invokes pydeconz with the correct path and data."""
-    data = {
-        "lights": {
+@pytest.mark.parametrize(
+    "light_payload",
+    [
+        {
             "1": {
                 "name": "Test",
                 "state": {"reachable": True},
@@ -68,16 +62,19 @@ async def test_configure_service_with_entity(
                 "uniqueid": "00:00:00:00:00:00:00:01-00",
             }
         }
-    }
-    with patch.dict(DECONZ_WEB_REQUEST, data):
-        config_entry = await setup_deconz_integration(hass, aioclient_mock)
-
+    ],
+)
+@pytest.mark.usefixtures("config_entry_setup")
+async def test_configure_service_with_entity(
+    hass: HomeAssistant,
+    mock_put_request: Callable[[str, str], AiohttpClientMocker],
+) -> None:
+    """Test that service invokes pydeconz with the correct path and data."""
     data = {
         SERVICE_ENTITY: "light.test",
         SERVICE_DATA: {"on": True, "attr1": 10, "attr2": 20},
     }
-
-    mock_deconz_put_request(aioclient_mock, config_entry.data, "/lights/1")
+    aioclient_mock = mock_put_request("/lights/1")
 
     await hass.services.async_call(
         DECONZ_DOMAIN, SERVICE_CONFIGURE_DEVICE, service_data=data, blocking=True
@@ -85,12 +82,10 @@ async def test_configure_service_with_entity(
     assert aioclient_mock.mock_calls[1][2] == {"on": True, "attr1": 10, "attr2": 20}
 
 
-async def test_configure_service_with_entity_and_field(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
-) -> None:
-    """Test that service invokes pydeconz with the correct path and data."""
-    data = {
-        "lights": {
+@pytest.mark.parametrize(
+    "light_payload",
+    [
+        {
             "1": {
                 "name": "Test",
                 "state": {"reachable": True},
@@ -98,17 +93,20 @@ async def test_configure_service_with_entity_and_field(
                 "uniqueid": "00:00:00:00:00:00:00:01-00",
             }
         }
-    }
-    with patch.dict(DECONZ_WEB_REQUEST, data):
-        config_entry = await setup_deconz_integration(hass, aioclient_mock)
-
+    ],
+)
+@pytest.mark.usefixtures("config_entry_setup")
+async def test_configure_service_with_entity_and_field(
+    hass: HomeAssistant,
+    mock_put_request: Callable[[str, str], AiohttpClientMocker],
+) -> None:
+    """Test that service invokes pydeconz with the correct path and data."""
     data = {
         SERVICE_ENTITY: "light.test",
         SERVICE_FIELD: "/state",
         SERVICE_DATA: {"on": True, "attr1": 10, "attr2": 20},
     }
-
-    mock_deconz_put_request(aioclient_mock, config_entry.data, "/lights/1/state")
+    aioclient_mock = mock_put_request("/lights/1/state")
 
     await hass.services.async_call(
         DECONZ_DOMAIN, SERVICE_CONFIGURE_DEVICE, service_data=data, blocking=True
@@ -116,11 +114,11 @@ async def test_configure_service_with_entity_and_field(
     assert aioclient_mock.mock_calls[1][2] == {"on": True, "attr1": 10, "attr2": 20}
 
 
+@pytest.mark.usefixtures("config_entry_setup")
 async def test_configure_service_with_faulty_bridgeid(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test that service fails on a bad bridge id."""
-    await setup_deconz_integration(hass, aioclient_mock)
     aioclient_mock.clear_requests()
 
     data = {
@@ -137,12 +135,9 @@ async def test_configure_service_with_faulty_bridgeid(
     assert len(aioclient_mock.mock_calls) == 0
 
 
-async def test_configure_service_with_faulty_field(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
-) -> None:
+@pytest.mark.usefixtures("config_entry_setup")
+async def test_configure_service_with_faulty_field(hass: HomeAssistant) -> None:
     """Test that service fails on a bad field."""
-    await setup_deconz_integration(hass, aioclient_mock)
-
     data = {SERVICE_FIELD: "light/2", SERVICE_DATA: {}}
 
     with pytest.raises(vol.Invalid):
@@ -151,11 +146,11 @@ async def test_configure_service_with_faulty_field(
         )
 
 
+@pytest.mark.usefixtures("config_entry_setup")
 async def test_configure_service_with_faulty_entity(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test that service on a non existing entity."""
-    await setup_deconz_integration(hass, aioclient_mock)
     aioclient_mock.clear_requests()
 
     data = {
@@ -171,13 +166,12 @@ async def test_configure_service_with_faulty_entity(
     assert len(aioclient_mock.mock_calls) == 0
 
 
+@pytest.mark.parametrize("config_entry_options", [{CONF_MASTER_GATEWAY: False}])
+@pytest.mark.usefixtures("config_entry_setup")
 async def test_calling_service_with_no_master_gateway_fails(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test that service call fails when no master gateway exist."""
-    await setup_deconz_integration(
-        hass, aioclient_mock, options={CONF_MASTER_GATEWAY: False}
-    )
     aioclient_mock.clear_requests()
 
     data = {
@@ -193,18 +187,19 @@ async def test_calling_service_with_no_master_gateway_fails(
     assert len(aioclient_mock.mock_calls) == 0
 
 
+@pytest.mark.usefixtures("config_entry_setup")
 async def test_service_refresh_devices(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    deconz_payload: dict[str, Any],
+    mock_requests,
 ) -> None:
     """Test that service can refresh devices."""
-    config_entry = await setup_deconz_integration(hass, aioclient_mock)
-
     assert len(hass.states.async_all()) == 0
 
     aioclient_mock.clear_requests()
 
-    data = {
-        "config": {},
+    deconz_payload |= {
         "groups": {
             "1": {
                 "id": "Group 1 id",
@@ -234,8 +229,7 @@ async def test_service_refresh_devices(
             }
         },
     }
-
-    mock_deconz_request(aioclient_mock, config_entry.data, data)
+    mock_requests()
 
     await hass.services.async_call(
         DECONZ_DOMAIN, SERVICE_DEVICE_REFRESH, service_data={CONF_BRIDGE_ID: BRIDGEID}
@@ -245,12 +239,10 @@ async def test_service_refresh_devices(
     assert len(hass.states.async_all()) == 5
 
 
-async def test_service_refresh_devices_trigger_no_state_update(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
-) -> None:
-    """Verify that gateway.ignore_state_updates are honored."""
-    data = {
-        "sensors": {
+@pytest.mark.parametrize(
+    "sensor_payload",
+    [
+        {
             "1": {
                 "name": "Switch 1",
                 "type": "ZHASwitch",
@@ -259,18 +251,23 @@ async def test_service_refresh_devices_trigger_no_state_update(
                 "uniqueid": "00:00:00:00:00:00:00:01-00",
             }
         }
-    }
-    with patch.dict(DECONZ_WEB_REQUEST, data):
-        config_entry = await setup_deconz_integration(hass, aioclient_mock)
-
+    ],
+)
+@pytest.mark.usefixtures("config_entry_setup")
+async def test_service_refresh_devices_trigger_no_state_update(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    deconz_payload: dict[str, Any],
+    mock_requests,
+) -> None:
+    """Verify that gateway.ignore_state_updates are honored."""
     assert len(hass.states.async_all()) == 1
 
     captured_events = async_capture_events(hass, CONF_DECONZ_EVENT)
 
     aioclient_mock.clear_requests()
 
-    data = {
-        "config": {},
+    deconz_payload |= {
         "groups": {
             "1": {
                 "id": "Group 1 id",
@@ -300,8 +297,7 @@ async def test_service_refresh_devices_trigger_no_state_update(
             }
         },
     }
-
-    mock_deconz_request(aioclient_mock, config_entry.data, data)
+    mock_requests()
 
     await hass.services.async_call(
         DECONZ_DOMAIN, SERVICE_DEVICE_REFRESH, service_data={CONF_BRIDGE_ID: BRIDGEID}
@@ -312,23 +308,23 @@ async def test_service_refresh_devices_trigger_no_state_update(
     assert len(captured_events) == 0
 
 
-async def test_remove_orphaned_entries_service(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    entity_registry: er.EntityRegistry,
-    aioclient_mock: AiohttpClientMocker,
-) -> None:
-    """Test service works and also don't remove more than expected."""
-    data = {
-        "lights": {
+@pytest.mark.parametrize(
+    "light_payload",
+    [
+        {
             "1": {
                 "name": "Light 1 name",
                 "state": {"reachable": True},
                 "type": "Light",
                 "uniqueid": "00:00:00:00:00:00:00:01-00",
             }
-        },
-        "sensors": {
+        }
+    ],
+)
+@pytest.mark.parametrize(
+    "sensor_payload",
+    [
+        {
             "1": {
                 "name": "Switch 1",
                 "type": "ZHASwitch",
@@ -336,13 +332,18 @@ async def test_remove_orphaned_entries_service(
                 "config": {"battery": 100},
                 "uniqueid": "00:00:00:00:00:00:00:03-00",
             },
-        },
-    }
-    with patch.dict(DECONZ_WEB_REQUEST, data):
-        config_entry = await setup_deconz_integration(hass, aioclient_mock)
-
+        }
+    ],
+)
+async def test_remove_orphaned_entries_service(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    config_entry_setup: ConfigEntry,
+) -> None:
+    """Test service works and also don't remove more than expected."""
     device = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
+        config_entry_id=config_entry_setup.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "123")},
     )
 
@@ -351,7 +352,7 @@ async def test_remove_orphaned_entries_service(
             [
                 entry
                 for entry in device_registry.devices.values()
-                if config_entry.entry_id in entry.config_entries
+                if config_entry_setup.entry_id in entry.config_entries
             ]
         )
         == 5  # Host, gateway, light, switch and orphan
@@ -362,12 +363,16 @@ async def test_remove_orphaned_entries_service(
         DECONZ_DOMAIN,
         "12345",
         suggested_object_id="Orphaned sensor",
-        config_entry=config_entry,
+        config_entry=config_entry_setup,
         device_id=device.id,
     )
 
     assert (
-        len(er.async_entries_for_config_entry(entity_registry, config_entry.entry_id))
+        len(
+            er.async_entries_for_config_entry(
+                entity_registry, config_entry_setup.entry_id
+            )
+        )
         == 3  # Light, switch battery and orphan
     )
 
@@ -383,13 +388,17 @@ async def test_remove_orphaned_entries_service(
             [
                 entry
                 for entry in device_registry.devices.values()
-                if config_entry.entry_id in entry.config_entries
+                if config_entry_setup.entry_id in entry.config_entries
             ]
         )
         == 4  # Host, gateway, light and switch
     )
 
     assert (
-        len(er.async_entries_for_config_entry(entity_registry, config_entry.entry_id))
+        len(
+            er.async_entries_for_config_entry(
+                entity_registry, config_entry_setup.entry_id
+            )
+        )
         == 2  # Light and switch battery
     )

--- a/tests/components/deconz/test_services.py
+++ b/tests/components/deconz/test_services.py
@@ -192,7 +192,7 @@ async def test_service_refresh_devices(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     deconz_payload: dict[str, Any],
-    mock_requests,
+    mock_requests: Callable[[], None],
 ) -> None:
     """Test that service can refresh devices."""
     assert len(hass.states.async_all()) == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

Related to https://github.com/home-assistant/core/pull/120863, https://github.com/home-assistant/core/pull/120936, https://github.com/home-assistant/core/pull/120938, https://github.com/home-assistant/core/pull/120943, https://github.com/home-assistant/core/pull/120944, https://github.com/home-assistant/core/pull/120947, https://github.com/home-assistant/core/pull/120948, https://github.com/home-assistant/core/pull/120953, https://github.com/home-assistant/core/pull/120954, https://github.com/home-assistant/core/pull/120966, https://github.com/home-assistant/core/pull/120967, https://github.com/home-assistant/core/pull/120968, https://github.com/home-assistant/core/pull/121103

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
