### PR TITLE
Use fixtures on deCONZ event tests

### DIFF
--- a/tests/components/deconz/test_deconz_event.py
+++ b/tests/components/deconz/test_deconz_event.py
@@ -1,12 +1,11 @@
 """Test deCONZ remote events."""
 
-from unittest.mock import patch
-
 from pydeconz.models.sensor.ancillary_control import (
     AncillaryControlAction,
     AncillaryControlPanel,
 )
 from pydeconz.models.sensor.presence import PresenceStatePresenceEvent
+import pytest
 
 from homeassistant.components.deconz.const import DOMAIN as DECONZ_DOMAIN
 from homeassistant.components.deconz.deconz_event import (
@@ -18,6 +17,7 @@ from homeassistant.components.deconz.deconz_event import (
     CONF_DECONZ_RELATIVE_ROTARY_EVENT,
     RELATIVE_ROTARY_DECONZ_TO_EVENT,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_DEVICE_ID,
     CONF_EVENT,
@@ -28,21 +28,13 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from .test_gateway import DECONZ_WEB_REQUEST, setup_deconz_integration
-
 from tests.common import async_capture_events
-from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_deconz_events(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    aioclient_mock: AiohttpClientMocker,
-    mock_deconz_websocket,
-) -> None:
-    """Test successful creation of deconz events."""
-    data = {
-        "sensors": {
+@pytest.mark.parametrize(
+    "sensor_payload",
+    [
+        {
             "1": {
                 "name": "Switch 1",
                 "type": "ZHASwitch",
@@ -79,14 +71,23 @@ async def test_deconz_events(
                 "uniqueid": "00:00:00:00:00:00:00:05-00",
             },
         }
-    }
-    with patch.dict(DECONZ_WEB_REQUEST, data):
-        config_entry = await setup_deconz_integration(hass, aioclient_mock)
-
+    ],
+)
+async def test_deconz_events(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    config_entry_setup: ConfigEntry,
+    mock_deconz_websocket,
+) -> None:
+    """Test successful creation of deconz events."""
     assert len(hass.states.async_all()) == 3
     # 5 switches + 2 additional devices for deconz service and host
     assert (
-        len(dr.async_entries_for_config_entry(device_registry, config_entry.entry_id))
+        len(
+            dr.async_entries_for_config_entry(
+                device_registry, config_entry_setup.entry_id
+            )
+        )
         == 7
     )
     assert hass.states.get("sensor.switch_2_battery").state == "100"
@@ -201,27 +202,22 @@ async def test_deconz_events(
 
     assert len(captured_events) == 4
 
-    await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.config_entries.async_unload(config_entry_setup.entry_id)
 
     states = hass.states.async_all()
     assert len(hass.states.async_all()) == 3
     for state in states:
         assert state.state == STATE_UNAVAILABLE
 
-    await hass.config_entries.async_remove(config_entry.entry_id)
+    await hass.config_entries.async_remove(config_entry_setup.entry_id)
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 0
 
 
-async def test_deconz_alarm_events(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    aioclient_mock: AiohttpClientMocker,
-    mock_deconz_websocket,
-) -> None:
-    """Test successful creation of deconz alarm events."""
-    data = {
-        "alarmsystems": {
+@pytest.mark.parametrize(
+    "alarm_system_payload",
+    [
+        {
             "0": {
                 "name": "default",
                 "config": {
@@ -248,8 +244,13 @@ async def test_deconz_alarm_events(
                     },
                 },
             }
-        },
-        "sensors": {
+        }
+    ],
+)
+@pytest.mark.parametrize(
+    "sensor_payload",
+    [
+        {
             "1": {
                 "config": {
                     "battery": 95,
@@ -276,15 +277,24 @@ async def test_deconz_alarm_events(
                 "type": "ZHAAncillaryControl",
                 "uniqueid": "00:00:00:00:00:00:00:01-00",
             }
-        },
-    }
-    with patch.dict(DECONZ_WEB_REQUEST, data):
-        config_entry = await setup_deconz_integration(hass, aioclient_mock)
-
+        }
+    ],
+)
+async def test_deconz_alarm_events(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    config_entry_setup: ConfigEntry,
+    mock_deconz_websocket,
+) -> None:
+    """Test successful creation of deconz alarm events."""
     assert len(hass.states.async_all()) == 4
     # 1 alarm control device + 2 additional devices for deconz service and host
     assert (
-        len(dr.async_entries_for_config_entry(device_registry, config_entry.entry_id))
+        len(
+            dr.async_entries_for_config_entry(
+                device_registry, config_entry_setup.entry_id
+            )
+        )
         == 3
     )
 
@@ -414,27 +424,22 @@ async def test_deconz_alarm_events(
 
     assert len(captured_events) == 4
 
-    await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.config_entries.async_unload(config_entry_setup.entry_id)
 
     states = hass.states.async_all()
     assert len(hass.states.async_all()) == 4
     for state in states:
         assert state.state == STATE_UNAVAILABLE
 
-    await hass.config_entries.async_remove(config_entry.entry_id)
+    await hass.config_entries.async_remove(config_entry_setup.entry_id)
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 0
 
 
-async def test_deconz_presence_events(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    aioclient_mock: AiohttpClientMocker,
-    mock_deconz_websocket,
-) -> None:
-    """Test successful creation of deconz presence events."""
-    data = {
-        "sensors": {
+@pytest.mark.parametrize(
+    "sensor_payload",
+    [
+        {
             "1": {
                 "config": {
                     "devicemode": "undirected",
@@ -459,13 +464,22 @@ async def test_deconz_presence_events(
                 "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0406",
             }
         }
-    }
-    with patch.dict(DECONZ_WEB_REQUEST, data):
-        config_entry = await setup_deconz_integration(hass, aioclient_mock)
-
+    ],
+)
+async def test_deconz_presence_events(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    config_entry_setup: ConfigEntry,
+    mock_deconz_websocket,
+) -> None:
+    """Test successful creation of deconz presence events."""
     assert len(hass.states.async_all()) == 5
     assert (
-        len(dr.async_entries_for_config_entry(device_registry, config_entry.entry_id))
+        len(
+            dr.async_entries_for_config_entry(
+                device_registry, config_entry_setup.entry_id
+            )
+        )
         == 3
     )
 
@@ -518,27 +532,22 @@ async def test_deconz_presence_events(
 
     assert len(captured_events) == 0
 
-    await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.config_entries.async_unload(config_entry_setup.entry_id)
 
     states = hass.states.async_all()
     assert len(hass.states.async_all()) == 5
     for state in states:
         assert state.state == STATE_UNAVAILABLE
 
-    await hass.config_entries.async_remove(config_entry.entry_id)
+    await hass.config_entries.async_remove(config_entry_setup.entry_id)
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 0
 
 
-async def test_deconz_relative_rotary_events(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    aioclient_mock: AiohttpClientMocker,
-    mock_deconz_websocket,
-) -> None:
-    """Test successful creation of deconz relative rotary events."""
-    data = {
-        "sensors": {
+@pytest.mark.parametrize(
+    "sensor_payload",
+    [
+        {
             "1": {
                 "config": {
                     "battery": 100,
@@ -562,13 +571,22 @@ async def test_deconz_relative_rotary_events(
                 "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-14-fc00",
             }
         }
-    }
-    with patch.dict(DECONZ_WEB_REQUEST, data):
-        config_entry = await setup_deconz_integration(hass, aioclient_mock)
-
+    ],
+)
+async def test_deconz_relative_rotary_events(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    config_entry_setup: ConfigEntry,
+    mock_deconz_websocket,
+) -> None:
+    """Test successful creation of deconz relative rotary events."""
     assert len(hass.states.async_all()) == 1
     assert (
-        len(dr.async_entries_for_config_entry(device_registry, config_entry.entry_id))
+        len(
+            dr.async_entries_for_config_entry(
+                device_registry, config_entry_setup.entry_id
+            )
+        )
         == 3
     )
 
@@ -618,26 +636,22 @@ async def test_deconz_relative_rotary_events(
 
     assert len(captured_events) == 0
 
-    await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.config_entries.async_unload(config_entry_setup.entry_id)
 
     states = hass.states.async_all()
     assert len(hass.states.async_all()) == 1
     for state in states:
         assert state.state == STATE_UNAVAILABLE
 
-    await hass.config_entries.async_remove(config_entry.entry_id)
+    await hass.config_entries.async_remove(config_entry_setup.entry_id)
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 0
 
 
-async def test_deconz_events_bad_unique_id(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    aioclient_mock: AiohttpClientMocker,
-) -> None:
-    """Verify no devices are created if unique id is bad or missing."""
-    data = {
-        "sensors": {
+@pytest.mark.parametrize(
+    "sensor_payload",
+    [
+        {
             "1": {
                 "name": "Switch 1 no unique id",
                 "type": "ZHASwitch",
@@ -652,12 +666,20 @@ async def test_deconz_events_bad_unique_id(
                 "uniqueid": "00:00-00",
             },
         }
-    }
-    with patch.dict(DECONZ_WEB_REQUEST, data):
-        config_entry = await setup_deconz_integration(hass, aioclient_mock)
-
+    ],
+)
+async def test_deconz_events_bad_unique_id(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    config_entry_setup: ConfigEntry,
+) -> None:
+    """Verify no devices are created if unique id is bad or missing."""
     assert len(hass.states.async_all()) == 1
     assert (
-        len(dr.async_entries_for_config_entry(device_registry, config_entry.entry_id))
+        len(
+            dr.async_entries_for_config_entry(
+                device_registry, config_entry_setup.entry_id
+            )
+        )
         == 2
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A couple of missed occurrences of setup_deconz_integration in fan and sensor tests

Related to 
- [x] https://github.com/home-assistant/core/pull/120863
- [x] https://github.com/home-assistant/core/pull/120936
- [x] https://github.com/home-assistant/core/pull/120938
- [x] https://github.com/home-assistant/core/pull/120943
- [x] https://github.com/home-assistant/core/pull/120944
- [x] https://github.com/home-assistant/core/pull/120947 
- [x] https://github.com/home-assistant/core/pull/120948
- [x]  https://github.com/home-assistant/core/pull/120953
- [x]  https://github.com/home-assistant/core/pull/120954
- [x]  https://github.com/home-assistant/core/pull/120966
- [x]  https://github.com/home-assistant/core/pull/120967
- [x]  https://github.com/home-assistant/core/pull/120968
- [x]  https://github.com/home-assistant/core/pull/121103
- [x]  https://github.com/home-assistant/core/pull/121108
- [x]  https://github.com/home-assistant/core/pull/121112
- [x]  https://github.com/home-assistant/core/pull/121116
- [x]  https://github.com/home-assistant/core/pull/121121
- [x]  https://github.com/home-assistant/core/pull/121203
- [x]  https://github.com/home-assistant/core/pull/121204
- [x]  https://github.com/home-assistant/core/pull/121208
- [ ]  https://github.com/home-assistant/core/pull/121217
- [x]  https://github.com/home-assistant/core/pull/121242
- [x]  https://github.com/home-assistant/core/pull/121244
- [ ]  https://github.com/home-assistant/core/pull/121303

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
