### PR TITLE
Make device_tracker fallback defaults cached_property

### DIFF
--- a/homeassistant/components/device_tracker/config_entry.py
+++ b/homeassistant/components/device_tracker/config_entry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from functools import cached_property
 from typing import final
 
 from homeassistant.components import zone
@@ -168,7 +169,7 @@ class BaseTrackerEntity(Entity):
     _attr_device_info: None = None
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
-    @property
+    @cached_property
     def battery_level(self) -> int | None:
         """Return the battery level of the device.
 
@@ -195,7 +196,7 @@ class BaseTrackerEntity(Entity):
 class TrackerEntity(BaseTrackerEntity):
     """Base class for a tracked device."""
 
-    @property
+    @cached_property
     def should_poll(self) -> bool:
         """No polling for entities that have location pushed."""
         return False
@@ -205,7 +206,7 @@ class TrackerEntity(BaseTrackerEntity):
         """All updates need to be written to the state machine if we're not polling."""
         return not self.should_poll
 
-    @property
+    @cached_property
     def location_accuracy(self) -> int:
         """Return the location accuracy of the device.
 
@@ -213,17 +214,17 @@ class TrackerEntity(BaseTrackerEntity):
         """
         return 0
 
-    @property
+    @cached_property
     def location_name(self) -> str | None:
         """Return a location name for the current location of the device."""
         return None
 
-    @property
+    @cached_property
     def latitude(self) -> float | None:
         """Return latitude value of the device."""
         return None
 
-    @property
+    @cached_property
     def longitude(self) -> float | None:
         """Return longitude value of the device."""
         return None
@@ -266,17 +267,17 @@ class TrackerEntity(BaseTrackerEntity):
 class ScannerEntity(BaseTrackerEntity):
     """Base class for a tracked device that is on a scanned network."""
 
-    @property
+    @cached_property
     def ip_address(self) -> str | None:
         """Return the primary ip address of the device."""
         return None
 
-    @property
+    @cached_property
     def mac_address(self) -> str | None:
         """Return the mac address of the device."""
         return None
 
-    @property
+    @cached_property
     def hostname(self) -> str | None:
         """Return hostname of the device."""
         return None


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If the integration does not define these, there is no reason to run the property over and over when it can be cached in the dict


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
