### PR TITLE
Add transmission download path to events + add_torrent service

### DIFF
--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -42,6 +42,7 @@ from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     ATTR_DELETE_DATA,
+    ATTR_DOWNLOAD_PATH,
     ATTR_TORRENT,
     CONF_ENTRY_ID,
     DEFAULT_DELETE_DATA,
@@ -82,7 +83,12 @@ SERVICE_BASE_SCHEMA = vol.Schema(
 )
 
 SERVICE_ADD_TORRENT_SCHEMA = vol.All(
-    SERVICE_BASE_SCHEMA.extend({vol.Required(ATTR_TORRENT): cv.string}),
+    SERVICE_BASE_SCHEMA.extend(
+        {
+            vol.Required(ATTR_TORRENT): cv.string,
+            vol.Optional(ATTR_DOWNLOAD_PATH, default=None): cv.string,
+        }
+    ),
 )
 
 
@@ -213,10 +219,18 @@ def setup_hass_services(hass: HomeAssistant) -> None:
         entry_id: str = service.data[CONF_ENTRY_ID]
         coordinator = _get_coordinator_from_service_data(hass, entry_id)
         torrent: str = service.data[ATTR_TORRENT]
+        download_path: str | None = service.data.get(ATTR_DOWNLOAD_PATH)
         if torrent.startswith(
             ("http", "ftp:", "magnet:")
         ) or hass.config.is_allowed_path(torrent):
-            await hass.async_add_executor_job(coordinator.api.add_torrent, torrent)
+            if download_path:
+                await hass.async_add_executor_job(
+                    partial(
+                        coordinator.api.add_torrent, torrent, download_dir=download_path
+                    )
+                )
+            else:
+                await hass.async_add_executor_job(coordinator.api.add_torrent, torrent)
             await coordinator.async_request_refresh()
         else:
             _LOGGER.warning("Could not add torrent: unsupported type or no permission")

--- a/homeassistant/components/transmission/const.py
+++ b/homeassistant/components/transmission/const.py
@@ -40,6 +40,7 @@ STATE_ATTR_TORRENT_INFO = "torrent_info"
 
 ATTR_DELETE_DATA = "delete_data"
 ATTR_TORRENT = "torrent"
+ATTR_DOWNLOAD_PATH = "download_path"
 
 SERVICE_ADD_TORRENT = "add_torrent"
 SERVICE_REMOVE_TORRENT = "remove_torrent"

--- a/homeassistant/components/transmission/coordinator.py
+++ b/homeassistant/components/transmission/coordinator.py
@@ -102,7 +102,12 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
         for torrent in current_completed_torrents:
             if torrent.id not in old_completed_torrents:
                 self.hass.bus.fire(
-                    EVENT_DOWNLOADED_TORRENT, {"name": torrent.name, "id": torrent.id}
+                    EVENT_DOWNLOADED_TORRENT,
+                    {
+                        "name": torrent.name,
+                        "id": torrent.id,
+                        "download_path": torrent.download_dir,
+                    },
                 )
 
         self._completed_torrents = current_completed_torrents
@@ -118,7 +123,12 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
         for torrent in current_started_torrents:
             if torrent.id not in old_started_torrents:
                 self.hass.bus.fire(
-                    EVENT_STARTED_TORRENT, {"name": torrent.name, "id": torrent.id}
+                    EVENT_STARTED_TORRENT,
+                    {
+                        "name": torrent.name,
+                        "id": torrent.id,
+                        "download_path": torrent.download_dir,
+                    },
                 )
 
         self._started_torrents = current_started_torrents
@@ -130,7 +140,12 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
         for torrent in self._all_torrents:
             if torrent.id not in current_torrents:
                 self.hass.bus.fire(
-                    EVENT_REMOVED_TORRENT, {"name": torrent.name, "id": torrent.id}
+                    EVENT_REMOVED_TORRENT,
+                    {
+                        "name": torrent.name,
+                        "id": torrent.id,
+                        "download_path": torrent.download_dir,
+                    },
                 )
 
         self._all_torrents = self.torrents.copy()

--- a/homeassistant/components/transmission/services.yaml
+++ b/homeassistant/components/transmission/services.yaml
@@ -9,6 +9,12 @@ add_torrent:
       example: http://releases.ubuntu.com/19.04/ubuntu-19.04-desktop-amd64.iso.torrent
       selector:
         text:
+    download_path:
+      required: false
+      default: None
+      example: "/path/to/download/directory"
+      selector:
+        text:
 
 remove_torrent:
   fields:

--- a/homeassistant/components/transmission/services.yaml
+++ b/homeassistant/components/transmission/services.yaml
@@ -11,7 +11,6 @@ add_torrent:
         text:
     download_path:
       required: false
-      default: None
       example: "/path/to/download/directory"
       selector:
         text:

--- a/homeassistant/components/transmission/strings.json
+++ b/homeassistant/components/transmission/strings.json
@@ -96,6 +96,10 @@
         "torrent": {
           "name": "Torrent",
           "description": "URL, magnet link or Base64 encoded file."
+        },
+        "download_path": {
+          "name": "Download path",
+          "description": "Optional path to specify where the torrent should be downloaded. If not specified, the default download directory is used."
         }
       }
     },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
1. Add download path to transmission add_torrent service.
2. Add download path to transmission torrent events.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This is my first HA PR and second ever PR. If I have made mistakes, please let me know what to do to fix them.
- PR is not related to issue.
- ~~No documentation PR yet. Would require update to https://www.home-assistant.io/integrations/transmission/#service-add_torrent~~ Documentation PR here: https://github.com/home-assistant/home-assistant.io/pull/35474

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

```
ha-venvvscode ➜ /workspaces/HA_core (transmission-download-path) $ pre-commit run --files /workspaces/HA_core/homeassistant/components/transmission/*       
ruff.....................................................................Passed
ruff-format..............................................................Passed
codespell................................................................Passed
check json...............................................................Passed
don't commit to branch...................................................Passed
yamllint.................................................................Passed
prettier.................................................................Passed
mypy.....................................................................Passed
pylint...................................................................Passed
gen_requirements_all.....................................................Passed
hassfest.................................................................Passed
hassfest-metadata....................................(no files to check)Skipped
hassfest-mypy-config.................................(no files to check)Skipped

ha-venvvscode ➜ /workspaces/HA_core (transmission-download-path) $ pytest ./tests/components/transmission --cov=homeassistant.components.transmission --cov-report term-missing -vv
Test session starts (platform: linux, Python 3.12.3, pytest 8.2.0, pytest-sugar 1.0.0)
cachedir: .pytest_cache
rootdir: /workspaces/HA_core
configfile: pyproject.toml
plugins: mock-3.14.0, typeguard-4.0.1, rerunfailures-14.0, socket-0.7.0, sugar-1.0.0, pytest_freezer-0.4.8, requests-mock-1.12.1, timeout-2.3.1, cov-5.0.0, aiohttp-1.0.5, syrupy-4.6.1, xdist-3.6.1, picked-0.5.0, unordered-0.6.0, respx-0.21.1, asyncio-0.23.6, github-actions-annotate-failures-0.2.0, anyio-4.4.0
asyncio: mode=Mode.AUTO
collected 27 items                                                                                                                                                                                                                                                                                                                        

 tests/components/transmission/test_config_flow.py::test_form ✓                                                                                                                                                                                                                                                               4% ▍         
 tests/components/transmission/test_config_flow.py::test_device_already_configured ✓                                                                                                                                                                                                                                          7% ▊         
 tests/components/transmission/test_config_flow.py::test_options ✓                                                                                                                                                                                                                                                           11% █▎        
 tests/components/transmission/test_config_flow.py::test_error_on_wrong_credentials ✓                                                                                                                                                                                                                                        15% █▌        
 tests/components/transmission/test_config_flow.py::test_unexpected_error ✓                                                                                                                                                                                                                                                  19% █▉        
 tests/components/transmission/test_config_flow.py::test_error_on_connection_failure ✓                                                                                                                                                                                                                                       22% ██▎       
 tests/components/transmission/test_config_flow.py::test_reauth_success ✓                                                                                                                                                                                                                                                    26% ██▋       
 tests/components/transmission/test_config_flow.py::test_reauth_failed ✓                                                                                                                                                                                                                                                     30% ██▉       
 tests/components/transmission/test_config_flow.py::test_reauth_failed_connection_error ✓                                                                                                                                                                                                                                    33% ███▍      
 tests/components/transmission/test_init.py::test_successful_config_entry ✓                                                                                                                                                                                                                                                  37% ███▊      
 tests/components/transmission/test_init.py::test_config_flow_entry_migrate_1_1_to_1_2 ✓                                                                                                                                                                                                                                     41% ████▏     
 tests/components/transmission/test_init.py::test_setup_failed_connection_error ✓                                                                                                                                                                                                                                            44% ████▌     
 tests/components/transmission/test_init.py::test_setup_failed_auth_error ✓                                                                                                                                                                                                                                                  48% ████▊     
 tests/components/transmission/test_init.py::test_setup_failed_unexpected_error ✓                                                                                                                                                                                                                                            52% █████▎    
 tests/components/transmission/test_init.py::test_unload_entry ✓                                                                                                                                                                                                                                                             56% █████▋    
 tests/components/transmission/test_init.py::test_migrate_unique_id[sensor-0.0.0.0-Transmission Down Speed-1234-download] ✓                                                                                                                                                                                                  59% █████▉    
 tests/components/transmission/test_init.py::test_migrate_unique_id[sensor-0.0.0.0-Transmission Up Speed-1234-upload] ✓                                                                                                                                                                                                      63% ██████▍   
 tests/components/transmission/test_init.py::test_migrate_unique_id[sensor-0.0.0.0-Transmission Status-1234-status] ✓                                                                                                                                                                                                        67% ██████▋   
 tests/components/transmission/test_init.py::test_migrate_unique_id[sensor-0.0.0.0-Transmission Active Torrents-1234-active_torrents] ✓                                                                                                                                                                                      70% ███████▏  
 tests/components/transmission/test_init.py::test_migrate_unique_id[sensor-0.0.0.0-Transmission Paused Torrents-1234-paused_torrents] ✓                                                                                                                                                                                      74% ███████▌  
 tests/components/transmission/test_init.py::test_migrate_unique_id[sensor-0.0.0.0-Transmission Total Torrents-1234-total_torrents] ✓                                                                                                                                                                                        78% ███████▊  
 tests/components/transmission/test_init.py::test_migrate_unique_id[sensor-0.0.0.0-Transmission Completed Torrents-1234-completed_torrents] ✓                                                                                                                                                                                81% ████████▎ 
 tests/components/transmission/test_init.py::test_migrate_unique_id[sensor-0.0.0.0-Transmission Started Torrents-1234-started_torrents] ✓                                                                                                                                                                                    85% ████████▌ 
 tests/components/transmission/test_init.py::test_migrate_unique_id[sensor-1234-started_torrents-1234-started_torrents] ✓                                                                                                                                                                                                    89% ████████▉ 
 tests/components/transmission/test_init.py::test_migrate_unique_id[switch-0.0.0.0-Transmission Switch-1234-on_off] ✓                                                                                                                                                                                                        93% █████████▍
 tests/components/transmission/test_init.py::test_migrate_unique_id[switch-0.0.0.0-Transmission Turtle Mode-1234-turtle_mode] ✓                                                                                                                                                                                              96% █████████▋
 tests/components/transmission/test_init.py::test_migrate_unique_id[switch-1234-turtle_mode-1234-turtle_mode] ✓                                                                                                                                                                                                             100% ██████████

---------- coverage: platform linux, python 3.12.3-final-0 -----------
Name                                                   Stmts   Miss  Cover   Missing
------------------------------------------------------------------------------------
homeassistant/components/transmission/config_flow.py      59      0   100%
homeassistant/components/transmission/const.py            34      0   100%
homeassistant/components/transmission/errors.py            4      0   100%
------------------------------------------------------------------------------------
TOTAL                                                     97      0   100%


Results (2.51s):
      27 passed
```

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]
    - No. Would require an update to: https://www.home-assistant.io/integrations/transmission/#service-add_torrent to be complete. However, that's in a separate repository, so that would require a separate PR, right?

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.
    - Skipped as this is my first PR and don't know enough to be an adequate reviewer.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
