### PR TITLE
Add support for event entity motion sensors to HomeKit

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -1126,7 +1126,7 @@ class HomeKit:
                 config[entity_id].setdefault(
                     CONF_LINKED_MOTION_SENSOR, motion_event_entity_id
                 )
-            if motion_binary_sensor_entity_id := lookup.get(MOTION_SENSOR):
+            elif motion_binary_sensor_entity_id := lookup.get(MOTION_SENSOR):
                 config[entity_id].setdefault(
                     CONF_LINKED_MOTION_SENSOR, motion_binary_sensor_entity_id
                 )

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -163,6 +163,7 @@ BATTERY_CHARGING_SENSOR = (
     BinarySensorDeviceClass.BATTERY_CHARGING,
 )
 BATTERY_SENSOR = (SENSOR_DOMAIN, SensorDeviceClass.BATTERY)
+MOTION_EVENT_SENSOR = (EVENT_DOMAIN, EventDeviceClass.MOTION)
 MOTION_SENSOR = (BINARY_SENSOR_DOMAIN, BinarySensorDeviceClass.MOTION)
 DOORBELL_EVENT_SENSOR = (EVENT_DOMAIN, EventDeviceClass.DOORBELL)
 DOORBELL_BINARY_SENSOR = (BINARY_SENSOR_DOMAIN, BinarySensorDeviceClass.OCCUPANCY)
@@ -1121,6 +1122,10 @@ class HomeKit:
             )
 
         if domain == CAMERA_DOMAIN:
+            if motion_event_entity_id := lookup.get(MOTION_EVENT_SENSOR):
+                config[entity_id].setdefault(
+                    CONF_LINKED_MOTION_SENSOR, motion_event_entity_id
+                )
             if motion_binary_sensor_entity_id := lookup.get(MOTION_SENSOR):
                 config[entity_id].setdefault(
                     CONF_LINKED_MOTION_SENSOR, motion_binary_sensor_entity_id

--- a/homeassistant/components/homekit/type_cameras.py
+++ b/homeassistant/components/homekit/type_cameras.py
@@ -317,7 +317,7 @@ class Camera(HomeAccessory, PyhapCamera):  # type: ignore[misc]
         char = self._char_motion_detected
         assert char is not None
         if self.motion_is_event:
-            if state in (STATE_ON, STATE_UNAVAILABLE):
+            if state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
                 return
             _LOGGER.debug(
                 "%s: Set linked motion %s sensor to True/False",

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -1939,12 +1939,21 @@ async def test_homekit_ignored_missing_devices(
     )
 
 
+@pytest.mark.parametrize(
+    ("domain", "device_class"),
+    [
+        ("binary_sensor", BinarySensorDeviceClass.MOTION),
+        ("event", EventDeviceClass.MOTION),
+    ],
+)
 @pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_homekit_finds_linked_motion_sensors(
     hass: HomeAssistant,
     hk_driver,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
+    domain: str,
+    device_class: EventDeviceClass | BinarySensorDeviceClass,
 ) -> None:
     """Test HomeKit start method."""
     entry = await async_init_integration(hass)
@@ -1964,21 +1973,21 @@ async def test_homekit_finds_linked_motion_sensors(
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
 
-    binary_motion_sensor = entity_registry.async_get_or_create(
-        "binary_sensor",
+    entry = entity_registry.async_get_or_create(
+        domain,
         "camera",
         "motion_sensor",
         device_id=device_entry.id,
-        original_device_class=BinarySensorDeviceClass.MOTION,
+        original_device_class=device_class,
     )
     camera = entity_registry.async_get_or_create(
         "camera", "camera", "demo", device_id=device_entry.id
     )
 
     hass.states.async_set(
-        binary_motion_sensor.entity_id,
+        entry.entity_id,
         STATE_ON,
-        {ATTR_DEVICE_CLASS: BinarySensorDeviceClass.MOTION},
+        {ATTR_DEVICE_CLASS: device_class},
     )
     hass.states.async_set(camera.entity_id, STATE_ON)
 
@@ -2001,7 +2010,7 @@ async def test_homekit_finds_linked_motion_sensors(
             "model": "Camera Server",
             "platform": "test",
             "sw_version": "0.16.0",
-            "linked_motion_sensor": "binary_sensor.camera_motion_sensor",
+            "linked_motion_sensor": entry.entity_id,
         },
     )
 

--- a/tests/components/homekit/test_type_cameras.py
+++ b/tests/components/homekit/test_type_cameras.py
@@ -795,6 +795,103 @@ async def test_camera_with_linked_motion_sensor(
     assert char.value is True
 
 
+async def test_camera_with_linked_motion_event(
+    hass: HomeAssistant, run_driver, events
+) -> None:
+    """Test a camera with a linked motion event entity can update."""
+    await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
+    await async_setup_component(
+        hass, camera.DOMAIN, {camera.DOMAIN: {"platform": "demo"}}
+    )
+    await hass.async_block_till_done()
+    motion_entity_id = "event.motion"
+
+    hass.states.async_set(
+        motion_entity_id,
+        dt_util.utcnow().isoformat(),
+        {ATTR_DEVICE_CLASS: EventDeviceClass.MOTION},
+    )
+    await hass.async_block_till_done()
+    entity_id = "camera.demo_camera"
+
+    hass.states.async_set(entity_id, None)
+    await hass.async_block_till_done()
+    acc = Camera(
+        hass,
+        run_driver,
+        "Camera",
+        entity_id,
+        2,
+        {
+            CONF_STREAM_SOURCE: "/dev/null",
+            CONF_SUPPORT_AUDIO: True,
+            CONF_VIDEO_CODEC: VIDEO_CODEC_H264_OMX,
+            CONF_AUDIO_CODEC: AUDIO_CODEC_COPY,
+            CONF_LINKED_MOTION_SENSOR: motion_entity_id,
+        },
+    )
+    bridge = HomeBridge("hass", run_driver, "Test Bridge")
+    bridge.add_accessory(acc)
+
+    acc.run()
+
+    assert acc.aid == 2
+    assert acc.category == 17  # Camera
+
+    service = acc.get_service(SERV_MOTION_SENSOR)
+    assert service
+    char = service.get_characteristic(CHAR_MOTION_DETECTED)
+    assert char
+
+    assert char.value is False
+    broker = MagicMock()
+    char.broker = broker
+
+    hass.states.async_set(
+        motion_entity_id, STATE_UNKNOWN, {ATTR_DEVICE_CLASS: EventDeviceClass.MOTION}
+    )
+    await hass.async_block_till_done()
+    assert len(broker.mock_calls) == 0
+    broker.reset_mock()
+    assert char.value is False
+
+    char.set_value(True)
+    fire_time = dt_util.utcnow().isoformat()
+    hass.states.async_set(
+        motion_entity_id, fire_time, {ATTR_DEVICE_CLASS: EventDeviceClass.MOTION}
+    )
+    await hass.async_block_till_done()
+    assert len(broker.mock_calls) == 4
+    broker.reset_mock()
+    assert char.value is False
+
+    hass.states.async_set(
+        motion_entity_id,
+        fire_time,
+        {ATTR_DEVICE_CLASS: EventDeviceClass.MOTION},
+        force_update=True,
+    )
+    await hass.async_block_till_done()
+    assert len(broker.mock_calls) == 0
+    broker.reset_mock()
+
+    hass.states.async_set(
+        motion_entity_id,
+        fire_time,
+        {ATTR_DEVICE_CLASS: EventDeviceClass.MOTION, "other": "attr"},
+    )
+    await hass.async_block_till_done()
+    assert len(broker.mock_calls) == 0
+    broker.reset_mock()
+    # Ensure we do not throw when the linked
+    # motion sensor is removed
+    hass.states.async_remove(motion_entity_id)
+    await hass.async_block_till_done()
+    acc.run()
+    await hass.async_block_till_done()
+    assert char.value is False
+
+
 async def test_camera_with_a_missing_linked_motion_sensor(
     hass: HomeAssistant, run_driver, events
 ) -> None:


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for event entity motion sensors to HomeKit

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
