### PR TITLE
Add type hints to homekit events fixture

### DIFF
--- a/tests/components/homekit/conftest.py
+++ b/tests/components/homekit/conftest.py
@@ -12,7 +12,7 @@ from homeassistant.components.device_tracker.legacy import YAML_DEVICES
 from homeassistant.components.homekit.accessories import HomeDriver
 from homeassistant.components.homekit.const import BRIDGE_NAME, EVENT_HOMEKIT_CHANGED
 from homeassistant.components.homekit.iidmanager import AccessoryIIDStorage
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, HomeAssistant
 
 from tests.common import async_capture_events
 
@@ -121,7 +121,7 @@ def mock_hap(
 
 
 @pytest.fixture
-def events(hass):
+def events(hass: HomeAssistant) -> list[Event]:
     """Yield caught homekit_changed events."""
     return async_capture_events(hass, EVENT_HOMEKIT_CHANGED)
 

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -47,7 +47,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     __version__ as hass_version,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, HomeAssistant
 
 from tests.common import async_mock_service
 
@@ -667,7 +667,9 @@ async def test_battery_appears_after_startup(
     assert acc._char_battery is None
 
 
-async def test_call_service(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_call_service(
+    hass: HomeAssistant, hk_driver, events: list[Event]
+) -> None:
     """Test call_service method."""
     entity_id = "homekit.accessory"
     hass.states.async_set(entity_id, None)

--- a/tests/components/homekit/test_diagnostics.py
+++ b/tests/components/homekit/test_diagnostics.py
@@ -12,7 +12,7 @@ from homeassistant.components.homekit.const import (
 )
 from homeassistant.const import CONF_NAME, CONF_PORT, EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from .util import async_init_integration
@@ -321,9 +321,7 @@ async def test_config_entry_with_trigger_accessory(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     hk_driver,
-    events,
     demo_cleanup,
-    device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test generating diagnostics for a bridge config entry with a trigger accessory."""

--- a/tests/components/homekit/test_type_cameras.py
+++ b/tests/components/homekit/test_type_cameras.py
@@ -132,9 +132,7 @@ def _get_failing_mock_ffmpeg():
     return ffmpeg
 
 
-async def test_camera_stream_source_configured(
-    hass: HomeAssistant, run_driver, events
-) -> None:
+async def test_camera_stream_source_configured(hass: HomeAssistant, run_driver) -> None:
     """Test a camera that can stream with a configured source."""
     await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
     await async_setup_component(
@@ -254,7 +252,7 @@ async def test_camera_stream_source_configured(
 
 
 async def test_camera_stream_source_configured_with_failing_ffmpeg(
-    hass: HomeAssistant, run_driver, events
+    hass: HomeAssistant, run_driver
 ) -> None:
     """Test a camera that can stream with a configured source with ffmpeg failing."""
     await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
@@ -310,9 +308,7 @@ async def test_camera_stream_source_configured_with_failing_ffmpeg(
         await _async_stop_all_streams(hass, acc)
 
 
-async def test_camera_stream_source_found(
-    hass: HomeAssistant, run_driver, events
-) -> None:
+async def test_camera_stream_source_found(hass: HomeAssistant, run_driver) -> None:
     """Test a camera that can stream and we get the source from the entity."""
     await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
     await async_setup_component(
@@ -398,9 +394,7 @@ async def test_camera_stream_source_found(
     )
 
 
-async def test_camera_stream_source_fails(
-    hass: HomeAssistant, run_driver, events
-) -> None:
+async def test_camera_stream_source_fails(hass: HomeAssistant, run_driver) -> None:
     """Test a camera that can stream and we cannot get the source from the entity."""
     await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
     await async_setup_component(
@@ -441,7 +435,7 @@ async def test_camera_stream_source_fails(
         await _async_stop_all_streams(hass, acc)
 
 
-async def test_camera_with_no_stream(hass: HomeAssistant, run_driver, events) -> None:
+async def test_camera_with_no_stream(hass: HomeAssistant, run_driver) -> None:
     """Test a camera that cannot stream."""
     await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
     await async_setup_component(hass, camera.DOMAIN, {camera.DOMAIN: {}})
@@ -474,7 +468,7 @@ async def test_camera_with_no_stream(hass: HomeAssistant, run_driver, events) ->
 
 
 async def test_camera_stream_source_configured_and_copy_codec(
-    hass: HomeAssistant, run_driver, events
+    hass: HomeAssistant, run_driver
 ) -> None:
     """Test a camera that can stream with a configured source."""
     await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
@@ -549,7 +543,7 @@ async def test_camera_stream_source_configured_and_copy_codec(
 
 
 async def test_camera_stream_source_configured_and_override_profile_names(
-    hass: HomeAssistant, run_driver, events
+    hass: HomeAssistant, run_driver
 ) -> None:
     """Test a camera that can stream with a configured source over overridden profile names."""
     await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
@@ -625,7 +619,7 @@ async def test_camera_stream_source_configured_and_override_profile_names(
 
 
 async def test_camera_streaming_fails_after_starting_ffmpeg(
-    hass: HomeAssistant, run_driver, events
+    hass: HomeAssistant, run_driver
 ) -> None:
     """Test a camera that can stream with a configured source."""
     await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
@@ -702,7 +696,7 @@ async def test_camera_streaming_fails_after_starting_ffmpeg(
 
 
 async def test_camera_with_linked_motion_sensor(
-    hass: HomeAssistant, run_driver, events
+    hass: HomeAssistant, run_driver
 ) -> None:
     """Test a camera with a linked motion sensor can update."""
     await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
@@ -795,9 +789,7 @@ async def test_camera_with_linked_motion_sensor(
     assert char.value is True
 
 
-async def test_camera_with_linked_motion_event(
-    hass: HomeAssistant, run_driver, events
-) -> None:
+async def test_camera_with_linked_motion_event(hass: HomeAssistant, run_driver) -> None:
     """Test a camera with a linked motion event entity can update."""
     await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
     await async_setup_component(
@@ -893,7 +885,7 @@ async def test_camera_with_linked_motion_event(
 
 
 async def test_camera_with_a_missing_linked_motion_sensor(
-    hass: HomeAssistant, run_driver, events
+    hass: HomeAssistant, run_driver
 ) -> None:
     """Test a camera with a configured linked motion sensor that is missing."""
     await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
@@ -925,7 +917,7 @@ async def test_camera_with_a_missing_linked_motion_sensor(
 
 
 async def test_camera_with_linked_doorbell_sensor(
-    hass: HomeAssistant, run_driver, events
+    hass: HomeAssistant, run_driver
 ) -> None:
     """Test a camera with a linked doorbell sensor can update."""
     await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
@@ -1041,7 +1033,7 @@ async def test_camera_with_linked_doorbell_sensor(
 
 
 async def test_camera_with_linked_doorbell_event(
-    hass: HomeAssistant, run_driver, events
+    hass: HomeAssistant, run_driver
 ) -> None:
     """Test a camera with a linked doorbell event can update."""
     await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})
@@ -1158,7 +1150,7 @@ async def test_camera_with_linked_doorbell_event(
 
 
 async def test_camera_with_a_missing_linked_doorbell_sensor(
-    hass: HomeAssistant, run_driver, events
+    hass: HomeAssistant, run_driver
 ) -> None:
     """Test a camera with a configured linked doorbell sensor that is missing."""
     await async_setup_component(hass, ffmpeg.DOMAIN, {ffmpeg.DOMAIN: {}})

--- a/tests/components/homekit/test_type_covers.py
+++ b/tests/components/homekit/test_type_covers.py
@@ -40,13 +40,15 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
-from homeassistant.core import CoreState, HomeAssistant
+from homeassistant.core import CoreState, Event, HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import async_mock_service
 
 
-async def test_garage_door_open_close(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_garage_door_open_close(
+    hass: HomeAssistant, hk_driver, events: list[Event]
+) -> None:
     """Test if accessory and HA are updated accordingly."""
     entity_id = "cover.garage_door"
 
@@ -132,9 +134,7 @@ async def test_garage_door_open_close(hass: HomeAssistant, hk_driver, events) ->
     assert events[-1].data[ATTR_VALUE] is None
 
 
-async def test_door_instantiate_set_position(
-    hass: HomeAssistant, hk_driver, events
-) -> None:
+async def test_door_instantiate_set_position(hass: HomeAssistant, hk_driver) -> None:
     """Test if Door accessory is instantiated correctly and can set position."""
     entity_id = "cover.door"
 
@@ -185,7 +185,7 @@ async def test_door_instantiate_set_position(
 
 
 async def test_windowcovering_set_cover_position(
-    hass: HomeAssistant, hk_driver, events
+    hass: HomeAssistant, hk_driver, events: list[Event]
 ) -> None:
     """Test if accessory and HA are updated accordingly."""
     entity_id = "cover.window"
@@ -295,9 +295,7 @@ async def test_windowcovering_set_cover_position(
     assert events[-1].data[ATTR_VALUE] == 75
 
 
-async def test_window_instantiate_set_position(
-    hass: HomeAssistant, hk_driver, events
-) -> None:
+async def test_window_instantiate_set_position(hass: HomeAssistant, hk_driver) -> None:
     """Test if Window accessory is instantiated correctly and can set position."""
     entity_id = "cover.window"
 
@@ -348,7 +346,7 @@ async def test_window_instantiate_set_position(
 
 
 async def test_windowcovering_cover_set_tilt(
-    hass: HomeAssistant, hk_driver, events
+    hass: HomeAssistant, hk_driver, events: list[Event]
 ) -> None:
     """Test if accessory and HA update slat tilt accordingly."""
     entity_id = "cover.window"
@@ -418,7 +416,7 @@ async def test_windowcovering_cover_set_tilt(
     assert events[-1].data[ATTR_VALUE] == 75
 
 
-async def test_windowcovering_tilt_only(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_windowcovering_tilt_only(hass: HomeAssistant, hk_driver) -> None:
     """Test we lock the window covering closed when its tilt only."""
     entity_id = "cover.window"
 
@@ -442,7 +440,7 @@ async def test_windowcovering_tilt_only(hass: HomeAssistant, hk_driver, events) 
 
 
 async def test_windowcovering_open_close(
-    hass: HomeAssistant, hk_driver, events
+    hass: HomeAssistant, hk_driver, events: list[Event]
 ) -> None:
     """Test if accessory and HA are updated accordingly."""
     entity_id = "cover.window"
@@ -525,7 +523,7 @@ async def test_windowcovering_open_close(
 
 
 async def test_windowcovering_open_close_stop(
-    hass: HomeAssistant, hk_driver, events
+    hass: HomeAssistant, hk_driver, events: list[Event]
 ) -> None:
     """Test if accessory and HA are updated accordingly."""
     entity_id = "cover.window"
@@ -574,7 +572,7 @@ async def test_windowcovering_open_close_stop(
 
 
 async def test_windowcovering_open_close_with_position_and_stop(
-    hass: HomeAssistant, hk_driver, events
+    hass: HomeAssistant, hk_driver, events: list[Event]
 ) -> None:
     """Test if accessory and HA are updated accordingly."""
     entity_id = "cover.stop_window"
@@ -608,7 +606,7 @@ async def test_windowcovering_open_close_with_position_and_stop(
 
 
 async def test_windowcovering_basic_restore(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, hk_driver, events
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, hk_driver
 ) -> None:
     """Test setting up an entity from state in the event registry."""
     hass.set_state(CoreState.not_running)
@@ -646,7 +644,7 @@ async def test_windowcovering_basic_restore(
 
 
 async def test_windowcovering_restore(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, hk_driver, events
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, hk_driver
 ) -> None:
     """Test setting up an entity from state in the event entity_registry."""
     hass.set_state(CoreState.not_running)
@@ -684,7 +682,7 @@ async def test_windowcovering_restore(
 
 
 async def test_garage_door_with_linked_obstruction_sensor(
-    hass: HomeAssistant, hk_driver, events
+    hass: HomeAssistant, hk_driver
 ) -> None:
     """Test if accessory and HA are updated accordingly with a linked obstruction sensor."""
     linked_obstruction_sensor_entity_id = "binary_sensor.obstruction"

--- a/tests/components/homekit/test_type_fans.py
+++ b/tests/components/homekit/test_type_fans.py
@@ -24,13 +24,13 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNKNOWN,
 )
-from homeassistant.core import CoreState, HomeAssistant
+from homeassistant.core import CoreState, Event, HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import async_mock_service
 
 
-async def test_fan_basic(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_fan_basic(hass: HomeAssistant, hk_driver, events: list[Event]) -> None:
     """Test fan with char state."""
     entity_id = "fan.demo"
 
@@ -108,7 +108,9 @@ async def test_fan_basic(hass: HomeAssistant, hk_driver, events) -> None:
     assert events[-1].data[ATTR_VALUE] is None
 
 
-async def test_fan_direction(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_fan_direction(
+    hass: HomeAssistant, hk_driver, events: list[Event]
+) -> None:
     """Test fan with direction."""
     entity_id = "fan.demo"
 
@@ -186,7 +188,9 @@ async def test_fan_direction(hass: HomeAssistant, hk_driver, events) -> None:
     assert events[-1].data[ATTR_VALUE] == DIRECTION_REVERSE
 
 
-async def test_fan_oscillate(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_fan_oscillate(
+    hass: HomeAssistant, hk_driver, events: list[Event]
+) -> None:
     """Test fan with oscillate."""
     entity_id = "fan.demo"
 
@@ -259,7 +263,7 @@ async def test_fan_oscillate(hass: HomeAssistant, hk_driver, events) -> None:
     assert events[-1].data[ATTR_VALUE] is True
 
 
-async def test_fan_speed(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_fan_speed(hass: HomeAssistant, hk_driver, events: list[Event]) -> None:
     """Test fan with speed."""
     entity_id = "fan.demo"
 
@@ -361,7 +365,9 @@ async def test_fan_speed(hass: HomeAssistant, hk_driver, events) -> None:
     assert call_turn_on[0].data[ATTR_ENTITY_ID] == entity_id
 
 
-async def test_fan_set_all_one_shot(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_fan_set_all_one_shot(
+    hass: HomeAssistant, hk_driver, events: list[Event]
+) -> None:
     """Test fan with speed."""
     entity_id = "fan.demo"
 
@@ -555,7 +561,7 @@ async def test_fan_set_all_one_shot(hass: HomeAssistant, hk_driver, events) -> N
 
 
 async def test_fan_restore(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, hk_driver, events
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, hk_driver
 ) -> None:
     """Test setting up an entity from state in the event registry."""
     hass.set_state(CoreState.not_running)
@@ -597,7 +603,7 @@ async def test_fan_restore(
 
 
 async def test_fan_multiple_preset_modes(
-    hass: HomeAssistant, hk_driver, events
+    hass: HomeAssistant, hk_driver, events: list[Event]
 ) -> None:
     """Test fan with multiple preset modes."""
     entity_id = "fan.demo"
@@ -678,7 +684,9 @@ async def test_fan_multiple_preset_modes(
     assert len(events) == 2
 
 
-async def test_fan_single_preset_mode(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_fan_single_preset_mode(
+    hass: HomeAssistant, hk_driver, events: list[Event]
+) -> None:
     """Test fan with a single preset mode."""
     entity_id = "fan.demo"
 

--- a/tests/components/homekit/test_type_humidifiers.py
+++ b/tests/components/homekit/test_type_humidifiers.py
@@ -42,12 +42,12 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, HomeAssistant
 
 from tests.common import async_mock_service
 
 
-async def test_humidifier(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_humidifier(hass: HomeAssistant, hk_driver, events: list[Event]) -> None:
     """Test if humidifier accessory and HA are updated accordingly."""
     entity_id = "humidifier.test"
 
@@ -132,7 +132,9 @@ async def test_humidifier(hass: HomeAssistant, hk_driver, events) -> None:
     assert events[-1].data[ATTR_VALUE] == "RelativeHumidityHumidifierThreshold to 39.0%"
 
 
-async def test_dehumidifier(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_dehumidifier(
+    hass: HomeAssistant, hk_driver, events: list[Event]
+) -> None:
     """Test if dehumidifier accessory and HA are updated accordingly."""
     entity_id = "humidifier.test"
 
@@ -220,7 +222,9 @@ async def test_dehumidifier(hass: HomeAssistant, hk_driver, events) -> None:
     )
 
 
-async def test_hygrostat_power_state(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_hygrostat_power_state(
+    hass: HomeAssistant, hk_driver, events: list[Event]
+) -> None:
     """Test if accessory and HA are updated accordingly."""
     entity_id = "humidifier.test"
 
@@ -301,7 +305,7 @@ async def test_hygrostat_power_state(hass: HomeAssistant, hk_driver, events) -> 
 
 
 async def test_hygrostat_get_humidity_range(
-    hass: HomeAssistant, hk_driver, events
+    hass: HomeAssistant, hk_driver, events: list[Event]
 ) -> None:
     """Test if humidity range is evaluated correctly."""
     entity_id = "humidifier.test"
@@ -452,7 +456,10 @@ async def test_humidifier_with_a_missing_linked_humidity_sensor(
 
 
 async def test_humidifier_as_dehumidifier(
-    hass: HomeAssistant, hk_driver, events, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    hk_driver,
+    events: list[Event],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test an invalid char_target_humidifier_dehumidifier from HomeKit."""
     entity_id = "humidifier.test"
@@ -495,7 +502,10 @@ async def test_humidifier_as_dehumidifier(
 
 
 async def test_dehumidifier_as_humidifier(
-    hass: HomeAssistant, hk_driver, events, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    hk_driver,
+    events: list[Event],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test an invalid char_target_humidifier_dehumidifier from HomeKit."""
     entity_id = "humidifier.test"

--- a/tests/components/homekit/test_type_lights.py
+++ b/tests/components/homekit/test_type_lights.py
@@ -39,7 +39,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNKNOWN,
 )
-from homeassistant.core import CoreState, HomeAssistant
+from homeassistant.core import CoreState, Event, HomeAssistant
 from homeassistant.helpers import entity_registry as er
 import homeassistant.util.dt as dt_util
 
@@ -53,7 +53,7 @@ async def _wait_for_light_coalesce(hass):
     await hass.async_block_till_done()
 
 
-async def test_light_basic(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_light_basic(hass: HomeAssistant, hk_driver, events: list[Event]) -> None:
     """Test light with char state."""
     entity_id = "light.demo"
 
@@ -127,7 +127,7 @@ async def test_light_basic(hass: HomeAssistant, hk_driver, events) -> None:
     [[ColorMode.BRIGHTNESS], [ColorMode.HS], [ColorMode.COLOR_TEMP]],
 )
 async def test_light_brightness(
-    hass: HomeAssistant, hk_driver, events, supported_color_modes
+    hass: HomeAssistant, hk_driver, events: list[Event], supported_color_modes
 ) -> None:
     """Test light with brightness."""
     entity_id = "light.demo"
@@ -274,7 +274,9 @@ async def test_light_brightness(
     assert acc.char_brightness.value == 1
 
 
-async def test_light_color_temperature(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_light_color_temperature(
+    hass: HomeAssistant, hk_driver, events: list[Event]
+) -> None:
     """Test light with color temperature."""
     entity_id = "light.demo"
 
@@ -323,7 +325,7 @@ async def test_light_color_temperature(hass: HomeAssistant, hk_driver, events) -
     [["color_temp", "hs"], ["color_temp", "rgb"], ["color_temp", "xy"]],
 )
 async def test_light_color_temperature_and_rgb_color(
-    hass: HomeAssistant, hk_driver, events, supported_color_modes
+    hass: HomeAssistant, hk_driver, events: list[Event], supported_color_modes
 ) -> None:
     """Test light with color temperature and rgb color not exposing temperature."""
     entity_id = "light.demo"
@@ -524,7 +526,7 @@ async def test_light_color_temperature_and_rgb_color(
     "supported_color_modes", [[ColorMode.HS], [ColorMode.RGB], [ColorMode.XY]]
 )
 async def test_light_rgb_color(
-    hass: HomeAssistant, hk_driver, events, supported_color_modes
+    hass: HomeAssistant, hk_driver, events: list[Event], supported_color_modes
 ) -> None:
     """Test light with rgb_color."""
     entity_id = "light.demo"
@@ -578,7 +580,7 @@ async def test_light_rgb_color(
 
 
 async def test_light_restore(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, hk_driver, events
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, hk_driver
 ) -> None:
     """Test setting up an entity from state in the event registry."""
     hass.set_state(CoreState.not_running)
@@ -642,7 +644,7 @@ async def test_light_restore(
 async def test_light_rgb_with_color_temp(
     hass: HomeAssistant,
     hk_driver,
-    events,
+    events: list[Event],
     supported_color_modes,
     state_props,
     turn_on_props_with_brightness,
@@ -762,7 +764,7 @@ async def test_light_rgb_with_color_temp(
 async def test_light_rgbwx_with_color_temp_and_brightness(
     hass: HomeAssistant,
     hk_driver,
-    events,
+    events: list[Event],
     supported_color_modes,
     state_props,
     turn_on_props_with_brightness,
@@ -824,7 +826,7 @@ async def test_light_rgbwx_with_color_temp_and_brightness(
 async def test_light_rgb_or_w_lights(
     hass: HomeAssistant,
     hk_driver,
-    events,
+    events: list[Event],
 ) -> None:
     """Test lights with RGB or W lights."""
     entity_id = "light.demo"
@@ -957,7 +959,7 @@ async def test_light_rgb_or_w_lights(
 async def test_light_rgb_with_white_switch_to_temp(
     hass: HomeAssistant,
     hk_driver,
-    events,
+    events: list[Event],
     supported_color_modes,
     state_props,
 ) -> None:
@@ -1034,11 +1036,7 @@ async def test_light_rgb_with_white_switch_to_temp(
     assert acc.char_brightness.value == 100
 
 
-async def test_light_rgb_with_hs_color_none(
-    hass: HomeAssistant,
-    hk_driver,
-    events,
-) -> None:
+async def test_light_rgb_with_hs_color_none(hass: HomeAssistant, hk_driver) -> None:
     """Test lights hs color set to None."""
     entity_id = "light.demo"
 
@@ -1071,7 +1069,7 @@ async def test_light_rgb_with_hs_color_none(
 async def test_light_rgbww_with_color_temp_conversion(
     hass: HomeAssistant,
     hk_driver,
-    events,
+    events: list[Event],
 ) -> None:
     """Test lights with RGBWW convert color temp as expected."""
     entity_id = "light.demo"
@@ -1192,7 +1190,7 @@ async def test_light_rgbww_with_color_temp_conversion(
 async def test_light_rgbw_with_color_temp_conversion(
     hass: HomeAssistant,
     hk_driver,
-    events,
+    events: list[Event],
 ) -> None:
     """Test lights with RGBW convert color temp as expected."""
     entity_id = "light.demo"
@@ -1280,7 +1278,7 @@ async def test_light_rgbw_with_color_temp_conversion(
 
 
 async def test_light_set_brightness_and_color(
-    hass: HomeAssistant, hk_driver, events
+    hass: HomeAssistant, hk_driver, events: list[Event]
 ) -> None:
     """Test light with all chars in one go."""
     entity_id = "light.demo"
@@ -1365,7 +1363,7 @@ async def test_light_set_brightness_and_color(
     )
 
 
-async def test_light_min_max_mireds(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_light_min_max_mireds(hass: HomeAssistant, hk_driver) -> None:
     """Test mireds are forced to ints."""
     entity_id = "light.demo"
 
@@ -1386,7 +1384,7 @@ async def test_light_min_max_mireds(hass: HomeAssistant, hk_driver, events) -> N
 
 
 async def test_light_set_brightness_and_color_temp(
-    hass: HomeAssistant, hk_driver, events
+    hass: HomeAssistant, hk_driver, events: list[Event]
 ) -> None:
     """Test light with all chars in one go."""
     entity_id = "light.demo"

--- a/tests/components/homekit/test_type_locks.py
+++ b/tests/components/homekit/test_type_locks.py
@@ -18,12 +18,12 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     STATE_UNLOCKED,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, HomeAssistant
 
 from tests.common import async_mock_service
 
 
-async def test_lock_unlock(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_lock_unlock(hass: HomeAssistant, hk_driver, events: list[Event]) -> None:
     """Test if accessory and HA are updated accordingly."""
     code = "1234"
     config = {ATTR_CODE: code}
@@ -121,7 +121,9 @@ async def test_lock_unlock(hass: HomeAssistant, hk_driver, events) -> None:
 
 
 @pytest.mark.parametrize("config", [{}, {ATTR_CODE: None}])
-async def test_no_code(hass: HomeAssistant, hk_driver, config, events) -> None:
+async def test_no_code(
+    hass: HomeAssistant, hk_driver, config, events: list[Event]
+) -> None:
     """Test accessory if lock doesn't require a code."""
     entity_id = "lock.kitchen_door"
 

--- a/tests/components/homekit/test_type_media_players.py
+++ b/tests/components/homekit/test_type_media_players.py
@@ -40,13 +40,15 @@ from homeassistant.const import (
     STATE_PLAYING,
     STATE_STANDBY,
 )
-from homeassistant.core import CoreState, HomeAssistant
+from homeassistant.core import CoreState, Event, HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import async_mock_service
 
 
-async def test_media_player_set_state(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_media_player_set_state(
+    hass: HomeAssistant, hk_driver, events: list[Event]
+) -> None:
     """Test if accessory and HA are updated accordingly."""
     config = {
         CONF_FEATURE_LIST: {
@@ -177,7 +179,10 @@ async def test_media_player_set_state(hass: HomeAssistant, hk_driver, events) ->
 
 
 async def test_media_player_television(
-    hass: HomeAssistant, hk_driver, events, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    hk_driver,
+    events: list[Event],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test if television accessory and HA are updated accordingly."""
     entity_id = "media_player.television"
@@ -366,7 +371,7 @@ async def test_media_player_television(
 
 
 async def test_media_player_television_basic(
-    hass: HomeAssistant, hk_driver, events, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant, hk_driver, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test if basic television accessory and HA are updated accordingly."""
     entity_id = "media_player.television"
@@ -409,7 +414,7 @@ async def test_media_player_television_basic(
 
 
 async def test_media_player_television_supports_source_select_no_sources(
-    hass: HomeAssistant, hk_driver, events, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant, hk_driver
 ) -> None:
     """Test if basic tv that supports source select but is missing a source list."""
     entity_id = "media_player.television"
@@ -429,7 +434,7 @@ async def test_media_player_television_supports_source_select_no_sources(
 
 
 async def test_tv_restore(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, hk_driver, events
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, hk_driver
 ) -> None:
     """Test setting up an entity from state in the event registry."""
     hass.set_state(CoreState.not_running)
@@ -482,7 +487,7 @@ async def test_tv_restore(
 
 
 async def test_media_player_television_max_sources(
-    hass: HomeAssistant, hk_driver, events, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant, hk_driver
 ) -> None:
     """Test if television accessory that reaches the maximum number of sources."""
     entity_id = "media_player.television"
@@ -541,7 +546,7 @@ async def test_media_player_television_max_sources(
 
 
 async def test_media_player_television_duplicate_sources(
-    hass: HomeAssistant, hk_driver, events, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant, hk_driver
 ) -> None:
     """Test if television accessory with duplicate sources."""
     entity_id = "media_player.television"
@@ -586,7 +591,7 @@ async def test_media_player_television_duplicate_sources(
 
 
 async def test_media_player_television_unsafe_chars(
-    hass: HomeAssistant, hk_driver, events, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant, hk_driver, events: list[Event]
 ) -> None:
     """Test if television accessory with unsafe characters."""
     entity_id = "media_player.television"

--- a/tests/components/homekit/test_type_remote.py
+++ b/tests/components/homekit/test_type_remote.py
@@ -26,13 +26,13 @@ from homeassistant.const import (
     STATE_ON,
     STATE_STANDBY,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, HomeAssistant
 
 from tests.common import async_mock_service
 
 
 async def test_activity_remote(
-    hass: HomeAssistant, hk_driver: HomeDriver, events, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant, hk_driver: HomeDriver, events: list[Event]
 ) -> None:
     """Test if remote accessory and HA are updated accordingly."""
     entity_id = "remote.harmony"
@@ -156,7 +156,10 @@ async def test_activity_remote(
 
 
 async def test_activity_remote_bad_names(
-    hass: HomeAssistant, hk_driver, events, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    hk_driver,
+    events: list[Event],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test if remote accessory with invalid names works as expected."""
     entity_id = "remote.harmony"

--- a/tests/components/homekit/test_type_security_systems.py
+++ b/tests/components/homekit/test_type_security_systems.py
@@ -21,12 +21,14 @@ from homeassistant.const import (
     STATE_ALARM_TRIGGERED,
     STATE_UNKNOWN,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, HomeAssistant
 
 from tests.common import async_mock_service
 
 
-async def test_switch_set_state(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_switch_set_state(
+    hass: HomeAssistant, hk_driver, events: list[Event]
+) -> None:
     """Test if accessory and HA are updated accordingly."""
     code = "1234"
     config = {ATTR_CODE: code}
@@ -118,7 +120,9 @@ async def test_switch_set_state(hass: HomeAssistant, hk_driver, events) -> None:
 
 
 @pytest.mark.parametrize("config", [{}, {ATTR_CODE: None}])
-async def test_no_alarm_code(hass: HomeAssistant, hk_driver, config, events) -> None:
+async def test_no_alarm_code(
+    hass: HomeAssistant, hk_driver, config, events: list[Event]
+) -> None:
     """Test accessory if security_system doesn't require an alarm_code."""
     entity_id = "alarm_control_panel.test"
 
@@ -139,7 +143,7 @@ async def test_no_alarm_code(hass: HomeAssistant, hk_driver, config, events) -> 
     assert events[-1].data[ATTR_VALUE] is None
 
 
-async def test_arming(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_arming(hass: HomeAssistant, hk_driver) -> None:
     """Test to make sure arming sets the right state."""
     entity_id = "alarm_control_panel.test"
 
@@ -190,7 +194,7 @@ async def test_arming(hass: HomeAssistant, hk_driver, events) -> None:
     assert acc.char_current_state.value == 4
 
 
-async def test_supported_states(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_supported_states(hass: HomeAssistant, hk_driver) -> None:
     """Test different supported states."""
     code = "1234"
     config = {ATTR_CODE: code}

--- a/tests/components/homekit/test_type_sensors.py
+++ b/tests/components/homekit/test_type_sensors.py
@@ -601,7 +601,7 @@ async def test_binary_device_classes(hass: HomeAssistant, hk_driver) -> None:
 
 
 async def test_sensor_restore(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, hk_driver, events
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, hk_driver
 ) -> None:
     """Test setting up an entity from state in the event registry."""
     hass.set_state(CoreState.not_running)

--- a/tests/components/homekit/test_type_switches.py
+++ b/tests/components/homekit/test_type_switches.py
@@ -42,13 +42,15 @@ from homeassistant.const import (
     STATE_ON,
     STATE_OPEN,
 )
-from homeassistant.core import HomeAssistant, split_entity_id
+from homeassistant.core import Event, HomeAssistant, split_entity_id
 import homeassistant.util.dt as dt_util
 
 from tests.common import async_fire_time_changed, async_mock_service
 
 
-async def test_outlet_set_state(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_outlet_set_state(
+    hass: HomeAssistant, hk_driver, events: list[Event]
+) -> None:
     """Test if Outlet accessory and HA are updated accordingly."""
     entity_id = "switch.outlet_test"
 
@@ -101,7 +103,7 @@ async def test_outlet_set_state(hass: HomeAssistant, hk_driver, events) -> None:
     ],
 )
 async def test_switch_set_state(
-    hass: HomeAssistant, hk_driver, entity_id, attrs, events
+    hass: HomeAssistant, hk_driver, entity_id, attrs, events: list[Event]
 ) -> None:
     """Test if accessory and HA are updated accordingly."""
     domain = split_entity_id(entity_id)[0]
@@ -145,7 +147,9 @@ async def test_switch_set_state(
     assert events[-1].data[ATTR_VALUE] is None
 
 
-async def test_valve_switch_set_state(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_valve_switch_set_state(
+    hass: HomeAssistant, hk_driver, events: list[Event]
+) -> None:
     """Test if Valve accessory and HA are updated accordingly."""
     entity_id = "switch.valve_test"
 
@@ -214,7 +218,9 @@ async def test_valve_switch_set_state(hass: HomeAssistant, hk_driver, events) ->
     assert events[-1].data[ATTR_VALUE] is None
 
 
-async def test_valve_set_state(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_valve_set_state(
+    hass: HomeAssistant, hk_driver, events: list[Event]
+) -> None:
     """Test if Valve accessory and HA are updated accordingly."""
     entity_id = "valve.valve_test"
 
@@ -264,7 +270,7 @@ async def test_valve_set_state(hass: HomeAssistant, hk_driver, events) -> None:
 
 
 async def test_vacuum_set_state_with_returnhome_and_start_support(
-    hass: HomeAssistant, hk_driver, events
+    hass: HomeAssistant, hk_driver, events: list[Event]
 ) -> None:
     """Test if Vacuum accessory and HA are updated accordingly."""
     entity_id = "vacuum.roomba"
@@ -333,7 +339,7 @@ async def test_vacuum_set_state_with_returnhome_and_start_support(
 
 
 async def test_vacuum_set_state_without_returnhome_and_start_support(
-    hass: HomeAssistant, hk_driver, events
+    hass: HomeAssistant, hk_driver, events: list[Event]
 ) -> None:
     """Test if Vacuum accessory and HA are updated accordingly."""
     entity_id = "vacuum.roomba"
@@ -378,7 +384,9 @@ async def test_vacuum_set_state_without_returnhome_and_start_support(
     assert events[-1].data[ATTR_VALUE] is None
 
 
-async def test_reset_switch(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_reset_switch(
+    hass: HomeAssistant, hk_driver, events: list[Event]
+) -> None:
     """Test if switch accessory is reset correctly."""
     domain = "scene"
     entity_id = "scene.test"
@@ -422,7 +430,9 @@ async def test_reset_switch(hass: HomeAssistant, hk_driver, events) -> None:
     assert len(events) == 1
 
 
-async def test_script_switch(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_script_switch(
+    hass: HomeAssistant, hk_driver, events: list[Event]
+) -> None:
     """Test if script switch accessory is reset correctly."""
     domain = "script"
     entity_id = "script.test"
@@ -471,7 +481,7 @@ async def test_script_switch(hass: HomeAssistant, hk_driver, events) -> None:
     ["input_select", "select"],
 )
 async def test_input_select_switch(
-    hass: HomeAssistant, hk_driver, events, domain
+    hass: HomeAssistant, hk_driver, events: list[Event], domain
 ) -> None:
     """Test if select switch accessory is handled correctly."""
     entity_id = f"{domain}.test"
@@ -526,7 +536,9 @@ async def test_input_select_switch(
     "domain",
     ["button", "input_button"],
 )
-async def test_button_switch(hass: HomeAssistant, hk_driver, events, domain) -> None:
+async def test_button_switch(
+    hass: HomeAssistant, hk_driver, events: list[Event], domain
+) -> None:
     """Test switch accessory from a (input) button entity."""
     entity_id = f"{domain}.test"
 

--- a/tests/components/homekit/test_type_thermostats.py
+++ b/tests/components/homekit/test_type_thermostats.py
@@ -74,13 +74,13 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     UnitOfTemperature,
 )
-from homeassistant.core import CoreState, HomeAssistant
+from homeassistant.core import CoreState, Event, HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import async_mock_service
 
 
-async def test_thermostat(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_thermostat(hass: HomeAssistant, hk_driver, events: list[Event]) -> None:
     """Test if accessory and HA are updated accordingly."""
     entity_id = "climate.test"
     base_attrs = {
@@ -375,7 +375,9 @@ async def test_thermostat(hass: HomeAssistant, hk_driver, events) -> None:
     assert events[-1].data[ATTR_VALUE] == "TargetHeatingCoolingState to 3"
 
 
-async def test_thermostat_auto(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_thermostat_auto(
+    hass: HomeAssistant, hk_driver, events: list[Event]
+) -> None:
     """Test if accessory and HA are updated accordingly."""
     entity_id = "climate.test"
     base_attrs = {
@@ -509,7 +511,7 @@ async def test_thermostat_auto(hass: HomeAssistant, hk_driver, events) -> None:
 
 
 async def test_thermostat_mode_and_temp_change(
-    hass: HomeAssistant, hk_driver, events
+    hass: HomeAssistant, hk_driver, events: list[Event]
 ) -> None:
     """Test if accessory where the mode and temp change in the same call."""
     entity_id = "climate.test"
@@ -616,7 +618,9 @@ async def test_thermostat_mode_and_temp_change(
     )
 
 
-async def test_thermostat_humidity(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_thermostat_humidity(
+    hass: HomeAssistant, hk_driver, events: list[Event]
+) -> None:
     """Test if accessory and HA are updated accordingly with humidity."""
     entity_id = "climate.test"
     base_attrs = {ATTR_SUPPORTED_FEATURES: 4}
@@ -680,7 +684,7 @@ async def test_thermostat_humidity(hass: HomeAssistant, hk_driver, events) -> No
 
 
 async def test_thermostat_humidity_with_target_humidity(
-    hass: HomeAssistant, hk_driver, events
+    hass: HomeAssistant, hk_driver
 ) -> None:
     """Test if accessory and HA are updated accordingly with humidity without target hudmidity.
 
@@ -704,7 +708,9 @@ async def test_thermostat_humidity_with_target_humidity(
     assert acc.char_current_humidity.value == 65
 
 
-async def test_thermostat_power_state(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_thermostat_power_state(
+    hass: HomeAssistant, hk_driver, events: list[Event]
+) -> None:
     """Test if accessory and HA are updated accordingly."""
     entity_id = "climate.test"
     base_attrs = {
@@ -812,7 +818,9 @@ async def test_thermostat_power_state(hass: HomeAssistant, hk_driver, events) ->
     assert acc.char_target_heat_cool.value == 2
 
 
-async def test_thermostat_fahrenheit(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_thermostat_fahrenheit(
+    hass: HomeAssistant, hk_driver, events: list[Event]
+) -> None:
     """Test if accessory and HA are updated accordingly."""
     entity_id = "climate.test"
 
@@ -969,7 +977,7 @@ async def test_thermostat_temperature_step_whole(
 
 
 async def test_thermostat_restore(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, hk_driver, events
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, hk_driver
 ) -> None:
     """Test setting up an entity from state in the event registry."""
     hass.set_state(CoreState.not_running)
@@ -1500,7 +1508,7 @@ async def test_thermostat_hvac_modes_without_off(
 
 
 async def test_thermostat_without_target_temp_only_range(
-    hass: HomeAssistant, hk_driver, events
+    hass: HomeAssistant, hk_driver, events: list[Event]
 ) -> None:
     """Test a thermostat that only supports a range."""
     entity_id = "climate.test"
@@ -1662,7 +1670,9 @@ async def test_thermostat_without_target_temp_only_range(
     assert events[-1].data[ATTR_VALUE] == "HeatingThresholdTemperature to 27.0°C"
 
 
-async def test_water_heater(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_water_heater(
+    hass: HomeAssistant, hk_driver, events: list[Event]
+) -> None:
     """Test if accessory and HA are updated accordingly."""
     entity_id = "water_heater.test"
 
@@ -1736,7 +1746,9 @@ async def test_water_heater(hass: HomeAssistant, hk_driver, events) -> None:
     assert acc.char_target_heat_cool.value == 1
 
 
-async def test_water_heater_fahrenheit(hass: HomeAssistant, hk_driver, events) -> None:
+async def test_water_heater_fahrenheit(
+    hass: HomeAssistant, hk_driver, events: list[Event]
+) -> None:
     """Test if accessory and HA are update accordingly."""
     entity_id = "water_heater.test"
 
@@ -1799,7 +1811,7 @@ async def test_water_heater_get_temperature_range(
 
 
 async def test_water_heater_restore(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, hk_driver, events
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, hk_driver
 ) -> None:
     """Test setting up an entity from state in the event registry."""
     hass.set_state(CoreState.not_running)
@@ -1849,7 +1861,7 @@ async def test_water_heater_restore(
 
 
 async def test_thermostat_with_no_modes_when_we_first_see(
-    hass: HomeAssistant, hk_driver, events
+    hass: HomeAssistant, hk_driver
 ) -> None:
     """Test if a thermostat that is not ready when we first see it."""
     entity_id = "climate.test"
@@ -1903,7 +1915,7 @@ async def test_thermostat_with_no_modes_when_we_first_see(
 
 
 async def test_thermostat_with_no_off_after_recheck(
-    hass: HomeAssistant, hk_driver, events
+    hass: HomeAssistant, hk_driver
 ) -> None:
     """Test if a thermostat that is not ready when we first see it that actually does not have off."""
     entity_id = "climate.test"
@@ -1956,9 +1968,7 @@ async def test_thermostat_with_no_off_after_recheck(
         assert mock_reload.called
 
 
-async def test_thermostat_with_temp_clamps(
-    hass: HomeAssistant, hk_driver, events
-) -> None:
+async def test_thermostat_with_temp_clamps(hass: HomeAssistant, hk_driver) -> None:
     """Test that temperatures are clamped to valid values to prevent homekit crash."""
     entity_id = "climate.test"
     base_attrs = {
@@ -2013,7 +2023,7 @@ async def test_thermostat_with_temp_clamps(
 
 
 async def test_thermostat_with_fan_modes_with_auto(
-    hass: HomeAssistant, hk_driver, events
+    hass: HomeAssistant, hk_driver
 ) -> None:
     """Test a thermostate with fan modes with an auto fan mode."""
     entity_id = "climate.test"
@@ -2219,7 +2229,7 @@ async def test_thermostat_with_fan_modes_with_auto(
 
 
 async def test_thermostat_with_fan_modes_with_off(
-    hass: HomeAssistant, hk_driver, events
+    hass: HomeAssistant, hk_driver
 ) -> None:
     """Test a thermostate with fan modes that can turn off."""
     entity_id = "climate.test"
@@ -2328,7 +2338,7 @@ async def test_thermostat_with_fan_modes_with_off(
 
 
 async def test_thermostat_with_fan_modes_set_to_none(
-    hass: HomeAssistant, hk_driver, events
+    hass: HomeAssistant, hk_driver
 ) -> None:
     """Test a thermostate with fan modes set to None."""
     entity_id = "climate.test"
@@ -2372,7 +2382,7 @@ async def test_thermostat_with_fan_modes_set_to_none(
 
 
 async def test_thermostat_with_fan_modes_set_to_none_not_supported(
-    hass: HomeAssistant, hk_driver, events
+    hass: HomeAssistant, hk_driver
 ) -> None:
     """Test a thermostate with fan modes set to None and supported feature missing."""
     entity_id = "climate.test"
@@ -2415,7 +2425,7 @@ async def test_thermostat_with_fan_modes_set_to_none_not_supported(
 
 
 async def test_thermostat_with_supported_features_target_temp_but_fan_mode_set(
-    hass: HomeAssistant, hk_driver, events
+    hass: HomeAssistant, hk_driver
 ) -> None:
     """Test a thermostate with fan mode and supported feature missing."""
     entity_id = "climate.test"
@@ -2452,9 +2462,7 @@ async def test_thermostat_with_supported_features_target_temp_but_fan_mode_set(
     assert not acc.fan_chars
 
 
-async def test_thermostat_handles_unknown_state(
-    hass: HomeAssistant, hk_driver, events
-) -> None:
+async def test_thermostat_handles_unknown_state(hass: HomeAssistant, hk_driver) -> None:
     """Test a thermostat can handle unknown state."""
     entity_id = "climate.test"
     attrs = {

--- a/tests/components/homekit/test_type_triggers.py
+++ b/tests/components/homekit/test_type_triggers.py
@@ -7,7 +7,7 @@ from homeassistant.components.homekit.const import CHAR_PROGRAMMABLE_SWITCH_EVEN
 from homeassistant.components.homekit.type_triggers import DeviceTriggerAccessory
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, async_get_device_automations
@@ -16,9 +16,7 @@ from tests.common import MockConfigEntry, async_get_device_automations
 async def test_programmable_switch_button_fires_on_trigger(
     hass: HomeAssistant,
     hk_driver,
-    events,
     demo_cleanup,
-    device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test that DeviceTriggerAccessory fires the programmable switch event on trigger."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
