### PR TITLE
Provide default values for common keys in deCONZ websocket fixture

### DIFF
--- a/tests/components/deconz/conftest.py
+++ b/tests/components/deconz/conftest.py
@@ -250,18 +250,12 @@ def fixture_websocket_data(_mock_websocket: _WebsocketMock) -> WebsocketDataType
     async def change_websocket_data(data: dict[str, Any]) -> None:
         """Provide new data on the websocket."""
         if "t" not in data:
-            await _mock_websocket(data=data)
-        else:
-            await _mock_websocket(
-                data={
-                    "t": "event",
-                    # "e": "changed",  # added, changed, deleted, scene-called
-                    # "r": resource,  # alarmsystem, group, light, sensor
-                    # "id": id,  # integer as string
-                }
-                | data
-            )
-        # await _mock_websocket(data=data)
+            data["t"] = "event"
+        if "e" not in data:
+            data["e"] = "changed"
+        if "id" not in data:
+            data["id"] = "0"
+        await _mock_websocket(data=data)
 
     return change_websocket_data
 

--- a/tests/components/deconz/conftest.py
+++ b/tests/components/deconz/conftest.py
@@ -249,7 +249,19 @@ def fixture_websocket_data(_mock_websocket: _WebsocketMock) -> WebsocketDataType
 
     async def change_websocket_data(data: dict[str, Any]) -> None:
         """Provide new data on the websocket."""
-        await _mock_websocket(data=data)
+        if "t" not in data:
+            await _mock_websocket(data=data)
+        else:
+            await _mock_websocket(
+                data={
+                    "t": "event",
+                    # "e": "changed",  # added, changed, deleted, scene-called
+                    # "r": resource,  # alarmsystem, group, light, sensor
+                    # "id": id,  # integer as string
+                }
+                | data
+            )
+        # await _mock_websocket(data=data)
 
     return change_websocket_data
 

--- a/tests/components/deconz/test_alarm_control_panel.py
+++ b/tests/components/deconz/test_alarm_control_panel.py
@@ -113,9 +113,7 @@ async def test_alarm_control_panel(
     # Event signals alarm control panel armed away
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
-        "id": "0",
         "state": {"panel": AncillaryControlPanel.ARMED_AWAY},
     }
     await mock_websocket_data(event_changed_sensor)
@@ -126,9 +124,7 @@ async def test_alarm_control_panel(
     # Event signals alarm control panel armed night
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
-        "id": "0",
         "state": {"panel": AncillaryControlPanel.ARMED_NIGHT},
     }
     await mock_websocket_data(event_changed_sensor)
@@ -141,9 +137,7 @@ async def test_alarm_control_panel(
     # Event signals alarm control panel armed home
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
-        "id": "0",
         "state": {"panel": AncillaryControlPanel.ARMED_STAY},
     }
     await mock_websocket_data(event_changed_sensor)
@@ -154,9 +148,7 @@ async def test_alarm_control_panel(
     # Event signals alarm control panel disarmed
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
-        "id": "0",
         "state": {"panel": AncillaryControlPanel.DISARMED},
     }
     await mock_websocket_data(event_changed_sensor)
@@ -172,9 +164,7 @@ async def test_alarm_control_panel(
         AncillaryControlPanel.ARMING_STAY,
     ):
         event_changed_sensor = {
-            "e": "changed",
             "r": "sensors",
-            "id": "0",
             "state": {"panel": arming_event},
         }
         await mock_websocket_data(event_changed_sensor)
@@ -189,9 +179,7 @@ async def test_alarm_control_panel(
         AncillaryControlPanel.EXIT_DELAY,
     ):
         event_changed_sensor = {
-            "e": "changed",
             "r": "sensors",
-            "id": "0",
             "state": {"panel": pending_event},
         }
         await mock_websocket_data(event_changed_sensor)
@@ -204,9 +192,7 @@ async def test_alarm_control_panel(
     # Event signals alarm control panel triggered
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
-        "id": "0",
         "state": {"panel": AncillaryControlPanel.IN_ALARM},
     }
     await mock_websocket_data(event_changed_sensor)
@@ -217,9 +203,7 @@ async def test_alarm_control_panel(
     # Event signals alarm control panel unknown state keeps previous state
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
-        "id": "0",
         "state": {"panel": AncillaryControlPanel.NOT_READY},
     }
     await mock_websocket_data(event_changed_sensor)

--- a/tests/components/deconz/test_alarm_control_panel.py
+++ b/tests/components/deconz/test_alarm_control_panel.py
@@ -113,7 +113,6 @@ async def test_alarm_control_panel(
     # Event signals alarm control panel armed away
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "0",
@@ -127,7 +126,6 @@ async def test_alarm_control_panel(
     # Event signals alarm control panel armed night
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "0",
@@ -143,7 +141,6 @@ async def test_alarm_control_panel(
     # Event signals alarm control panel armed home
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "0",
@@ -157,7 +154,6 @@ async def test_alarm_control_panel(
     # Event signals alarm control panel disarmed
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "0",
@@ -176,7 +172,6 @@ async def test_alarm_control_panel(
         AncillaryControlPanel.ARMING_STAY,
     ):
         event_changed_sensor = {
-            "t": "event",
             "e": "changed",
             "r": "sensors",
             "id": "0",
@@ -194,7 +189,6 @@ async def test_alarm_control_panel(
         AncillaryControlPanel.EXIT_DELAY,
     ):
         event_changed_sensor = {
-            "t": "event",
             "e": "changed",
             "r": "sensors",
             "id": "0",
@@ -210,7 +204,6 @@ async def test_alarm_control_panel(
     # Event signals alarm control panel triggered
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "0",
@@ -224,7 +217,6 @@ async def test_alarm_control_panel(
     # Event signals alarm control panel unknown state keeps previous state
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "0",

--- a/tests/components/deconz/test_binary_sensor.py
+++ b/tests/components/deconz/test_binary_sensor.py
@@ -493,7 +493,6 @@ async def test_binary_sensors(
     # Change state
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "1",
@@ -607,7 +606,6 @@ async def test_add_new_binary_sensor(
     assert len(hass.states.async_all()) == 0
 
     event_added_sensor = {
-        "t": "event",
         "e": "added",
         "r": "sensors",
         "id": "1",
@@ -647,7 +645,6 @@ async def test_add_new_binary_sensor_ignored_load_entities_on_service_call(
         "uniqueid": "00:00:00:00:00:00:00:00-00",
     }
     event_added_sensor = {
-        "t": "event",
         "e": "added",
         "r": "sensors",
         "id": "1",
@@ -701,7 +698,6 @@ async def test_add_new_binary_sensor_ignored_load_entities_on_options_change(
         "uniqueid": "00:00:00:00:00:00:00:00-00",
     }
     event_added_sensor = {
-        "t": "event",
         "e": "added",
         "r": "sensors",
         "id": "1",

--- a/tests/components/deconz/test_binary_sensor.py
+++ b/tests/components/deconz/test_binary_sensor.py
@@ -493,7 +493,6 @@ async def test_binary_sensors(
     # Change state
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
         "id": "1",
         "state": expected["websocket_event"],

--- a/tests/components/deconz/test_climate.py
+++ b/tests/components/deconz/test_climate.py
@@ -113,9 +113,7 @@ async def test_simple_climate_device(
     # Event signals thermostat configured off
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
-        "id": "0",
         "state": {"on": False},
     }
     await mock_websocket_data(event_changed_sensor)
@@ -130,9 +128,7 @@ async def test_simple_climate_device(
     # Event signals thermostat state on
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
-        "id": "0",
         "state": {"on": True},
     }
     await mock_websocket_data(event_changed_sensor)
@@ -228,7 +224,6 @@ async def test_climate_device_without_cooling_support(
     # Event signals thermostat configured off
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
         "id": "1",
         "config": {"mode": "off"},
@@ -245,7 +240,6 @@ async def test_climate_device_without_cooling_support(
     # Event signals thermostat state on
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
         "id": "1",
         "config": {"mode": "other"},
@@ -263,7 +257,6 @@ async def test_climate_device_without_cooling_support(
     # Event signals thermostat state off
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
         "id": "1",
         "state": {"on": False},
@@ -415,9 +408,7 @@ async def test_climate_device_with_cooling_support(
     # Event signals thermostat mode cool
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
-        "id": "0",
         "config": {"mode": "cool"},
     }
     await mock_websocket_data(event_changed_sensor)
@@ -433,9 +424,7 @@ async def test_climate_device_with_cooling_support(
     # Event signals thermostat state on
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
-        "id": "0",
         "state": {"on": True},
     }
     await mock_websocket_data(event_changed_sensor)
@@ -521,9 +510,7 @@ async def test_climate_device_with_fan_support(
     # Event signals fan mode defaults to off
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
-        "id": "0",
         "config": {"fanmode": "unsupported"},
     }
     await mock_websocket_data(event_changed_sensor)
@@ -537,9 +524,7 @@ async def test_climate_device_with_fan_support(
     # Event signals unsupported fan mode
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
-        "id": "0",
         "config": {"fanmode": "unsupported"},
         "state": {"on": True},
     }
@@ -555,9 +540,7 @@ async def test_climate_device_with_fan_support(
     # Event signals unsupported fan mode
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
-        "id": "0",
         "config": {"fanmode": "unsupported"},
     }
     await mock_websocket_data(event_changed_sensor)
@@ -667,9 +650,7 @@ async def test_climate_device_with_preset(
     # Event signals deCONZ preset
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
-        "id": "0",
         "config": {"preset": "manual"},
     }
     await mock_websocket_data(event_changed_sensor)
@@ -683,9 +664,7 @@ async def test_climate_device_with_preset(
     # Event signals unknown preset
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
-        "id": "0",
         "config": {"preset": "unsupported"},
     }
     await mock_websocket_data(event_changed_sensor)
@@ -825,7 +804,6 @@ async def test_verify_state_update(
     )
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
         "id": "1",
         "state": {"on": False},
@@ -997,9 +975,7 @@ async def test_boost_mode(
 
     # Event signals thermostat preset boost and valve 100 (real data)
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
-        "id": "0",
         "config": {"preset": "boost"},
         "state": {"valve": 100},
     }

--- a/tests/components/deconz/test_climate.py
+++ b/tests/components/deconz/test_climate.py
@@ -113,7 +113,6 @@ async def test_simple_climate_device(
     # Event signals thermostat configured off
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "0",
@@ -131,7 +130,6 @@ async def test_simple_climate_device(
     # Event signals thermostat state on
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "0",
@@ -230,7 +228,6 @@ async def test_climate_device_without_cooling_support(
     # Event signals thermostat configured off
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "1",
@@ -248,7 +245,6 @@ async def test_climate_device_without_cooling_support(
     # Event signals thermostat state on
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "1",
@@ -267,7 +263,6 @@ async def test_climate_device_without_cooling_support(
     # Event signals thermostat state off
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "1",
@@ -420,7 +415,6 @@ async def test_climate_device_with_cooling_support(
     # Event signals thermostat mode cool
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "0",
@@ -439,7 +433,6 @@ async def test_climate_device_with_cooling_support(
     # Event signals thermostat state on
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "0",
@@ -528,7 +521,6 @@ async def test_climate_device_with_fan_support(
     # Event signals fan mode defaults to off
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "0",
@@ -545,7 +537,6 @@ async def test_climate_device_with_fan_support(
     # Event signals unsupported fan mode
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "0",
@@ -564,7 +555,6 @@ async def test_climate_device_with_fan_support(
     # Event signals unsupported fan mode
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "0",
@@ -677,7 +667,6 @@ async def test_climate_device_with_preset(
     # Event signals deCONZ preset
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "0",
@@ -694,7 +683,6 @@ async def test_climate_device_with_preset(
     # Event signals unknown preset
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "0",
@@ -837,7 +825,6 @@ async def test_verify_state_update(
     )
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "1",
@@ -860,7 +847,6 @@ async def test_add_new_climate_device(
 ) -> None:
     """Test that adding a new climate device works."""
     event_added_sensor = {
-        "t": "event",
         "e": "added",
         "r": "sensors",
         "id": "1",
@@ -1011,7 +997,6 @@ async def test_boost_mode(
 
     # Event signals thermostat preset boost and valve 100 (real data)
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "0",

--- a/tests/components/deconz/test_cover.py
+++ b/tests/components/deconz/test_cover.py
@@ -69,7 +69,6 @@ async def test_cover(
     # Event signals cover is open
 
     event_changed_light = {
-        "t": "event",
         "e": "changed",
         "r": "lights",
         "id": "1",

--- a/tests/components/deconz/test_cover.py
+++ b/tests/components/deconz/test_cover.py
@@ -69,7 +69,6 @@ async def test_cover(
     # Event signals cover is open
 
     event_changed_light = {
-        "e": "changed",
         "r": "lights",
         "id": "1",
         "state": {"lift": 0, "open": True},

--- a/tests/components/deconz/test_deconz_event.py
+++ b/tests/components/deconz/test_deconz_event.py
@@ -99,7 +99,6 @@ async def test_deconz_events(
     captured_events = async_capture_events(hass, CONF_DECONZ_EVENT)
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
         "id": "1",
         "state": {"buttonevent": 2000},
@@ -120,7 +119,6 @@ async def test_deconz_events(
     }
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
         "id": "3",
         "state": {"buttonevent": 2000},
@@ -142,7 +140,6 @@ async def test_deconz_events(
     }
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
         "id": "4",
         "state": {"gesture": 0},
@@ -164,7 +161,6 @@ async def test_deconz_events(
     }
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
         "id": "5",
         "state": {"buttonevent": 6002, "angle": 110, "xy": [0.5982, 0.3897]},
@@ -189,7 +185,6 @@ async def test_deconz_events(
     # Unsupported event
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
         "id": "1",
         "name": "other name",
@@ -300,7 +295,6 @@ async def test_deconz_alarm_events(
     # Emergency event
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
         "id": "1",
         "state": {"action": AncillaryControlAction.EMERGENCY},
@@ -323,7 +317,6 @@ async def test_deconz_alarm_events(
     # Fire event
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
         "id": "1",
         "state": {"action": AncillaryControlAction.FIRE},
@@ -346,7 +339,6 @@ async def test_deconz_alarm_events(
     # Invalid code event
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
         "id": "1",
         "state": {"action": AncillaryControlAction.INVALID_CODE},
@@ -369,7 +361,6 @@ async def test_deconz_alarm_events(
     # Panic event
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
         "id": "1",
         "state": {"action": AncillaryControlAction.PANIC},
@@ -392,7 +383,6 @@ async def test_deconz_alarm_events(
     # Only care for changes to specific action events
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
         "id": "1",
         "state": {"action": AncillaryControlAction.ARMED_AWAY},
@@ -405,7 +395,6 @@ async def test_deconz_alarm_events(
     # Only care for action events
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
         "id": "1",
         "state": {"panel": AncillaryControlPanel.ARMED_AWAY},
@@ -491,7 +480,6 @@ async def test_deconz_presence_events(
         PresenceStatePresenceEvent.RIGHT_LEAVE,
     ):
         event_changed_sensor = {
-            "e": "changed",
             "r": "sensors",
             "id": "1",
             "state": {"presenceevent": presence_event},
@@ -511,7 +499,6 @@ async def test_deconz_presence_events(
     # Unsupported presence event
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
         "id": "1",
         "state": {"presenceevent": PresenceStatePresenceEvent.NINE},
@@ -587,7 +574,6 @@ async def test_deconz_relative_rotary_events(
 
     for rotary_event, duration, rotation in ((1, 100, 50), (2, 200, -50)):
         event_changed_sensor = {
-            "e": "changed",
             "r": "sensors",
             "id": "1",
             "state": {
@@ -613,7 +599,6 @@ async def test_deconz_relative_rotary_events(
     # Unsupported relative rotary event
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
         "id": "1",
         "name": "123",

--- a/tests/components/deconz/test_deconz_event.py
+++ b/tests/components/deconz/test_deconz_event.py
@@ -99,7 +99,6 @@ async def test_deconz_events(
     captured_events = async_capture_events(hass, CONF_DECONZ_EVENT)
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "1",
@@ -121,7 +120,6 @@ async def test_deconz_events(
     }
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "3",
@@ -144,7 +142,6 @@ async def test_deconz_events(
     }
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "4",
@@ -167,7 +164,6 @@ async def test_deconz_events(
     }
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "5",
@@ -193,7 +189,6 @@ async def test_deconz_events(
     # Unsupported event
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "1",
@@ -305,7 +300,6 @@ async def test_deconz_alarm_events(
     # Emergency event
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "1",
@@ -329,7 +323,6 @@ async def test_deconz_alarm_events(
     # Fire event
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "1",
@@ -353,7 +346,6 @@ async def test_deconz_alarm_events(
     # Invalid code event
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "1",
@@ -377,7 +369,6 @@ async def test_deconz_alarm_events(
     # Panic event
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "1",
@@ -401,7 +392,6 @@ async def test_deconz_alarm_events(
     # Only care for changes to specific action events
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "1",
@@ -415,7 +405,6 @@ async def test_deconz_alarm_events(
     # Only care for action events
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "1",
@@ -502,7 +491,6 @@ async def test_deconz_presence_events(
         PresenceStatePresenceEvent.RIGHT_LEAVE,
     ):
         event_changed_sensor = {
-            "t": "event",
             "e": "changed",
             "r": "sensors",
             "id": "1",
@@ -523,7 +511,6 @@ async def test_deconz_presence_events(
     # Unsupported presence event
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "1",
@@ -600,7 +587,6 @@ async def test_deconz_relative_rotary_events(
 
     for rotary_event, duration, rotation in ((1, 100, 50), (2, 200, -50)):
         event_changed_sensor = {
-            "t": "event",
             "e": "changed",
             "r": "sensors",
             "id": "1",
@@ -627,7 +613,6 @@ async def test_deconz_relative_rotary_events(
     # Unsupported relative rotary event
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "1",

--- a/tests/components/deconz/test_device_trigger.py
+++ b/tests/components/deconz/test_device_trigger.py
@@ -352,7 +352,6 @@ async def test_functional_device_trigger(
     assert len(hass.states.async_entity_ids(AUTOMATION_DOMAIN)) == 1
 
     event_changed_sensor = {
-        "e": "changed",
         "r": "sensors",
         "id": "1",
         "state": {"buttonevent": 1002},

--- a/tests/components/deconz/test_device_trigger.py
+++ b/tests/components/deconz/test_device_trigger.py
@@ -352,7 +352,6 @@ async def test_functional_device_trigger(
     assert len(hass.states.async_entity_ids(AUTOMATION_DOMAIN)) == 1
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "1",

--- a/tests/components/deconz/test_fan.py
+++ b/tests/components/deconz/test_fan.py
@@ -59,7 +59,6 @@ async def test_fans(
     # Test states
 
     event_changed_light = {
-        "e": "changed",
         "r": "lights",
         "id": "1",
         "state": {"speed": 1},
@@ -71,7 +70,6 @@ async def test_fans(
     assert hass.states.get("fan.ceiling_fan").attributes[ATTR_PERCENTAGE] == 25
 
     event_changed_light = {
-        "e": "changed",
         "r": "lights",
         "id": "1",
         "state": {"speed": 2},
@@ -83,7 +81,6 @@ async def test_fans(
     assert hass.states.get("fan.ceiling_fan").attributes[ATTR_PERCENTAGE] == 50
 
     event_changed_light = {
-        "e": "changed",
         "r": "lights",
         "id": "1",
         "state": {"speed": 3},
@@ -95,7 +92,6 @@ async def test_fans(
     assert hass.states.get("fan.ceiling_fan").attributes[ATTR_PERCENTAGE] == 75
 
     event_changed_light = {
-        "e": "changed",
         "r": "lights",
         "id": "1",
         "state": {"speed": 4},
@@ -107,7 +103,6 @@ async def test_fans(
     assert hass.states.get("fan.ceiling_fan").attributes[ATTR_PERCENTAGE] == 100
 
     event_changed_light = {
-        "e": "changed",
         "r": "lights",
         "id": "1",
         "state": {"speed": 0},
@@ -205,7 +200,6 @@ async def test_fans(
     # Events with an unsupported speed does not get converted
 
     event_changed_light = {
-        "e": "changed",
         "r": "lights",
         "id": "1",
         "state": {"speed": 5},

--- a/tests/components/deconz/test_fan.py
+++ b/tests/components/deconz/test_fan.py
@@ -59,7 +59,6 @@ async def test_fans(
     # Test states
 
     event_changed_light = {
-        "t": "event",
         "e": "changed",
         "r": "lights",
         "id": "1",
@@ -72,7 +71,6 @@ async def test_fans(
     assert hass.states.get("fan.ceiling_fan").attributes[ATTR_PERCENTAGE] == 25
 
     event_changed_light = {
-        "t": "event",
         "e": "changed",
         "r": "lights",
         "id": "1",
@@ -85,7 +83,6 @@ async def test_fans(
     assert hass.states.get("fan.ceiling_fan").attributes[ATTR_PERCENTAGE] == 50
 
     event_changed_light = {
-        "t": "event",
         "e": "changed",
         "r": "lights",
         "id": "1",
@@ -98,7 +95,6 @@ async def test_fans(
     assert hass.states.get("fan.ceiling_fan").attributes[ATTR_PERCENTAGE] == 75
 
     event_changed_light = {
-        "t": "event",
         "e": "changed",
         "r": "lights",
         "id": "1",
@@ -111,7 +107,6 @@ async def test_fans(
     assert hass.states.get("fan.ceiling_fan").attributes[ATTR_PERCENTAGE] == 100
 
     event_changed_light = {
-        "t": "event",
         "e": "changed",
         "r": "lights",
         "id": "1",
@@ -210,7 +205,6 @@ async def test_fans(
     # Events with an unsupported speed does not get converted
 
     event_changed_light = {
-        "t": "event",
         "e": "changed",
         "r": "lights",
         "id": "1",

--- a/tests/components/deconz/test_light.py
+++ b/tests/components/deconz/test_light.py
@@ -479,9 +479,7 @@ async def test_light_state_change(
     assert hass.states.get("light.hue_go").state == STATE_ON
 
     event_changed_light = {
-        "e": "changed",
         "r": "lights",
-        "id": "0",
         "state": {"on": False},
     }
     await mock_websocket_data(event_changed_light)
@@ -1320,7 +1318,6 @@ async def test_non_color_light_reports_color(
     # Updating a scene will return a faulty color value
     # for a non-color light causing an exception in hs_color
     event_changed_light = {
-        "e": "changed",
         "id": "1",
         "r": "lights",
         "state": {
@@ -1522,7 +1519,6 @@ async def test_verify_group_color_mode_fallback(
 
     await mock_websocket_data(
         {
-            "e": "changed",
             "id": "13",
             "r": "lights",
             "state": {
@@ -1537,7 +1533,6 @@ async def test_verify_group_color_mode_fallback(
     )
     await mock_websocket_data(
         {
-            "e": "changed",
             "id": "43",
             "r": "groups",
             "state": {"all_on": True, "any_on": True},

--- a/tests/components/deconz/test_light.py
+++ b/tests/components/deconz/test_light.py
@@ -479,7 +479,6 @@ async def test_light_state_change(
     assert hass.states.get("light.hue_go").state == STATE_ON
 
     event_changed_light = {
-        "t": "event",
         "e": "changed",
         "r": "lights",
         "id": "0",
@@ -1332,7 +1331,6 @@ async def test_non_color_light_reports_color(
             "on": True,
             "reachable": True,
         },
-        "t": "event",
         "uniqueid": "ec:1b:bd:ff:fe:ee:ed:dd-01",
     }
     await mock_websocket_data(event_changed_light)
@@ -1534,7 +1532,6 @@ async def test_verify_group_color_mode_fallback(
                 "on": True,
                 "reachable": True,
             },
-            "t": "event",
             "uniqueid": "00:17:88:01:08:11:22:33-01",
         }
     )
@@ -1544,7 +1541,6 @@ async def test_verify_group_color_mode_fallback(
             "id": "43",
             "r": "groups",
             "state": {"all_on": True, "any_on": True},
-            "t": "event",
         }
     )
     group_state = hass.states.get("light.opbergruimte")

--- a/tests/components/deconz/test_lock.py
+++ b/tests/components/deconz/test_lock.py
@@ -54,7 +54,6 @@ async def test_lock_from_light(
     assert hass.states.get("lock.door_lock").state == STATE_UNLOCKED
 
     event_changed_light = {
-        "e": "changed",
         "r": "lights",
         "id": "1",
         "state": {"on": True},
@@ -139,7 +138,6 @@ async def test_lock_from_sensor(
     assert hass.states.get("lock.door_lock").state == STATE_UNLOCKED
 
     event_changed_light = {
-        "e": "changed",
         "r": "sensors",
         "id": "1",
         "state": {"lockstate": "locked"},

--- a/tests/components/deconz/test_lock.py
+++ b/tests/components/deconz/test_lock.py
@@ -54,7 +54,6 @@ async def test_lock_from_light(
     assert hass.states.get("lock.door_lock").state == STATE_UNLOCKED
 
     event_changed_light = {
-        "t": "event",
         "e": "changed",
         "r": "lights",
         "id": "1",
@@ -140,7 +139,6 @@ async def test_lock_from_sensor(
     assert hass.states.get("lock.door_lock").state == STATE_UNLOCKED
 
     event_changed_light = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "1",

--- a/tests/components/deconz/test_number.py
+++ b/tests/components/deconz/test_number.py
@@ -138,11 +138,7 @@ async def test_number_entities(
 
     # Change state
 
-    event_changed_sensor = {
-        "e": "changed",
-        "r": "sensors",
-        "id": "0",
-    } | expected["websocket_event"]
+    event_changed_sensor = {"r": "sensors"} | expected["websocket_event"]
     await mock_websocket_data(event_changed_sensor)
     await hass.async_block_till_done()
     assert hass.states.get(expected["entity_id"]).state == expected["next_state"]

--- a/tests/components/deconz/test_number.py
+++ b/tests/components/deconz/test_number.py
@@ -139,7 +139,6 @@ async def test_number_entities(
     # Change state
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "0",

--- a/tests/components/deconz/test_scene.py
+++ b/tests/components/deconz/test_scene.py
@@ -126,7 +126,6 @@ async def test_only_new_scenes_are_created(
     assert len(hass.states.async_all()) == 2
 
     event_changed_group = {
-        "e": "changed",
         "r": "groups",
         "id": "1",
         "scenes": [{"id": "1", "name": "Scene"}],

--- a/tests/components/deconz/test_scene.py
+++ b/tests/components/deconz/test_scene.py
@@ -126,7 +126,6 @@ async def test_only_new_scenes_are_created(
     assert len(hass.states.async_all()) == 2
 
     event_changed_group = {
-        "t": "event",
         "e": "changed",
         "r": "groups",
         "id": "1",

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -952,7 +952,7 @@ async def test_sensors(
 
     # Change state
 
-    event_changed_sensor = {"t": "event", "e": "changed", "r": "sensors", "id": "1"}
+    event_changed_sensor = {"e": "changed", "r": "sensors", "id": "1"}
     event_changed_sensor |= expected["websocket_event"]
     await mock_websocket_data(event_changed_sensor)
     await hass.async_block_till_done()
@@ -1063,7 +1063,6 @@ async def test_add_new_sensor(
 ) -> None:
     """Test that adding a new sensor works."""
     event_added_sensor = {
-        "t": "event",
         "e": "added",
         "r": "sensors",
         "id": "1",
@@ -1183,7 +1182,6 @@ async def test_add_battery_later(
     assert len(hass.states.async_all()) == 0
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "2",
@@ -1195,7 +1193,6 @@ async def test_add_battery_later(
     assert len(hass.states.async_all()) == 0
 
     event_changed_sensor = {
-        "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "1",

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -952,7 +952,7 @@ async def test_sensors(
 
     # Change state
 
-    event_changed_sensor = {"e": "changed", "r": "sensors", "id": "1"}
+    event_changed_sensor = {"r": "sensors", "id": "1"}
     event_changed_sensor |= expected["websocket_event"]
     await mock_websocket_data(event_changed_sensor)
     await hass.async_block_till_done()

--- a/tests/components/deconz/test_siren.py
+++ b/tests/components/deconz/test_siren.py
@@ -52,7 +52,6 @@ async def test_sirens(
     assert not hass.states.get("siren.unsupported_siren")
 
     event_changed_light = {
-        "t": "event",
         "e": "changed",
         "r": "lights",
         "id": "1",

--- a/tests/components/deconz/test_siren.py
+++ b/tests/components/deconz/test_siren.py
@@ -52,7 +52,6 @@ async def test_sirens(
     assert not hass.states.get("siren.unsupported_siren")
 
     event_changed_light = {
-        "e": "changed",
         "r": "lights",
         "id": "1",
         "state": {"alert": None},

--- a/tests/components/deconz/test_switch.py
+++ b/tests/components/deconz/test_switch.py
@@ -66,7 +66,6 @@ async def test_power_plugs(
     assert hass.states.get("switch.unsupported_switch") is None
 
     event_changed_light = {
-        "t": "event",
         "e": "changed",
         "r": "lights",
         "id": "1",

--- a/tests/components/deconz/test_switch.py
+++ b/tests/components/deconz/test_switch.py
@@ -66,7 +66,6 @@ async def test_power_plugs(
     assert hass.states.get("switch.unsupported_switch") is None
 
     event_changed_light = {
-        "e": "changed",
         "r": "lights",
         "id": "1",
         "state": {"on": False},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve websocket data fixture by providing default values for the most common keys

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
