### PR TITLE
Add warnings for deprecated json helpers

### DIFF
--- a/homeassistant/helpers/json.py
+++ b/homeassistant/helpers/json.py
@@ -29,13 +29,13 @@ from .deprecation import (
 )
 
 _DEPRECATED_JSON_DECODE_EXCEPTIONS = DeprecatedConstant(
-    _JSON_DECODE_EXCEPTIONS, "homeassistant.util.json.JSON_DECODE_EXCEPTIONS", "2025.2"
+    _JSON_DECODE_EXCEPTIONS, "homeassistant.util.json.JSON_DECODE_EXCEPTIONS", "2025.8"
 )
 _DEPRECATED_JSON_ENCODE_EXCEPTIONS = DeprecatedConstant(
-    _JSON_ENCODE_EXCEPTIONS, "homeassistant.util.json.JSON_ENCODE_EXCEPTIONS", "2025.2"
+    _JSON_ENCODE_EXCEPTIONS, "homeassistant.util.json.JSON_ENCODE_EXCEPTIONS", "2025.8"
 )
 json_loads = deprecated_function(
-    "homeassistant.util.json.json_loads", breaks_in_ha_version="2025.2"
+    "homeassistant.util.json.json_loads", breaks_in_ha_version="2025.8"
 )(_json_loads)
 
 # These can be removed if no deprecated constant are in this module anymore

--- a/homeassistant/helpers/json.py
+++ b/homeassistant/helpers/json.py
@@ -13,12 +13,38 @@ import orjson
 
 from homeassistant.util.file import write_utf8_file, write_utf8_file_atomic
 from homeassistant.util.json import (  # noqa: F401
-    JSON_DECODE_EXCEPTIONS,
-    JSON_ENCODE_EXCEPTIONS,
+    JSON_DECODE_EXCEPTIONS as _JSON_DECODE_EXCEPTIONS,
+    JSON_ENCODE_EXCEPTIONS as _JSON_ENCODE_EXCEPTIONS,
     SerializationError,
     format_unserializable_data,
-    json_loads,
+    json_loads as _json_loads,
 )
+
+from .deprecation import (
+    DeprecatedAlias,
+    all_with_deprecated_constants,
+    check_if_deprecated_constant,
+    deprecated_function,
+    dir_with_deprecated_constants,
+)
+
+_DEPRECATED_JSON_DECODE_EXCEPTIONS = DeprecatedAlias(
+    _JSON_DECODE_EXCEPTIONS, "homeassistant.util.json.JSON_DECODE_EXCEPTIONS", "2024.2"
+)
+_DEPRECATED_JSON_ENCODE_EXCEPTIONS = DeprecatedAlias(
+    _JSON_ENCODE_EXCEPTIONS, "homeassistant.util.json.JSON_ENCODE_EXCEPTIONS", "2024.2"
+)
+json_loads = deprecated_function(
+    "homeassistant.util.json.json_loads", breaks_in_ha_version="2024.2"
+)(_json_loads)
+
+# These can be removed if no deprecated constant are in this module anymore
+__getattr__ = partial(check_if_deprecated_constant, module_globals=globals())
+__dir__ = partial(
+    dir_with_deprecated_constants, module_globals_keys=[*globals().keys()]
+)
+__all__ = all_with_deprecated_constants(globals())
+
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/helpers/json.py
+++ b/homeassistant/helpers/json.py
@@ -21,21 +21,21 @@ from homeassistant.util.json import (  # noqa: F401
 )
 
 from .deprecation import (
-    DeprecatedAlias,
+    DeprecatedConstant,
     all_with_deprecated_constants,
     check_if_deprecated_constant,
     deprecated_function,
     dir_with_deprecated_constants,
 )
 
-_DEPRECATED_JSON_DECODE_EXCEPTIONS = DeprecatedAlias(
-    _JSON_DECODE_EXCEPTIONS, "homeassistant.util.json.JSON_DECODE_EXCEPTIONS", "2024.2"
+_DEPRECATED_JSON_DECODE_EXCEPTIONS = DeprecatedConstant(
+    _JSON_DECODE_EXCEPTIONS, "homeassistant.util.json.JSON_DECODE_EXCEPTIONS", "2025.2"
 )
-_DEPRECATED_JSON_ENCODE_EXCEPTIONS = DeprecatedAlias(
-    _JSON_ENCODE_EXCEPTIONS, "homeassistant.util.json.JSON_ENCODE_EXCEPTIONS", "2024.2"
+_DEPRECATED_JSON_ENCODE_EXCEPTIONS = DeprecatedConstant(
+    _JSON_ENCODE_EXCEPTIONS, "homeassistant.util.json.JSON_ENCODE_EXCEPTIONS", "2025.2"
 )
 json_loads = deprecated_function(
-    "homeassistant.util.json.json_loads", breaks_in_ha_version="2024.2"
+    "homeassistant.util.json.json_loads", breaks_in_ha_version="2025.2"
 )(_json_loads)
 
 # These can be removed if no deprecated constant are in this module anymore

--- a/tests/helpers/test_json.py
+++ b/tests/helpers/test_json.py
@@ -351,24 +351,22 @@ def test_deprecated_json_loads(caplog: pytest.LogCaptureFixture) -> None:
     json_helper.json_loads("{}")
     assert (
         "json_loads is a deprecated function which will be removed in "
-        "HA Core 2025.2. Use homeassistant.util.json.json_loads instead"
+        "HA Core 2025.8. Use homeassistant.util.json.json_loads instead"
     ) in caplog.text
 
 
 @pytest.mark.parametrize(
-    ("constant_name", "replacement_name", "replacement", "breaks_in_ha_version"),
+    ("constant_name", "replacement_name", "replacement"),
     [
         (
             "JSON_DECODE_EXCEPTIONS",
             "homeassistant.util.json.JSON_DECODE_EXCEPTIONS",
             JSON_DECODE_EXCEPTIONS,
-            "2025.2",
         ),
         (
             "JSON_ENCODE_EXCEPTIONS",
             "homeassistant.util.json.JSON_ENCODE_EXCEPTIONS",
             JSON_ENCODE_EXCEPTIONS,
-            "2025.2",
         ),
     ],
 )
@@ -377,7 +375,6 @@ def test_deprecated_aliases(
     constant_name: str,
     replacement_name: str,
     replacement: Any,
-    breaks_in_ha_version: str,
 ) -> None:
     """Test deprecated JSON_DECODE_EXCEPTIONS and JSON_ENCODE_EXCEPTIONS constants.
 
@@ -389,5 +386,5 @@ def test_deprecated_aliases(
         constant_name,
         replacement_name,
         replacement,
-        breaks_in_ha_version,
+        "2025.8",
     )

--- a/tests/helpers/test_json.py
+++ b/tests/helpers/test_json.py
@@ -13,6 +13,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from homeassistant.core import Event, HomeAssistant, State
+from homeassistant.helpers import json as json_helper
 from homeassistant.helpers.json import (
     ExtendedJSONEncoder,
     JSONEncoder as DefaultHASSJSONEncoder,
@@ -25,9 +26,14 @@ from homeassistant.helpers.json import (
 )
 from homeassistant.util import dt as dt_util
 from homeassistant.util.color import RGBColor
-from homeassistant.util.json import SerializationError, load_json
+from homeassistant.util.json import (
+    JSON_DECODE_EXCEPTIONS,
+    JSON_ENCODE_EXCEPTIONS,
+    SerializationError,
+    load_json,
+)
 
-from tests.common import json_round_trip
+from tests.common import import_and_test_deprecated_constant, json_round_trip
 
 # Test data that can be saved as JSON
 TEST_JSON_A = {"a": 1, "B": "two"}
@@ -335,3 +341,53 @@ def test_find_unserializable_data() -> None:
         BadData(),
         dump=partial(json.dumps, cls=MockJSONEncoder),
     ) == {"$(BadData).bla": bad_data}
+
+
+def test_deprecated_json_loads(caplog: pytest.LogCaptureFixture) -> None:
+    """Test deprecated json_loads function.
+
+    It was moved from helpers to util in #88099
+    """
+    json_helper.json_loads("{}")
+    assert (
+        "json_loads is a deprecated function which will be removed in "
+        "HA Core 2025.2. Use homeassistant.util.json.json_loads instead"
+    ) in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("constant_name", "replacement_name", "replacement", "breaks_in_ha_version"),
+    [
+        (
+            "JSON_DECODE_EXCEPTIONS",
+            "homeassistant.util.json.JSON_DECODE_EXCEPTIONS",
+            JSON_DECODE_EXCEPTIONS,
+            "2025.2",
+        ),
+        (
+            "JSON_ENCODE_EXCEPTIONS",
+            "homeassistant.util.json.JSON_ENCODE_EXCEPTIONS",
+            JSON_ENCODE_EXCEPTIONS,
+            "2025.2",
+        ),
+    ],
+)
+def test_deprecated_aliases(
+    caplog: pytest.LogCaptureFixture,
+    constant_name: str,
+    replacement_name: str,
+    replacement: Any,
+    breaks_in_ha_version: str,
+) -> None:
+    """Test deprecated JSON_DECODE_EXCEPTIONS and JSON_ENCODE_EXCEPTIONS constants.
+
+    They were moved from helpers to util in #88099
+    """
+    import_and_test_deprecated_constant(
+        caplog,
+        json_helper,
+        constant_name,
+        replacement_name,
+        replacement,
+        breaks_in_ha_version,
+    )


### PR DESCRIPTION
## ~Breaking change~ Deprecation
FOR DEVELOPPERS ONLY:
- `json_loads` function, and `JSON_ENCODE_EXCEPTIONS` and `JSON_DECODE_EXCEPTIONS` constants have been moved from `homeassistant.helpers.json` to `homeassistant.util.json`

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, follow-up to #88099


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
