### PR TITLE
Improve type hints in google_travel_time tests

### DIFF
--- a/tests/components/google_travel_time/conftest.py
+++ b/tests/components/google_travel_time/conftest.py
@@ -1,17 +1,22 @@
 """Fixtures for Google Time Travel tests."""
 
-from unittest.mock import patch
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 from googlemaps.exceptions import ApiError, Timeout, TransportError
 import pytest
 
 from homeassistant.components.google_travel_time.const import DOMAIN
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 
 @pytest.fixture(name="mock_config")
-async def mock_config_fixture(hass, data, options):
+async def mock_config_fixture(
+    hass: HomeAssistant, data: dict[str, Any], options: dict[str, Any]
+) -> MockConfigEntry:
     """Mock a Google Travel Time config entry."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -26,7 +31,7 @@ async def mock_config_fixture(hass, data, options):
 
 
 @pytest.fixture(name="bypass_setup")
-def bypass_setup_fixture():
+def bypass_setup_fixture() -> Generator[None]:
     """Bypass entry setup."""
     with patch(
         "homeassistant.components.google_travel_time.async_setup_entry",
@@ -36,7 +41,7 @@ def bypass_setup_fixture():
 
 
 @pytest.fixture(name="bypass_platform_setup")
-def bypass_platform_setup_fixture():
+def bypass_platform_setup_fixture() -> Generator[None]:
     """Bypass platform setup."""
     with patch(
         "homeassistant.components.google_travel_time.sensor.async_setup_entry",
@@ -46,7 +51,7 @@ def bypass_platform_setup_fixture():
 
 
 @pytest.fixture(name="validate_config_entry")
-def validate_config_entry_fixture():
+def validate_config_entry_fixture() -> Generator[MagicMock]:
     """Return valid config entry."""
     with (
         patch("homeassistant.components.google_travel_time.helpers.Client"),
@@ -59,24 +64,24 @@ def validate_config_entry_fixture():
 
 
 @pytest.fixture(name="invalidate_config_entry")
-def invalidate_config_entry_fixture(validate_config_entry):
+def invalidate_config_entry_fixture(validate_config_entry: MagicMock) -> None:
     """Return invalid config entry."""
     validate_config_entry.side_effect = ApiError("test")
 
 
 @pytest.fixture(name="invalid_api_key")
-def invalid_api_key_fixture(validate_config_entry):
+def invalid_api_key_fixture(validate_config_entry: MagicMock) -> None:
     """Throw a REQUEST_DENIED ApiError."""
     validate_config_entry.side_effect = ApiError("REQUEST_DENIED", "Invalid API key.")
 
 
 @pytest.fixture(name="timeout")
-def timeout_fixture(validate_config_entry):
+def timeout_fixture(validate_config_entry: MagicMock) -> None:
     """Throw a Timeout exception."""
     validate_config_entry.side_effect = Timeout()
 
 
 @pytest.fixture(name="transport_error")
-def transport_error_fixture(validate_config_entry):
+def transport_error_fixture(validate_config_entry: MagicMock) -> None:
     """Throw a TransportError exception."""
     validate_config_entry.side_effect = TransportError("Unknown.")

--- a/tests/components/google_travel_time/test_config_flow.py
+++ b/tests/components/google_travel_time/test_config_flow.py
@@ -29,6 +29,8 @@ from homeassistant.data_entry_flow import FlowResultType
 
 from .const import MOCK_CONFIG, RECONFIGURE_CONFIG
 
+from tests.common import MockConfigEntry
+
 
 async def assert_common_reconfigure_steps(
     hass: HomeAssistant, reconfigure_result: config_entries.ConfigFlowResult
@@ -194,7 +196,7 @@ async def test_malformed_api_key(hass: HomeAssistant) -> None:
     ],
 )
 @pytest.mark.usefixtures("validate_config_entry", "bypass_setup")
-async def test_reconfigure(hass: HomeAssistant, mock_config) -> None:
+async def test_reconfigure(hass: HomeAssistant, mock_config: MockConfigEntry) -> None:
     """Test reconfigure flow."""
     reconfigure_result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -223,7 +225,7 @@ async def test_reconfigure(hass: HomeAssistant, mock_config) -> None:
 )
 @pytest.mark.usefixtures("invalidate_config_entry")
 async def test_reconfigure_invalid_config_entry(
-    hass: HomeAssistant, mock_config
+    hass: HomeAssistant, mock_config: MockConfigEntry
 ) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
@@ -259,7 +261,9 @@ async def test_reconfigure_invalid_config_entry(
     ],
 )
 @pytest.mark.usefixtures("invalid_api_key")
-async def test_reconfigure_invalid_api_key(hass: HomeAssistant, mock_config) -> None:
+async def test_reconfigure_invalid_api_key(
+    hass: HomeAssistant, mock_config: MockConfigEntry
+) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -293,7 +297,9 @@ async def test_reconfigure_invalid_api_key(hass: HomeAssistant, mock_config) -> 
     ],
 )
 @pytest.mark.usefixtures("transport_error")
-async def test_reconfigure_transport_error(hass: HomeAssistant, mock_config) -> None:
+async def test_reconfigure_transport_error(
+    hass: HomeAssistant, mock_config: MockConfigEntry
+) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -327,7 +333,9 @@ async def test_reconfigure_transport_error(hass: HomeAssistant, mock_config) -> 
     ],
 )
 @pytest.mark.usefixtures("timeout")
-async def test_reconfigure_timeout(hass: HomeAssistant, mock_config) -> None:
+async def test_reconfigure_timeout(
+    hass: HomeAssistant, mock_config: MockConfigEntry
+) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -361,7 +369,7 @@ async def test_reconfigure_timeout(hass: HomeAssistant, mock_config) -> None:
     ],
 )
 @pytest.mark.usefixtures("validate_config_entry")
-async def test_options_flow(hass: HomeAssistant, mock_config) -> None:
+async def test_options_flow(hass: HomeAssistant, mock_config: MockConfigEntry) -> None:
     """Test options flow."""
     result = await hass.config_entries.options.async_init(
         mock_config.entry_id, data=None
@@ -422,7 +430,9 @@ async def test_options_flow(hass: HomeAssistant, mock_config) -> None:
     ],
 )
 @pytest.mark.usefixtures("validate_config_entry")
-async def test_options_flow_departure_time(hass: HomeAssistant, mock_config) -> None:
+async def test_options_flow_departure_time(
+    hass: HomeAssistant, mock_config: MockConfigEntry
+) -> None:
     """Test options flow with departure time."""
     result = await hass.config_entries.options.async_init(
         mock_config.entry_id, data=None
@@ -492,7 +502,9 @@ async def test_options_flow_departure_time(hass: HomeAssistant, mock_config) -> 
     ],
 )
 @pytest.mark.usefixtures("validate_config_entry")
-async def test_reset_departure_time(hass: HomeAssistant, mock_config) -> None:
+async def test_reset_departure_time(
+    hass: HomeAssistant, mock_config: MockConfigEntry
+) -> None:
     """Test resetting departure time."""
     result = await hass.config_entries.options.async_init(
         mock_config.entry_id, data=None
@@ -538,7 +550,9 @@ async def test_reset_departure_time(hass: HomeAssistant, mock_config) -> None:
     ],
 )
 @pytest.mark.usefixtures("validate_config_entry")
-async def test_reset_arrival_time(hass: HomeAssistant, mock_config) -> None:
+async def test_reset_arrival_time(
+    hass: HomeAssistant, mock_config: MockConfigEntry
+) -> None:
     """Test resetting arrival time."""
     result = await hass.config_entries.options.async_init(
         mock_config.entry_id, data=None
@@ -582,7 +596,9 @@ async def test_reset_arrival_time(hass: HomeAssistant, mock_config) -> None:
     ],
 )
 @pytest.mark.usefixtures("validate_config_entry")
-async def test_reset_options_flow_fields(hass: HomeAssistant, mock_config) -> None:
+async def test_reset_options_flow_fields(
+    hass: HomeAssistant, mock_config: MockConfigEntry
+) -> None:
     """Test resetting options flow fields that are not time related to None."""
     result = await hass.config_entries.options.async_init(
         mock_config.entry_id, data=None

--- a/tests/components/google_travel_time/test_sensor.py
+++ b/tests/components/google_travel_time/test_sensor.py
@@ -1,6 +1,7 @@
 """Test the Google Maps Travel Time sensors."""
 
-from unittest.mock import patch
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -25,7 +26,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture(name="mock_update")
-def mock_update_fixture():
+def mock_update_fixture() -> Generator[MagicMock]:
     """Mock an update to the sensor."""
     with (
         patch("homeassistant.components.google_travel_time.sensor.Client"),
@@ -56,7 +57,7 @@ def mock_update_fixture():
 
 
 @pytest.fixture(name="mock_update_duration")
-def mock_update_duration_fixture(mock_update):
+def mock_update_duration_fixture(mock_update: MagicMock) -> MagicMock:
     """Mock an update to the sensor returning no duration_in_traffic."""
     mock_update.return_value = {
         "rows": [
@@ -77,7 +78,7 @@ def mock_update_duration_fixture(mock_update):
 
 
 @pytest.fixture(name="mock_update_empty")
-def mock_update_empty_fixture(mock_update):
+def mock_update_empty_fixture(mock_update: MagicMock) -> MagicMock:
     """Mock an update to the sensor with an empty response."""
     mock_update.return_value = None
     return mock_update


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
