### PR TITLE
Improve type hints in generic_hygrostat/thermostat tests

### DIFF
--- a/tests/components/generic_hygrostat/test_humidifier.py
+++ b/tests/components/generic_hygrostat/test_humidifier.py
@@ -87,13 +87,14 @@ async def test_valid_conf(hass: HomeAssistant) -> None:
 
 
 @pytest.fixture
-async def setup_comp_1(hass):
+async def setup_comp_1(hass: HomeAssistant) -> None:
     """Initialize components."""
     assert await async_setup_component(hass, "homeassistant", {})
     await hass.async_block_till_done()
 
 
-async def test_humidifier_input_boolean(hass: HomeAssistant, setup_comp_1) -> None:
+@pytest.mark.usefixtures("setup_comp_1")
+async def test_humidifier_input_boolean(hass: HomeAssistant) -> None:
     """Test humidifier switching input_boolean."""
     humidifier_switch = "input_boolean.test"
     assert await async_setup_component(
@@ -132,8 +133,9 @@ async def test_humidifier_input_boolean(hass: HomeAssistant, setup_comp_1) -> No
     assert hass.states.get(ENTITY).attributes.get("action") == "humidifying"
 
 
+@pytest.mark.usefixtures("setup_comp_1")
 async def test_humidifier_switch(
-    hass: HomeAssistant, setup_comp_1, mock_switch_entities: list[MockSwitch]
+    hass: HomeAssistant, mock_switch_entities: list[MockSwitch]
 ) -> None:
     """Test humidifier switching test switch."""
     setup_test_component_platform(hass, switch.DOMAIN, mock_switch_entities)
@@ -176,8 +178,9 @@ async def test_humidifier_switch(
     assert hass.states.get(ENTITY).attributes.get("action") == "humidifying"
 
 
+@pytest.mark.usefixtures("setup_comp_1")
 async def test_unique_id(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, setup_comp_1
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test setting a unique ID."""
     unique_id = "some_unique_id"
@@ -209,7 +212,7 @@ def _setup_sensor(hass, humidity):
 
 
 @pytest.fixture
-async def setup_comp_0(hass):
+async def setup_comp_0(hass: HomeAssistant) -> None:
     """Initialize components."""
     _setup_sensor(hass, 45)
     hass.states.async_set(ENT_SWITCH, STATE_OFF)
@@ -235,7 +238,7 @@ async def setup_comp_0(hass):
 
 
 @pytest.fixture
-async def setup_comp_2(hass):
+async def setup_comp_2(hass: HomeAssistant) -> None:
     """Initialize components."""
     _setup_sensor(hass, 45)
     hass.states.async_set(ENT_SWITCH, STATE_OFF)
@@ -307,7 +310,8 @@ async def test_setup_defaults_to_unknown(hass: HomeAssistant) -> None:
     assert hass.states.get(ENTITY).state == STATE_UNAVAILABLE
 
 
-async def test_default_setup_params(hass: HomeAssistant, setup_comp_2) -> None:
+@pytest.mark.usefixtures("setup_comp_2")
+async def test_default_setup_params(hass: HomeAssistant) -> None:
     """Test the setup with default parameters."""
     state = hass.states.get(ENTITY)
     assert state.attributes.get("min_humidity") == 0
@@ -316,9 +320,8 @@ async def test_default_setup_params(hass: HomeAssistant, setup_comp_2) -> None:
     assert state.attributes.get("action") == "idle"
 
 
-async def test_default_setup_params_dehumidifier(
-    hass: HomeAssistant, setup_comp_0
-) -> None:
+@pytest.mark.usefixtures("setup_comp_0")
+async def test_default_setup_params_dehumidifier(hass: HomeAssistant) -> None:
     """Test the setup with default parameters for dehumidifier."""
     state = hass.states.get(ENTITY)
     assert state.attributes.get("min_humidity") == 0
@@ -327,14 +330,16 @@ async def test_default_setup_params_dehumidifier(
     assert state.attributes.get("action") == "idle"
 
 
-async def test_get_modes(hass: HomeAssistant, setup_comp_2) -> None:
+@pytest.mark.usefixtures("setup_comp_2")
+async def test_get_modes(hass: HomeAssistant) -> None:
     """Test that the attributes returns the correct modes."""
     state = hass.states.get(ENTITY)
     modes = state.attributes.get("available_modes")
     assert modes == [MODE_NORMAL, MODE_AWAY]
 
 
-async def test_set_target_humidity(hass: HomeAssistant, setup_comp_2) -> None:
+@pytest.mark.usefixtures("setup_comp_2")
+async def test_set_target_humidity(hass: HomeAssistant) -> None:
     """Test the setting of the target humidity."""
     await hass.services.async_call(
         DOMAIN,
@@ -357,7 +362,8 @@ async def test_set_target_humidity(hass: HomeAssistant, setup_comp_2) -> None:
     assert state.attributes.get("humidity") == 40
 
 
-async def test_set_away_mode(hass: HomeAssistant, setup_comp_2) -> None:
+@pytest.mark.usefixtures("setup_comp_2")
+async def test_set_away_mode(hass: HomeAssistant) -> None:
     """Test the setting away mode."""
     await hass.services.async_call(
         DOMAIN,
@@ -377,9 +383,8 @@ async def test_set_away_mode(hass: HomeAssistant, setup_comp_2) -> None:
     assert state.attributes.get("humidity") == 35
 
 
-async def test_set_away_mode_and_restore_prev_humidity(
-    hass: HomeAssistant, setup_comp_2
-) -> None:
+@pytest.mark.usefixtures("setup_comp_2")
+async def test_set_away_mode_and_restore_prev_humidity(hass: HomeAssistant) -> None:
     """Test the setting and removing away mode.
 
     Verify original humidity is restored.
@@ -411,8 +416,9 @@ async def test_set_away_mode_and_restore_prev_humidity(
     assert state.attributes.get("humidity") == 44
 
 
+@pytest.mark.usefixtures("setup_comp_2")
 async def test_set_away_mode_twice_and_restore_prev_humidity(
-    hass: HomeAssistant, setup_comp_2
+    hass: HomeAssistant,
 ) -> None:
     """Test the setting away mode twice in a row.
 
@@ -452,7 +458,8 @@ async def test_set_away_mode_twice_and_restore_prev_humidity(
     assert state.attributes.get("humidity") == 44
 
 
-async def test_sensor_affects_attribute(hass: HomeAssistant, setup_comp_2) -> None:
+@pytest.mark.usefixtures("setup_comp_2")
+async def test_sensor_affects_attribute(hass: HomeAssistant) -> None:
     """Test that the sensor changes are reflected in the current_humidity attribute."""
     state = hass.states.get(ENTITY)
     assert state.attributes.get("current_humidity") == 45
@@ -464,7 +471,8 @@ async def test_sensor_affects_attribute(hass: HomeAssistant, setup_comp_2) -> No
     assert state.attributes.get("current_humidity") == 47
 
 
-async def test_sensor_bad_value(hass: HomeAssistant, setup_comp_2) -> None:
+@pytest.mark.usefixtures("setup_comp_2")
+async def test_sensor_bad_value(hass: HomeAssistant) -> None:
     """Test sensor that have None as state."""
     assert hass.states.get(ENTITY).state == STATE_ON
 
@@ -474,8 +482,9 @@ async def test_sensor_bad_value(hass: HomeAssistant, setup_comp_2) -> None:
     assert hass.states.get(ENTITY).state == STATE_UNAVAILABLE
 
 
+@pytest.mark.usefixtures("setup_comp_2")
 async def test_sensor_bad_value_twice(
-    hass: HomeAssistant, setup_comp_2, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test sensor that the second bad value is not logged as warning."""
     assert hass.states.get(ENTITY).state == STATE_ON
@@ -503,9 +512,8 @@ async def test_sensor_bad_value_twice(
     ] == ["DEBUG"]
 
 
-async def test_set_target_humidity_humidifier_on(
-    hass: HomeAssistant, setup_comp_2
-) -> None:
+@pytest.mark.usefixtures("setup_comp_2")
+async def test_set_target_humidity_humidifier_on(hass: HomeAssistant) -> None:
     """Test if target humidity turn humidifier on."""
     calls = await _setup_switch(hass, False)
     _setup_sensor(hass, 36)
@@ -524,9 +532,8 @@ async def test_set_target_humidity_humidifier_on(
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_set_target_humidity_humidifier_off(
-    hass: HomeAssistant, setup_comp_2
-) -> None:
+@pytest.mark.usefixtures("setup_comp_2")
+async def test_set_target_humidity_humidifier_off(hass: HomeAssistant) -> None:
     """Test if target humidity turn humidifier off."""
     calls = await _setup_switch(hass, True)
     _setup_sensor(hass, 45)
@@ -545,8 +552,9 @@ async def test_set_target_humidity_humidifier_off(
     assert call.data["entity_id"] == ENT_SWITCH
 
 
+@pytest.mark.usefixtures("setup_comp_2")
 async def test_humidity_change_humidifier_on_within_tolerance(
-    hass: HomeAssistant, setup_comp_2
+    hass: HomeAssistant,
 ) -> None:
     """Test if humidity change doesn't turn on within tolerance."""
     calls = await _setup_switch(hass, False)
@@ -562,8 +570,9 @@ async def test_humidity_change_humidifier_on_within_tolerance(
     assert len(calls) == 0
 
 
+@pytest.mark.usefixtures("setup_comp_2")
 async def test_humidity_change_humidifier_on_outside_tolerance(
-    hass: HomeAssistant, setup_comp_2
+    hass: HomeAssistant,
 ) -> None:
     """Test if humidity change turn humidifier on outside dry tolerance."""
     calls = await _setup_switch(hass, False)
@@ -583,8 +592,9 @@ async def test_humidity_change_humidifier_on_outside_tolerance(
     assert call.data["entity_id"] == ENT_SWITCH
 
 
+@pytest.mark.usefixtures("setup_comp_2")
 async def test_humidity_change_humidifier_off_within_tolerance(
-    hass: HomeAssistant, setup_comp_2
+    hass: HomeAssistant,
 ) -> None:
     """Test if humidity change doesn't turn off within tolerance."""
     calls = await _setup_switch(hass, True)
@@ -600,8 +610,9 @@ async def test_humidity_change_humidifier_off_within_tolerance(
     assert len(calls) == 0
 
 
+@pytest.mark.usefixtures("setup_comp_2")
 async def test_humidity_change_humidifier_off_outside_tolerance(
-    hass: HomeAssistant, setup_comp_2
+    hass: HomeAssistant,
 ) -> None:
     """Test if humidity change turn humidifier off outside wet tolerance."""
     calls = await _setup_switch(hass, True)
@@ -621,7 +632,8 @@ async def test_humidity_change_humidifier_off_outside_tolerance(
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_operation_mode_humidify(hass: HomeAssistant, setup_comp_2) -> None:
+@pytest.mark.usefixtures("setup_comp_2")
+async def test_operation_mode_humidify(hass: HomeAssistant) -> None:
     """Test change mode from OFF to HUMIDIFY.
 
     Switch turns on when humidity below setpoint and mode changes.
@@ -675,7 +687,7 @@ async def _setup_switch(hass, is_on):
 
 
 @pytest.fixture
-async def setup_comp_3(hass):
+async def setup_comp_3(hass: HomeAssistant) -> None:
     """Initialize components."""
     assert await async_setup_component(
         hass,
@@ -698,7 +710,8 @@ async def setup_comp_3(hass):
     await hass.async_block_till_done()
 
 
-async def test_set_target_humidity_dry_off(hass: HomeAssistant, setup_comp_3) -> None:
+@pytest.mark.usefixtures("setup_comp_3")
+async def test_set_target_humidity_dry_off(hass: HomeAssistant) -> None:
     """Test if target humidity turn dry off."""
     calls = await _setup_switch(hass, True)
     _setup_sensor(hass, 50)
@@ -718,7 +731,8 @@ async def test_set_target_humidity_dry_off(hass: HomeAssistant, setup_comp_3) ->
     assert hass.states.get(ENTITY).attributes.get("action") == "drying"
 
 
-async def test_turn_away_mode_on_drying(hass: HomeAssistant, setup_comp_3) -> None:
+@pytest.mark.usefixtures("setup_comp_3")
+async def test_turn_away_mode_on_drying(hass: HomeAssistant) -> None:
     """Test the setting away mode when drying."""
     await _setup_switch(hass, True)
     _setup_sensor(hass, 50)
@@ -741,7 +755,8 @@ async def test_turn_away_mode_on_drying(hass: HomeAssistant, setup_comp_3) -> No
     assert state.attributes.get("humidity") == 30
 
 
-async def test_operation_mode_dry(hass: HomeAssistant, setup_comp_3) -> None:
+@pytest.mark.usefixtures("setup_comp_3")
+async def test_operation_mode_dry(hass: HomeAssistant) -> None:
     """Test change mode from OFF to DRY.
 
     Switch turns on when humidity below setpoint and state changes.
@@ -774,7 +789,8 @@ async def test_operation_mode_dry(hass: HomeAssistant, setup_comp_3) -> None:
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_set_target_humidity_dry_on(hass: HomeAssistant, setup_comp_3) -> None:
+@pytest.mark.usefixtures("setup_comp_3")
+async def test_set_target_humidity_dry_on(hass: HomeAssistant) -> None:
     """Test if target humidity turn dry on."""
     calls = await _setup_switch(hass, False)
     _setup_sensor(hass, 45)
@@ -786,7 +802,8 @@ async def test_set_target_humidity_dry_on(hass: HomeAssistant, setup_comp_3) -> 
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_init_ignores_tolerance(hass: HomeAssistant, setup_comp_3) -> None:
+@pytest.mark.usefixtures("setup_comp_3")
+async def test_init_ignores_tolerance(hass: HomeAssistant) -> None:
     """Test if tolerance is ignored on initialization."""
     calls = await _setup_switch(hass, True)
     _setup_sensor(hass, 39)
@@ -798,9 +815,8 @@ async def test_init_ignores_tolerance(hass: HomeAssistant, setup_comp_3) -> None
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_humidity_change_dry_off_within_tolerance(
-    hass: HomeAssistant, setup_comp_3
-) -> None:
+@pytest.mark.usefixtures("setup_comp_3")
+async def test_humidity_change_dry_off_within_tolerance(hass: HomeAssistant) -> None:
     """Test if humidity change doesn't turn dry off within tolerance."""
     calls = await _setup_switch(hass, True)
     _setup_sensor(hass, 45)
@@ -809,8 +825,9 @@ async def test_humidity_change_dry_off_within_tolerance(
     assert len(calls) == 0
 
 
+@pytest.mark.usefixtures("setup_comp_3")
 async def test_set_humidity_change_dry_off_outside_tolerance(
-    hass: HomeAssistant, setup_comp_3
+    hass: HomeAssistant,
 ) -> None:
     """Test if humidity change turn dry off."""
     calls = await _setup_switch(hass, True)
@@ -823,9 +840,8 @@ async def test_set_humidity_change_dry_off_outside_tolerance(
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_humidity_change_dry_on_within_tolerance(
-    hass: HomeAssistant, setup_comp_3
-) -> None:
+@pytest.mark.usefixtures("setup_comp_3")
+async def test_humidity_change_dry_on_within_tolerance(hass: HomeAssistant) -> None:
     """Test if humidity change doesn't turn dry on within tolerance."""
     calls = await _setup_switch(hass, False)
     _setup_sensor(hass, 37)
@@ -834,9 +850,8 @@ async def test_humidity_change_dry_on_within_tolerance(
     assert len(calls) == 0
 
 
-async def test_humidity_change_dry_on_outside_tolerance(
-    hass: HomeAssistant, setup_comp_3
-) -> None:
+@pytest.mark.usefixtures("setup_comp_3")
+async def test_humidity_change_dry_on_outside_tolerance(hass: HomeAssistant) -> None:
     """Test if humidity change turn dry on."""
     calls = await _setup_switch(hass, False)
     _setup_sensor(hass, 45)
@@ -848,9 +863,8 @@ async def test_humidity_change_dry_on_outside_tolerance(
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_running_when_operating_mode_is_off_2(
-    hass: HomeAssistant, setup_comp_3
-) -> None:
+@pytest.mark.usefixtures("setup_comp_3")
+async def test_running_when_operating_mode_is_off_2(hass: HomeAssistant) -> None:
     """Test that the switch turns off when enabled is set False."""
     calls = await _setup_switch(hass, True)
     _setup_sensor(hass, 45)
@@ -870,9 +884,8 @@ async def test_running_when_operating_mode_is_off_2(
     assert hass.states.get(ENTITY).attributes.get("action") == "off"
 
 
-async def test_no_state_change_when_operation_mode_off_2(
-    hass: HomeAssistant, setup_comp_3
-) -> None:
+@pytest.mark.usefixtures("setup_comp_3")
+async def test_no_state_change_when_operation_mode_off_2(hass: HomeAssistant) -> None:
     """Test that the switch doesn't turn on when enabled is False."""
     calls = await _setup_switch(hass, False)
     _setup_sensor(hass, 30)
@@ -891,7 +904,7 @@ async def test_no_state_change_when_operation_mode_off_2(
 
 
 @pytest.fixture
-async def setup_comp_4(hass):
+async def setup_comp_4(hass: HomeAssistant) -> None:
     """Initialize components."""
     assert await async_setup_component(
         hass,
@@ -914,8 +927,9 @@ async def setup_comp_4(hass):
     await hass.async_block_till_done()
 
 
+@pytest.mark.usefixtures("setup_comp_4")
 async def test_humidity_change_dry_trigger_on_not_long_enough(
-    hass: HomeAssistant, setup_comp_4
+    hass: HomeAssistant,
 ) -> None:
     """Test if humidity change turn dry on."""
     calls = await _setup_switch(hass, False)
@@ -928,9 +942,8 @@ async def test_humidity_change_dry_trigger_on_not_long_enough(
     assert len(calls) == 0
 
 
-async def test_humidity_change_dry_trigger_on_long_enough(
-    hass: HomeAssistant, setup_comp_4
-) -> None:
+@pytest.mark.usefixtures("setup_comp_4")
+async def test_humidity_change_dry_trigger_on_long_enough(hass: HomeAssistant) -> None:
     """Test if humidity change turn dry on."""
     fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=datetime.UTC)
     with freeze_time(fake_changed):
@@ -948,8 +961,9 @@ async def test_humidity_change_dry_trigger_on_long_enough(
     assert call.data["entity_id"] == ENT_SWITCH
 
 
+@pytest.mark.usefixtures("setup_comp_4")
 async def test_humidity_change_dry_trigger_off_not_long_enough(
-    hass: HomeAssistant, setup_comp_4
+    hass: HomeAssistant,
 ) -> None:
     """Test if humidity change turn dry on."""
     calls = await _setup_switch(hass, True)
@@ -962,9 +976,8 @@ async def test_humidity_change_dry_trigger_off_not_long_enough(
     assert len(calls) == 0
 
 
-async def test_humidity_change_dry_trigger_off_long_enough(
-    hass: HomeAssistant, setup_comp_4
-) -> None:
+@pytest.mark.usefixtures("setup_comp_4")
+async def test_humidity_change_dry_trigger_off_long_enough(hass: HomeAssistant) -> None:
     """Test if humidity change turn dry on."""
     fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=datetime.UTC)
     with freeze_time(fake_changed):
@@ -982,9 +995,8 @@ async def test_humidity_change_dry_trigger_off_long_enough(
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_mode_change_dry_trigger_off_not_long_enough(
-    hass: HomeAssistant, setup_comp_4
-) -> None:
+@pytest.mark.usefixtures("setup_comp_4")
+async def test_mode_change_dry_trigger_off_not_long_enough(hass: HomeAssistant) -> None:
     """Test if mode change turns dry off despite minimum cycle."""
     calls = await _setup_switch(hass, True)
     _setup_sensor(hass, 45)
@@ -1004,9 +1016,8 @@ async def test_mode_change_dry_trigger_off_not_long_enough(
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_mode_change_dry_trigger_on_not_long_enough(
-    hass: HomeAssistant, setup_comp_4
-) -> None:
+@pytest.mark.usefixtures("setup_comp_4")
+async def test_mode_change_dry_trigger_on_not_long_enough(hass: HomeAssistant) -> None:
     """Test if mode change turns dry on despite minimum cycle."""
     calls = await _setup_switch(hass, False)
     _setup_sensor(hass, 35)
@@ -1036,7 +1047,7 @@ async def test_mode_change_dry_trigger_on_not_long_enough(
 
 
 @pytest.fixture
-async def setup_comp_6(hass):
+async def setup_comp_6(hass: HomeAssistant) -> None:
     """Initialize components."""
     assert await async_setup_component(
         hass,
@@ -1058,8 +1069,9 @@ async def setup_comp_6(hass):
     await hass.async_block_till_done()
 
 
+@pytest.mark.usefixtures("setup_comp_6")
 async def test_humidity_change_humidifier_trigger_off_not_long_enough(
-    hass: HomeAssistant, setup_comp_6
+    hass: HomeAssistant,
 ) -> None:
     """Test if humidity change doesn't turn humidifier off because of time."""
     calls = await _setup_switch(hass, True)
@@ -1072,8 +1084,9 @@ async def test_humidity_change_humidifier_trigger_off_not_long_enough(
     assert len(calls) == 0
 
 
+@pytest.mark.usefixtures("setup_comp_6")
 async def test_humidity_change_humidifier_trigger_on_not_long_enough(
-    hass: HomeAssistant, setup_comp_6
+    hass: HomeAssistant,
 ) -> None:
     """Test if humidity change doesn't turn humidifier on because of time."""
     calls = await _setup_switch(hass, False)
@@ -1086,8 +1099,9 @@ async def test_humidity_change_humidifier_trigger_on_not_long_enough(
     assert len(calls) == 0
 
 
+@pytest.mark.usefixtures("setup_comp_6")
 async def test_humidity_change_humidifier_trigger_on_long_enough(
-    hass: HomeAssistant, setup_comp_6
+    hass: HomeAssistant,
 ) -> None:
     """Test if humidity change turn humidifier on after min cycle."""
     fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=datetime.UTC)
@@ -1106,8 +1120,9 @@ async def test_humidity_change_humidifier_trigger_on_long_enough(
     assert call.data["entity_id"] == ENT_SWITCH
 
 
+@pytest.mark.usefixtures("setup_comp_6")
 async def test_humidity_change_humidifier_trigger_off_long_enough(
-    hass: HomeAssistant, setup_comp_6
+    hass: HomeAssistant,
 ) -> None:
     """Test if humidity change turn humidifier off after min cycle."""
     fake_changed = datetime.datetime(1970, 11, 11, 11, 11, 11, tzinfo=datetime.UTC)
@@ -1126,8 +1141,9 @@ async def test_humidity_change_humidifier_trigger_off_long_enough(
     assert call.data["entity_id"] == ENT_SWITCH
 
 
+@pytest.mark.usefixtures("setup_comp_6")
 async def test_mode_change_humidifier_trigger_off_not_long_enough(
-    hass: HomeAssistant, setup_comp_6
+    hass: HomeAssistant,
 ) -> None:
     """Test if mode change turns humidifier off despite minimum cycle."""
     calls = await _setup_switch(hass, True)
@@ -1149,8 +1165,9 @@ async def test_mode_change_humidifier_trigger_off_not_long_enough(
     assert call.data["entity_id"] == ENT_SWITCH
 
 
+@pytest.mark.usefixtures("setup_comp_6")
 async def test_mode_change_humidifier_trigger_on_not_long_enough(
-    hass: HomeAssistant, setup_comp_6
+    hass: HomeAssistant,
 ) -> None:
     """Test if mode change turns humidifier on despite minimum cycle."""
     calls = await _setup_switch(hass, False)
@@ -1186,7 +1203,7 @@ async def test_mode_change_humidifier_trigger_on_not_long_enough(
 
 
 @pytest.fixture
-async def setup_comp_7(hass):
+async def setup_comp_7(hass: HomeAssistant) -> None:
     """Initialize components."""
     assert await async_setup_component(
         hass,
@@ -1210,8 +1227,9 @@ async def setup_comp_7(hass):
     await hass.async_block_till_done()
 
 
+@pytest.mark.usefixtures("setup_comp_7")
 async def test_humidity_change_dry_trigger_on_long_enough_3(
-    hass: HomeAssistant, setup_comp_7
+    hass: HomeAssistant,
 ) -> None:
     """Test if turn on signal is sent at keep-alive intervals."""
     calls = await _setup_switch(hass, True)
@@ -1230,8 +1248,9 @@ async def test_humidity_change_dry_trigger_on_long_enough_3(
     assert call.data["entity_id"] == ENT_SWITCH
 
 
+@pytest.mark.usefixtures("setup_comp_7")
 async def test_humidity_change_dry_trigger_off_long_enough_3(
-    hass: HomeAssistant, setup_comp_7
+    hass: HomeAssistant,
 ) -> None:
     """Test if turn on signal is sent at keep-alive intervals."""
     calls = await _setup_switch(hass, False)
@@ -1251,7 +1270,7 @@ async def test_humidity_change_dry_trigger_off_long_enough_3(
 
 
 @pytest.fixture
-async def setup_comp_8(hass):
+async def setup_comp_8(hass: HomeAssistant) -> None:
     """Initialize components."""
     assert await async_setup_component(
         hass,
@@ -1274,8 +1293,9 @@ async def setup_comp_8(hass):
     await hass.async_block_till_done()
 
 
+@pytest.mark.usefixtures("setup_comp_8")
 async def test_humidity_change_humidifier_trigger_on_long_enough_2(
-    hass: HomeAssistant, setup_comp_8
+    hass: HomeAssistant,
 ) -> None:
     """Test if turn on signal is sent at keep-alive intervals."""
     calls = await _setup_switch(hass, True)
@@ -1294,8 +1314,9 @@ async def test_humidity_change_humidifier_trigger_on_long_enough_2(
     assert call.data["entity_id"] == ENT_SWITCH
 
 
+@pytest.mark.usefixtures("setup_comp_8")
 async def test_humidity_change_humidifier_trigger_off_long_enough_2(
-    hass: HomeAssistant, setup_comp_8
+    hass: HomeAssistant,
 ) -> None:
     """Test if turn on signal is sent at keep-alive intervals."""
     calls = await _setup_switch(hass, False)
@@ -1706,8 +1727,9 @@ async def test_away_fixed_humidity_mode(hass: HomeAssistant) -> None:
     assert state.state == STATE_OFF
 
 
+@pytest.mark.usefixtures("setup_comp_1")
 async def test_sensor_stale_duration(
-    hass: HomeAssistant, setup_comp_1, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test turn off on sensor stale."""
 

--- a/tests/components/generic_thermostat/test_climate.py
+++ b/tests/components/generic_thermostat/test_climate.py
@@ -103,14 +103,15 @@ async def test_valid_conf(hass: HomeAssistant) -> None:
 
 
 @pytest.fixture
-async def setup_comp_1(hass):
+async def setup_comp_1(hass: HomeAssistant) -> None:
     """Initialize components."""
     hass.config.units = METRIC_SYSTEM
     assert await async_setup_component(hass, "homeassistant", {})
     await hass.async_block_till_done()
 
 
-async def test_heater_input_boolean(hass: HomeAssistant, setup_comp_1) -> None:
+@pytest.mark.usefixtures("setup_comp_1")
+async def test_heater_input_boolean(hass: HomeAssistant) -> None:
     """Test heater switching input_boolean."""
     heater_switch = "input_boolean.test"
     assert await async_setup_component(
@@ -142,8 +143,9 @@ async def test_heater_input_boolean(hass: HomeAssistant, setup_comp_1) -> None:
     assert hass.states.get(heater_switch).state == STATE_ON
 
 
+@pytest.mark.usefixtures("setup_comp_1")
 async def test_heater_switch(
-    hass: HomeAssistant, setup_comp_1, mock_switch_entities: list[MockSwitch]
+    hass: HomeAssistant, mock_switch_entities: list[MockSwitch]
 ) -> None:
     """Test heater switching test switch."""
     setup_test_component_platform(hass, switch.DOMAIN, mock_switch_entities)
@@ -178,8 +180,9 @@ async def test_heater_switch(
     assert hass.states.get(heater_switch).state == STATE_ON
 
 
+@pytest.mark.usefixtures("setup_comp_1")
 async def test_unique_id(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, setup_comp_1
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test setting a unique ID."""
     unique_id = "some_unique_id"
@@ -211,7 +214,7 @@ def _setup_sensor(hass, temp):
 
 
 @pytest.fixture
-async def setup_comp_2(hass):
+async def setup_comp_2(hass: HomeAssistant) -> None:
     """Initialize components."""
     hass.config.units = METRIC_SYSTEM
     assert await async_setup_component(
@@ -284,7 +287,8 @@ async def test_setup_gets_current_temp_from_sensor(hass: HomeAssistant) -> None:
     assert hass.states.get(ENTITY).attributes["current_temperature"] == 18
 
 
-async def test_default_setup_params(hass: HomeAssistant, setup_comp_2) -> None:
+@pytest.mark.usefixtures("setup_comp_2")
+async def test_default_setup_params(hass: HomeAssistant) -> None:
     """Test the setup with default parameters."""
     state = hass.states.get(ENTITY)
     assert state.attributes.get("min_temp") == 7
@@ -293,14 +297,16 @@ async def test_default_setup_params(hass: HomeAssistant, setup_comp_2) -> None:
     assert state.attributes.get("target_temp_step") == 0.1
 
 
-async def test_get_hvac_modes(hass: HomeAssistant, setup_comp_2) -> None:
+@pytest.mark.usefixtures("setup_comp_2")
+async def test_get_hvac_modes(hass: HomeAssistant) -> None:
     """Test that the operation list returns the correct modes."""
     state = hass.states.get(ENTITY)
     modes = state.attributes.get("hvac_modes")
     assert modes == [HVACMode.HEAT, HVACMode.OFF]
 
 
-async def test_set_target_temp(hass: HomeAssistant, setup_comp_2) -> None:
+@pytest.mark.usefixtures("setup_comp_2")
+async def test_set_target_temp(hass: HomeAssistant) -> None:
     """Test the setting of the target temperature."""
     await common.async_set_temperature(hass, 30)
     state = hass.states.get(ENTITY)
@@ -323,7 +329,8 @@ async def test_set_target_temp(hass: HomeAssistant, setup_comp_2) -> None:
         (PRESET_ACTIVITY, 21),
     ],
 )
-async def test_set_away_mode(hass: HomeAssistant, setup_comp_2, preset, temp) -> None:
+@pytest.mark.usefixtures("setup_comp_2")
+async def test_set_away_mode(hass: HomeAssistant, preset, temp) -> None:
     """Test the setting away mode."""
     await common.async_set_temperature(hass, 23)
     await common.async_set_preset_mode(hass, preset)
@@ -343,8 +350,9 @@ async def test_set_away_mode(hass: HomeAssistant, setup_comp_2, preset, temp) ->
         (PRESET_ACTIVITY, 21),
     ],
 )
+@pytest.mark.usefixtures("setup_comp_2")
 async def test_set_away_mode_and_restore_prev_temp(
-    hass: HomeAssistant, setup_comp_2, preset, temp
+    hass: HomeAssistant, preset, temp
 ) -> None:
     """Test the setting and removing away mode.
 
@@ -371,8 +379,9 @@ async def test_set_away_mode_and_restore_prev_temp(
         (PRESET_ACTIVITY, 21),
     ],
 )
+@pytest.mark.usefixtures("setup_comp_2")
 async def test_set_away_mode_twice_and_restore_prev_temp(
-    hass: HomeAssistant, setup_comp_2, preset, temp
+    hass: HomeAssistant, preset, temp
 ) -> None:
     """Test the setting away mode twice in a row.
 
@@ -388,7 +397,8 @@ async def test_set_away_mode_twice_and_restore_prev_temp(
     assert state.attributes.get("temperature") == 23
 
 
-async def test_set_preset_mode_invalid(hass: HomeAssistant, setup_comp_2) -> None:
+@pytest.mark.usefixtures("setup_comp_2")
+async def test_set_preset_mode_invalid(hass: HomeAssistant) -> None:
     """Test an invalid mode raises an error and ignore case when checking modes."""
     await common.async_set_temperature(hass, 23)
     await common.async_set_preset_mode(hass, "away")
@@ -403,7 +413,8 @@ async def test_set_preset_mode_invalid(hass: HomeAssistant, setup_comp_2) -> Non
     assert state.attributes.get("preset_mode") == "none"
 
 
-async def test_sensor_bad_value(hass: HomeAssistant, setup_comp_2) -> None:
+@pytest.mark.usefixtures("setup_comp_2")
+async def test_sensor_bad_value(hass: HomeAssistant) -> None:
     """Test sensor that have None as state."""
     state = hass.states.get(ENTITY)
     temp = state.attributes.get("current_temperature")
@@ -464,7 +475,8 @@ async def test_sensor_unavailable(hass: HomeAssistant) -> None:
     assert state.attributes.get("current_temperature") is None
 
 
-async def test_set_target_temp_heater_on(hass: HomeAssistant, setup_comp_2) -> None:
+@pytest.mark.usefixtures("setup_comp_2")
+async def test_set_target_temp_heater_on(hass: HomeAssistant) -> None:
     """Test if target temperature turn heater on."""
     calls = _setup_switch(hass, False)
     _setup_sensor(hass, 25)
@@ -477,7 +489,8 @@ async def test_set_target_temp_heater_on(hass: HomeAssistant, setup_comp_2) -> N
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_set_target_temp_heater_off(hass: HomeAssistant, setup_comp_2) -> None:
+@pytest.mark.usefixtures("setup_comp_2")
+async def test_set_target_temp_heater_off(hass: HomeAssistant) -> None:
     """Test if target temperature turn heater off."""
     calls = _setup_switch(hass, True)
     _setup_sensor(hass, 30)
@@ -490,9 +503,8 @@ async def test_set_target_temp_heater_off(hass: HomeAssistant, setup_comp_2) -> 
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_temp_change_heater_on_within_tolerance(
-    hass: HomeAssistant, setup_comp_2
-) -> None:
+@pytest.mark.usefixtures("setup_comp_2")
+async def test_temp_change_heater_on_within_tolerance(hass: HomeAssistant) -> None:
     """Test if temperature change doesn't turn on within tolerance."""
     calls = _setup_switch(hass, False)
     await common.async_set_temperature(hass, 30)
@@ -501,9 +513,8 @@ async def test_temp_change_heater_on_within_tolerance(
     assert len(calls) == 0
 
 
-async def test_temp_change_heater_on_outside_tolerance(
-    hass: HomeAssistant, setup_comp_2
-) -> None:
+@pytest.mark.usefixtures("setup_comp_2")
+async def test_temp_change_heater_on_outside_tolerance(hass: HomeAssistant) -> None:
     """Test if temperature change turn heater on outside cold tolerance."""
     calls = _setup_switch(hass, False)
     await common.async_set_temperature(hass, 30)
@@ -516,9 +527,8 @@ async def test_temp_change_heater_on_outside_tolerance(
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_temp_change_heater_off_within_tolerance(
-    hass: HomeAssistant, setup_comp_2
-) -> None:
+@pytest.mark.usefixtures("setup_comp_2")
+async def test_temp_change_heater_off_within_tolerance(hass: HomeAssistant) -> None:
     """Test if temperature change doesn't turn off within tolerance."""
     calls = _setup_switch(hass, True)
     await common.async_set_temperature(hass, 30)
@@ -527,9 +537,8 @@ async def test_temp_change_heater_off_within_tolerance(
     assert len(calls) == 0
 
 
-async def test_temp_change_heater_off_outside_tolerance(
-    hass: HomeAssistant, setup_comp_2
-) -> None:
+@pytest.mark.usefixtures("setup_comp_2")
+async def test_temp_change_heater_off_outside_tolerance(hass: HomeAssistant) -> None:
     """Test if temperature change turn heater off outside hot tolerance."""
     calls = _setup_switch(hass, True)
     await common.async_set_temperature(hass, 30)
@@ -542,7 +551,8 @@ async def test_temp_change_heater_off_outside_tolerance(
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_running_when_hvac_mode_is_off(hass: HomeAssistant, setup_comp_2) -> None:
+@pytest.mark.usefixtures("setup_comp_2")
+async def test_running_when_hvac_mode_is_off(hass: HomeAssistant) -> None:
     """Test that the switch turns off when enabled is set False."""
     calls = _setup_switch(hass, True)
     await common.async_set_temperature(hass, 30)
@@ -554,9 +564,8 @@ async def test_running_when_hvac_mode_is_off(hass: HomeAssistant, setup_comp_2) 
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_no_state_change_when_hvac_mode_off(
-    hass: HomeAssistant, setup_comp_2
-) -> None:
+@pytest.mark.usefixtures("setup_comp_2")
+async def test_no_state_change_when_hvac_mode_off(hass: HomeAssistant) -> None:
     """Test that the switch doesn't turn on when enabled is False."""
     calls = _setup_switch(hass, False)
     await common.async_set_temperature(hass, 30)
@@ -566,7 +575,8 @@ async def test_no_state_change_when_hvac_mode_off(
     assert len(calls) == 0
 
 
-async def test_hvac_mode_heat(hass: HomeAssistant, setup_comp_2) -> None:
+@pytest.mark.usefixtures("setup_comp_2")
+async def test_hvac_mode_heat(hass: HomeAssistant) -> None:
     """Test change mode from OFF to HEAT.
 
     Switch turns on when temp below setpoint and mode changes.
@@ -601,7 +611,7 @@ def _setup_switch(hass, is_on):
 
 
 @pytest.fixture
-async def setup_comp_3(hass):
+async def setup_comp_3(hass: HomeAssistant) -> None:
     """Initialize components."""
     hass.config.temperature_unit = UnitOfTemperature.CELSIUS
     assert await async_setup_component(
@@ -624,7 +634,8 @@ async def setup_comp_3(hass):
     await hass.async_block_till_done()
 
 
-async def test_set_target_temp_ac_off(hass: HomeAssistant, setup_comp_3) -> None:
+@pytest.mark.usefixtures("setup_comp_3")
+async def test_set_target_temp_ac_off(hass: HomeAssistant) -> None:
     """Test if target temperature turn ac off."""
     calls = _setup_switch(hass, True)
     _setup_sensor(hass, 25)
@@ -637,7 +648,8 @@ async def test_set_target_temp_ac_off(hass: HomeAssistant, setup_comp_3) -> None
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_turn_away_mode_on_cooling(hass: HomeAssistant, setup_comp_3) -> None:
+@pytest.mark.usefixtures("setup_comp_3")
+async def test_turn_away_mode_on_cooling(hass: HomeAssistant) -> None:
     """Test the setting away mode when cooling."""
     _setup_switch(hass, True)
     _setup_sensor(hass, 25)
@@ -648,7 +660,8 @@ async def test_turn_away_mode_on_cooling(hass: HomeAssistant, setup_comp_3) -> N
     assert state.attributes.get("temperature") == 30
 
 
-async def test_hvac_mode_cool(hass: HomeAssistant, setup_comp_3) -> None:
+@pytest.mark.usefixtures("setup_comp_3")
+async def test_hvac_mode_cool(hass: HomeAssistant) -> None:
     """Test change mode from OFF to COOL.
 
     Switch turns on when temp below setpoint and mode changes.
@@ -666,7 +679,8 @@ async def test_hvac_mode_cool(hass: HomeAssistant, setup_comp_3) -> None:
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_set_target_temp_ac_on(hass: HomeAssistant, setup_comp_3) -> None:
+@pytest.mark.usefixtures("setup_comp_3")
+async def test_set_target_temp_ac_on(hass: HomeAssistant) -> None:
     """Test if target temperature turn ac on."""
     calls = _setup_switch(hass, False)
     _setup_sensor(hass, 30)
@@ -679,9 +693,8 @@ async def test_set_target_temp_ac_on(hass: HomeAssistant, setup_comp_3) -> None:
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_temp_change_ac_off_within_tolerance(
-    hass: HomeAssistant, setup_comp_3
-) -> None:
+@pytest.mark.usefixtures("setup_comp_3")
+async def test_temp_change_ac_off_within_tolerance(hass: HomeAssistant) -> None:
     """Test if temperature change doesn't turn ac off within tolerance."""
     calls = _setup_switch(hass, True)
     await common.async_set_temperature(hass, 30)
@@ -690,9 +703,8 @@ async def test_temp_change_ac_off_within_tolerance(
     assert len(calls) == 0
 
 
-async def test_set_temp_change_ac_off_outside_tolerance(
-    hass: HomeAssistant, setup_comp_3
-) -> None:
+@pytest.mark.usefixtures("setup_comp_3")
+async def test_set_temp_change_ac_off_outside_tolerance(hass: HomeAssistant) -> None:
     """Test if temperature change turn ac off."""
     calls = _setup_switch(hass, True)
     await common.async_set_temperature(hass, 30)
@@ -705,9 +717,8 @@ async def test_set_temp_change_ac_off_outside_tolerance(
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_temp_change_ac_on_within_tolerance(
-    hass: HomeAssistant, setup_comp_3
-) -> None:
+@pytest.mark.usefixtures("setup_comp_3")
+async def test_temp_change_ac_on_within_tolerance(hass: HomeAssistant) -> None:
     """Test if temperature change doesn't turn ac on within tolerance."""
     calls = _setup_switch(hass, False)
     await common.async_set_temperature(hass, 25)
@@ -716,9 +727,8 @@ async def test_temp_change_ac_on_within_tolerance(
     assert len(calls) == 0
 
 
-async def test_temp_change_ac_on_outside_tolerance(
-    hass: HomeAssistant, setup_comp_3
-) -> None:
+@pytest.mark.usefixtures("setup_comp_3")
+async def test_temp_change_ac_on_outside_tolerance(hass: HomeAssistant) -> None:
     """Test if temperature change turn ac on."""
     calls = _setup_switch(hass, False)
     await common.async_set_temperature(hass, 25)
@@ -731,9 +741,8 @@ async def test_temp_change_ac_on_outside_tolerance(
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_running_when_operating_mode_is_off_2(
-    hass: HomeAssistant, setup_comp_3
-) -> None:
+@pytest.mark.usefixtures("setup_comp_3")
+async def test_running_when_operating_mode_is_off_2(hass: HomeAssistant) -> None:
     """Test that the switch turns off when enabled is set False."""
     calls = _setup_switch(hass, True)
     await common.async_set_temperature(hass, 30)
@@ -745,9 +754,8 @@ async def test_running_when_operating_mode_is_off_2(
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_no_state_change_when_operation_mode_off_2(
-    hass: HomeAssistant, setup_comp_3
-) -> None:
+@pytest.mark.usefixtures("setup_comp_3")
+async def test_no_state_change_when_operation_mode_off_2(hass: HomeAssistant) -> None:
     """Test that the switch doesn't turn on when enabled is False."""
     calls = _setup_switch(hass, False)
     await common.async_set_temperature(hass, 30)
@@ -912,7 +920,7 @@ async def test_hvac_mode_change_toggles_heating_cooling_switch_even_when_within_
 
 
 @pytest.fixture
-async def setup_comp_7(hass):
+async def setup_comp_7(hass: HomeAssistant) -> None:
     """Initialize components."""
     hass.config.temperature_unit = UnitOfTemperature.CELSIUS
     assert await async_setup_component(
@@ -938,9 +946,8 @@ async def setup_comp_7(hass):
     await hass.async_block_till_done()
 
 
-async def test_temp_change_ac_trigger_on_long_enough_3(
-    hass: HomeAssistant, setup_comp_7
-) -> None:
+@pytest.mark.usefixtures("setup_comp_7")
+async def test_temp_change_ac_trigger_on_long_enough_3(hass: HomeAssistant) -> None:
     """Test if turn on signal is sent at keep-alive intervals."""
     calls = _setup_switch(hass, True)
     await hass.async_block_till_done()
@@ -963,9 +970,8 @@ async def test_temp_change_ac_trigger_on_long_enough_3(
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def test_temp_change_ac_trigger_off_long_enough_3(
-    hass: HomeAssistant, setup_comp_7
-) -> None:
+@pytest.mark.usefixtures("setup_comp_7")
+async def test_temp_change_ac_trigger_off_long_enough_3(hass: HomeAssistant) -> None:
     """Test if turn on signal is sent at keep-alive intervals."""
     calls = _setup_switch(hass, False)
     await hass.async_block_till_done()
@@ -989,7 +995,7 @@ async def test_temp_change_ac_trigger_off_long_enough_3(
 
 
 @pytest.fixture
-async def setup_comp_8(hass):
+async def setup_comp_8(hass: HomeAssistant) -> None:
     """Initialize components."""
     hass.config.temperature_unit = UnitOfTemperature.CELSIUS
     assert await async_setup_component(
@@ -1013,9 +1019,8 @@ async def setup_comp_8(hass):
     await hass.async_block_till_done()
 
 
-async def test_temp_change_heater_trigger_on_long_enough_2(
-    hass: HomeAssistant, setup_comp_8
-) -> None:
+@pytest.mark.usefixtures("setup_comp_8")
+async def test_temp_change_heater_trigger_on_long_enough_2(hass: HomeAssistant) -> None:
     """Test if turn on signal is sent at keep-alive intervals."""
     calls = _setup_switch(hass, True)
     await hass.async_block_till_done()
@@ -1038,8 +1043,9 @@ async def test_temp_change_heater_trigger_on_long_enough_2(
     assert call.data["entity_id"] == ENT_SWITCH
 
 
+@pytest.mark.usefixtures("setup_comp_8")
 async def test_temp_change_heater_trigger_off_long_enough_2(
-    hass: HomeAssistant, setup_comp_8
+    hass: HomeAssistant,
 ) -> None:
     """Test if turn on signal is sent at keep-alive intervals."""
     calls = _setup_switch(hass, False)
@@ -1064,7 +1070,7 @@ async def test_temp_change_heater_trigger_off_long_enough_2(
 
 
 @pytest.fixture
-async def setup_comp_9(hass):
+async def setup_comp_9(hass: HomeAssistant) -> None:
     """Initialize components."""
     assert await async_setup_component(
         hass,
@@ -1087,7 +1093,8 @@ async def setup_comp_9(hass):
     await hass.async_block_till_done()
 
 
-async def test_precision(hass: HomeAssistant, setup_comp_9) -> None:
+@pytest.mark.usefixtures("setup_comp_9")
+async def test_precision(hass: HomeAssistant) -> None:
     """Test that setting precision to tenths works as intended."""
     hass.config.units = US_CUSTOMARY_SYSTEM
     await common.async_set_temperature(hass, 23.27)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
