### PR TITLE
Add Deako integration

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -139,6 +139,7 @@ homeassistant.components.cpuspeed.*
 homeassistant.components.crownstone.*
 homeassistant.components.date.*
 homeassistant.components.datetime.*
+homeassistant.components.deako.*
 homeassistant.components.deconz.*
 homeassistant.components.default_config.*
 homeassistant.components.demo.*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -289,6 +289,8 @@ build.json @home-assistant/supervisor
 /tests/components/date/ @home-assistant/core
 /homeassistant/components/datetime/ @home-assistant/core
 /tests/components/datetime/ @home-assistant/core
+/homeassistant/components/deako/ @sebirdman @balake @deakolights
+/tests/components/deako/ @sebirdman @balake @deakolights
 /homeassistant/components/debugpy/ @frenck
 /tests/components/debugpy/ @frenck
 /homeassistant/components/deconz/ @Kane610

--- a/homeassistant/components/deako/__init__.py
+++ b/homeassistant/components/deako/__init__.py
@@ -1,0 +1,62 @@
+"""The deako integration."""
+
+from __future__ import annotations
+
+import logging
+
+from pydeako.deako import Deako, DeviceListTimeout, FindDevicesTimeout
+from pydeako.discover import DeakoDiscoverer
+
+from homeassistant.components import zeroconf
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+
+from .const import DOMAIN
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+
+PLATFORMS: list[Platform] = [Platform.LIGHT]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up deako."""
+    _zc = await zeroconf.async_get_instance(hass)
+    discoverer = DeakoDiscoverer(_zc)
+
+    connection = Deako(discoverer.get_address)
+
+    await connection.connect()
+    try:
+        await connection.find_devices()
+    except DeviceListTimeout as exc:  # device list never received
+        _LOGGER.warning("Device not responding to device list")
+        await connection.disconnect()
+        raise ConfigEntryNotReady(exc) from exc
+    except FindDevicesTimeout as exc:  # total devices expected not received
+        _LOGGER.warning("Device not responding to device requests")
+        await connection.disconnect()
+        raise ConfigEntryNotReady(exc) from exc
+
+    # If deako devices are advertising on mdns, we should be able to get at least one device
+    devices = connection.get_devices()
+    if len(devices) == 0:
+        await connection.disconnect()
+        raise ConfigEntryNotReady(devices)
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = connection
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    await hass.data[DOMAIN][entry.entry_id].disconnect()
+
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/homeassistant/components/deako/__init__.py
+++ b/homeassistant/components/deako/__init__.py
@@ -18,7 +18,13 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 PLATFORMS: list[Platform] = [Platform.LIGHT]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+class DeakoConfigEntry(ConfigEntry):
+    """Typed config entry."""
+
+    runtime_data: Deako | None
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: DeakoConfigEntry) -> bool:
     """Set up deako."""
     _zc = await zeroconf.async_get_instance(hass)
     discoverer = DeakoDiscoverer(_zc)
@@ -50,8 +56,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: DeakoConfigEntry) -> bool:
     """Unload a config entry."""
-    await entry.runtime_data.disconnect()
+    if entry.runtime_data is not None:
+        await entry.runtime_data.disconnect()
 
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/deako/__init__.py
+++ b/homeassistant/components/deako/__init__.py
@@ -13,8 +13,6 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import DOMAIN
-
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [Platform.LIGHT]
@@ -45,7 +43,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await connection.disconnect()
         raise ConfigEntryNotReady(devices)
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = connection
+    entry.runtime_data = connection
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -54,9 +52,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    await hass.data[DOMAIN][entry.entry_id].disconnect()
+    await entry.runtime_data.disconnect()
 
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/deako/__init__.py
+++ b/homeassistant/components/deako/__init__.py
@@ -17,11 +17,7 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [Platform.LIGHT]
 
-
-class DeakoConfigEntry(ConfigEntry):
-    """Typed config entry."""
-
-    runtime_data: Deako | None
+type DeakoConfigEntry = ConfigEntry[Deako]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: DeakoConfigEntry) -> bool:

--- a/homeassistant/components/deako/__init__.py
+++ b/homeassistant/components/deako/__init__.py
@@ -54,7 +54,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: DeakoConfigEntry) -> boo
 
 async def async_unload_entry(hass: HomeAssistant, entry: DeakoConfigEntry) -> bool:
     """Unload a config entry."""
-    if entry.runtime_data is not None:
-        await entry.runtime_data.disconnect()
+    await entry.runtime_data.disconnect()
 
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/deako/config_flow.py
+++ b/homeassistant/components/deako/config_flow.py
@@ -1,0 +1,26 @@
+"""Config flow for deako."""
+
+from pydeako.discover import DeakoDiscoverer, DevicesNotFoundException
+
+from homeassistant.components import zeroconf
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_entry_flow
+
+from .const import DOMAIN, NAME
+
+
+async def _async_has_devices(hass: HomeAssistant) -> bool:
+    """Return if there are devices that can be discovered."""
+    _zc = await zeroconf.async_get_instance(hass)
+    discoverer = DeakoDiscoverer(_zc)
+
+    try:
+        await discoverer.get_address()
+        # address exists, there's at least one device
+        return True
+
+    except DevicesNotFoundException:
+        return False
+
+
+config_entry_flow.register_discovery_flow(DOMAIN, NAME, _async_has_devices)

--- a/homeassistant/components/deako/config_flow.py
+++ b/homeassistant/components/deako/config_flow.py
@@ -16,11 +16,11 @@ async def _async_has_devices(hass: HomeAssistant) -> bool:
 
     try:
         await discoverer.get_address()
-        # address exists, there's at least one device
-        return True
-
     except DevicesNotFoundException:
         return False
+    else:
+        # address exists, there's at least one device
+        return True
 
 
 config_entry_flow.register_discovery_flow(DOMAIN, NAME, _async_has_devices)

--- a/homeassistant/components/deako/const.py
+++ b/homeassistant/components/deako/const.py
@@ -1,0 +1,5 @@
+"""Constants for Deako."""
+
+# Base component constants
+NAME = "Deako"
+DOMAIN = "deako"

--- a/homeassistant/components/deako/light.py
+++ b/homeassistant/components/deako/light.py
@@ -26,18 +26,15 @@ async def async_setup_entry(
     add_entities: AddEntitiesCallback,
 ) -> None:
     """Configure the platform."""
-    client: Deako = hass.data[DOMAIN][config.entry_id]
+    client: Deako = config.runtime_data
 
     devices = client.get_devices()
-    lights = [DeakoLightEntity(client, uuid) for uuid in devices]
-    add_entities(lights)
+    add_entities([DeakoLightEntity(client, uuid) for uuid in devices])
 
 
 class DeakoLightEntity(LightEntity):
     """Deako LightEntity class."""
 
-    # retype because these will be set
-    _attr_unique_id: str
     _attr_supported_color_modes: set[ColorMode]
 
     _attr_has_entity_name = True
@@ -75,12 +72,14 @@ class DeakoLightEntity(LightEntity):
         self.update()
         self.schedule_update_ha_state()
 
-    def get_state(self) -> dict:
+    def get_state(self) -> dict[str, bool | int]:
         """Return state of entity from client."""
+        assert self._attr_unique_id is not None
         return self.client.get_state(self._attr_unique_id) or {}
 
     async def control_device(self, power: bool, dim: int | None = None) -> None:
         """Control entity state via client."""
+        assert self._attr_unique_id is not None
         await self.client.control_device(self._attr_unique_id, power, dim)
 
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/homeassistant/components/deako/light.py
+++ b/homeassistant/components/deako/light.py
@@ -1,0 +1,102 @@
+"""Binary sensor platform for integration_blueprint."""
+
+import logging
+from typing import Any
+
+from pydeako.deako import Deako
+
+from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+
+# Model names
+MODEL_SMART = "smart"
+MODEL_DIMMER = "dimmer"
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config: ConfigEntry,
+    add_entities: AddEntitiesCallback,
+) -> None:
+    """Configure the platform."""
+    client: Deako = hass.data[DOMAIN][config.entry_id]
+
+    devices = client.get_devices()
+    lights = [DeakoLightEntity(client, uuid) for uuid in devices]
+    add_entities(lights)
+
+
+class DeakoLightEntity(LightEntity):
+    """Deako LightEntity class."""
+
+    # retype because these will be set
+    _attr_unique_id: str
+    _attr_supported_color_modes: set[ColorMode]
+
+    _attr_has_entity_name = True
+    _attr_name = None
+    _attr_is_on = False
+    _attr_available = True
+
+    def __init__(self, client: Deako, uuid: str) -> None:
+        """Save connection reference."""
+        self.client = client
+        self._attr_unique_id = uuid
+
+        dimmable = client.is_dimmable(uuid)
+
+        model = MODEL_SMART
+        self._attr_color_mode = ColorMode.ONOFF
+        if dimmable:
+            model = MODEL_DIMMER
+            self._attr_color_mode = ColorMode.BRIGHTNESS
+
+        self._attr_supported_color_modes = {self._attr_color_mode}
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, uuid)},
+            name=client.get_name(uuid),
+            manufacturer="Deako",
+            model=model,
+        )
+
+        client.set_state_callback(uuid, self.on_update)
+        self.update()  # set initial state
+
+    def on_update(self) -> None:
+        """State update callback."""
+        self.update()
+        self.schedule_update_ha_state()
+
+    def get_state(self) -> dict:
+        """Return state of entity from client."""
+        return self.client.get_state(self._attr_unique_id) or {}
+
+    async def control_device(self, power: bool, dim: int | None = None) -> None:
+        """Control entity state via client."""
+        await self.client.control_device(self._attr_unique_id, power, dim)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the light."""
+        dim = None
+        if ATTR_BRIGHTNESS in kwargs:
+            dim = round(kwargs[ATTR_BRIGHTNESS] / 2.55, 0)
+        await self.control_device(True, dim)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the device."""
+        await self.control_device(False)
+
+    def update(self) -> None:
+        """Call to update state."""
+        state = self.get_state()
+        self._attr_is_on = bool(state.get("power", False))
+        if ColorMode.BRIGHTNESS in self._attr_supported_color_modes:
+            self._attr_brightness = int(round(state.get("dim", 0) * 2.55))

--- a/homeassistant/components/deako/light.py
+++ b/homeassistant/components/deako/light.py
@@ -1,6 +1,5 @@
 """Binary sensor platform for integration_blueprint."""
 
-import logging
 from typing import Any
 
 from pydeako.deako import Deako
@@ -17,8 +16,6 @@ from .const import DOMAIN
 MODEL_SMART = "smart"
 MODEL_DIMMER = "dimmer"
 
-_LOGGER: logging.Logger = logging.getLogger(__name__)
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -28,10 +25,7 @@ async def async_setup_entry(
     """Configure the platform."""
     client = config.runtime_data
 
-    if client is not None:
-        add_entities([DeakoLightEntity(client, uuid) for uuid in client.get_devices()])
-    else:
-        _LOGGER.error("Deako client not set in config entry")
+    add_entities([DeakoLightEntity(client, uuid) for uuid in client.get_devices()])
 
 
 class DeakoLightEntity(LightEntity):
@@ -74,11 +68,6 @@ class DeakoLightEntity(LightEntity):
         self.update()
         self.schedule_update_ha_state()
 
-    def get_state(self) -> dict[str, bool | int]:
-        """Return state of entity from client."""
-        assert self._attr_unique_id is not None
-        return self.client.get_state(self._attr_unique_id) or {}
-
     async def control_device(self, power: bool, dim: int | None = None) -> None:
         """Control entity state via client."""
         assert self._attr_unique_id is not None
@@ -97,7 +86,8 @@ class DeakoLightEntity(LightEntity):
 
     def update(self) -> None:
         """Call to update state."""
-        state = self.get_state()
+        assert self._attr_unique_id is not None
+        state = self.client.get_state(self._attr_unique_id) or {}
         self._attr_is_on = bool(state.get("power", False))
         if (
             self._attr_supported_color_modes is not None

--- a/homeassistant/components/deako/manifest.json
+++ b/homeassistant/components/deako/manifest.json
@@ -8,5 +8,6 @@
   "iot_class": "local_polling",
   "loggers": ["pydeako"],
   "requirements": ["pydeako==0.4.0"],
+  "single_config_entry": true,
   "zeroconf": ["_deako._tcp.local."]
 }

--- a/homeassistant/components/deako/manifest.json
+++ b/homeassistant/components/deako/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "deako",
+  "name": "Deako",
+  "codeowners": ["@sebirdman", "@balake", "@deakolights"],
+  "config_flow": true,
+  "dependencies": ["zeroconf"],
+  "documentation": "https://www.home-assistant.io/integrations/deako",
+  "iot_class": "local_polling",
+  "loggers": ["pydeako"],
+  "requirements": ["pydeako==0.4.0"],
+  "zeroconf": ["_deako._tcp.local."]
+}

--- a/homeassistant/components/deako/strings.json
+++ b/homeassistant/components/deako/strings.json
@@ -1,0 +1,13 @@
+{
+  "config": {
+    "step": {
+      "confirm": {
+        "description": "Please confirm setting up the Deako integration"
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]"
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -111,6 +111,7 @@ FLOWS = {
         "cpuspeed",
         "crownstone",
         "daikin",
+        "deako",
         "deconz",
         "deluge",
         "denonavr",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -1113,7 +1113,8 @@
       "name": "Deako",
       "integration_type": "hub",
       "config_flow": true,
-      "iot_class": "local_polling"
+      "iot_class": "local_polling",
+      "single_config_entry": true
     },
     "debugpy": {
       "name": "Remote Python Debugger",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -1109,6 +1109,12 @@
       "config_flow": false,
       "iot_class": "local_polling"
     },
+    "deako": {
+      "name": "Deako",
+      "integration_type": "hub",
+      "config_flow": true,
+      "iot_class": "local_polling"
+    },
     "debugpy": {
       "name": "Remote Python Debugger",
       "integration_type": "service",

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -415,6 +415,11 @@ ZEROCONF = {
             "domain": "forked_daapd",
         },
     ],
+    "_deako._tcp.local.": [
+        {
+            "domain": "deako",
+        },
+    ],
     "_devialet-http._tcp.local.": [
         {
             "domain": "devialet",

--- a/mypy.ini
+++ b/mypy.ini
@@ -1152,6 +1152,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.deako.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.deconz.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1791,6 +1791,9 @@ pydaikin==2.13.1
 # homeassistant.components.danfoss_air
 pydanfossair==0.1.0
 
+# homeassistant.components.deako
+pydeako==0.4.0
+
 # homeassistant.components.deconz
 pydeconz==116
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1417,6 +1417,9 @@ pycsspeechtts==1.0.8
 # homeassistant.components.daikin
 pydaikin==2.13.1
 
+# homeassistant.components.deako
+pydeako==0.4.0
+
 # homeassistant.components.deconz
 pydeconz==116
 

--- a/tests/components/deako/__init__.py
+++ b/tests/components/deako/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Deako integration."""

--- a/tests/components/deako/conftest.py
+++ b/tests/components/deako/conftest.py
@@ -14,14 +14,7 @@ def mock_config_entry() -> MockConfigEntry:
     """Return the default mocked config entry."""
     return MockConfigEntry(
         domain=DOMAIN,
-        data={},
-        unique_id="aabbccddeeff",
     )
-
-
-@pytest.fixture(autouse=True)
-def deako_mock_async_zeroconf(mock_async_zeroconf: MagicMock):
-    """Auto mock zeroconf."""
 
 
 @pytest.fixture(name="pydeako_deako_mock", autouse=True)
@@ -32,7 +25,7 @@ def pydeako_deako_mock():
 
 
 @pytest.fixture(name="pydeako_discoverer_mock", autouse=True)
-def pydeako_discoverer_mock():
+def pydeako_discoverer_mock(mock_async_zeroconf: MagicMock):
     """Mock pydeako discovery client."""
     with patch("homeassistant.components.deako.DeakoDiscoverer", autospec=True) as mock:
         yield mock

--- a/tests/components/deako/conftest.py
+++ b/tests/components/deako/conftest.py
@@ -1,0 +1,38 @@
+"""deako session fixtures."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from homeassistant.components.deako.const import DOMAIN
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return the default mocked config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+        unique_id="aabbccddeeff",
+    )
+
+
+@pytest.fixture(autouse=True)
+def deako_mock_async_zeroconf(mock_async_zeroconf: MagicMock):
+    """Auto mock zeroconf."""
+
+
+@pytest.fixture(name="pydeako_deako_mock", autouse=True)
+def pydeako_deako_mock():
+    """Mock pydeako deako client."""
+    with patch("homeassistant.components.deako.Deako", autospec=True) as mock:
+        yield mock
+
+
+@pytest.fixture(name="pydeako_discoverer_mock", autouse=True)
+def pydeako_discoverer_mock():
+    """Mock pydeako discovery client."""
+    with patch("homeassistant.components.deako.DeakoDiscoverer", autospec=True) as mock:
+        yield mock

--- a/tests/components/deako/conftest.py
+++ b/tests/components/deako/conftest.py
@@ -1,5 +1,6 @@
 """deako session fixtures."""
 
+from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -17,15 +18,28 @@ def mock_config_entry() -> MockConfigEntry:
     )
 
 
-@pytest.fixture(name="pydeako_deako_mock", autouse=True)
-def pydeako_deako_mock():
+@pytest.fixture(autouse=True)
+def pydeako_deako_mock() -> Generator[MagicMock]:
     """Mock pydeako deako client."""
     with patch("homeassistant.components.deako.Deako", autospec=True) as mock:
         yield mock
 
 
-@pytest.fixture(name="pydeako_discoverer_mock", autouse=True)
-def pydeako_discoverer_mock(mock_async_zeroconf: MagicMock):
+@pytest.fixture(autouse=True)
+def pydeako_discoverer_mock(mock_async_zeroconf: MagicMock) -> Generator[MagicMock]:
     """Mock pydeako discovery client."""
-    with patch("homeassistant.components.deako.DeakoDiscoverer", autospec=True) as mock:
+    with (
+        patch("homeassistant.components.deako.DeakoDiscoverer", autospec=True) as mock,
+        patch("homeassistant.components.deako.config_flow.DeakoDiscoverer", new=mock),
+    ):
         yield mock
+
+
+@pytest.fixture
+def mock_deako_setup() -> Generator[MagicMock]:
+    """Mock async_setup_entry for config flow tests."""
+    with patch(
+        "homeassistant.components.deako.async_setup_entry",
+        return_value=True,
+    ) as mock_setup:
+        yield mock_setup

--- a/tests/components/deako/snapshots/test_light.ambr
+++ b/tests/components/deako/snapshots/test_light.ambr
@@ -1,0 +1,168 @@
+# serializer version: 1
+# name: test_dimmable_light_props[light.kitchen-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'supported_color_modes': list([
+        <ColorMode.BRIGHTNESS: 'brightness'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.kitchen',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'deako',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uuid',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_dimmable_light_props[light.kitchen-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'brightness': 127,
+      'color_mode': <ColorMode.BRIGHTNESS: 'brightness'>,
+      'friendly_name': 'kitchen',
+      'supported_color_modes': list([
+        <ColorMode.BRIGHTNESS: 'brightness'>,
+      ]),
+      'supported_features': <LightEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.kitchen',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_light_initial_props[light.kitchen-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'supported_color_modes': list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.kitchen',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'deako',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'uuid',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_light_initial_props[light.kitchen-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'color_mode': None,
+      'friendly_name': 'kitchen',
+      'supported_color_modes': list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+      'supported_features': <LightEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.kitchen',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_light_setup_with_device[light.some_device-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'supported_color_modes': list([
+        <ColorMode.BRIGHTNESS: 'brightness'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.some_device',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'deako',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'some_device',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_light_setup_with_device[light.some_device-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'brightness': 1,
+      'color_mode': <ColorMode.BRIGHTNESS: 'brightness'>,
+      'friendly_name': 'some device',
+      'supported_color_modes': list([
+        <ColorMode.BRIGHTNESS: 'brightness'>,
+      ]),
+      'supported_features': <LightEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.some_device',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/deako/test_config_flow.py
+++ b/tests/components/deako/test_config_flow.py
@@ -1,83 +1,59 @@
 """Tests for the deako component config flow."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock
 
 from pydeako.discover import DevicesNotFoundException
-import pytest
 
-from homeassistant import config_entries
 from homeassistant.components.deako.const import DOMAIN
+from homeassistant.config_entries import SOURCE_USER
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from tests.common import MockConfigEntry
 
-
-@pytest.mark.asyncio
 async def test_found(
     hass: HomeAssistant,
+    pydeako_discoverer_mock: MagicMock,
+    mock_deako_setup: MagicMock,
 ) -> None:
     """Test finding a Deako device."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
 
-    with patch(
-        "homeassistant.components.deako.config_flow.DeakoDiscoverer", autospec=True
-    ) as mock_discoverer:
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_USER}
-        )
+    # Confirmation form
+    assert result["type"] is FlowResultType.FORM
 
-        # Confirmation form
-        assert result["type"] is FlowResultType.FORM
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    await hass.async_block_till_done()
 
-        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    pydeako_discoverer_mock.return_value.get_address.assert_called_once()
 
-        assert result["type"] is FlowResultType.CREATE_ENTRY
-        mock_discoverer.return_value.get_address.assert_called_once()
+    mock_deako_setup.assert_called_once()
 
 
-@pytest.mark.asyncio
 async def test_not_found(
     hass: HomeAssistant,
+    pydeako_discoverer_mock: MagicMock,
+    mock_deako_setup: MagicMock,
 ) -> None:
     """Test not finding any Deako devices."""
+    pydeako_discoverer_mock.return_value.get_address.side_effect = (
+        DevicesNotFoundException()
+    )
 
-    with patch(
-        "homeassistant.components.deako.config_flow.DeakoDiscoverer", autospec=True
-    ) as mock_discoverer:
-        mock_discoverer.return_value.get_address.side_effect = (
-            DevicesNotFoundException()
-        )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
 
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_USER}
-        )
+    # Confirmation form
+    assert result["type"] is FlowResultType.FORM
 
-        # Confirmation form
-        assert result["type"] is FlowResultType.FORM
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    await hass.async_block_till_done()
 
-        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "no_devices_found"
+    pydeako_discoverer_mock.return_value.get_address.assert_called_once()
 
-        assert result["type"] is FlowResultType.ABORT
-        assert result["reason"] == "no_devices_found"
-        mock_discoverer.return_value.get_address.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_single_instance_allowed(hass: HomeAssistant) -> None:
-    """Test single instance allowed."""
-    config_entry = MockConfigEntry(domain=DOMAIN)
-    config_entry.add_to_hass(hass)
-
-    with patch(
-        "homeassistant.components.deako.config_flow.DeakoDiscoverer", autospec=True
-    ) as mock_discoverer:
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_USER}
-        )
-        await hass.async_block_till_done()
-
-        assert result.get("type") is FlowResultType.ABORT
-        assert result.get("reason") == "single_instance_allowed"
-        mock_discoverer.return_value.get_address.assert_not_called()
+    mock_deako_setup.assert_not_called()

--- a/tests/components/deako/test_config_flow.py
+++ b/tests/components/deako/test_config_flow.py
@@ -1,36 +1,46 @@
 """Tests for the deako component config flow."""
+
 from unittest.mock import patch
 
 from pydeako.discover import DevicesNotFoundException
 import pytest
 
-from homeassistant.components.deako.config_flow import _async_has_devices
+from homeassistant import config_entries
+from homeassistant.components.deako.const import DOMAIN
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
 
 
 @pytest.mark.asyncio
-async def test_deako_async_has_devices(
+async def test_found(
     hass: HomeAssistant,
-    mock_async_zeroconf: None,
 ) -> None:
-    """Test successful device discovery."""
+    """Test finding a Deako device."""
 
     with patch(
         "homeassistant.components.deako.config_flow.DeakoDiscoverer", autospec=True
     ) as mock_discoverer:
-        ret = await _async_has_devices(hass)
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
 
-        assert ret
-        mock_discoverer.assert_called_once()
+        # Confirmation form
+        assert result["type"] is FlowResultType.FORM
+
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        await hass.async_block_till_done()
+
+        assert result["type"] is FlowResultType.CREATE_ENTRY
         mock_discoverer.return_value.get_address.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_deako_async_has_devices_error(
+async def test_not_found(
     hass: HomeAssistant,
-    mock_async_zeroconf: None,
 ) -> None:
-    """Test successful device discovery."""
+    """Test not finding any Deako devices."""
 
     with patch(
         "homeassistant.components.deako.config_flow.DeakoDiscoverer", autospec=True
@@ -38,8 +48,36 @@ async def test_deako_async_has_devices_error(
         mock_discoverer.return_value.get_address.side_effect = (
             DevicesNotFoundException()
         )
-        ret = await _async_has_devices(hass)
 
-        assert not ret
-        mock_discoverer.assert_called_once()
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+
+        # Confirmation form
+        assert result["type"] is FlowResultType.FORM
+
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        await hass.async_block_till_done()
+
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "no_devices_found"
         mock_discoverer.return_value.get_address.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_single_instance_allowed(hass: HomeAssistant) -> None:
+    """Test single instance allowed."""
+    config_entry = MockConfigEntry(domain=DOMAIN)
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.deako.config_flow.DeakoDiscoverer", autospec=True
+    ) as mock_discoverer:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        await hass.async_block_till_done()
+
+        assert result.get("type") is FlowResultType.ABORT
+        assert result.get("reason") == "single_instance_allowed"
+        mock_discoverer.return_value.get_address.assert_not_called()

--- a/tests/components/deako/test_config_flow.py
+++ b/tests/components/deako/test_config_flow.py
@@ -1,0 +1,45 @@
+"""Tests for the deako component config flow."""
+from unittest.mock import patch
+
+from pydeako.discover import DevicesNotFoundException
+import pytest
+
+from homeassistant.components.deako.config_flow import _async_has_devices
+from homeassistant.core import HomeAssistant
+
+
+@pytest.mark.asyncio
+async def test_deako_async_has_devices(
+    hass: HomeAssistant,
+    mock_async_zeroconf: None,
+) -> None:
+    """Test successful device discovery."""
+
+    with patch(
+        "homeassistant.components.deako.config_flow.DeakoDiscoverer", autospec=True
+    ) as mock_discoverer:
+        ret = await _async_has_devices(hass)
+
+        assert ret
+        mock_discoverer.assert_called_once()
+        mock_discoverer.return_value.get_address.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_deako_async_has_devices_error(
+    hass: HomeAssistant,
+    mock_async_zeroconf: None,
+) -> None:
+    """Test successful device discovery."""
+
+    with patch(
+        "homeassistant.components.deako.config_flow.DeakoDiscoverer", autospec=True
+    ) as mock_discoverer:
+        mock_discoverer.return_value.get_address.side_effect = (
+            DevicesNotFoundException()
+        )
+        ret = await _async_has_devices(hass)
+
+        assert not ret
+        mock_discoverer.assert_called_once()
+        mock_discoverer.return_value.get_address.assert_called_once()

--- a/tests/components/deako/test_config_flow.py
+++ b/tests/components/deako/test_config_flow.py
@@ -9,6 +9,8 @@ from homeassistant.config_entries import SOURCE_USER
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
+from tests.common import MockConfigEntry
+
 
 async def test_found(
     hass: HomeAssistant,
@@ -55,5 +57,24 @@ async def test_not_found(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "no_devices_found"
     pydeako_discoverer_mock.return_value.get_address.assert_called_once()
+
+    mock_deako_setup.assert_not_called()
+
+
+async def test_already_configured(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_deako_setup: MagicMock,
+) -> None:
+    """Test flow aborts when already configured."""
+
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "single_instance_allowed"
 
     mock_deako_setup.assert_not_called()

--- a/tests/components/deako/test_init.py
+++ b/tests/components/deako/test_init.py
@@ -1,0 +1,127 @@
+"""Tests for the deako component init."""
+
+from unittest.mock import patch
+
+from pydeako.deako import DeviceListTimeout, FindDevicesTimeout
+import pytest
+
+from homeassistant.components.deako.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.asyncio
+async def test_deako_async_setup_entry(
+    hass: HomeAssistant,
+    mock_async_zeroconf: None,
+    mock_config_entry: MockConfigEntry,
+    pydeako_deako_mock,
+    pydeako_discoverer_mock,
+) -> None:
+    """Test successful setup entry."""
+    pydeako_deako_mock.return_value.get_devices.return_value = [1, 2]
+
+    mock_config_entry.add_to_hass(hass)
+
+    with patch.object(
+        hass.config_entries, "async_forward_entry_setups"
+    ) as async_forward_entry_setups_mock:
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        pydeako_deako_mock.assert_called_once_with(
+            pydeako_discoverer_mock.return_value.get_address
+        )
+        pydeako_deako_mock.return_value.connect.assert_called_once()
+        pydeako_deako_mock.return_value.find_devices.assert_called_once()
+        pydeako_deako_mock.return_value.get_devices.assert_called_once()
+        async_forward_entry_setups_mock.assert_called_once()
+
+        assert (
+            hass.data[DOMAIN][mock_config_entry.entry_id]
+            == pydeako_deako_mock.return_value
+        )
+
+
+@pytest.mark.asyncio
+async def test_deako_async_setup_entry_device_list_timeout(
+    hass: HomeAssistant,
+    mock_async_zeroconf: None,
+    mock_config_entry: MockConfigEntry,
+    pydeako_deako_mock,
+    pydeako_discoverer_mock,
+) -> None:
+    """Test async_setup_entry raises ConfigEntryNotReady when pydeako raises DeviceListTimeout."""
+
+    mock_config_entry.add_to_hass(hass)
+
+    pydeako_deako_mock.return_value.find_devices.side_effect = DeviceListTimeout()
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    pydeako_deako_mock.assert_called_once_with(
+        pydeako_discoverer_mock.return_value.get_address
+    )
+    pydeako_deako_mock.return_value.connect.assert_called_once()
+    pydeako_deako_mock.return_value.find_devices.assert_called_once()
+    pydeako_deako_mock.return_value.disconnect.assert_called_once()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+@pytest.mark.asyncio
+async def test_deako_async_setup_entry_find_devices_timeout(
+    hass: HomeAssistant,
+    mock_async_zeroconf: None,
+    mock_config_entry: MockConfigEntry,
+    pydeako_deako_mock,
+    pydeako_discoverer_mock,
+) -> None:
+    """Test async_setup_entry raises ConfigEntryNotReady when pydeako raises FindDevicesTimeout."""
+
+    mock_config_entry.add_to_hass(hass)
+
+    pydeako_deako_mock.return_value.find_devices.side_effect = FindDevicesTimeout()
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    pydeako_deako_mock.assert_called_once_with(
+        pydeako_discoverer_mock.return_value.get_address
+    )
+    pydeako_deako_mock.return_value.connect.assert_called_once()
+    pydeako_deako_mock.return_value.find_devices.assert_called_once()
+    pydeako_deako_mock.return_value.disconnect.assert_called_once()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+@pytest.mark.asyncio
+async def test_deako_async_setup_entry_device_list_empty(
+    hass: HomeAssistant,
+    mock_async_zeroconf: None,
+    mock_config_entry: MockConfigEntry,
+    pydeako_deako_mock,
+    pydeako_discoverer_mock,
+) -> None:
+    """Test async_setup_entry raises ConfigEntryNotReady when pydeako raises returns zero devices after discovery."""
+
+    mock_config_entry.add_to_hass(hass)
+
+    pydeako_deako_mock.return_value.get_devices.return_value = []
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    pydeako_deako_mock.assert_called_once_with(
+        pydeako_discoverer_mock.return_value.get_address
+    )
+    pydeako_deako_mock.return_value.connect.assert_called_once()
+    pydeako_deako_mock.return_value.find_devices.assert_called_once()
+    pydeako_deako_mock.return_value.get_devices.assert_called_once()
+    pydeako_deako_mock.return_value.disconnect.assert_called_once()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/deako/test_init.py
+++ b/tests/components/deako/test_init.py
@@ -1,7 +1,8 @@
 """Tests for the deako component init."""
 
+from unittest.mock import MagicMock
+
 from pydeako.deako import DeviceListTimeout, FindDevicesTimeout
-import pytest
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -9,12 +10,11 @@ from homeassistant.core import HomeAssistant
 from tests.common import MockConfigEntry
 
 
-@pytest.mark.asyncio
 async def test_deako_async_setup_entry(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    pydeako_deako_mock,
-    pydeako_discoverer_mock,
+    pydeako_deako_mock: MagicMock,
+    pydeako_discoverer_mock: MagicMock,
 ) -> None:
     """Test successful setup entry."""
     pydeako_deako_mock.return_value.get_devices.return_value = {
@@ -37,12 +37,11 @@ async def test_deako_async_setup_entry(
     assert mock_config_entry.runtime_data == pydeako_deako_mock.return_value
 
 
-@pytest.mark.asyncio
 async def test_deako_async_setup_entry_device_list_timeout(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    pydeako_deako_mock,
-    pydeako_discoverer_mock,
+    pydeako_deako_mock: MagicMock,
+    pydeako_discoverer_mock: MagicMock,
 ) -> None:
     """Test async_setup_entry raises ConfigEntryNotReady when pydeako raises DeviceListTimeout."""
 
@@ -63,12 +62,11 @@ async def test_deako_async_setup_entry_device_list_timeout(
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-@pytest.mark.asyncio
 async def test_deako_async_setup_entry_find_devices_timeout(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    pydeako_deako_mock,
-    pydeako_discoverer_mock,
+    pydeako_deako_mock: MagicMock,
+    pydeako_discoverer_mock: MagicMock,
 ) -> None:
     """Test async_setup_entry raises ConfigEntryNotReady when pydeako raises FindDevicesTimeout."""
 

--- a/tests/components/deako/test_init.py
+++ b/tests/components/deako/test_init.py
@@ -1,11 +1,8 @@
 """Tests for the deako component init."""
 
-from unittest.mock import patch
-
 from pydeako.deako import DeviceListTimeout, FindDevicesTimeout
 import pytest
 
-from homeassistant.components.deako.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
@@ -15,40 +12,34 @@ from tests.common import MockConfigEntry
 @pytest.mark.asyncio
 async def test_deako_async_setup_entry(
     hass: HomeAssistant,
-    mock_async_zeroconf: None,
     mock_config_entry: MockConfigEntry,
     pydeako_deako_mock,
     pydeako_discoverer_mock,
 ) -> None:
     """Test successful setup entry."""
-    pydeako_deako_mock.return_value.get_devices.return_value = [1, 2]
+    pydeako_deako_mock.return_value.get_devices.return_value = {
+        "id1": {},
+        "id2": {},
+    }
 
     mock_config_entry.add_to_hass(hass)
 
-    with patch.object(
-        hass.config_entries, "async_forward_entry_setups"
-    ) as async_forward_entry_setups_mock:
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
-        pydeako_deako_mock.assert_called_once_with(
-            pydeako_discoverer_mock.return_value.get_address
-        )
-        pydeako_deako_mock.return_value.connect.assert_called_once()
-        pydeako_deako_mock.return_value.find_devices.assert_called_once()
-        pydeako_deako_mock.return_value.get_devices.assert_called_once()
-        async_forward_entry_setups_mock.assert_called_once()
+    pydeako_deako_mock.assert_called_once_with(
+        pydeako_discoverer_mock.return_value.get_address
+    )
+    pydeako_deako_mock.return_value.connect.assert_called_once()
+    pydeako_deako_mock.return_value.find_devices.assert_called_once()
+    pydeako_deako_mock.return_value.get_devices.assert_called()
 
-        assert (
-            hass.data[DOMAIN][mock_config_entry.entry_id]
-            == pydeako_deako_mock.return_value
-        )
+    assert mock_config_entry.runtime_data == pydeako_deako_mock.return_value
 
 
 @pytest.mark.asyncio
 async def test_deako_async_setup_entry_device_list_timeout(
     hass: HomeAssistant,
-    mock_async_zeroconf: None,
     mock_config_entry: MockConfigEntry,
     pydeako_deako_mock,
     pydeako_discoverer_mock,
@@ -75,7 +66,6 @@ async def test_deako_async_setup_entry_device_list_timeout(
 @pytest.mark.asyncio
 async def test_deako_async_setup_entry_find_devices_timeout(
     hass: HomeAssistant,
-    mock_async_zeroconf: None,
     mock_config_entry: MockConfigEntry,
     pydeako_deako_mock,
     pydeako_discoverer_mock,
@@ -94,34 +84,6 @@ async def test_deako_async_setup_entry_find_devices_timeout(
     )
     pydeako_deako_mock.return_value.connect.assert_called_once()
     pydeako_deako_mock.return_value.find_devices.assert_called_once()
-    pydeako_deako_mock.return_value.disconnect.assert_called_once()
-
-    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
-
-
-@pytest.mark.asyncio
-async def test_deako_async_setup_entry_device_list_empty(
-    hass: HomeAssistant,
-    mock_async_zeroconf: None,
-    mock_config_entry: MockConfigEntry,
-    pydeako_deako_mock,
-    pydeako_discoverer_mock,
-) -> None:
-    """Test async_setup_entry raises ConfigEntryNotReady when pydeako raises returns zero devices after discovery."""
-
-    mock_config_entry.add_to_hass(hass)
-
-    pydeako_deako_mock.return_value.get_devices.return_value = []
-
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    pydeako_deako_mock.assert_called_once_with(
-        pydeako_discoverer_mock.return_value.get_address
-    )
-    pydeako_deako_mock.return_value.connect.assert_called_once()
-    pydeako_deako_mock.return_value.find_devices.assert_called_once()
-    pydeako_deako_mock.return_value.get_devices.assert_called_once()
     pydeako_deako_mock.return_value.disconnect.assert_called_once()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/deako/test_light.py
+++ b/tests/components/deako/test_light.py
@@ -13,7 +13,6 @@ from homeassistant.helpers import entity_registry as er
 from tests.common import MockConfigEntry, snapshot_platform
 
 
-@pytest.mark.asyncio
 async def test_light_setup_with_device(
     hass: HomeAssistant,
     pydeako_deako_mock: MagicMock,
@@ -35,7 +34,6 @@ async def test_light_setup_with_device(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
-@pytest.mark.asyncio
 async def test_light_initial_props(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -63,7 +61,6 @@ async def test_light_initial_props(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
-@pytest.mark.asyncio
 async def test_dimmable_light_props(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -92,7 +89,6 @@ async def test_dimmable_light_props(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
-@pytest.mark.asyncio
 async def test_light_power_change_on(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -123,7 +119,6 @@ async def test_light_power_change_on(
     )
 
 
-@pytest.mark.asyncio
 async def test_light_power_change_off(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -162,7 +157,6 @@ async def test_light_power_change_off(
         (127, 50),
     ],
 )
-@pytest.mark.asyncio
 async def test_light_brightness_change(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,

--- a/tests/components/deako/test_light.py
+++ b/tests/components/deako/test_light.py
@@ -1,0 +1,259 @@
+"""Tests for the light module."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from homeassistant.components.deako.const import DOMAIN
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    DOMAIN as LIGHT_DOMAIN,
+    ColorMode,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.asyncio
+async def test_light_setup_no_devices(
+    hass: HomeAssistant,
+    pydeako_deako_mock: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test light platform setup with no devices returned."""
+    mock_config_entry.add_to_hass(hass)
+
+    # no devices
+    pydeako_deako_mock.get_devices.return_value = {}
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+
+@pytest.mark.asyncio
+async def test_light_setup_with_device(
+    hass: HomeAssistant,
+    pydeako_deako_mock: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test light platform setup with device returned."""
+    mock_config_entry.add_to_hass(hass)
+
+    pydeako_deako_mock.return_value.get_devices.return_value = {
+        "some_device": {},
+    }
+    pydeako_deako_mock.return_value.get_name.return_value = "some device"
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_entry = entity_registry.async_get("light.some_device")
+    assert entity_entry
+
+
+@pytest.mark.asyncio
+async def test_light_initial_props(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    pydeako_deako_mock: MagicMock,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test on/off light is setup with accurate initial properties."""
+    mock_config_entry.add_to_hass(hass)
+
+    pydeako_deako_mock.return_value.get_devices.return_value = {
+        "uuid": {
+            "name": "kitchen",
+        }
+    }
+    pydeako_deako_mock.return_value.get_name.return_value = "kitchen"
+    pydeako_deako_mock.return_value.get_state.return_value = {
+        "power": False,
+    }
+    pydeako_deako_mock.return_value.is_dimmable.return_value = False
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # make sure our initial state exists
+    assert (state := hass.states.get(f"{LIGHT_DOMAIN}.kitchen"))
+    assert state.state == STATE_OFF
+
+    # test other properties
+    entity = entity_registry.async_get(f"{LIGHT_DOMAIN}.kitchen")
+    assert entity
+    assert entity.unique_id == "uuid"
+    assert entity.original_name is None
+    assert ColorMode.ONOFF in entity.capabilities.get("supported_color_modes")
+
+    # test ha device
+    device = device_registry.async_get(entity.device_id)
+    assert device
+    assert device.model == "smart"
+    assert device.manufacturer == "Deako"
+    assert device.name == "kitchen"
+    assert (DOMAIN, "uuid") in device.identifiers
+
+
+@pytest.mark.asyncio
+async def test_dimmable_light_props(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    pydeako_deako_mock: MagicMock,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test dimmable on/off light is setup with accurate initial properties."""
+    mock_config_entry.add_to_hass(hass)
+
+    pydeako_deako_mock.return_value.get_devices.return_value = {
+        "uuid": {
+            "name": "kitchen",
+        }
+    }
+    pydeako_deako_mock.return_value.get_name.return_value = "kitchen"
+    pydeako_deako_mock.return_value.get_state.return_value = {
+        "power": True,
+        "dim": 50,
+    }
+    pydeako_deako_mock.return_value.is_dimmable.return_value = True
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # make sure our initial state exists
+    assert (state := hass.states.get(f"{LIGHT_DOMAIN}.kitchen"))
+    assert state.state == STATE_ON
+    assert state.attributes.get(ATTR_BRIGHTNESS) == 127  # the converted brightness
+
+    # test other properties
+    entity = entity_registry.async_get(f"{LIGHT_DOMAIN}.kitchen")
+    assert entity
+    assert entity.unique_id == "uuid"
+    assert entity.original_name is None
+    assert ColorMode.BRIGHTNESS in entity.capabilities.get("supported_color_modes")
+
+    # test ha device
+    device = device_registry.async_get(entity.device_id)
+    assert device
+    assert device.model == "dimmer"
+    assert device.manufacturer == "Deako"
+    assert device.name == "kitchen"
+    assert (DOMAIN, "uuid") in device.identifiers
+
+
+@pytest.mark.asyncio
+async def test_light_power_change_on(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    pydeako_deako_mock: MagicMock,
+) -> None:
+    """Test turing on a deako device."""
+    mock_config_entry.add_to_hass(hass)
+
+    pydeako_deako_mock.return_value.get_devices.return_value = {
+        "uuid": {
+            "name": "kitchen",
+        }
+    }
+    pydeako_deako_mock.return_value.get_name.return_value = "kitchen"
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "light.kitchen"},
+        blocking=True,
+    )
+
+    pydeako_deako_mock.return_value.control_device.assert_called_once_with(
+        "uuid", True, None
+    )
+
+
+@pytest.mark.asyncio
+async def test_light_power_change_off(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    pydeako_deako_mock: MagicMock,
+) -> None:
+    """Test turing off a deako device."""
+    mock_config_entry.add_to_hass(hass)
+
+    pydeako_deako_mock.return_value.get_devices.return_value = {
+        "uuid": {
+            "name": "kitchen",
+        }
+    }
+    pydeako_deako_mock.return_value.get_name.return_value = "kitchen"
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: "light.kitchen"},
+        blocking=True,
+    )
+
+    pydeako_deako_mock.return_value.control_device.assert_called_once_with(
+        "uuid", False, None
+    )
+
+
+@pytest.mark.parametrize(
+    ("dim_input", "expected_dim_value"),
+    [
+        (3, 1),
+        (255, 100),
+        (127, 50),
+    ],
+)
+@pytest.mark.asyncio
+async def test_light_brightness_change(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    pydeako_deako_mock: MagicMock,
+    dim_input: int,
+    expected_dim_value: int,
+) -> None:
+    """Test turing on a deako device."""
+    mock_config_entry.add_to_hass(hass)
+
+    pydeako_deako_mock.return_value.get_devices.return_value = {
+        "uuid": {
+            "name": "kitchen",
+        }
+    }
+    pydeako_deako_mock.return_value.get_name.return_value = "kitchen"
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {
+            ATTR_ENTITY_ID: "light.kitchen",
+            ATTR_BRIGHTNESS: dim_input,
+        },
+        blocking=True,
+    )
+
+    pydeako_deako_mock.return_value.control_device.assert_called_once_with(
+        "uuid", True, expected_dim_value
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a Deako integration using the pydeako library.

### Deako devices
Deako devices are smart home light switches that communicate over BLE. Typical installations range from 1 device to over 50.

There is one device that is always online, as it's acting as the remote "bridge" from the internet to other devices on the network. All other devices get online periodically to check in and get potential updates. All devices currently reboot daily.  Since communication is over BLE, not all devices need to be on the network to control all devices, just one.

### Pydeako
The pydeako library has two main components: discovery and connection. pydeako serves as an integration to Deako devices, allowing for control of devices (power, dim, etc) over the network locally.

**Discovery** takes in a zeroconf instance and collects all the current addresses being advertised by Deako devices that are currently on the local network. This discovery client will continue to update this pool of addresses as devices come on the network or fall off.

**Connection** happens over a socket and the pydeako library maintains this connection. If the connection is dropped, a new address is retrieved and the process starts over. If a device is connected to over a socket, the device will remain online as long as it can. The device list and controls are implementations of the [Deako local API](https://github.com/DeakoLights/local-integrations/blob/master/API.md).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33554

Note: I had a previous PR which got closed because I didn't have time to address comments: https://github.com/home-assistant/core/pull/102190

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
