### PR TITLE
Add demand window sensor for amberelectric

### DIFF
--- a/homeassistant/components/amberelectric/binary_sensor.py
+++ b/homeassistant/components/amberelectric/binary_sensor.py
@@ -105,7 +105,8 @@ async def async_setup_entry(
         name=f"{entry.title} - Price Spike",
     )
     demand_window_description = BinarySensorEntityDescription(
-        key="deman_window", name=f"{entry.title} - Demand Window"
+        key="demand_window",
+        name=f"{entry.title} - Demand Window",
     )
     async_add_entities(
         [

--- a/homeassistant/components/amberelectric/binary_sensor.py
+++ b/homeassistant/components/amberelectric/binary_sensor.py
@@ -22,8 +22,6 @@ PRICE_SPIKE_ICONS = {
     "spike": "mdi:power-plug-off",
 }
 
-DEMAND_WINDOW_ICONS = {False: "mdi:meter-electric-outline", True: "mdi:meter-electric"}
-
 
 class AmberPriceGridSensor(
     CoordinatorEntity[AmberUpdateCoordinator], BinarySensorEntity
@@ -77,13 +75,6 @@ class AmberDemandWindowBinarySensor(AmberPriceGridSensor):
     """Sensor to show whether demand window is active."""
 
     @property
-    def icon(self) -> str:
-        """Return the sensor icon."""
-        if self.is_on:
-            return DEMAND_WINDOW_ICONS[True]
-        return DEMAND_WINDOW_ICONS[False]
-
-    @property
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
         grid = self.coordinator.data["grid"]
@@ -107,6 +98,7 @@ async def async_setup_entry(
     demand_window_description = BinarySensorEntityDescription(
         key="demand_window",
         name=f"{entry.title} - Demand Window",
+        translation_key="demand_window",
     )
     async_add_entities(
         [

--- a/homeassistant/components/amberelectric/coordinator.py
+++ b/homeassistant/components/amberelectric/coordinator.py
@@ -111,6 +111,9 @@ class AmberUpdateCoordinator(DataUpdateCoordinator):
         ]
         result["grid"]["renewables"] = round(general[0].renewables)
         result["grid"]["price_spike"] = general[0].spike_status.value
+        tariff_information = general[0].tariff_information
+        if tariff_information:
+            result["grid"]["demand_window"] = tariff_information.demand_window
 
         controlled_load = [
             interval for interval in current if is_controlled_load(interval)

--- a/homeassistant/components/amberelectric/icons.json
+++ b/homeassistant/components/amberelectric/icons.json
@@ -13,6 +13,14 @@
       "renewables": {
         "default": "mdi:solar-power"
       }
+    },
+    "binary_sensor": {
+      "demand_window": {
+        "default": "mdi:meter-electric",
+        "state": {
+          "off": "mdi:meter-electric-outline"
+        }
+      }
     }
   }
 }

--- a/tests/components/amberelectric/test_binary_sensor.py
+++ b/tests/components/amberelectric/test_binary_sensor.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock, patch
 from amberelectric.model.channel import ChannelType
 from amberelectric.model.current_interval import CurrentInterval
 from amberelectric.model.interval import SpikeStatus
+from amberelectric.model.tariff_information import TariffInformation
 from dateutil import parser
 import pytest
 
@@ -111,7 +112,7 @@ async def setup_spike(hass: HomeAssistant) -> AsyncGenerator[Mock]:
 @pytest.mark.usefixtures("setup_no_spike")
 def test_no_spike_sensor(hass: HomeAssistant) -> None:
     """Testing the creation of the Amber renewables sensor."""
-    assert len(hass.states.async_all()) == 5
+    assert len(hass.states.async_all()) == 6
     sensor = hass.states.get("binary_sensor.mock_title_price_spike")
     assert sensor
     assert sensor.state == "off"
@@ -122,7 +123,7 @@ def test_no_spike_sensor(hass: HomeAssistant) -> None:
 @pytest.mark.usefixtures("setup_potential_spike")
 def test_potential_spike_sensor(hass: HomeAssistant) -> None:
     """Testing the creation of the Amber renewables sensor."""
-    assert len(hass.states.async_all()) == 5
+    assert len(hass.states.async_all()) == 6
     sensor = hass.states.get("binary_sensor.mock_title_price_spike")
     assert sensor
     assert sensor.state == "off"
@@ -133,9 +134,87 @@ def test_potential_spike_sensor(hass: HomeAssistant) -> None:
 @pytest.mark.usefixtures("setup_spike")
 def test_spike_sensor(hass: HomeAssistant) -> None:
     """Testing the creation of the Amber renewables sensor."""
-    assert len(hass.states.async_all()) == 5
+    assert len(hass.states.async_all()) == 6
     sensor = hass.states.get("binary_sensor.mock_title_price_spike")
     assert sensor
     assert sensor.state == "on"
     assert sensor.attributes["icon"] == "mdi:power-plug-off"
     assert sensor.attributes["spike_status"] == "spike"
+
+
+@pytest.fixture
+async def setup_inactive_demand_window(hass: HomeAssistant) -> AsyncGenerator[Mock]:
+    """Set up general channel."""
+    MockConfigEntry(
+        domain="amberelectric",
+        data={
+            CONF_SITE_NAME: "mock_title",
+            CONF_API_TOKEN: MOCK_API_TOKEN,
+            CONF_SITE_ID: GENERAL_ONLY_SITE_ID,
+        },
+    ).add_to_hass(hass)
+
+    instance = Mock()
+    with patch(
+        "amberelectric.api.AmberApi.create",
+        return_value=instance,
+    ) as mock_update:
+        general_channel: list[CurrentInterval] = [
+            generate_current_interval(
+                ChannelType.GENERAL, parser.parse("2021-09-21T08:30:00+10:00")
+            ),
+        ]
+        general_channel[0].tariff_information = TariffInformation(demandWindow=False)
+        instance.get_current_price = Mock(return_value=general_channel)
+        assert await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+        yield mock_update.return_value
+
+
+@pytest.fixture
+async def setup_active_demand_window(hass: HomeAssistant) -> AsyncGenerator[Mock]:
+    """Set up general channel."""
+    MockConfigEntry(
+        domain="amberelectric",
+        data={
+            CONF_SITE_NAME: "mock_title",
+            CONF_API_TOKEN: MOCK_API_TOKEN,
+            CONF_SITE_ID: GENERAL_ONLY_SITE_ID,
+        },
+    ).add_to_hass(hass)
+
+    instance = Mock()
+    with patch(
+        "amberelectric.api.AmberApi.create",
+        return_value=instance,
+    ) as mock_update:
+        general_channel: list[CurrentInterval] = [
+            generate_current_interval(
+                ChannelType.GENERAL, parser.parse("2021-09-21T08:30:00+10:00")
+            ),
+        ]
+        general_channel[0].tariff_information = TariffInformation(demandWindow=True)
+        instance.get_current_price = Mock(return_value=general_channel)
+        assert await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+        yield mock_update.return_value
+
+
+@pytest.mark.usefixtures("setup_inactive_demand_window")
+def test_inactive_demand_window_sensor(hass: HomeAssistant) -> None:
+    """Testing the creation of the Amber demand_window sensor."""
+    assert len(hass.states.async_all()) == 6
+    sensor = hass.states.get("binary_sensor.mock_title_demand_window")
+    assert sensor
+    assert sensor.state == "off"
+    assert sensor.attributes["icon"] == "mdi:meter-electric-outline"
+
+
+@pytest.mark.usefixtures("setup_active_demand_window")
+def test_active_demand_window_sensor(hass: HomeAssistant) -> None:
+    """Testing the creation of the Amber demand_window sensor."""
+    assert len(hass.states.async_all()) == 6
+    sensor = hass.states.get("binary_sensor.mock_title_demand_window")
+    assert sensor
+    assert sensor.state == "on"
+    assert sensor.attributes["icon"] == "mdi:meter-electric"

--- a/tests/components/amberelectric/test_binary_sensor.py
+++ b/tests/components/amberelectric/test_binary_sensor.py
@@ -207,7 +207,6 @@ def test_inactive_demand_window_sensor(hass: HomeAssistant) -> None:
     sensor = hass.states.get("binary_sensor.mock_title_demand_window")
     assert sensor
     assert sensor.state == "off"
-    assert sensor.attributes["icon"] == "mdi:meter-electric-outline"
 
 
 @pytest.mark.usefixtures("setup_active_demand_window")
@@ -217,4 +216,3 @@ def test_active_demand_window_sensor(hass: HomeAssistant) -> None:
     sensor = hass.states.get("binary_sensor.mock_title_demand_window")
     assert sensor
     assert sensor.state == "on"
-    assert sensor.attributes["icon"] == "mdi:meter-electric"

--- a/tests/components/amberelectric/test_sensor.py
+++ b/tests/components/amberelectric/test_sensor.py
@@ -105,7 +105,7 @@ async def setup_general_and_feed_in(hass: HomeAssistant) -> AsyncGenerator[Mock]
 
 async def test_general_price_sensor(hass: HomeAssistant, setup_general: Mock) -> None:
     """Test the General Price sensor."""
-    assert len(hass.states.async_all()) == 5
+    assert len(hass.states.async_all()) == 6
     price = hass.states.get("sensor.mock_title_general_price")
     assert price
     assert price.state == "0.08"
@@ -143,7 +143,7 @@ async def test_general_price_sensor(hass: HomeAssistant, setup_general: Mock) ->
 @pytest.mark.usefixtures("setup_general_and_controlled_load")
 async def test_general_and_controlled_load_price_sensor(hass: HomeAssistant) -> None:
     """Test the Controlled Price sensor."""
-    assert len(hass.states.async_all()) == 8
+    assert len(hass.states.async_all()) == 9
     price = hass.states.get("sensor.mock_title_controlled_load_price")
     assert price
     assert price.state == "0.08"
@@ -165,7 +165,7 @@ async def test_general_and_controlled_load_price_sensor(hass: HomeAssistant) -> 
 @pytest.mark.usefixtures("setup_general_and_feed_in")
 async def test_general_and_feed_in_price_sensor(hass: HomeAssistant) -> None:
     """Test the Feed In sensor."""
-    assert len(hass.states.async_all()) == 8
+    assert len(hass.states.async_all()) == 9
     price = hass.states.get("sensor.mock_title_feed_in_price")
     assert price
     assert price.state == "-0.08"
@@ -188,7 +188,7 @@ async def test_general_forecast_sensor(
     hass: HomeAssistant, setup_general: Mock
 ) -> None:
     """Test the General Forecast sensor."""
-    assert len(hass.states.async_all()) == 5
+    assert len(hass.states.async_all()) == 6
     price = hass.states.get("sensor.mock_title_general_forecast")
     assert price
     assert price.state == "0.09"
@@ -230,7 +230,7 @@ async def test_general_forecast_sensor(
 @pytest.mark.usefixtures("setup_general_and_controlled_load")
 async def test_controlled_load_forecast_sensor(hass: HomeAssistant) -> None:
     """Test the Controlled Load Forecast sensor."""
-    assert len(hass.states.async_all()) == 8
+    assert len(hass.states.async_all()) == 9
     price = hass.states.get("sensor.mock_title_controlled_load_forecast")
     assert price
     assert price.state == "0.09"
@@ -254,7 +254,7 @@ async def test_controlled_load_forecast_sensor(hass: HomeAssistant) -> None:
 @pytest.mark.usefixtures("setup_general_and_feed_in")
 async def test_feed_in_forecast_sensor(hass: HomeAssistant) -> None:
     """Test the Feed In Forecast sensor."""
-    assert len(hass.states.async_all()) == 8
+    assert len(hass.states.async_all()) == 9
     price = hass.states.get("sensor.mock_title_feed_in_forecast")
     assert price
     assert price.state == "-0.09"
@@ -278,7 +278,7 @@ async def test_feed_in_forecast_sensor(hass: HomeAssistant) -> None:
 @pytest.mark.usefixtures("setup_general")
 def test_renewable_sensor(hass: HomeAssistant) -> None:
     """Testing the creation of the Amber renewables sensor."""
-    assert len(hass.states.async_all()) == 5
+    assert len(hass.states.async_all()) == 6
     sensor = hass.states.get("sensor.mock_title_renewables")
     assert sensor
     assert sensor.state == "51"
@@ -287,7 +287,7 @@ def test_renewable_sensor(hass: HomeAssistant) -> None:
 @pytest.mark.usefixtures("setup_general")
 def test_general_price_descriptor_descriptor_sensor(hass: HomeAssistant) -> None:
     """Test the General Price Descriptor sensor."""
-    assert len(hass.states.async_all()) == 5
+    assert len(hass.states.async_all()) == 6
     price = hass.states.get("sensor.mock_title_general_price_descriptor")
     assert price
     assert price.state == "extremely_low"
@@ -298,7 +298,7 @@ def test_general_and_controlled_load_price_descriptor_sensor(
     hass: HomeAssistant,
 ) -> None:
     """Test the Controlled Price Descriptor sensor."""
-    assert len(hass.states.async_all()) == 8
+    assert len(hass.states.async_all()) == 9
     price = hass.states.get("sensor.mock_title_controlled_load_price_descriptor")
     assert price
     assert price.state == "extremely_low"
@@ -307,7 +307,7 @@ def test_general_and_controlled_load_price_descriptor_sensor(
 @pytest.mark.usefixtures("setup_general_and_feed_in")
 def test_general_and_feed_in_price_descriptor_sensor(hass: HomeAssistant) -> None:
     """Test the Feed In Price Descriptor sensor."""
-    assert len(hass.states.async_all()) == 8
+    assert len(hass.states.async_all()) == 9
     price = hass.states.get("sensor.mock_title_feed_in_price_descriptor")
     assert price
     assert price.state == "extremely_low"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change adds a binary sensor for whether demand window is current active. The demand window may be a useful indicator for automations to avoid running devices with high demand.

While the demand window is relatively fixed, it needs extra work to implement and keep up-to-date with the latest tariff structure, so it's the best to have a sensor that simply follows the information from Amber API.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
