### PR TITLE
Improve type hints in group tests

### DIFF
--- a/tests/components/group/test_cover.py
+++ b/tests/components/group/test_cover.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from datetime import timedelta
+from typing import Any
 
 import pytest
 
@@ -90,7 +91,9 @@ CONFIG_ATTRIBUTES = {
 
 
 @pytest.fixture
-async def setup_comp(hass, config_count):
+async def setup_comp(
+    hass: HomeAssistant, config_count: tuple[dict[str, Any], int]
+) -> None:
     """Set up group cover component."""
     config, count = config_count
     with assert_setup_component(count, DOMAIN):
@@ -101,7 +104,8 @@ async def setup_comp(hass, config_count):
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ATTRIBUTES, 1)])
-async def test_state(hass: HomeAssistant, setup_comp) -> None:
+@pytest.mark.usefixtures("setup_comp")
+async def test_state(hass: HomeAssistant) -> None:
     """Test handling of state.
 
     The group state is unknown if all group members are unknown or unavailable.
@@ -250,8 +254,9 @@ async def test_state(hass: HomeAssistant, setup_comp) -> None:
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ATTRIBUTES, 1)])
+@pytest.mark.usefixtures("setup_comp")
 async def test_attributes(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, setup_comp
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test handling of state attributes."""
     state = hass.states.get(COVER_GROUP)
@@ -416,9 +421,8 @@ async def test_attributes(
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_TILT_ONLY, 2)])
-async def test_cover_that_only_supports_tilt_removed(
-    hass: HomeAssistant, setup_comp
-) -> None:
+@pytest.mark.usefixtures("setup_comp")
+async def test_cover_that_only_supports_tilt_removed(hass: HomeAssistant) -> None:
     """Test removing a cover that support tilt."""
     hass.states.async_set(
         DEMO_COVER_TILT,
@@ -446,7 +450,8 @@ async def test_cover_that_only_supports_tilt_removed(
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
-async def test_open_covers(hass: HomeAssistant, setup_comp) -> None:
+@pytest.mark.usefixtures("setup_comp")
+async def test_open_covers(hass: HomeAssistant) -> None:
     """Test open cover function."""
     await hass.services.async_call(
         DOMAIN, SERVICE_OPEN_COVER, {ATTR_ENTITY_ID: COVER_GROUP}, blocking=True
@@ -467,7 +472,8 @@ async def test_open_covers(hass: HomeAssistant, setup_comp) -> None:
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
-async def test_close_covers(hass: HomeAssistant, setup_comp) -> None:
+@pytest.mark.usefixtures("setup_comp")
+async def test_close_covers(hass: HomeAssistant) -> None:
     """Test close cover function."""
     await hass.services.async_call(
         DOMAIN, SERVICE_CLOSE_COVER, {ATTR_ENTITY_ID: COVER_GROUP}, blocking=True
@@ -488,7 +494,8 @@ async def test_close_covers(hass: HomeAssistant, setup_comp) -> None:
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
-async def test_toggle_covers(hass: HomeAssistant, setup_comp) -> None:
+@pytest.mark.usefixtures("setup_comp")
+async def test_toggle_covers(hass: HomeAssistant) -> None:
     """Test toggle cover function."""
     # Start covers in open state
     await hass.services.async_call(
@@ -538,7 +545,8 @@ async def test_toggle_covers(hass: HomeAssistant, setup_comp) -> None:
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
-async def test_stop_covers(hass: HomeAssistant, setup_comp) -> None:
+@pytest.mark.usefixtures("setup_comp")
+async def test_stop_covers(hass: HomeAssistant) -> None:
     """Test stop cover function."""
     await hass.services.async_call(
         DOMAIN, SERVICE_OPEN_COVER, {ATTR_ENTITY_ID: COVER_GROUP}, blocking=True
@@ -564,7 +572,8 @@ async def test_stop_covers(hass: HomeAssistant, setup_comp) -> None:
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
-async def test_set_cover_position(hass: HomeAssistant, setup_comp) -> None:
+@pytest.mark.usefixtures("setup_comp")
+async def test_set_cover_position(hass: HomeAssistant) -> None:
     """Test set cover position function."""
     await hass.services.async_call(
         DOMAIN,
@@ -587,7 +596,8 @@ async def test_set_cover_position(hass: HomeAssistant, setup_comp) -> None:
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
-async def test_open_tilts(hass: HomeAssistant, setup_comp) -> None:
+@pytest.mark.usefixtures("setup_comp")
+async def test_open_tilts(hass: HomeAssistant) -> None:
     """Test open tilt function."""
     await hass.services.async_call(
         DOMAIN, SERVICE_OPEN_COVER_TILT, {ATTR_ENTITY_ID: COVER_GROUP}, blocking=True
@@ -607,7 +617,8 @@ async def test_open_tilts(hass: HomeAssistant, setup_comp) -> None:
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
-async def test_close_tilts(hass: HomeAssistant, setup_comp) -> None:
+@pytest.mark.usefixtures("setup_comp")
+async def test_close_tilts(hass: HomeAssistant) -> None:
     """Test close tilt function."""
     await hass.services.async_call(
         DOMAIN, SERVICE_CLOSE_COVER_TILT, {ATTR_ENTITY_ID: COVER_GROUP}, blocking=True
@@ -625,7 +636,8 @@ async def test_close_tilts(hass: HomeAssistant, setup_comp) -> None:
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
-async def test_toggle_tilts(hass: HomeAssistant, setup_comp) -> None:
+@pytest.mark.usefixtures("setup_comp")
+async def test_toggle_tilts(hass: HomeAssistant) -> None:
     """Test toggle tilt function."""
     # Start tilted open
     await hass.services.async_call(
@@ -678,7 +690,8 @@ async def test_toggle_tilts(hass: HomeAssistant, setup_comp) -> None:
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
-async def test_stop_tilts(hass: HomeAssistant, setup_comp) -> None:
+@pytest.mark.usefixtures("setup_comp")
+async def test_stop_tilts(hass: HomeAssistant) -> None:
     """Test stop tilts function."""
     await hass.services.async_call(
         DOMAIN, SERVICE_OPEN_COVER_TILT, {ATTR_ENTITY_ID: COVER_GROUP}, blocking=True
@@ -702,7 +715,8 @@ async def test_stop_tilts(hass: HomeAssistant, setup_comp) -> None:
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ALL, 2)])
-async def test_set_tilt_positions(hass: HomeAssistant, setup_comp) -> None:
+@pytest.mark.usefixtures("setup_comp")
+async def test_set_tilt_positions(hass: HomeAssistant) -> None:
     """Test set tilt position function."""
     await hass.services.async_call(
         DOMAIN,
@@ -723,7 +737,8 @@ async def test_set_tilt_positions(hass: HomeAssistant, setup_comp) -> None:
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_POS, 2)])
-async def test_is_opening_closing(hass: HomeAssistant, setup_comp) -> None:
+@pytest.mark.usefixtures("setup_comp")
+async def test_is_opening_closing(hass: HomeAssistant) -> None:
     """Test is_opening property."""
     await hass.services.async_call(
         DOMAIN, SERVICE_OPEN_COVER, {ATTR_ENTITY_ID: COVER_GROUP}, blocking=True

--- a/tests/components/group/test_fan.py
+++ b/tests/components/group/test_fan.py
@@ -1,6 +1,7 @@
 """The tests for the group fan platform."""
 
 import asyncio
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -102,7 +103,9 @@ CONFIG_ATTRIBUTES = {
 
 
 @pytest.fixture
-async def setup_comp(hass, config_count):
+async def setup_comp(
+    hass: HomeAssistant, config_count: tuple[dict[str, Any], int]
+) -> None:
     """Set up group fan component."""
     config, count = config_count
     with assert_setup_component(count, DOMAIN):
@@ -113,9 +116,8 @@ async def setup_comp(hass, config_count):
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ATTRIBUTES, 1)])
-async def test_state(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, setup_comp
-) -> None:
+@pytest.mark.usefixtures("setup_comp")
+async def test_state(hass: HomeAssistant, entity_registry: er.EntityRegistry) -> None:
     """Test handling of state.
 
     The group state is on if at least one group member is on.
@@ -210,7 +212,8 @@ async def test_state(
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_ATTRIBUTES, 1)])
-async def test_attributes(hass: HomeAssistant, setup_comp) -> None:
+@pytest.mark.usefixtures("setup_comp")
+async def test_attributes(hass: HomeAssistant) -> None:
     """Test handling of state attributes."""
     state = hass.states.get(FAN_GROUP)
     assert state.state == STATE_UNAVAILABLE
@@ -267,7 +270,8 @@ async def test_attributes(hass: HomeAssistant, setup_comp) -> None:
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_FULL_SUPPORT, 2)])
-async def test_direction_oscillating(hass: HomeAssistant, setup_comp) -> None:
+@pytest.mark.usefixtures("setup_comp")
+async def test_direction_oscillating(hass: HomeAssistant) -> None:
     """Test handling of direction and oscillating attributes."""
 
     hass.states.async_set(
@@ -378,7 +382,8 @@ async def test_direction_oscillating(hass: HomeAssistant, setup_comp) -> None:
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_MISSING_FAN, 2)])
-async def test_state_missing_entity_id(hass: HomeAssistant, setup_comp) -> None:
+@pytest.mark.usefixtures("setup_comp")
+async def test_state_missing_entity_id(hass: HomeAssistant) -> None:
     """Test we can still setup with a missing entity id."""
     state = hass.states.get(FAN_GROUP)
     await hass.async_block_till_done()
@@ -398,7 +403,8 @@ async def test_setup_before_started(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_MISSING_FAN, 2)])
-async def test_reload(hass: HomeAssistant, setup_comp) -> None:
+@pytest.mark.usefixtures("setup_comp")
+async def test_reload(hass: HomeAssistant) -> None:
     """Test the ability to reload fans."""
     await hass.async_block_till_done()
     await hass.async_start()
@@ -421,7 +427,8 @@ async def test_reload(hass: HomeAssistant, setup_comp) -> None:
 
 
 @pytest.mark.parametrize("config_count", [(CONFIG_FULL_SUPPORT, 2)])
-async def test_service_calls(hass: HomeAssistant, setup_comp) -> None:
+@pytest.mark.usefixtures("setup_comp")
+async def test_service_calls(hass: HomeAssistant) -> None:
     """Test calling services."""
     await hass.services.async_call(
         DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: FAN_GROUP}, blocking=True


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
