### PR TITLE
Expose Twitch "Started At" attribute

### DIFF
--- a/homeassistant/components/twitch/sensor.py
+++ b/homeassistant/components/twitch/sensor.py
@@ -28,6 +28,7 @@ ATTR_FOLLOW = "following"
 ATTR_FOLLOW_SINCE = "following_since"
 ATTR_FOLLOWING = "followers"
 ATTR_VIEWS = "views"
+ATTR_STARTED_AT = "started_at"
 
 STATE_OFFLINE = "offline"
 STATE_STREAMING = "streaming"
@@ -104,6 +105,7 @@ class TwitchSensor(SensorEntity):
             self._attr_native_value = STATE_STREAMING
             self._attr_extra_state_attributes[ATTR_GAME] = stream.game_name
             self._attr_extra_state_attributes[ATTR_TITLE] = stream.title
+            self._attr_extra_state_attributes[ATTR_STARTED_AT] = stream.started_at
             self._attr_entity_picture = stream.thumbnail_url
             if self._attr_entity_picture is not None:
                 self._attr_entity_picture = self._attr_entity_picture.format(
@@ -114,6 +116,7 @@ class TwitchSensor(SensorEntity):
             self._attr_native_value = STATE_OFFLINE
             self._attr_extra_state_attributes[ATTR_GAME] = None
             self._attr_extra_state_attributes[ATTR_TITLE] = None
+            self._attr_extra_state_attributes[ATTR_STARTED_AT] = None
             self._attr_entity_picture = self._channel.profile_image_url
 
     async def _async_add_user_attributes(self) -> None:

--- a/tests/components/twitch/fixtures/get_streams.json
+++ b/tests/components/twitch/fixtures/get_streams.json
@@ -2,6 +2,7 @@
   {
     "game_name": "Good game",
     "title": "Title",
-    "thumbnail_url": "stream-medium.png"
+    "thumbnail_url": "stream-medium.png",
+    "started_at": "2021-03-10T03:18:11Z"
   }
 ]

--- a/tests/components/twitch/test_sensor.py
+++ b/tests/components/twitch/test_sensor.py
@@ -41,6 +41,7 @@ async def test_streaming(
     assert sensor_state.attributes["entity_picture"] == "stream-medium.png"
     assert sensor_state.attributes["game"] == "Good game"
     assert sensor_state.attributes["title"] == "Title"
+    assert sensor_state.attributes["started_at"] == "2021-03-10T03:18:11Z"
 
 
 async def test_oauth_without_sub_and_follow(

--- a/tests/components/twitch/test_sensor.py
+++ b/tests/components/twitch/test_sensor.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 from unittest.mock import AsyncMock
 
+from dateutil.tz import tzutc
 from twitchAPI.object.api import FollowedChannel, Stream, UserSubscription
 from twitchAPI.type import TwitchResourceNotFound
 
@@ -41,7 +42,9 @@ async def test_streaming(
     assert sensor_state.attributes["entity_picture"] == "stream-medium.png"
     assert sensor_state.attributes["game"] == "Good game"
     assert sensor_state.attributes["title"] == "Title"
-    assert sensor_state.attributes["started_at"] == "2021-03-10T03:18:11Z"
+    assert sensor_state.attributes["started_at"] == datetime(
+        year=2021, month=3, day=10, hour=3, minute=18, second=11, tzinfo=tzutc()
+    )
 
 
 async def test_oauth_without_sub_and_follow(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Exposes the "Started At" timestamp as an attribute on the sensors. The timestamp is useful for automations that trigger when a stream starts. A example usage would be during "subathons", where a Twitch streamer may be streaming for weeks on end restarting the stream as required by Twitch, but too quickly to be detected by polling the state. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
