### PR TITLE
Fix defaults for cloud STT/TTS

### DIFF
--- a/homeassistant/components/stt/__init__.py
+++ b/homeassistant/components/stt/__init__.py
@@ -72,9 +72,18 @@ CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 @callback
 def async_default_engine(hass: HomeAssistant) -> str | None:
     """Return the domain or entity id of the default engine."""
-    return next(
-        iter(hass.states.async_entity_ids(DOMAIN)), None
-    ) or async_default_provider(hass)
+    component: EntityComponent[SpeechToTextEntity] = hass.data[DOMAIN]
+
+    default_entity_id: str | None = None
+
+    for entity in component.entities:
+        if entity.platform and entity.platform.platform_name == "cloud":
+            return entity.entity_id
+
+        if default_entity_id is None:
+            default_entity_id = entity.entity_id
+
+    return async_default_provider(hass) or default_entity_id
 
 
 @callback

--- a/homeassistant/components/stt/__init__.py
+++ b/homeassistant/components/stt/__init__.py
@@ -83,7 +83,7 @@ def async_default_engine(hass: HomeAssistant) -> str | None:
         if default_entity_id is None:
             default_entity_id = entity.entity_id
 
-    return async_default_provider(hass) or default_entity_id
+    return default_entity_id or async_default_provider(hass)
 
 
 @callback

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -146,7 +146,7 @@ def async_default_engine(hass: HomeAssistant) -> str | None:
         if default_entity_id is None:
             default_entity_id = entity.entity_id
 
-    return next(iter(manager.providers), None) or default_entity_id
+    return default_entity_id or next(iter(manager.providers), None)
 
 
 @callback

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -137,15 +137,16 @@ def async_default_engine(hass: HomeAssistant) -> str | None:
     component: EntityComponent[TextToSpeechEntity] = hass.data[DOMAIN]
     manager: SpeechManager = hass.data[DATA_TTS_MANAGER]
 
-    if "cloud" in manager.providers:
-        return "cloud"
+    default_entity_id: str | None = None
 
-    entity = next(iter(component.entities), None)
+    for entity in component.entities:
+        if entity.platform and entity.platform.platform_name == "cloud":
+            return entity.entity_id
 
-    if entity is not None:
-        return entity.entity_id
+        if default_entity_id is None:
+            default_entity_id = entity.entity_id
 
-    return next(iter(manager.providers), None)
+    return next(iter(manager.providers), None) or default_entity_id
 
 
 @callback

--- a/tests/components/stt/test_init.py
+++ b/tests/components/stt/test_init.py
@@ -3,7 +3,7 @@
 from collections.abc import AsyncIterable, Generator
 from http import HTTPStatus
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -494,6 +494,26 @@ async def test_default_engine_entity(
     await mock_config_entry_setup(hass, tmp_path, mock_provider_entity)
 
     assert async_default_engine(hass) == f"{DOMAIN}.{TEST_DOMAIN}"
+
+
+async def test_default_engine_with_cloud(
+    hass: HomeAssistant,
+    tmp_path: Path,
+    mock_provider_entity: MockProviderEntity,
+) -> None:
+    """Test async_default_engine."""
+    await mock_config_entry_setup(hass, tmp_path, mock_provider_entity)
+
+    with patch.dict(
+        hass.data["stt"]._entities,
+        {
+            "stt.home_assistant_cloud": Mock(
+                entity_id="stt.home_assistant_cloud",
+                platform=Mock(platform_name="cloud"),
+            )
+        },
+    ):
+        assert async_default_engine(hass) == "stt.home_assistant_cloud"
 
 
 @pytest.mark.parametrize("config_flow_test_domain", ["new_test"])

--- a/tests/components/stt/test_init.py
+++ b/tests/components/stt/test_init.py
@@ -3,7 +3,7 @@
 from collections.abc import AsyncIterable, Generator
 from http import HTTPStatus
 from pathlib import Path
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -494,26 +494,6 @@ async def test_default_engine_entity(
     await mock_config_entry_setup(hass, tmp_path, mock_provider_entity)
 
     assert async_default_engine(hass) == f"{DOMAIN}.{TEST_DOMAIN}"
-
-
-async def test_default_engine_with_cloud(
-    hass: HomeAssistant,
-    tmp_path: Path,
-    mock_provider_entity: MockProviderEntity,
-) -> None:
-    """Test async_default_engine."""
-    await mock_config_entry_setup(hass, tmp_path, mock_provider_entity)
-
-    with patch.dict(
-        hass.data["stt"]._entities,
-        {
-            "stt.home_assistant_cloud": Mock(
-                entity_id="stt.home_assistant_cloud",
-                platform=Mock(platform_name="cloud"),
-            )
-        },
-    ):
-        assert async_default_engine(hass) == "stt.home_assistant_cloud"
 
 
 @pytest.mark.parametrize("config_flow_test_domain", ["new_test"])

--- a/tests/components/stt/test_init.py
+++ b/tests/components/stt/test_init.py
@@ -1,6 +1,7 @@
 """Test STT component setup."""
 
-from collections.abc import AsyncIterable, Generator
+from collections.abc import AsyncIterable, Generator, Iterable
+from contextlib import ExitStack
 from http import HTTPStatus
 from pathlib import Path
 from unittest.mock import AsyncMock
@@ -122,20 +123,23 @@ class STTFlow(ConfigFlow):
     """Test flow."""
 
 
-@pytest.fixture(name="config_flow_test_domain")
-def config_flow_test_domain_fixture() -> str:
+@pytest.fixture(name="config_flow_test_domains")
+def config_flow_test_domain_fixture() -> Iterable[str]:
     """Test domain fixture."""
-    return TEST_DOMAIN
+    return (TEST_DOMAIN,)
 
 
 @pytest.fixture(autouse=True)
 def config_flow_fixture(
-    hass: HomeAssistant, config_flow_test_domain: str
+    hass: HomeAssistant, config_flow_test_domains: Iterable[str]
 ) -> Generator[None]:
     """Mock config flow."""
-    mock_platform(hass, f"{config_flow_test_domain}.config_flow")
+    for domain in config_flow_test_domains:
+        mock_platform(hass, f"{domain}.config_flow")
 
-    with mock_config_flow(config_flow_test_domain, STTFlow):
+    with ExitStack() as stack:
+        for domain in config_flow_test_domains:
+            stack.enter_context(mock_config_flow(domain, STTFlow))
         yield
 
 
@@ -496,21 +500,25 @@ async def test_default_engine_entity(
     assert async_default_engine(hass) == f"{DOMAIN}.{TEST_DOMAIN}"
 
 
-@pytest.mark.parametrize("config_flow_test_domain", ["new_test"])
+@pytest.mark.parametrize("config_flow_test_domains", [("new_test",)])
 async def test_default_engine_prefer_entity(
     hass: HomeAssistant,
     tmp_path: Path,
     mock_provider_entity: MockProviderEntity,
     mock_provider: MockProvider,
-    config_flow_test_domain: str,
+    config_flow_test_domains: str,
 ) -> None:
-    """Test async_default_engine."""
+    """Test async_default_engine.
+
+    In this tests there's an entity and a legacy provider.
+    The test asserts async_default_engine returns the entity.
+    """
     mock_provider_entity.url_path = "stt.new_test"
     mock_provider_entity._attr_name = "New test"
 
     await mock_setup(hass, tmp_path, mock_provider)
     await mock_config_entry_setup(
-        hass, tmp_path, mock_provider_entity, test_domain=config_flow_test_domain
+        hass, tmp_path, mock_provider_entity, test_domain=config_flow_test_domains[0]
     )
     await hass.async_block_till_done()
 
@@ -521,6 +529,48 @@ async def test_default_engine_prefer_entity(
     assert provider_engine is not None
     assert provider_engine.name == "test"
     assert async_default_engine(hass) == "stt.new_test"
+
+
+@pytest.mark.parametrize(
+    "config_flow_test_domains",
+    [
+        # Test different setup order to ensure the default is not influenced
+        # by setup order.
+        ("cloud", "new_test"),
+        ("new_test", "cloud"),
+    ],
+)
+async def test_default_engine_prefer_cloud_entity(
+    hass: HomeAssistant,
+    tmp_path: Path,
+    mock_provider: MockProvider,
+    config_flow_test_domains: str,
+) -> None:
+    """Test async_default_engine.
+
+    In this tests there's an entity from domain cloud, an entity from domain new_test
+    and a legacy provider.
+    The test asserts async_default_engine returns the entity from domain cloud.
+    """
+    await mock_setup(hass, tmp_path, mock_provider)
+    for domain in config_flow_test_domains:
+        entity = MockProviderEntity()
+        entity.url_path = f"stt.{domain}"
+        entity._attr_name = f"{domain} STT entity"
+        await mock_config_entry_setup(hass, tmp_path, entity, test_domain=domain)
+    await hass.async_block_till_done()
+
+    for domain in config_flow_test_domains:
+        entity_engine = async_get_speech_to_text_engine(
+            hass, f"stt.{domain}_stt_entity"
+        )
+        assert entity_engine is not None
+        assert entity_engine.name == f"{domain} STT entity"
+
+    provider_engine = async_get_speech_to_text_engine(hass, "test")
+    assert provider_engine is not None
+    assert provider_engine.name == "test"
+    assert async_default_engine(hass) == "stt.cloud_stt_entity"
 
 
 async def test_get_engine_legacy(

--- a/tests/components/tts/common.py
+++ b/tests/components/tts/common.py
@@ -215,7 +215,9 @@ async def mock_setup(
 
 
 async def mock_config_entry_setup(
-    hass: HomeAssistant, tts_entity: MockTTSEntity
+    hass: HomeAssistant,
+    tts_entity: MockTTSEntity,
+    test_domain: str = TEST_DOMAIN,
 ) -> MockConfigEntry:
     """Set up a test tts platform via config entry."""
 
@@ -236,7 +238,7 @@ async def mock_config_entry_setup(
     mock_integration(
         hass,
         MockModule(
-            TEST_DOMAIN,
+            test_domain,
             async_setup_entry=async_setup_entry_init,
             async_unload_entry=async_unload_entry_init,
         ),
@@ -251,9 +253,9 @@ async def mock_config_entry_setup(
         async_add_entities([tts_entity])
 
     loaded_platform = MockPlatform(async_setup_entry=async_setup_entry_platform)
-    mock_platform(hass, f"{TEST_DOMAIN}.{TTS_DOMAIN}", loaded_platform)
+    mock_platform(hass, f"{test_domain}.{TTS_DOMAIN}", loaded_platform)
 
-    config_entry = MockConfigEntry(domain=TEST_DOMAIN)
+    config_entry = MockConfigEntry(domain=test_domain)
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/tts/conftest.py
+++ b/tests/components/tts/conftest.py
@@ -3,7 +3,8 @@
 From http://doc.pytest.org/en/latest/example/simple.html#making-test-result-information-available-in-fixtures
 """
 
-from collections.abc import Generator
+from collections.abc import Generator, Iterable
+from contextlib import ExitStack
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -81,12 +82,23 @@ class TTSFlow(ConfigFlow):
     """Test flow."""
 
 
-@pytest.fixture(autouse=True)
-def config_flow_fixture(hass: HomeAssistant) -> Generator[None]:
-    """Mock config flow."""
-    mock_platform(hass, f"{TEST_DOMAIN}.config_flow")
+@pytest.fixture(name="config_flow_test_domains")
+def config_flow_test_domain_fixture() -> Iterable[str]:
+    """Test domain fixture."""
+    return (TEST_DOMAIN,)
 
-    with mock_config_flow(TEST_DOMAIN, TTSFlow):
+
+@pytest.fixture(autouse=True)
+def config_flow_fixture(
+    hass: HomeAssistant, config_flow_test_domains: Iterable[str]
+) -> Generator[None]:
+    """Mock config flow."""
+    for domain in config_flow_test_domains:
+        mock_platform(hass, f"{domain}.config_flow")
+
+    with ExitStack() as stack:
+        for domain in config_flow_test_domains:
+            stack.enter_context(mock_config_flow(domain, TTSFlow))
         yield
 
 

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -1842,7 +1842,11 @@ async def test_default_engine_prefer_entity(
     mock_tts_entity: MockTTSEntity,
     mock_provider: MockProvider,
 ) -> None:
-    """Test async_default_engine."""
+    """Test async_default_engine.
+
+    In this tests there's an entity and a legacy provider.
+    The test asserts async_default_engine returns the entity.
+    """
     mock_tts_entity._attr_name = "New test"
 
     await mock_setup(hass, mock_provider)
@@ -1854,3 +1858,38 @@ async def test_default_engine_prefer_entity(
     provider_engine = tts.async_resolve_engine(hass, "test")
     assert provider_engine == "test"
     assert tts.async_default_engine(hass) == "tts.new_test"
+
+
+@pytest.mark.parametrize(
+    "config_flow_test_domains",
+    [
+        # Test different setup order to ensure the default is not influenced
+        # by setup order.
+        ("cloud", "new_test"),
+        ("new_test", "cloud"),
+    ],
+)
+async def test_default_engine_prefer_cloud_entity(
+    hass: HomeAssistant,
+    mock_provider: MockProvider,
+    config_flow_test_domains: str,
+) -> None:
+    """Test async_default_engine.
+
+    In this tests there's an entity from domain cloud, an entity from domain new_test
+    and a legacy provider.
+    The test asserts async_default_engine returns the entity from domain cloud.
+    """
+    await mock_setup(hass, mock_provider)
+    for domain in config_flow_test_domains:
+        entity = MockTTSEntity(DEFAULT_LANG)
+        entity._attr_name = f"{domain} TTS entity"
+        await mock_config_entry_setup(hass, entity, test_domain=domain)
+    await hass.async_block_till_done()
+
+    for domain in config_flow_test_domains:
+        entity_engine = tts.async_resolve_engine(hass, f"tts.{domain}_tts_entity")
+        assert entity_engine == f"tts.{domain}_tts_entity"
+    provider_engine = tts.async_resolve_engine(hass, "test")
+    assert provider_engine == "test"
+    assert tts.async_default_engine(hass) == "tts.cloud_tts_entity"

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -4,7 +4,7 @@ import asyncio
 from http import HTTPStatus
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
@@ -1388,34 +1388,6 @@ def test_resolve_engine(hass: HomeAssistant, setup: str, engine_id: str) -> None
         patch.dict(hass.data[tts.DOMAIN]._entities, {}, clear=True),
     ):
         assert tts.async_resolve_engine(hass, None) is None
-
-
-@pytest.mark.parametrize(
-    ("setup", "engine_id"),
-    [
-        ("mock_setup", "test"),
-        ("mock_config_entry_setup", "tts.test"),
-    ],
-    indirect=["setup"],
-)
-def test_resolve_engine_with_cloud(
-    hass: HomeAssistant, setup: str, engine_id: str
-) -> None:
-    """Test resolving engine."""
-    with patch.dict(
-        hass.data["tts"]._entities,
-        {
-            "tts.home_assistant_cloud": Mock(
-                entity_id="tts.home_assistant_cloud",
-                platform=Mock(platform_name="cloud"),
-            )
-        },
-    ):
-        assert tts.async_resolve_engine(hass, None) == "tts.home_assistant_cloud"
-        assert (
-            tts.async_resolve_engine(hass, "tts.home_assistant_cloud")
-            == "tts.home_assistant_cloud"
-        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When we migrated the cloud integration to STT and TTS entities, we broke the behavior when selecting a default STT/ TTS engine to use.

#### Priority order, for both STT and TTS, with this PR:
1. Cloud STT/TTS entity
2. Any STT/TTS entity
3. Any legacy provider

#### Without this PR, the priority was:
STT:
1. Any STT entity
2. Any legacy STT provider

TTS:
1. Legacy TTS cloud provider
2. Any TTS entity
3. Any legacy provider

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
