### PR TITLE
Use fixtures in deCONZ gateway tests

### DIFF
--- a/tests/components/deconz/test_gateway.py
+++ b/tests/components/deconz/test_gateway.py
@@ -1,5 +1,6 @@
 """Test deCONZ gateway."""
 
+from collections.abc import Callable
 from copy import deepcopy
 from typing import Any
 from unittest.mock import patch
@@ -34,7 +35,12 @@ from homeassistant.components.ssdp import (
     ATTR_UPNP_UDN,
 )
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.config_entries import SOURCE_HASSIO, SOURCE_SSDP, SOURCE_USER
+from homeassistant.config_entries import (
+    SOURCE_HASSIO,
+    SOURCE_SSDP,
+    SOURCE_USER,
+    ConfigEntry,
+)
 from homeassistant.const import (
     CONF_API_KEY,
     CONF_HOST,
@@ -134,8 +140,8 @@ async def setup_deconz_integration(
 
 async def test_gateway_setup(
     hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
     device_registry: dr.DeviceRegistry,
+    config_entry_factory: Callable[[], ConfigEntry],
 ) -> None:
     """Successful setup."""
     # Patching async_forward_entry_setup* is not advisable, and should be refactored
@@ -144,7 +150,7 @@ async def test_gateway_setup(
         "homeassistant.config_entries.ConfigEntries.async_forward_entry_setups",
         return_value=True,
     ) as forward_entry_setup:
-        config_entry = await setup_deconz_integration(hass, aioclient_mock)
+        config_entry = await config_entry_factory()
         gateway = DeconzHub.get_hub(hass, config_entry)
         assert gateway.bridgeid == BRIDGEID
         assert gateway.master is True
@@ -183,10 +189,11 @@ async def test_gateway_setup(
     assert gateway_entry.entry_type is dr.DeviceEntryType.SERVICE
 
 
+@pytest.mark.parametrize("config_entry_source", [SOURCE_HASSIO])
 async def test_gateway_device_configuration_url_when_addon(
     hass: HomeAssistant,
-    aioclient_mock: AiohttpClientMocker,
     device_registry: dr.DeviceRegistry,
+    config_entry_factory: Callable[[], ConfigEntry],
 ) -> None:
     """Successful setup."""
     # Patching async_forward_entry_setup* is not advisable, and should be refactored
@@ -195,9 +202,7 @@ async def test_gateway_device_configuration_url_when_addon(
         "homeassistant.config_entries.ConfigEntries.async_forward_entry_setups",
         return_value=True,
     ):
-        config_entry = await setup_deconz_integration(
-            hass, aioclient_mock, source=SOURCE_HASSIO
-        )
+        config_entry = await config_entry_factory()
         gateway = DeconzHub.get_hub(hass, config_entry)
 
     gateway_entry = device_registry.async_get_device(
@@ -209,12 +214,10 @@ async def test_gateway_device_configuration_url_when_addon(
     )
 
 
-async def test_connection_status_signalling(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
-) -> None:
-    """Make sure that connection status triggers a dispatcher send."""
-    data = {
-        "sensors": {
+@pytest.mark.parametrize(
+    "sensor_payload",
+    [
+        {
             "1": {
                 "name": "presence",
                 "type": "ZHAPresence",
@@ -223,10 +226,13 @@ async def test_connection_status_signalling(
                 "uniqueid": "00:00:00:00:00:00:00:00-00",
             }
         }
-    }
-    with patch.dict(DECONZ_WEB_REQUEST, data):
-        await setup_deconz_integration(hass, aioclient_mock)
-
+    ],
+)
+@pytest.mark.usefixtures("config_entry_setup")
+async def test_connection_status_signalling(
+    hass: HomeAssistant, mock_deconz_websocket
+) -> None:
+    """Make sure that connection status triggers a dispatcher send."""
     assert hass.states.get("binary_sensor.presence").state == STATE_OFF
 
     await mock_deconz_websocket(state=State.RETRYING)
@@ -241,11 +247,10 @@ async def test_connection_status_signalling(
 
 
 async def test_update_address(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, config_entry_setup: ConfigEntry
 ) -> None:
     """Make sure that connection status triggers a dispatcher send."""
-    config_entry = await setup_deconz_integration(hass, aioclient_mock)
-    gateway = DeconzHub.get_hub(hass, config_entry)
+    gateway = DeconzHub.get_hub(hass, config_entry_setup)
     assert gateway.api.host == "1.2.3.4"
 
     with patch(
@@ -273,11 +278,10 @@ async def test_update_address(
 
 
 async def test_reset_after_successful_setup(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, config_entry_setup: ConfigEntry
 ) -> None:
     """Make sure that connection status triggers a dispatcher send."""
-    config_entry = await setup_deconz_integration(hass, aioclient_mock)
-    gateway = DeconzHub.get_hub(hass, config_entry)
+    gateway = DeconzHub.get_hub(hass, config_entry_setup)
 
     result = await gateway.async_reset()
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A couple of missed occurrences of setup_deconz_integration in fan and sensor tests

Related to 
- [x] https://github.com/home-assistant/core/pull/120863
- [x] https://github.com/home-assistant/core/pull/120936
- [x] https://github.com/home-assistant/core/pull/120938
- [x] https://github.com/home-assistant/core/pull/120943
- [x] https://github.com/home-assistant/core/pull/120944
- [x] https://github.com/home-assistant/core/pull/120947 
- [x] https://github.com/home-assistant/core/pull/120948
- [x]  https://github.com/home-assistant/core/pull/120953
- [x]  https://github.com/home-assistant/core/pull/120954
- [x]  https://github.com/home-assistant/core/pull/120966
- [x]  https://github.com/home-assistant/core/pull/120967
- [x]  https://github.com/home-assistant/core/pull/120968
- [x]  https://github.com/home-assistant/core/pull/121103
- [x]  https://github.com/home-assistant/core/pull/121108
- [x]  https://github.com/home-assistant/core/pull/121112
- [x]  https://github.com/home-assistant/core/pull/121116
- [x]  https://github.com/home-assistant/core/pull/121121
- [x]  https://github.com/home-assistant/core/pull/121203
- [x]  https://github.com/home-assistant/core/pull/121204
- [x]  https://github.com/home-assistant/core/pull/121208
- [x]  https://github.com/home-assistant/core/pull/121217
- [x]  https://github.com/home-assistant/core/pull/121242
- [x]  https://github.com/home-assistant/core/pull/121244
- [x]  https://github.com/home-assistant/core/pull/121303
- [x]  https://github.com/home-assistant/core/pull/121305

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
