### PR TITLE
Add AsyncCallable type alias

### DIFF
--- a/homeassistant/components/adguard/sensor.py
+++ b/homeassistant/components/adguard/sensor.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Any
 
 from adguardhome import AdGuardHome
 
@@ -13,6 +11,7 @@ from homeassistant.components.sensor import SensorEntity, SensorEntityDescriptio
 from homeassistant.const import PERCENTAGE, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import AsyncCallable
 
 from . import AdGuardConfigEntry, AdGuardData
 from .const import DOMAIN
@@ -26,7 +25,7 @@ PARALLEL_UPDATES = 4
 class AdGuardHomeEntityDescription(SensorEntityDescription):
     """Describes AdGuard Home sensor entity."""
 
-    value_fn: Callable[[AdGuardHome], Coroutine[Any, Any, int | float]]
+    value_fn: AsyncCallable[[AdGuardHome], int | float]
 
 
 SENSORS: tuple[AdGuardHomeEntityDescription, ...] = (

--- a/homeassistant/components/adguard/switch.py
+++ b/homeassistant/components/adguard/switch.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any
@@ -12,6 +12,7 @@ from adguardhome import AdGuardHome, AdGuardHomeError
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import AsyncCallable
 
 from . import AdGuardConfigEntry, AdGuardData
 from .const import DOMAIN, LOGGER
@@ -25,9 +26,9 @@ PARALLEL_UPDATES = 1
 class AdGuardHomeSwitchEntityDescription(SwitchEntityDescription):
     """Describes AdGuard Home switch entity."""
 
-    is_on_fn: Callable[[AdGuardHome], Callable[[], Coroutine[Any, Any, bool]]]
-    turn_on_fn: Callable[[AdGuardHome], Callable[[], Coroutine[Any, Any, None]]]
-    turn_off_fn: Callable[[AdGuardHome], Callable[[], Coroutine[Any, Any, None]]]
+    is_on_fn: Callable[[AdGuardHome], AsyncCallable[[], bool]]
+    turn_on_fn: Callable[[AdGuardHome], AsyncCallable[[], None]]
+    turn_off_fn: Callable[[AdGuardHome], AsyncCallable[[], None]]
 
 
 SWITCHES: tuple[AdGuardHomeSwitchEntityDescription, ...] = (

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Coroutine
 import logging
 import math
 from typing import Any
@@ -54,6 +53,7 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.helpers import network
+from homeassistant.helpers.typing import AsyncCallable
 from homeassistant.util import color as color_util, dt as dt_util
 from homeassistant.util.decorator import Registry
 from homeassistant.util.unit_conversion import TemperatureConverter
@@ -102,9 +102,8 @@ SERVICE_SET_TEMPERATURE = {
 
 HANDLERS: Registry[
     tuple[str, str],
-    Callable[
-        [ha.HomeAssistant, AbstractConfig, AlexaDirective, ha.Context],
-        Coroutine[Any, Any, AlexaResponse],
+    AsyncCallable[
+        [ha.HomeAssistant, AbstractConfig, AlexaDirective, ha.Context], AlexaResponse
     ],
 ] = Registry()
 

--- a/homeassistant/components/alexa/intent.py
+++ b/homeassistant/components/alexa/intent.py
@@ -1,6 +1,5 @@
 """Support for Alexa skill service end point."""
 
-from collections.abc import Callable, Coroutine
 import enum
 import logging
 from typing import Any
@@ -11,6 +10,7 @@ from homeassistant.components import http
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import intent
+from homeassistant.helpers.typing import AsyncCallable
 from homeassistant.util.decorator import Registry
 
 from .const import DOMAIN, SYN_RESOLUTION_MATCH
@@ -18,7 +18,7 @@ from .const import DOMAIN, SYN_RESOLUTION_MATCH
 _LOGGER = logging.getLogger(__name__)
 
 HANDLERS: Registry[
-    str, Callable[[HomeAssistant, dict[str, Any]], Coroutine[Any, Any, dict[str, Any]]]
+    str, AsyncCallable[[HomeAssistant, dict[str, Any]], dict[str, Any]]
 ] = Registry()
 
 INTENTS_API_ENDPOINT = "/api/alexa"

--- a/homeassistant/components/android_ip_webcam/switch.py
+++ b/homeassistant/components/android_ip_webcam/switch.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from typing import Any
 
@@ -13,6 +12,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import AsyncCallable
 
 from .const import DOMAIN
 from .coordinator import AndroidIPCamDataUpdateCoordinator
@@ -23,8 +23,8 @@ from .entity import AndroidIPCamBaseEntity
 class AndroidIPWebcamSwitchEntityDescription(SwitchEntityDescription):
     """Entity description class for Android IP Webcam switches."""
 
-    on_func: Callable[[PyDroidIPCam], Coroutine[Any, Any, bool]]
-    off_func: Callable[[PyDroidIPCam], Coroutine[Any, Any, bool]]
+    on_func: AsyncCallable[[PyDroidIPCam], bool]
+    off_func: AsyncCallable[[PyDroidIPCam], bool]
 
 
 SWITCH_TYPES: tuple[AndroidIPWebcamSwitchEntityDescription, ...] = (

--- a/homeassistant/components/androidtv/entity.py
+++ b/homeassistant/components/androidtv/entity.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Coroutine
+from collections.abc import Callable
 import functools
 import logging
-from typing import Any, Concatenate
+from typing import Concatenate
 
 from androidtv.exceptions import LockNotAcquiredException
 
@@ -21,6 +21,7 @@ from homeassistant.const import (
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.typing import AsyncCallable
 
 from . import (
     ADB_PYTHON_EXCEPTIONS,
@@ -35,10 +36,8 @@ PREFIX_FIRETV = "Fire TV"
 
 _LOGGER = logging.getLogger(__name__)
 
-type _FuncType[_T, **_P, _R] = Callable[Concatenate[_T, _P], Awaitable[_R]]
-type _ReturnFuncType[_T, **_P, _R] = Callable[
-    Concatenate[_T, _P], Coroutine[Any, Any, _R | None]
-]
+type _FuncType[_T, **_P, _R] = AsyncCallable[Concatenate[_T, _P], _R]
+type _ReturnFuncType[_T, **_P, _R] = AsyncCallable[Concatenate[_T, _P], _R | None]
 
 
 def adb_decorator[_ADBDeviceT: AndroidTVEntity, **_P, _R](

--- a/homeassistant/components/androidtv/entity.py
+++ b/homeassistant/components/androidtv/entity.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable, Coroutine
 import functools
 import logging
-from typing import Concatenate
+from typing import Any, Concatenate
 
 from androidtv.exceptions import LockNotAcquiredException
 
@@ -21,7 +21,6 @@ from homeassistant.const import (
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.typing import AsyncCallable
 
 from . import (
     ADB_PYTHON_EXCEPTIONS,
@@ -36,8 +35,10 @@ PREFIX_FIRETV = "Fire TV"
 
 _LOGGER = logging.getLogger(__name__)
 
-type _FuncType[_T, **_P, _R] = AsyncCallable[Concatenate[_T, _P], _R]
-type _ReturnFuncType[_T, **_P, _R] = AsyncCallable[Concatenate[_T, _P], _R | None]
+type _FuncType[_T, **_P, _R] = Callable[Concatenate[_T, _P], Awaitable[_R]]
+type _ReturnFuncType[_T, **_P, _R] = Callable[
+    Concatenate[_T, _P], Coroutine[Any, Any, _R | None]
+]
 
 
 def adb_decorator[_ADBDeviceT: AndroidTVEntity, **_P, _R](

--- a/homeassistant/components/androidtv/entity.py
+++ b/homeassistant/components/androidtv/entity.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Coroutine
+from collections.abc import Awaitable, Callable
 import functools
 import logging
-from typing import Any, Concatenate
+from typing import Concatenate
 
 from androidtv.exceptions import LockNotAcquiredException
 
@@ -21,6 +21,7 @@ from homeassistant.const import (
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.typing import AsyncCallable
 
 from . import (
     ADB_PYTHON_EXCEPTIONS,
@@ -36,9 +37,7 @@ PREFIX_FIRETV = "Fire TV"
 _LOGGER = logging.getLogger(__name__)
 
 type _FuncType[_T, **_P, _R] = Callable[Concatenate[_T, _P], Awaitable[_R]]
-type _ReturnFuncType[_T, **_P, _R] = Callable[
-    Concatenate[_T, _P], Coroutine[Any, Any, _R | None]
-]
+type _ReturnFuncType[_T, **_P, _R] = AsyncCallable[Concatenate[_T, _P], _R | None]
 
 
 def adb_decorator[_ADBDeviceT: AndroidTVEntity, **_P, _R](

--- a/homeassistant/components/arcam_fmj/media_player.py
+++ b/homeassistant/components/arcam_fmj/media_player.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Coroutine
 import functools
 import logging
 from typing import Any
@@ -26,6 +25,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import AsyncCallable
 
 from .config_flow import get_entry_client
 from .const import (
@@ -61,9 +61,7 @@ async def async_setup_entry(
     )
 
 
-def convert_exception[**_P, _R](
-    func: Callable[_P, Coroutine[Any, Any, _R]],
-) -> Callable[_P, Coroutine[Any, Any, _R]]:
+def convert_exception[**_P, _R](func: AsyncCallable[_P, _R]) -> AsyncCallable[_P, _R]:
     """Return decorator to convert a connection error into a home assistant error."""
 
     @functools.wraps(func)

--- a/homeassistant/components/asuswrt/bridge.py
+++ b/homeassistant/components/asuswrt/bridge.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections import namedtuple
-from collections.abc import Awaitable, Callable, Coroutine
+from collections.abc import Awaitable, Callable
 import functools
 import logging
 from typing import Any, cast
@@ -25,6 +25,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.typing import AsyncCallable
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from .const import (
@@ -57,7 +58,7 @@ WrtDevice = namedtuple("WrtDevice", ["ip", "name", "connected_to"])
 _LOGGER = logging.getLogger(__name__)
 
 type _FuncType[_T] = Callable[[_T], Awaitable[list[Any] | tuple[Any] | dict[str, Any]]]
-type _ReturnFuncType[_T] = Callable[[_T], Coroutine[Any, Any, dict[str, Any]]]
+type _ReturnFuncType[_T] = AsyncCallable[[_T], dict[str, Any]]
 
 
 def handle_errors_and_zip[_AsusWrtBridgeT: AsusWrtBridge](

--- a/homeassistant/components/asuswrt/bridge.py
+++ b/homeassistant/components/asuswrt/bridge.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections import namedtuple
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 import functools
 import logging
 from typing import Any, cast
@@ -57,7 +57,7 @@ WrtDevice = namedtuple("WrtDevice", ["ip", "name", "connected_to"])
 
 _LOGGER = logging.getLogger(__name__)
 
-type _FuncType[_T] = Callable[[_T], Awaitable[list[Any] | tuple[Any] | dict[str, Any]]]
+type _FuncType[_T] = AsyncCallable[[_T], list[Any] | tuple[Any] | dict[str, Any]]
 type _ReturnFuncType[_T] = AsyncCallable[[_T], dict[str, Any]]
 
 

--- a/homeassistant/components/august/lock.py
+++ b/homeassistant/components/august/lock.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Coroutine
 import logging
 from typing import Any
 
@@ -16,6 +15,7 @@ from homeassistant.const import ATTR_BATTERY_LEVEL
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.typing import AsyncCallable
 import homeassistant.util.dt as dt_util
 
 from . import AugustConfigEntry, AugustData
@@ -70,7 +70,7 @@ class AugustLock(AugustEntityMixin, RestoreEntity, LockEntity):
         await self._call_lock_operation(self._data.async_unlock)
 
     async def _call_lock_operation(
-        self, lock_operation: Callable[[str], Coroutine[Any, Any, list[ActivityTypes]]]
+        self, lock_operation: AsyncCallable[[str], list[ActivityTypes]]
     ) -> None:
         try:
             activities = await lock_operation(self._device_id)

--- a/homeassistant/helpers/httpx_client.py
+++ b/homeassistant/helpers/httpx_client.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Coroutine
 import sys
 from typing import Any, Self
 
@@ -19,6 +18,7 @@ from homeassistant.util.ssl import (
 )
 
 from .frame import warn_use
+from .typing import AsyncCallable
 
 # We have a lot of integrations that poll every 10-30 seconds
 # and we want to keep the connection open for a while so we
@@ -105,7 +105,7 @@ def create_async_httpx_client(
 def _async_register_async_client_shutdown(
     hass: HomeAssistant,
     client: httpx.AsyncClient,
-    original_aclose: Callable[[], Coroutine[Any, Any, None]],
+    original_aclose: AsyncCallable[[], None],
 ) -> None:
     """Register httpx AsyncClient aclose on Home Assistant shutdown.
 

--- a/homeassistant/helpers/schema_config_entry_flow.py
+++ b/homeassistant/helpers/schema_config_entry_flow.py
@@ -22,7 +22,7 @@ from homeassistant.core import HomeAssistant, callback, split_entity_id
 from homeassistant.data_entry_flow import UnknownHandler
 
 from . import entity_registry as er, selector
-from .typing import UNDEFINED, UndefinedType
+from .typing import UNDEFINED, AsyncCallable, UndefinedType
 
 
 class SchemaFlowError(Exception):
@@ -39,9 +39,7 @@ class SchemaFlowFormStep(SchemaFlowStep):
     """Define a config or options flow form step."""
 
     schema: (
-        vol.Schema
-        | Callable[[SchemaCommonFlowHandler], Coroutine[Any, Any, vol.Schema | None]]
-        | None
+        vol.Schema | AsyncCallable[[SchemaCommonFlowHandler], vol.Schema | None] | None
     ) = None
     """Optional voluptuous schema, or function which returns a schema or None, for
     requesting and validating user input.
@@ -67,9 +65,7 @@ class SchemaFlowFormStep(SchemaFlowStep):
     - The `validate_user_input` should raise `SchemaFlowError` if user input is invalid.
     """
 
-    next_step: (
-        Callable[[dict[str, Any]], Coroutine[Any, Any, str | None]] | str | None
-    ) = None
+    next_step: AsyncCallable[[dict[str, Any]], str | None] | str | None = None
     """Optional property to identify next step.
 
     - If `next_step` is a function, it is called if the schema validates successfully or
@@ -80,9 +76,7 @@ class SchemaFlowFormStep(SchemaFlowStep):
     """
 
     suggested_values: (
-        Callable[[SchemaCommonFlowHandler], Coroutine[Any, Any, dict[str, Any]]]
-        | None
-        | UndefinedType
+        AsyncCallable[[SchemaCommonFlowHandler], dict[str, Any]] | None | UndefinedType
     ) = UNDEFINED
     """Optional property to populate suggested values.
 
@@ -412,8 +406,7 @@ class SchemaOptionsFlowHandler(OptionsFlowWithConfigEntry):
         options_flow: Mapping[str, SchemaFlowStep],
         async_options_flow_finished: Callable[[HomeAssistant, Mapping[str, Any]], None]
         | None = None,
-        async_setup_preview: Callable[[HomeAssistant], Coroutine[Any, Any, None]]
-        | None = None,
+        async_setup_preview: AsyncCallable[[HomeAssistant], None] | None = None,
     ) -> None:
         """Initialize options flow.
 

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable, Coroutine, Iterable
+from collections.abc import Awaitable, Callable, Iterable
 import dataclasses
 from enum import Enum
 from functools import cache, partial
@@ -63,7 +63,7 @@ from . import (
 )
 from .group import expand_entity_ids
 from .selector import TargetSelector
-from .typing import ConfigType, TemplateVarsType, VolSchemaType
+from .typing import AsyncCallable, ConfigType, TemplateVarsType, VolSchemaType
 
 if TYPE_CHECKING:
     from .entity import Entity
@@ -1189,7 +1189,7 @@ class ReloadServiceHelper[_T]:
 
     def __init__(
         self,
-        service_func: Callable[[ServiceCall], Coroutine[Any, Any, Any]],
+        service_func: AsyncCallable[[ServiceCall], Any],
         reload_targets_func: Callable[[ServiceCall], set[_T]],
     ) -> None:
         """Initialize ReloadServiceHelper."""

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -33,7 +33,7 @@ from homeassistant.util.async_ import create_eager_task
 from homeassistant.util.hass_dict import HassKey
 
 from .template import Template
-from .typing import ConfigType, TemplateVarsType
+from .typing import AsyncCallable, ConfigType, TemplateVarsType
 
 _PLATFORM_ALIASES = {
     "device": "device_automation",
@@ -265,9 +265,9 @@ def _trigger_action_wrapper(
     while isinstance(check_func, functools.partial):
         check_func = check_func.func
 
-    wrapper_func: Callable[..., None] | Callable[..., Coroutine[Any, Any, None]]
+    wrapper_func: Callable[..., None] | AsyncCallable[..., None]
     if asyncio.iscoroutinefunction(check_func):
-        async_action = cast(Callable[..., Coroutine[Any, Any, None]], action)
+        async_action = cast(AsyncCallable[..., None], action)
 
         @functools.wraps(async_action)
         async def async_with_vars(

--- a/homeassistant/helpers/typing.py
+++ b/homeassistant/helpers/typing.py
@@ -15,6 +15,8 @@ from .deprecation import (
 )
 
 type AsyncCallable[**_P, _R_co] = Callable[_P, Coroutine[Any, Any, _R_co]]
+"""Mirrors `Callable` but for async functions."""
+
 type GPSType = tuple[float, float]
 type ConfigType = dict[str, Any]
 type DiscoveryInfoType = dict[str, Any]

--- a/homeassistant/helpers/typing.py
+++ b/homeassistant/helpers/typing.py
@@ -1,6 +1,6 @@
 """Typing Helpers for Home Assistant."""
 
-from collections.abc import Mapping
+from collections.abc import Callable, Coroutine, Mapping
 from enum import Enum
 from functools import partial
 from typing import Any, Never
@@ -14,6 +14,7 @@ from .deprecation import (
     dir_with_deprecated_constants,
 )
 
+type AsyncCallable[**_P, _R_co] = Callable[_P, Coroutine[Any, Any, _R_co]]
 type GPSType = tuple[float, float]
 type ConfigType = dict[str, Any]
 type DiscoveryInfoType = dict[str, Any]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adding type hints for a `Callable` is already verbose, but when the `Callable` refers to an async function it becomes really messy.
I propose to add `AsyncCallable` as a type alias, with a signature which mirrors `Callable`

```python
# Current:
value_fn: Callable[[AdGuardHome], Coroutine[Any, Any, int | float]]
value_fn: Callable[[HomeAssistant, dict[str, Any]], Coroutine[Any, Any, dict[str, Any]]]

# With AsyncCallable:
value_fn: AsyncCallable[[AdGuardHome], int | float]
value_fn: AsyncCallable[[HomeAssistant, dict[str, Any]], dict[str, Any]]
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
