### PR TITLE
Improve type hints in hdmi_cec tests

### DIFF
--- a/tests/components/hdmi_cec/conftest.py
+++ b/tests/components/hdmi_cec/conftest.py
@@ -1,16 +1,22 @@
 """Tests for the HDMI-CEC component."""
 
-from unittest.mock import patch
+from collections.abc import Callable, Coroutine, Generator
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from homeassistant.components.hdmi_cec import DOMAIN
 from homeassistant.const import EVENT_HOMEASSISTANT_START
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+
+type CecEntityCreator = Callable[..., Coroutine[Any, Any, None]]
+type HDMINetworkCreator = Callable[..., Coroutine[Any, Any, MagicMock]]
 
 
 @pytest.fixture(name="mock_cec_adapter", autouse=True)
-def mock_cec_adapter_fixture():
+def mock_cec_adapter_fixture() -> Generator[MagicMock]:
     """Mock CecAdapter.
 
     Always mocked as it imports the `cec` library which is part of `libcec`.
@@ -22,7 +28,7 @@ def mock_cec_adapter_fixture():
 
 
 @pytest.fixture(name="mock_hdmi_network")
-def mock_hdmi_network_fixture():
+def mock_hdmi_network_fixture() -> Generator[MagicMock]:
     """Mock HDMINetwork."""
     with patch(
         "homeassistant.components.hdmi_cec.HDMINetwork", autospec=True
@@ -31,7 +37,9 @@ def mock_hdmi_network_fixture():
 
 
 @pytest.fixture
-def create_hdmi_network(hass, mock_hdmi_network):
+def create_hdmi_network(
+    hass: HomeAssistant, mock_hdmi_network: MagicMock
+) -> HDMINetworkCreator:
     """Create an initialized mock hdmi_network."""
 
     async def hdmi_network(config=None):
@@ -49,7 +57,7 @@ def create_hdmi_network(hass, mock_hdmi_network):
 
 
 @pytest.fixture
-def create_cec_entity(hass):
+def create_cec_entity(hass: HomeAssistant) -> CecEntityCreator:
     """Create a CecEntity."""
 
     async def cec_entity(hdmi_network, device):

--- a/tests/components/hdmi_cec/test_init.py
+++ b/tests/components/hdmi_cec/test_init.py
@@ -1,7 +1,9 @@
 """Tests for the HDMI-CEC component."""
 
+from collections.abc import Generator
 from datetime import timedelta
-from unittest.mock import ANY, PropertyMock, call, patch
+from typing import Any
+from unittest.mock import ANY, MagicMock, PropertyMock, call, patch
 
 import pytest
 import voluptuous as vol
@@ -28,6 +30,7 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
 from . import assert_key_press_release
+from .conftest import HDMINetworkCreator
 
 from tests.common import (
     MockEntity,
@@ -38,7 +41,7 @@ from tests.common import (
 
 
 @pytest.fixture(name="mock_tcp_adapter")
-def mock_tcp_adapter_fixture():
+def mock_tcp_adapter_fixture() -> Generator[MagicMock]:
     """Mock TcpAdapter."""
     with patch(
         "homeassistant.components.hdmi_cec.TcpAdapter", autospec=True
@@ -88,7 +91,9 @@ def mock_tcp_adapter_fixture():
         ),
     ],
 )
-def test_parse_mapping_physical_address(mapping, expected) -> None:
+def test_parse_mapping_physical_address(
+    mapping: dict[str, Any], expected: list[tuple[str, list[int]]]
+) -> None:
     """Test the device config mapping function."""
     result = parse_mapping(mapping)
     result = [
@@ -101,7 +106,7 @@ def test_parse_mapping_physical_address(mapping, expected) -> None:
 
 
 async def test_setup_cec_adapter(
-    hass: HomeAssistant, mock_cec_adapter, mock_hdmi_network
+    hass: HomeAssistant, mock_cec_adapter: MagicMock, mock_hdmi_network: MagicMock
 ) -> None:
     """Test the general setup of this component."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
@@ -125,7 +130,7 @@ async def test_setup_cec_adapter(
 
 @pytest.mark.parametrize("osd_name", ["test", "test_a_long_name"])
 async def test_setup_set_osd_name(
-    hass: HomeAssistant, osd_name, mock_cec_adapter
+    hass: HomeAssistant, osd_name: str, mock_cec_adapter: MagicMock
 ) -> None:
     """Test the setup of this component with the `osd_name` config setting."""
     await async_setup_component(hass, DOMAIN, {DOMAIN: {"osd_name": osd_name}})
@@ -134,7 +139,7 @@ async def test_setup_set_osd_name(
 
 
 async def test_setup_tcp_adapter(
-    hass: HomeAssistant, mock_tcp_adapter, mock_hdmi_network
+    hass: HomeAssistant, mock_tcp_adapter: MagicMock, mock_hdmi_network: MagicMock
 ) -> None:
     """Test the setup of this component with the TcpAdapter (`host` config setting)."""
     host = "0.0.0.0"
@@ -161,7 +166,9 @@ async def test_setup_tcp_adapter(
 # Test services
 
 
-async def test_service_power_on(hass: HomeAssistant, create_hdmi_network) -> None:
+async def test_service_power_on(
+    hass: HomeAssistant, create_hdmi_network: HDMINetworkCreator
+) -> None:
     """Test the power on service call."""
     mock_hdmi_network_instance = await create_hdmi_network()
 
@@ -175,7 +182,9 @@ async def test_service_power_on(hass: HomeAssistant, create_hdmi_network) -> Non
     mock_hdmi_network_instance.power_on.assert_called_once_with()
 
 
-async def test_service_standby(hass: HomeAssistant, create_hdmi_network) -> None:
+async def test_service_standby(
+    hass: HomeAssistant, create_hdmi_network: HDMINetworkCreator
+) -> None:
     """Test the standby service call."""
     mock_hdmi_network_instance = await create_hdmi_network()
 
@@ -190,7 +199,7 @@ async def test_service_standby(hass: HomeAssistant, create_hdmi_network) -> None
 
 
 async def test_service_select_device_alias(
-    hass: HomeAssistant, create_hdmi_network
+    hass: HomeAssistant, create_hdmi_network: HDMINetworkCreator
 ) -> None:
     """Test the select device service call with a known alias."""
     mock_hdmi_network_instance = await create_hdmi_network(
@@ -220,7 +229,7 @@ class MockCecEntity(MockEntity):
 
 
 async def test_service_select_device_entity(
-    hass: HomeAssistant, create_hdmi_network
+    hass: HomeAssistant, create_hdmi_network: HDMINetworkCreator
 ) -> None:
     """Test the select device service call with an existing entity."""
     platform = MockEntityPlatform(hass)
@@ -244,7 +253,7 @@ async def test_service_select_device_entity(
 
 
 async def test_service_select_device_physical_address(
-    hass: HomeAssistant, create_hdmi_network
+    hass: HomeAssistant, create_hdmi_network: HDMINetworkCreator
 ) -> None:
     """Test the select device service call with a raw physical address."""
     mock_hdmi_network_instance = await create_hdmi_network()
@@ -262,7 +271,9 @@ async def test_service_select_device_physical_address(
     assert str(physical_address) == "1.1.0.0"
 
 
-async def test_service_update_devices(hass: HomeAssistant, create_hdmi_network) -> None:
+async def test_service_update_devices(
+    hass: HomeAssistant, create_hdmi_network: HDMINetworkCreator
+) -> None:
     """Test the update devices service call."""
     mock_hdmi_network_instance = await create_hdmi_network()
 
@@ -295,11 +306,11 @@ async def test_service_update_devices(hass: HomeAssistant, create_hdmi_network) 
 @pytest.mark.parametrize(("direction", "key"), [("up", 65), ("down", 66)])
 async def test_service_volume_x_times(
     hass: HomeAssistant,
-    create_hdmi_network,
+    create_hdmi_network: HDMINetworkCreator,
     count: int,
     call_count: int,
-    direction,
-    key,
+    direction: str,
+    key: int,
 ) -> None:
     """Test the volume service call with steps."""
     mock_hdmi_network_instance = await create_hdmi_network()
@@ -320,7 +331,10 @@ async def test_service_volume_x_times(
 
 @pytest.mark.parametrize(("direction", "key"), [("up", 65), ("down", 66)])
 async def test_service_volume_press(
-    hass: HomeAssistant, create_hdmi_network, direction, key
+    hass: HomeAssistant,
+    create_hdmi_network: HDMINetworkCreator,
+    direction: str,
+    key: int,
 ) -> None:
     """Test the volume service call with press attribute."""
     mock_hdmi_network_instance = await create_hdmi_network()
@@ -341,7 +355,10 @@ async def test_service_volume_press(
 
 @pytest.mark.parametrize(("direction", "key"), [("up", 65), ("down", 66)])
 async def test_service_volume_release(
-    hass: HomeAssistant, create_hdmi_network, direction, key
+    hass: HomeAssistant,
+    create_hdmi_network: HDMINetworkCreator,
+    direction: str,
+    key: int,
 ) -> None:
     """Test the volume service call with release attribute."""
     mock_hdmi_network_instance = await create_hdmi_network()
@@ -376,7 +393,7 @@ async def test_service_volume_release(
     ],
 )
 async def test_service_volume_mute(
-    hass: HomeAssistant, create_hdmi_network, attr, key
+    hass: HomeAssistant, create_hdmi_network: HDMINetworkCreator, attr: str, key: int
 ) -> None:
     """Test the volume service call with mute."""
     mock_hdmi_network_instance = await create_hdmi_network()
@@ -447,7 +464,10 @@ async def test_service_volume_mute(
     ],
 )
 async def test_service_send_command(
-    hass: HomeAssistant, create_hdmi_network, data, expected
+    hass: HomeAssistant,
+    create_hdmi_network: HDMINetworkCreator,
+    data: dict[str, Any],
+    expected: str,
 ) -> None:
     """Test the send command service call."""
     mock_hdmi_network_instance = await create_hdmi_network()
@@ -470,10 +490,10 @@ async def test_service_send_command(
 )
 async def test_watchdog(
     hass: HomeAssistant,
-    create_hdmi_network,
-    mock_cec_adapter,
-    adapter_initialized_value,
-    watchdog_actions,
+    create_hdmi_network: HDMINetworkCreator,
+    mock_cec_adapter: MagicMock,
+    adapter_initialized_value: bool,
+    watchdog_actions: int,
 ) -> None:
     """Test the watchdog when adapter is down/up."""
     adapter_initialized = PropertyMock(return_value=adapter_initialized_value)

--- a/tests/components/hdmi_cec/test_media_player.py
+++ b/tests/components/hdmi_cec/test_media_player.py
@@ -1,6 +1,7 @@
 """Tests for the HDMI-CEC media player platform."""
 
 from collections.abc import Callable
+from typing import Any
 
 from pycec.const import (
     DEVICE_TYPE_NAMES,
@@ -55,6 +56,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 
 from . import MockHDMIDevice, assert_key_press_release
+from .conftest import CecEntityCreator, HDMINetworkCreator
 
 type AssertState = Callable[[str, str], None]
 
@@ -91,7 +93,9 @@ def assert_state_fixture(request: pytest.FixtureRequest) -> AssertState:
 
 
 async def test_load_platform(
-    hass: HomeAssistant, create_hdmi_network, create_cec_entity
+    hass: HomeAssistant,
+    create_hdmi_network: HDMINetworkCreator,
+    create_cec_entity: CecEntityCreator,
 ) -> None:
     """Test that media_player entity is loaded."""
     hdmi_network = await create_hdmi_network(config={"platform": "media_player"})
@@ -107,7 +111,10 @@ async def test_load_platform(
 
 @pytest.mark.parametrize("platform", [{}, {"platform": "switch"}])
 async def test_load_types(
-    hass: HomeAssistant, create_hdmi_network, create_cec_entity, platform
+    hass: HomeAssistant,
+    create_hdmi_network: HDMINetworkCreator,
+    create_cec_entity: CecEntityCreator,
+    platform: dict[str, Any],
 ) -> None:
     """Test that media_player entity is loaded when types is set."""
     config = platform | {"types": {"hdmi_cec.hdmi_4": "media_player"}}
@@ -133,8 +140,8 @@ async def test_load_types(
 
 async def test_service_on(
     hass: HomeAssistant,
-    create_hdmi_network,
-    create_cec_entity,
+    create_hdmi_network: HDMINetworkCreator,
+    create_cec_entity: CecEntityCreator,
     assert_state: AssertState,
 ) -> None:
     """Test that media_player triggers on `on` service."""
@@ -160,8 +167,8 @@ async def test_service_on(
 
 async def test_service_off(
     hass: HomeAssistant,
-    create_hdmi_network,
-    create_cec_entity,
+    create_hdmi_network: HDMINetworkCreator,
+    create_cec_entity: CecEntityCreator,
     assert_state: AssertState,
 ) -> None:
     """Test that media_player triggers on `off` service."""
@@ -260,10 +267,10 @@ async def test_service_off(
 )
 async def test_supported_features(
     hass: HomeAssistant,
-    create_hdmi_network,
-    create_cec_entity,
-    type_id,
-    expected_features,
+    create_hdmi_network: HDMINetworkCreator,
+    create_cec_entity: CecEntityCreator,
+    type_id: int,
+    expected_features: MPEF,
 ) -> None:
     """Test that features load as expected."""
     hdmi_network = await create_hdmi_network({"platform": "media_player"})
@@ -289,11 +296,11 @@ async def test_supported_features(
 )
 async def test_volume_services(
     hass: HomeAssistant,
-    create_hdmi_network,
-    create_cec_entity,
-    service,
-    extra_data,
-    key,
+    create_hdmi_network: HDMINetworkCreator,
+    create_cec_entity: CecEntityCreator,
+    service: str,
+    extra_data: dict[str, Any] | None,
+    key: int,
 ) -> None:
     """Test volume related commands."""
     hdmi_network = await create_hdmi_network({"platform": "media_player"})
@@ -324,7 +331,11 @@ async def test_volume_services(
     ],
 )
 async def test_track_change_services(
-    hass: HomeAssistant, create_hdmi_network, create_cec_entity, service, key
+    hass: HomeAssistant,
+    create_hdmi_network: HDMINetworkCreator,
+    create_cec_entity: CecEntityCreator,
+    service: str,
+    key: int,
 ) -> None:
     """Test track change related commands."""
     hdmi_network = await create_hdmi_network({"platform": "media_player"})
@@ -360,8 +371,8 @@ async def test_track_change_services(
 )
 async def test_playback_services(
     hass: HomeAssistant,
-    create_hdmi_network,
-    create_cec_entity,
+    create_hdmi_network: HDMINetworkCreator,
+    create_cec_entity: CecEntityCreator,
     assert_state: AssertState,
     service: str,
     key: int,
@@ -390,8 +401,8 @@ async def test_playback_services(
 @pytest.mark.xfail(reason="PLAY feature isn't enabled")
 async def test_play_pause_service(
     hass: HomeAssistant,
-    create_hdmi_network,
-    create_cec_entity,
+    create_hdmi_network: HDMINetworkCreator,
+    create_cec_entity: CecEntityCreator,
     assert_state: AssertState,
 ) -> None:
     """Test play pause service."""
@@ -452,11 +463,11 @@ async def test_play_pause_service(
 )
 async def test_update_state(
     hass: HomeAssistant,
-    create_hdmi_network,
-    create_cec_entity,
-    type_id,
-    update_data,
-    expected_state,
+    create_hdmi_network: HDMINetworkCreator,
+    create_cec_entity: CecEntityCreator,
+    type_id: int,
+    update_data: dict[str, Any],
+    expected_state: str,
 ) -> None:
     """Test state updates work as expected."""
     hdmi_network = await create_hdmi_network({"platform": "media_player"})
@@ -502,7 +513,11 @@ async def test_update_state(
     ],
 )
 async def test_starting_state(
-    hass: HomeAssistant, create_hdmi_network, create_cec_entity, data, expected_state
+    hass: HomeAssistant,
+    create_hdmi_network: HDMINetworkCreator,
+    create_cec_entity: CecEntityCreator,
+    data: dict[str, Any],
+    expected_state: str,
 ) -> None:
     """Test starting states are set as expected."""
     hdmi_network = await create_hdmi_network({"platform": "media_player"})
@@ -516,7 +531,9 @@ async def test_starting_state(
     reason="The code only sets the state to unavailable, doesn't set the `_attr_available` to false."
 )
 async def test_unavailable_status(
-    hass: HomeAssistant, create_hdmi_network, create_cec_entity
+    hass: HomeAssistant,
+    create_hdmi_network: HDMINetworkCreator,
+    create_cec_entity: CecEntityCreator,
 ) -> None:
     """Test entity goes into unavailable status when expected."""
     hdmi_network = await create_hdmi_network({"platform": "media_player"})

--- a/tests/components/hdmi_cec/test_switch.py
+++ b/tests/components/hdmi_cec/test_switch.py
@@ -17,11 +17,15 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 
 from . import MockHDMIDevice
+from .conftest import CecEntityCreator, HDMINetworkCreator
 
 
 @pytest.mark.parametrize("config", [{}, {"platform": "switch"}])
 async def test_load_platform(
-    hass: HomeAssistant, create_hdmi_network, create_cec_entity, config
+    hass: HomeAssistant,
+    create_hdmi_network: HDMINetworkCreator,
+    create_cec_entity: CecEntityCreator,
+    config,
 ) -> None:
     """Test that switch entity is loaded."""
     hdmi_network = await create_hdmi_network(config=config)
@@ -36,7 +40,9 @@ async def test_load_platform(
 
 
 async def test_load_types(
-    hass: HomeAssistant, create_hdmi_network, create_cec_entity
+    hass: HomeAssistant,
+    create_hdmi_network: HDMINetworkCreator,
+    create_cec_entity: CecEntityCreator,
 ) -> None:
     """Test that switch entity is loaded when types is set."""
     config = {"platform": "media_player", "types": {"hdmi_cec.hdmi_3": "switch"}}
@@ -61,7 +67,9 @@ async def test_load_types(
 
 
 async def test_service_on(
-    hass: HomeAssistant, create_hdmi_network, create_cec_entity
+    hass: HomeAssistant,
+    create_hdmi_network: HDMINetworkCreator,
+    create_cec_entity: CecEntityCreator,
 ) -> None:
     """Test that switch triggers on `on` service."""
     hdmi_network = await create_hdmi_network()
@@ -81,7 +89,9 @@ async def test_service_on(
 
 
 async def test_service_off(
-    hass: HomeAssistant, create_hdmi_network, create_cec_entity
+    hass: HomeAssistant,
+    create_hdmi_network: HDMINetworkCreator,
+    create_cec_entity: CecEntityCreator,
 ) -> None:
     """Test that switch triggers on `off` service."""
     hdmi_network = await create_hdmi_network()
@@ -118,8 +128,8 @@ async def test_service_off(
 )
 async def test_device_status_change(
     hass: HomeAssistant,
-    create_hdmi_network,
-    create_cec_entity,
+    create_hdmi_network: HDMINetworkCreator,
+    create_cec_entity: CecEntityCreator,
     power_status,
     expected_state,
     status,
@@ -154,7 +164,11 @@ async def test_device_status_change(
     ],
 )
 async def test_friendly_name(
-    hass: HomeAssistant, create_hdmi_network, create_cec_entity, device_values, expected
+    hass: HomeAssistant,
+    create_hdmi_network: HDMINetworkCreator,
+    create_cec_entity: CecEntityCreator,
+    device_values,
+    expected,
 ) -> None:
     """Test friendly name setup."""
     hdmi_network = await create_hdmi_network()
@@ -207,8 +221,8 @@ async def test_friendly_name(
 )
 async def test_extra_state_attributes(
     hass: HomeAssistant,
-    create_hdmi_network,
-    create_cec_entity,
+    create_hdmi_network: HDMINetworkCreator,
+    create_cec_entity: CecEntityCreator,
     device_values,
     expected_attributes,
 ) -> None:
@@ -239,8 +253,8 @@ async def test_extra_state_attributes(
 )
 async def test_icon(
     hass: HomeAssistant,
-    create_hdmi_network,
-    create_cec_entity,
+    create_hdmi_network: HDMINetworkCreator,
+    create_cec_entity: CecEntityCreator,
     device_type,
     expected_icon,
 ) -> None:
@@ -254,7 +268,9 @@ async def test_icon(
 
 
 async def test_unavailable_status(
-    hass: HomeAssistant, create_hdmi_network, create_cec_entity
+    hass: HomeAssistant,
+    create_hdmi_network: HDMINetworkCreator,
+    create_cec_entity: CecEntityCreator,
 ) -> None:
     """Test entity goes into unavailable status when expected."""
     hdmi_network = await create_hdmi_network()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
