### PR TITLE
Use fixtures in deCONZ light tests PT2

### DIFF
--- a/tests/components/deconz/conftest.py
+++ b/tests/components/deconz/conftest.py
@@ -162,6 +162,14 @@ def fixture_group_data() -> dict[str, Any]:
 
 
 @pytest.fixture(name="light_payload")
+def fixture_light_0_data(light_0_payload: dict[str, Any]) -> dict[str, Any]:
+    """Light data."""
+    if light_0_payload:
+        return {"0": light_0_payload}
+    return {}
+
+
+@pytest.fixture(name="light_0_payload")
 def fixture_light_data() -> dict[str, Any]:
     """Light data."""
     return {}

--- a/tests/components/deconz/test_light.py
+++ b/tests/components/deconz/test_light.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Callable
 from typing import Any
-from unittest.mock import patch
 
 import pytest
 
@@ -41,25 +40,11 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from .test_gateway import (
-    DECONZ_WEB_REQUEST,
-    mock_deconz_put_request,
-    setup_deconz_integration,
-)
-
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_no_lights_or_groups(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
-) -> None:
-    """Test that no lights or groups entities are created."""
-    await setup_deconz_integration(hass, aioclient_mock)
-    assert len(hass.states.async_all()) == 0
-
-
 @pytest.mark.parametrize(
-    ("input", "expected"),
+    ("light_0_payload", "expected"),
     [
         (  # RGB light in color temp color mode
             {
@@ -426,13 +411,11 @@ async def test_no_lights_or_groups(
     ],
 )
 async def test_lights(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, input, expected
+    hass: HomeAssistant,
+    config_entry_setup: ConfigEntry,
+    expected: dict[str, Any],
 ) -> None:
     """Test that different light entities are created with expected values."""
-    data = {"lights": {"0": input}}
-    with patch.dict(DECONZ_WEB_REQUEST, data):
-        config_entry = await setup_deconz_integration(hass, aioclient_mock)
-
     assert len(hass.states.async_all()) == 1
 
     light = hass.states.get(expected["entity_id"])
@@ -440,23 +423,21 @@ async def test_lights(
     for attribute, expected_value in expected["attributes"].items():
         assert light.attributes[attribute] == expected_value
 
-    await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.config_entries.async_unload(config_entry_setup.entry_id)
 
     states = hass.states.async_all()
     for state in states:
         assert state.state == STATE_UNAVAILABLE
 
-    await hass.config_entries.async_remove(config_entry.entry_id)
+    await hass.config_entries.async_remove(config_entry_setup.entry_id)
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 0
 
 
-async def test_light_state_change(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
-) -> None:
-    """Verify light can change state on websocket event."""
-    data = {
-        "lights": {
+@pytest.mark.parametrize(
+    "light_payload",
+    [
+        {
             "0": {
                 "colorcapabilities": 31,
                 "ctmax": 500,
@@ -485,10 +466,11 @@ async def test_light_state_change(
                 "uniqueid": "00:17:88:01:01:23:45:67-00",
             }
         }
-    }
-    with patch.dict(DECONZ_WEB_REQUEST, data):
-        await setup_deconz_integration(hass, aioclient_mock)
-
+    ],
+)
+@pytest.mark.usefixtures("config_entry_setup")
+async def test_light_state_change(hass: HomeAssistant, mock_deconz_websocket) -> None:
+    """Verify light can change state on websocket event."""
     assert hass.states.get("light.hue_go").state == STATE_ON
 
     event_changed_light = {
@@ -642,44 +624,47 @@ async def test_light_state_change(
     ],
 )
 async def test_light_service_calls(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, input, expected
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    config_entry_factory: Callable[[], ConfigEntry],
+    light_payload: dict[str, Any],
+    mock_put_request: Callable[[str, str], AiohttpClientMocker],
+    input: dict[str, Any],
+    expected: dict[str, Any],
 ) -> None:
     """Verify light can change state on websocket event."""
-    data = {
-        "lights": {
-            "0": {
-                "colorcapabilities": 31,
-                "ctmax": 500,
-                "ctmin": 153,
-                "etag": "055485a82553e654f156d41c9301b7cf",
-                "hascolor": True,
-                "lastannounced": None,
-                "lastseen": "2021-06-10T20:25Z",
-                "manufacturername": "Philips",
-                "modelid": "LLC020",
-                "name": "Hue Go",
-                "state": {
-                    "alert": "none",
-                    "bri": 254,
-                    "colormode": "ct",
-                    "ct": 375,
-                    "effect": "none",
-                    "hue": 8348,
-                    "on": input["light_on"],
-                    "reachable": True,
-                    "sat": 147,
-                    "xy": [0.462, 0.4111],
-                },
-                "swversion": "5.127.1.26420",
-                "type": "Extended color light",
-                "uniqueid": "00:17:88:01:01:23:45:67-00",
-            }
+    light_payload |= {
+        "0": {
+            "colorcapabilities": 31,
+            "ctmax": 500,
+            "ctmin": 153,
+            "etag": "055485a82553e654f156d41c9301b7cf",
+            "hascolor": True,
+            "lastannounced": None,
+            "lastseen": "2021-06-10T20:25Z",
+            "manufacturername": "Philips",
+            "modelid": "LLC020",
+            "name": "Hue Go",
+            "state": {
+                "alert": "none",
+                "bri": 254,
+                "colormode": "ct",
+                "ct": 375,
+                "effect": "none",
+                "hue": 8348,
+                "on": input["light_on"],
+                "reachable": True,
+                "sat": 147,
+                "xy": [0.462, 0.4111],
+            },
+            "swversion": "5.127.1.26420",
+            "type": "Extended color light",
+            "uniqueid": "00:17:88:01:01:23:45:67-00",
         }
     }
-    with patch.dict(DECONZ_WEB_REQUEST, data):
-        config_entry = await setup_deconz_integration(hass, aioclient_mock)
+    await config_entry_factory()
 
-    mock_deconz_put_request(aioclient_mock, config_entry.data, "/lights/0/state")
+    aioclient_mock = mock_put_request("/lights/0/state")
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -693,12 +678,10 @@ async def test_light_service_calls(
         assert len(aioclient_mock.mock_calls) == 1  # not called
 
 
-async def test_ikea_default_transition_time(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
-) -> None:
-    """Verify that service calls to IKEA lights always extend with transition tinme 0 if absent."""
-    data = {
-        "lights": {
+@pytest.mark.parametrize(
+    "light_payload",
+    [
+        {
             "0": {
                 "colorcapabilities": 0,
                 "ctmax": 65535,
@@ -721,13 +704,17 @@ async def test_ikea_default_transition_time(
                 "swversion": "2.0.022",
                 "type": "Color temperature light",
                 "uniqueid": "ec:1b:bd:ff:fe:ee:ed:dd-01",
-            },
-        },
-    }
-    with patch.dict(DECONZ_WEB_REQUEST, data):
-        config_entry = await setup_deconz_integration(hass, aioclient_mock)
-
-    mock_deconz_put_request(aioclient_mock, config_entry.data, "/lights/0/state")
+            }
+        }
+    ],
+)
+@pytest.mark.usefixtures("config_entry_setup")
+async def test_ikea_default_transition_time(
+    hass: HomeAssistant,
+    mock_put_request: Callable[[str, str], AiohttpClientMocker],
+) -> None:
+    """Verify that service calls to IKEA lights always extend with transition tinme 0 if absent."""
+    aioclient_mock = mock_put_request("/lights/0/state")
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -761,12 +748,10 @@ async def test_ikea_default_transition_time(
     }
 
 
-async def test_lidl_christmas_light(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
-) -> None:
-    """Test that lights or groups entities are created."""
-    data = {
-        "lights": {
+@pytest.mark.parametrize(
+    "light_payload",
+    [
+        {
             "0": {
                 "etag": "87a89542bf9b9d0aa8134919056844f8",
                 "hascolor": True,
@@ -789,12 +774,15 @@ async def test_lidl_christmas_light(
                 "uniqueid": "58:8e:81:ff:fe:db:7b:be-01",
             }
         }
-    }
-
-    with patch.dict(DECONZ_WEB_REQUEST, data):
-        config_entry = await setup_deconz_integration(hass, aioclient_mock)
-
-    mock_deconz_put_request(aioclient_mock, config_entry.data, "/lights/0/state")
+    ],
+)
+@pytest.mark.usefixtures("config_entry_setup")
+async def test_lidl_christmas_light(
+    hass: HomeAssistant,
+    mock_put_request: Callable[[str, str], AiohttpClientMocker],
+) -> None:
+    """Test that lights or groups entities are created."""
+    aioclient_mock = mock_put_request("/lights/0/state")
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -806,16 +794,13 @@ async def test_lidl_christmas_light(
         blocking=True,
     )
     assert aioclient_mock.mock_calls[1][2] == {"on": True, "hue": 3640, "sat": 76}
-
     assert hass.states.get("light.lidl_xmas_light")
 
 
-async def test_configuration_tool(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
-) -> None:
-    """Verify that configuration tool is not created."""
-    data = {
-        "lights": {
+@pytest.mark.parametrize(
+    "light_payload",
+    [
+        {
             "0": {
                 "etag": "26839cb118f5bf7ba1f2108256644010",
                 "hascolor": False,
@@ -830,13 +815,53 @@ async def test_configuration_tool(
                 "uniqueid": "00:21:2e:ff:ff:05:a7:a3-01",
             }
         }
-    }
-    with patch.dict(DECONZ_WEB_REQUEST, data):
-        await setup_deconz_integration(hass, aioclient_mock)
-
+    ],
+)
+@pytest.mark.usefixtures("config_entry_setup")
+async def test_configuration_tool(hass: HomeAssistant) -> None:
+    """Verify that configuration tool is not created."""
     assert len(hass.states.async_all()) == 0
 
 
+@pytest.mark.parametrize(
+    "light_payload",
+    [
+        {
+            "1": {
+                "name": "RGB light",
+                "state": {
+                    "on": True,
+                    "bri": 50,
+                    "colormode": "xy",
+                    "effect": "colorloop",
+                    "xy": (0.5, 0.5),
+                    "reachable": True,
+                },
+                "type": "Extended color light",
+                "uniqueid": "00:00:00:00:00:00:00:00-00",
+            },
+            "2": {
+                "ctmax": 454,
+                "ctmin": 155,
+                "name": "Tunable white light",
+                "state": {
+                    "on": True,
+                    "colormode": "ct",
+                    "ct": 2500,
+                    "reachable": True,
+                },
+                "type": "Tunable white light",
+                "uniqueid": "00:00:00:00:00:00:00:01-00",
+            },
+            "3": {
+                "name": "Dimmable light",
+                "type": "Dimmable light",
+                "state": {"bri": 255, "on": True, "reachable": True},
+                "uniqueid": "00:00:00:00:00:00:00:02-00",
+            },
+        }
+    ],
+)
 @pytest.mark.parametrize(
     ("input", "expected"),
     [
@@ -908,69 +933,36 @@ async def test_configuration_tool(
     ],
 )
 async def test_groups(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, input, expected
+    hass: HomeAssistant,
+    config_entry_factory: Callable[[], ConfigEntry],
+    group_payload: dict[str, Any],
+    input: dict[str, list[str]],
+    expected: dict[str, Any],
 ) -> None:
     """Test that different group entities are created with expected values."""
-    data = {
-        "groups": {
-            "0": {
-                "id": "Light group id",
-                "name": "Group",
-                "type": "LightGroup",
-                "state": {"all_on": False, "any_on": True},
-                "action": {
-                    "alert": "none",
-                    "bri": 127,
-                    "colormode": "hs",
-                    "ct": 0,
-                    "effect": "none",
-                    "hue": 0,
-                    "on": True,
-                    "sat": 127,
-                    "scene": None,
-                    "xy": [0, 0],
-                },
-                "scenes": [],
-                "lights": input["lights"],
+    group_payload |= {
+        "0": {
+            "id": "Light group id",
+            "name": "Group",
+            "type": "LightGroup",
+            "state": {"all_on": False, "any_on": True},
+            "action": {
+                "alert": "none",
+                "bri": 127,
+                "colormode": "hs",
+                "ct": 0,
+                "effect": "none",
+                "hue": 0,
+                "on": True,
+                "sat": 127,
+                "scene": None,
+                "xy": [0, 0],
             },
-        },
-        "lights": {
-            "1": {
-                "name": "RGB light",
-                "state": {
-                    "on": True,
-                    "bri": 50,
-                    "colormode": "xy",
-                    "effect": "colorloop",
-                    "xy": (0.5, 0.5),
-                    "reachable": True,
-                },
-                "type": "Extended color light",
-                "uniqueid": "00:00:00:00:00:00:00:00-00",
-            },
-            "2": {
-                "ctmax": 454,
-                "ctmin": 155,
-                "name": "Tunable white light",
-                "state": {
-                    "on": True,
-                    "colormode": "ct",
-                    "ct": 2500,
-                    "reachable": True,
-                },
-                "type": "Tunable white light",
-                "uniqueid": "00:00:00:00:00:00:00:01-00",
-            },
-            "3": {
-                "name": "Dimmable light",
-                "type": "Dimmable light",
-                "state": {"bri": 255, "on": True, "reachable": True},
-                "uniqueid": "00:00:00:00:00:00:00:02-00",
-            },
+            "scenes": [],
+            "lights": input["lights"],
         },
     }
-    with patch.dict(DECONZ_WEB_REQUEST, data):
-        config_entry = await setup_deconz_integration(hass, aioclient_mock)
+    config_entry = await config_entry_factory()
 
     assert len(hass.states.async_all()) == 4
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

Related to 
- [ ] https://github.com/home-assistant/core/pull/120863
- [ ] https://github.com/home-assistant/core/pull/120936
- [ ] https://github.com/home-assistant/core/pull/120938
- [ ] https://github.com/home-assistant/core/pull/120943
- [ ] https://github.com/home-assistant/core/pull/120944
- [ ] https://github.com/home-assistant/core/pull/120947 
- [ ] https://github.com/home-assistant/core/pull/120948
- [ ]  https://github.com/home-assistant/core/pull/120953
- [ ]  https://github.com/home-assistant/core/pull/120954
- [ ]  https://github.com/home-assistant/core/pull/120966
- [ ]  https://github.com/home-assistant/core/pull/120967
- [ ]  https://github.com/home-assistant/core/pull/120968
- [ ]  https://github.com/home-assistant/core/pull/121103
- [ ]  https://github.com/home-assistant/core/pull/121108
- [ ]  https://github.com/home-assistant/core/pull/121112
- [ ]  https://github.com/home-assistant/core/pull/121116
- [ ]  https://github.com/home-assistant/core/pull/121121
- [ ]  https://github.com/home-assistant/core/pull/121203
- [ ]  https://github.com/home-assistant/core/pull/121204
- [ ]  https://github.com/home-assistant/core/pull/121208
- [ ]  https://github.com/home-assistant/core/pull/121217
- [ ]  https://github.com/home-assistant/core/pull/121242
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
