### PR TITLE
Add max current number entity for TechnoVE

### DIFF
--- a/homeassistant/components/technove/__init__.py
+++ b/homeassistant/components/technove/__init__.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from .const import DOMAIN
 from .coordinator import TechnoVEDataUpdateCoordinator
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.NUMBER, Platform.SENSOR, Platform.SWITCH]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/technove/number.py
+++ b/homeassistant/components/technove/number.py
@@ -1,0 +1,106 @@
+"""Support for TechnoVE number entities."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
+from typing import Any
+
+from technove import MIN_CURRENT, TechnoVE
+
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberEntityDescription,
+    NumberMode,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import TechnoVEDataUpdateCoordinator
+from .entity import TechnoVEEntity
+from .helpers import technove_exception_handler
+
+
+@dataclass(frozen=True, kw_only=True)
+class TechnoVENumberDescription(NumberEntityDescription):
+    """Describes TechnoVE number entity."""
+
+    native_max_value_fn: Callable[[TechnoVE], float]
+    native_value_fn: Callable[[TechnoVE], float]
+    set_value_fn: Callable[
+        [TechnoVEDataUpdateCoordinator, float], Coroutine[Any, Any, None]
+    ]
+
+
+async def _set_max_current(
+    coordinator: TechnoVEDataUpdateCoordinator, value: float
+) -> None:
+    if coordinator.data.info.in_sharing_mode:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN, translation_key="max_current_in_sharing_mode"
+        )
+    await coordinator.technove.set_max_current(value)
+
+
+NUMBERS = [
+    TechnoVENumberDescription(
+        key="max_current",
+        translation_key="max_current",
+        entity_category=EntityCategory.CONFIG,
+        device_class=NumberDeviceClass.CURRENT,
+        mode=NumberMode.BOX,
+        native_step=1,
+        native_min_value=MIN_CURRENT,
+        native_max_value_fn=lambda station: station.info.max_station_current,
+        native_value_fn=lambda station: station.info.max_current,
+        set_value_fn=_set_max_current,
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up TechnoVE number entity based on a config entry."""
+    coordinator: TechnoVEDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    async_add_entities(
+        TechnoVENumberEntity(coordinator, description) for description in NUMBERS
+    )
+
+
+class TechnoVENumberEntity(TechnoVEEntity, NumberEntity):
+    """Defines a TechnoVE number entity."""
+
+    entity_description: TechnoVENumberDescription
+
+    def __init__(
+        self,
+        coordinator: TechnoVEDataUpdateCoordinator,
+        description: TechnoVENumberDescription,
+    ) -> None:
+        """Initialize a TechnoVE switch entity."""
+        self.entity_description = description
+        super().__init__(coordinator, description.key)
+
+    @property
+    def native_max_value(self) -> float:
+        """Return the max value of the TechnoVE number entity."""
+        return self.entity_description.native_max_value_fn(self.coordinator.data)
+
+    @property
+    def native_value(self) -> float:
+        """Return the native value of the TechnoVE number entity."""
+        return self.entity_description.native_value_fn(self.coordinator.data)
+
+    @technove_exception_handler
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the value for the TechnoVE number entity."""
+        await self.entity_description.set_value_fn(self.coordinator, value)

--- a/homeassistant/components/technove/strings.json
+++ b/homeassistant/components/technove/strings.json
@@ -39,6 +39,11 @@
         "name": "Static IP"
       }
     },
+    "number": {
+      "max_current": {
+        "name": "Maximum Current"
+      }
+    },
     "sensor": {
       "voltage_in": {
         "name": "Input voltage"
@@ -73,6 +78,11 @@
       "auto_charge": {
         "name": "Auto charge"
       }
+    }
+  },
+  "exceptions": {
+    "max_current_in_sharing_mode": {
+      "message": "Cannot set the max current when power sharing mode is enabled."
     }
   }
 }

--- a/homeassistant/components/technove/strings.json
+++ b/homeassistant/components/technove/strings.json
@@ -41,7 +41,7 @@
     },
     "number": {
       "max_current": {
-        "name": "Maximum Current"
+        "name": "Maximum current"
       }
     },
     "sensor": {

--- a/tests/components/technove/fixtures/station_charging.json
+++ b/tests/components/technove/fixtures/station_charging.json
@@ -11,7 +11,7 @@
   "normalPeriodActive": false,
   "maxChargePourcentage": 0.9,
   "isBatteryProtected": false,
-  "inSharingMode": true,
+  "inSharingMode": false,
   "energySession": 12.34,
   "energyTotal": 1234,
   "version": "1.82",

--- a/tests/components/technove/snapshots/test_binary_sensor.ambr
+++ b/tests/components/technove/snapshots/test_binary_sensor.ambr
@@ -181,7 +181,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'on',
+    'state': 'off',
   })
 # ---
 # name: test_sensors[binary_sensor.technove_station_static_ip-entry]

--- a/tests/components/technove/snapshots/test_number.ambr
+++ b/tests/components/technove/snapshots/test_number.ambr
@@ -1,0 +1,57 @@
+# serializer version: 1
+# name: test_numbers[number.technove_station_maximum_current-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 32,
+      'min': 8,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.technove_station_maximum_current',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <NumberDeviceClass.CURRENT: 'current'>,
+    'original_icon': None,
+    'original_name': 'Maximum Current',
+    'platform': 'technove',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'max_current',
+    'unique_id': 'AA:AA:AA:AA:AA:BB_max_current',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_numbers[number.technove_station_maximum_current-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'TechnoVE Station Maximum Current',
+      'max': 32,
+      'min': 8,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.technove_station_maximum_current',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '24',
+  })
+# ---

--- a/tests/components/technove/snapshots/test_number.ambr
+++ b/tests/components/technove/snapshots/test_number.ambr
@@ -28,7 +28,7 @@
     }),
     'original_device_class': <NumberDeviceClass.CURRENT: 'current'>,
     'original_icon': None,
-    'original_name': 'Maximum Current',
+    'original_name': 'Maximum current',
     'platform': 'technove',
     'previous_unique_id': None,
     'supported_features': 0,
@@ -41,7 +41,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'current',
-      'friendly_name': 'TechnoVE Station Maximum Current',
+      'friendly_name': 'TechnoVE Station Maximum current',
       'max': 32,
       'min': 8,
       'mode': <NumberMode.BOX: 'box'>,

--- a/tests/components/technove/test_number.py
+++ b/tests/components/technove/test_number.py
@@ -1,0 +1,210 @@
+"""Tests for the TechnoVE number platform."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+from technove import TechnoVEConnectionError, TechnoVEError
+
+from homeassistant.components.number import (
+    ATTR_VALUE,
+    DOMAIN as NUMBER_DOMAIN,
+    SERVICE_SET_VALUE,
+)
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_with_selected_platforms
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "mock_technove")
+async def test_numbers(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the creation and values of the TechnoVE numbers."""
+    await setup_with_selected_platforms(hass, mock_config_entry, [Platform.NUMBER])
+
+    entity_entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+
+    assert entity_entries
+    for entity_entry in entity_entries:
+        assert entity_entry == snapshot(name=f"{entity_entry.entity_id}-entry")
+        assert (state := hass.states.get(entity_entry.entity_id))
+        assert state == snapshot(name=f"{entity_entry.entity_id}-state")
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "method", "called_with_value"),
+    [
+        (
+            "number.technove_station_maximum_current",
+            "set_max_current",
+            {"max_current": 10},
+        ),
+    ],
+)
+@pytest.mark.usefixtures("init_integration")
+async def test_number_expected_value(
+    hass: HomeAssistant,
+    mock_technove: MagicMock,
+    entity_id: str,
+    method: str,
+    called_with_value: dict[str, bool | int],
+) -> None:
+    """Test set value services with valid values."""
+    state = hass.states.get(entity_id)
+    method_mock = getattr(mock_technove, method)
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: state.entity_id, ATTR_VALUE: called_with_value["max_current"]},
+        blocking=True,
+    )
+
+    assert method_mock.call_count == 1
+    method_mock.assert_called_with(**called_with_value)
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "value"),
+    [
+        (
+            "number.technove_station_maximum_current",
+            1,
+        ),
+        (
+            "number.technove_station_maximum_current",
+            1000,
+        ),
+    ],
+)
+@pytest.mark.usefixtures("init_integration")
+async def test_number_out_of_bound(
+    hass: HomeAssistant,
+    entity_id: str,
+    value: float,
+) -> None:
+    """Test set value services with out of bound values."""
+    state = hass.states.get(entity_id)
+
+    with pytest.raises(ServiceValidationError, match="is outside valid range"):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: state.entity_id, ATTR_VALUE: value},
+            blocking=True,
+        )
+
+    assert (state := hass.states.get(state.entity_id))
+    assert state.state != STATE_UNAVAILABLE
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_set_max_current_sharing_mode(
+    hass: HomeAssistant,
+    mock_technove: MagicMock,
+) -> None:
+    """Test failure to set the max current when the station is in sharing mode."""
+    entity_id = "number.technove_station_maximum_current"
+    state = hass.states.get(entity_id)
+
+    # Enable power sharing mode
+    device = mock_technove.update.return_value
+    device.info.in_sharing_mode = True
+
+    with pytest.raises(
+        ServiceValidationError,
+        match="Cannot set the max current when sharing mode is enabled",
+    ):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: entity_id,
+                ATTR_VALUE: 10,
+            },
+            blocking=True,
+        )
+
+    assert (state := hass.states.get(state.entity_id))
+    assert state.state != STATE_UNAVAILABLE
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "method"),
+    [
+        (
+            "number.technove_station_maximum_current",
+            "set_max_current",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("init_integration")
+async def test_invalid_response(
+    hass: HomeAssistant,
+    mock_technove: MagicMock,
+    entity_id: str,
+    method: str,
+) -> None:
+    """Test invalid response, not becoming unavailable."""
+    state = hass.states.get(entity_id)
+    method_mock = getattr(mock_technove, method)
+
+    method_mock.side_effect = TechnoVEError
+    with pytest.raises(HomeAssistantError, match="Invalid response from TechnoVE API"):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: state.entity_id, ATTR_VALUE: 10},
+            blocking=True,
+        )
+
+    assert method_mock.call_count == 1
+    assert (state := hass.states.get(state.entity_id))
+    assert state.state != STATE_UNAVAILABLE
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "method"),
+    [
+        (
+            "number.technove_station_maximum_current",
+            "set_max_current",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("init_integration")
+async def test_connection_error(
+    hass: HomeAssistant,
+    mock_technove: MagicMock,
+    entity_id: str,
+    method: str,
+) -> None:
+    """Test connection error, leading to becoming unavailable."""
+    state = hass.states.get(entity_id)
+    method_mock = getattr(mock_technove, method)
+
+    method_mock.side_effect = TechnoVEConnectionError
+    with pytest.raises(
+        HomeAssistantError, match="Error communicating with TechnoVE API"
+    ):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: state.entity_id, ATTR_VALUE: 10},
+            blocking=True,
+        )
+
+    assert method_mock.call_count == 1
+    assert (state := hass.states.get(state.entity_id))
+    assert state.state == STATE_UNAVAILABLE

--- a/tests/components/technove/test_number.py
+++ b/tests/components/technove/test_number.py
@@ -18,7 +18,7 @@ from homeassistant.helpers import entity_registry as er
 
 from . import setup_with_selected_platforms
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, snapshot_platform
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default", "mock_technove")
@@ -30,16 +30,7 @@ async def test_numbers(
 ) -> None:
     """Test the creation and values of the TechnoVE numbers."""
     await setup_with_selected_platforms(hass, mock_config_entry, [Platform.NUMBER])
-
-    entity_entries = er.async_entries_for_config_entry(
-        entity_registry, mock_config_entry.entry_id
-    )
-
-    assert entity_entries
-    for entity_entry in entity_entries:
-        assert entity_entry == snapshot(name=f"{entity_entry.entity_id}-entry")
-        assert (state := hass.states.get(entity_entry.entity_id))
-        assert state == snapshot(name=f"{entity_entry.entity_id}-state")
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/technove/test_number.py
+++ b/tests/components/technove/test_number.py
@@ -124,7 +124,7 @@ async def test_set_max_current_sharing_mode(
 
     with pytest.raises(
         ServiceValidationError,
-        match="Cannot set the max current when sharing mode is enabled",
+        match="power sharing mode is enabled",
     ):
         await hass.services.async_call(
             NUMBER_DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds number entity to the TechnoVE integration. The first one is the "max current" number, which allows a user to limit how much current their charging station can provide to their vehicle.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33555

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
