### PR TITLE
Add binary sensors for netatmo NIS and NACamDoorTag devices

### DIFF
--- a/homeassistant/components/netatmo/binary_sensor.py
+++ b/homeassistant/components/netatmo/binary_sensor.py
@@ -1,5 +1,9 @@
 """Support for Netatmo binary sensors."""
 
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import cast
+
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -9,14 +13,118 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import StateType
 
-from .const import NETATMO_CREATE_WEATHER_SENSOR
-from .data_handler import NetatmoDevice
-from .entity import NetatmoWeatherModuleEntity
+from .const import (
+    CONF_URL_SECURITY,
+    DOMAIN,
+    EVENT_TYPE_DOOR_TAG_BIG_MOVE,
+    EVENT_TYPE_DOOR_TAG_OPEN,
+    EVENT_TYPE_DOOR_TAG_SMALL_MOVE,
+    EVENT_TYPE_HOME_ALARM,
+    NETATMO_CREATE_OPENING_SENSOR,
+    NETATMO_CREATE_SIREN_SENSOR,
+    NETATMO_CREATE_WEATHER_SENSOR,
+)
+from .data_handler import HOME, SIGNAL_NAME, NetatmoDevice
+from .entity import NetatmoModuleEntity, NetatmoWeatherModuleEntity
 
-BINARY_SENSOR_TYPES: tuple[BinarySensorEntityDescription, ...] = (
-    BinarySensorEntityDescription(
+
+def process_open_status(status: StateType) -> bool | None:
+    """Process health index and return string for display."""
+    if not isinstance(status, str):
+        return None
+
+    if status == "open":
+        return True
+
+    return False
+
+
+def process_monitoring_status(status: StateType) -> bool | None:
+    """Process monitoring siren status and return boolean for display."""
+    if not isinstance(status, bool):
+        return None
+
+    return not status
+
+
+def process_sound_status(status: StateType) -> bool | None:
+    """Process sound siren status and return boolean for display."""
+    if not isinstance(status, str):
+        return None
+
+    if status == "sound":
+        return True
+
+    return False
+
+
+@dataclass(frozen=True, kw_only=True)
+class NetatmoBinarySensorEntityDescription(BinarySensorEntityDescription):
+    """Describes Netatmo sensor entity."""
+
+    netatmo_name: str
+    value_fn: Callable[[StateType], StateType] = lambda x: x
+
+
+BINARY_SENSOR_TYPES: tuple[NetatmoBinarySensorEntityDescription, ...] = (
+    NetatmoBinarySensorEntityDescription(
         key="reachable",
+        netatmo_name="reachable",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+    ),
+)
+
+
+BINARY_SENSOR_OPENING_TYPES: tuple[NetatmoBinarySensorEntityDescription, ...] = (
+    NetatmoBinarySensorEntityDescription(
+        key="opening",
+        netatmo_name="status",
+        device_class=BinarySensorDeviceClass.WINDOW,
+        value_fn=process_open_status,
+    ),
+    NetatmoBinarySensorEntityDescription(
+        key="reachable",
+        netatmo_name="reachable",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+    ),
+    NetatmoBinarySensorEntityDescription(
+        key="motion",
+        netatmo_name="status",
+        device_class=BinarySensorDeviceClass.MOTION,
+        value_fn=lambda x: False,
+    ),
+    NetatmoBinarySensorEntityDescription(
+        key="vibration",
+        netatmo_name="status",
+        device_class=BinarySensorDeviceClass.VIBRATION,
+        value_fn=lambda x: False,
+    ),
+)
+
+OPENING_KEYS_TO_EVENT = {
+    "motion": EVENT_TYPE_DOOR_TAG_BIG_MOVE,
+    "opening": EVENT_TYPE_DOOR_TAG_OPEN,
+    "vibration": EVENT_TYPE_DOOR_TAG_SMALL_MOVE,
+}
+
+BINARY_SENSOR_SIREN_TYPES: tuple[NetatmoBinarySensorEntityDescription, ...] = (
+    NetatmoBinarySensorEntityDescription(
+        key="monitoring",
+        netatmo_name="monitoring",
+        device_class=BinarySensorDeviceClass.SAFETY,
+        value_fn=process_monitoring_status,
+    ),
+    NetatmoBinarySensorEntityDescription(
+        key="sound",
+        netatmo_name="status",
+        device_class=BinarySensorDeviceClass.SOUND,
+        value_fn=process_sound_status,
+    ),
+    NetatmoBinarySensorEntityDescription(
+        key="reachable",
+        netatmo_name="reachable",
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
     ),
 )
@@ -32,7 +140,7 @@ async def async_setup_entry(
         async_add_entities(
             NetatmoWeatherBinarySensor(netatmo_device, description)
             for description in BINARY_SENSOR_TYPES
-            if description.key in netatmo_device.device.features
+            if description.netatmo_name in netatmo_device.device.features
         )
 
     entry.async_on_unload(
@@ -41,12 +149,40 @@ async def async_setup_entry(
         )
     )
 
+    @callback
+    def _create_opening_binary_sensor_entity(netatmo_device: NetatmoDevice) -> None:
+        async_add_entities(
+            NetatmoOpeningBinarySensor(netatmo_device, description)
+            for description in BINARY_SENSOR_OPENING_TYPES
+            if description.netatmo_name in netatmo_device.device.features
+        )
+
+    entry.async_on_unload(
+        async_dispatcher_connect(
+            hass, NETATMO_CREATE_OPENING_SENSOR, _create_opening_binary_sensor_entity
+        )
+    )
+
+    @callback
+    def _create_siren_binary_sensor_entity(netatmo_device: NetatmoDevice) -> None:
+        async_add_entities(
+            NetatmoSirenBinarySensor(netatmo_device, description)
+            for description in BINARY_SENSOR_SIREN_TYPES
+            if description.netatmo_name in netatmo_device.device.features
+        )
+
+    entry.async_on_unload(
+        async_dispatcher_connect(
+            hass, NETATMO_CREATE_SIREN_SENSOR, _create_siren_binary_sensor_entity
+        )
+    )
+
 
 class NetatmoWeatherBinarySensor(NetatmoWeatherModuleEntity, BinarySensorEntity):
     """Implementation of a Netatmo binary sensor."""
 
     def __init__(
-        self, device: NetatmoDevice, description: BinarySensorEntityDescription
+        self, device: NetatmoDevice, description: NetatmoBinarySensorEntityDescription
     ) -> None:
         """Initialize a Netatmo binary sensor."""
         super().__init__(device)
@@ -58,3 +194,106 @@ class NetatmoWeatherBinarySensor(NetatmoWeatherModuleEntity, BinarySensorEntity)
         """Update the entity's state."""
         self._attr_is_on = self.device.reachable
         self.async_write_ha_state()
+
+
+class NetatmoOpeningSirenBinarySensor(NetatmoModuleEntity, BinarySensorEntity):
+    """Implementation of a Netatmo binary sensor."""
+
+    entity_description: NetatmoBinarySensorEntityDescription
+    _attr_configuration_url = CONF_URL_SECURITY
+
+    def __init__(
+        self, device: NetatmoDevice, description: NetatmoBinarySensorEntityDescription
+    ) -> None:
+        """Initialize a Netatmo binary sensor."""
+        super().__init__(device)
+        self.entity_description = description
+        self._attr_unique_id = f"{self.device.entity_id}-{description.key}"
+        self._attr_translation_key = description.netatmo_name
+
+        self._publishers.extend(
+            [
+                {
+                    "name": HOME,
+                    "home_id": self.home.entity_id,
+                    SIGNAL_NAME: f"{HOME}-{self.home.entity_id}",
+                },
+            ]
+        )
+
+    @callback
+    def async_update_callback(self) -> None:
+        """Update the entity's state."""
+        if not self.device.reachable:
+            if self.available:
+                self._attr_available = False
+            return
+
+        state = cast(
+            StateType, getattr(self.device, self.entity_description.netatmo_name)
+        )
+        if state is None:
+            self._attr_is_on = None
+        else:
+            self._attr_is_on = bool(self.entity_description.value_fn(state))
+
+        self._attr_available = True
+        self.async_write_ha_state()
+
+
+class NetatmoOpeningBinarySensor(NetatmoOpeningSirenBinarySensor):
+    """Implementation of a Netatmo binary sensor."""
+
+    async def async_added_to_hass(self) -> None:
+        """Entity created."""
+        await super().async_added_to_hass()
+
+        for key in OPENING_KEYS_TO_EVENT.items():
+            if key[0] == self.entity_description.key:
+                self.async_on_remove(
+                    async_dispatcher_connect(
+                        self.hass,
+                        f"signal-{DOMAIN}-webhook-{key[1]}",
+                        self.handle_event,
+                    )
+                )
+
+    @callback
+    def handle_event(self, event: dict) -> None:
+        """Handle webhook events."""
+        data = event["data"]
+
+        if (
+            data["home_id"] == self.home.entity_id
+            and data["module_id"] == self.device.entity_id
+        ):
+            self.is_on = True
+            self.async_write_ha_state()
+
+
+class NetatmoSirenBinarySensor(NetatmoOpeningSirenBinarySensor):
+    """Implementation of a Netatmo binary sensor."""
+
+    async def async_added_to_hass(self) -> None:
+        """Entity created."""
+        await super().async_added_to_hass()
+
+        if self.entity_description.key == "monitoring":
+            self.async_on_remove(
+                async_dispatcher_connect(
+                    self.hass,
+                    f"signal-{DOMAIN}-webhook-{EVENT_TYPE_HOME_ALARM}",
+                    self.handle_event,
+                )
+            )
+
+    @callback
+    def handle_event(self, event: dict) -> None:
+        """Handle webhook events."""
+        data = event["data"]
+
+        if (
+            self.home.entity_id == data["home_id"]
+            and self.device.bridge == data["device_id"]
+        ):
+            self.data_handler.async_force_update(f"{HOME}-{self.home.entity_id}")

--- a/homeassistant/components/netatmo/binary_sensor.py
+++ b/homeassistant/components/netatmo/binary_sensor.py
@@ -35,10 +35,7 @@ def process_open_status(status: StateType) -> bool | None:
     if not isinstance(status, str):
         return None
 
-    if status == "open":
-        return True
-
-    return False
+    return status == "open"
 
 
 def process_monitoring_status(status: StateType) -> bool | None:

--- a/homeassistant/components/netatmo/const.py
+++ b/homeassistant/components/netatmo/const.py
@@ -47,9 +47,11 @@ NETATMO_CREATE_CLIMATE = "netatmo_create_climate"
 NETATMO_CREATE_COVER = "netatmo_create_cover"
 NETATMO_CREATE_FAN = "netatmo_create_fan"
 NETATMO_CREATE_LIGHT = "netatmo_create_light"
+NETATMO_CREATE_OPENING_SENSOR = "netatmo_create_opening_sensor"
 NETATMO_CREATE_ROOM_SENSOR = "netatmo_create_room_sensor"
 NETATMO_CREATE_SELECT = "netatmo_create_select"
 NETATMO_CREATE_SENSOR = "netatmo_create_sensor"
+NETATMO_CREATE_SIREN_SENSOR = "netatmo_create_siren_sensor"
 NETATMO_CREATE_SWITCH = "netatmo_create_switch"
 NETATMO_CREATE_WEATHER_SENSOR = "netatmo_create_weather_sensor"
 
@@ -126,6 +128,8 @@ EVENT_TYPE_DOOR_TAG_OPEN = "tag_open"
 EVENT_TYPE_DOOR_TAG_SMALL_MOVE = "tag_small_move"
 EVENT_TYPE_OFF = "off"
 EVENT_TYPE_ON = "on"
+# Siren Tag
+EVENT_TYPE_HOME_ALARM = "home_alarm"
 
 OUTDOOR_CAMERA_TRIGGERS = [
     EVENT_TYPE_CAMERA_ANIMAL,

--- a/homeassistant/components/netatmo/data_handler.py
+++ b/homeassistant/components/netatmo/data_handler.py
@@ -39,9 +39,11 @@ from .const import (
     NETATMO_CREATE_COVER,
     NETATMO_CREATE_FAN,
     NETATMO_CREATE_LIGHT,
+    NETATMO_CREATE_OPENING_SENSOR,
     NETATMO_CREATE_ROOM_SENSOR,
     NETATMO_CREATE_SELECT,
     NETATMO_CREATE_SENSOR,
+    NETATMO_CREATE_SIREN_SENSOR,
     NETATMO_CREATE_SWITCH,
     NETATMO_CREATE_WEATHER_SENSOR,
     PLATFORMS,
@@ -358,6 +360,8 @@ class NetatmoDataHandler:
             ],
             NetatmoDeviceCategory.meter: [NETATMO_CREATE_SENSOR],
             NetatmoDeviceCategory.fan: [NETATMO_CREATE_FAN],
+            NetatmoDeviceCategory.siren: [NETATMO_CREATE_SIREN_SENSOR],
+            NetatmoDeviceCategory.opening: [NETATMO_CREATE_OPENING_SENSOR],
         }
         for module in home.modules.values():
             if not module.device_category:

--- a/tests/components/netatmo/fixtures/homestatus_91763b24c43d3e344f424e8b.json
+++ b/tests/components/netatmo/fixtures/homestatus_91763b24c43d3e344f424e8b.json
@@ -161,9 +161,9 @@
           "rf_strength": 58,
           "last_seen": 1642698124,
           "last_activity": 1627757310,
-          "reachable": false,
+          "reachable": true,
           "bridge": "12:34:56:00:f1:62",
-          "status": "no_news"
+          "status": "closed"
         },
         {
           "id": "12:34:56:00:e3:9b",

--- a/tests/components/netatmo/snapshots/test_binary_sensor.ambr
+++ b/tests/components/netatmo/snapshots/test_binary_sensor.ambr
@@ -249,6 +249,150 @@
     'state': 'on',
   })
 # ---
+# name: test_entity[binary_sensor.sirene_in_hall_connectivity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.sirene_in_hall_connectivity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': 'Connectivity',
+    'platform': 'netatmo',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'reachable',
+    'unique_id': '12:34:56:00:e3:9b-reachable',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entity[binary_sensor.sirene_in_hall_connectivity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by Netatmo',
+      'device_class': 'connectivity',
+      'friendly_name': 'Sirene in hall Connectivity',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.sirene_in_hall_connectivity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_entity[binary_sensor.sirene_in_hall_safety-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.sirene_in_hall_safety',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.SAFETY: 'safety'>,
+    'original_icon': None,
+    'original_name': 'Safety',
+    'platform': 'netatmo',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'monitoring',
+    'unique_id': '12:34:56:00:e3:9b-monitoring',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entity[binary_sensor.sirene_in_hall_safety-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by Netatmo',
+      'device_class': 'safety',
+      'friendly_name': 'Sirene in hall Safety',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.sirene_in_hall_safety',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_entity[binary_sensor.sirene_in_hall_sound-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.sirene_in_hall_sound',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.SOUND: 'sound'>,
+    'original_icon': None,
+    'original_name': 'Sound',
+    'platform': 'netatmo',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'status',
+    'unique_id': '12:34:56:00:e3:9b-sound',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entity[binary_sensor.sirene_in_hall_sound-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by Netatmo',
+      'device_class': 'sound',
+      'friendly_name': 'Sirene in hall Sound',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.sirene_in_hall_sound',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_entity[binary_sensor.villa_bathroom_connectivity-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -537,5 +681,197 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
+  })
+# ---
+# name: test_entity[binary_sensor.window_hall_connectivity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.window_hall_connectivity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': 'Connectivity',
+    'platform': 'netatmo',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'reachable',
+    'unique_id': '12:34:56:00:86:99-reachable',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entity[binary_sensor.window_hall_connectivity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by Netatmo',
+      'device_class': 'connectivity',
+      'friendly_name': 'Window Hall Connectivity',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.window_hall_connectivity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_entity[binary_sensor.window_hall_motion-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.window_hall_motion',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.MOTION: 'motion'>,
+    'original_icon': None,
+    'original_name': 'Motion',
+    'platform': 'netatmo',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'status',
+    'unique_id': '12:34:56:00:86:99-motion',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entity[binary_sensor.window_hall_motion-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by Netatmo',
+      'device_class': 'motion',
+      'friendly_name': 'Window Hall Motion',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.window_hall_motion',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entity[binary_sensor.window_hall_vibration-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.window_hall_vibration',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.VIBRATION: 'vibration'>,
+    'original_icon': None,
+    'original_name': 'Vibration',
+    'platform': 'netatmo',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'status',
+    'unique_id': '12:34:56:00:86:99-vibration',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entity[binary_sensor.window_hall_vibration-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by Netatmo',
+      'device_class': 'vibration',
+      'friendly_name': 'Window Hall Vibration',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.window_hall_vibration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entity[binary_sensor.window_hall_window-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.window_hall_window',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.WINDOW: 'window'>,
+    'original_icon': None,
+    'original_name': 'Window',
+    'platform': 'netatmo',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'status',
+    'unique_id': '12:34:56:00:86:99-opening',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entity[binary_sensor.window_hall_window-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by Netatmo',
+      'device_class': 'window',
+      'friendly_name': 'Window Hall Window',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.window_hall_window',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
   })
 # ---

--- a/tests/components/netatmo/test_binary_sensor.py
+++ b/tests/components/netatmo/test_binary_sensor.py
@@ -5,13 +5,14 @@ from unittest.mock import AsyncMock
 import pytest
 from syrupy import SnapshotAssertion
 
-from homeassistant.const import Platform
+from homeassistant.components.netatmo.const import NETATMO_EVENT
+from homeassistant.const import CONF_WEBHOOK_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .common import snapshot_platform_entities
+from .common import selected_platforms, simulate_webhook, snapshot_platform_entities
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_capture_events
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -30,3 +31,60 @@ async def test_entity(
         entity_registry,
         snapshot,
     )
+
+
+async def test_webhook_siren_event(
+    hass: HomeAssistant, config_entry: MockConfigEntry, netatmo_auth: AsyncMock
+) -> None:
+    """Test that person events are handled."""
+    with selected_platforms([Platform.BINARY_SENSOR]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+        await hass.async_block_till_done()
+
+    test_netatmo_event = async_capture_events(hass, NETATMO_EVENT)
+    assert not test_netatmo_event
+
+    fake_webhook_event = {
+        "event_type": "home_alarm",
+        "camera_id": "12:34:56:00:f1:62",
+        "device_id": "12:34:56:00:f1:62",
+        "module_id": "12:34:56:00:e3",
+        "event_id": "1234567890",
+        "message": "Update Siren",
+        "push_type": "NACamerahome_alarm",
+    }
+
+    webhook_id = config_entry.data[CONF_WEBHOOK_ID]
+    await simulate_webhook(hass, webhook_id, fake_webhook_event)
+    assert test_netatmo_event
+
+
+async def test_webhook_opening_event(
+    hass: HomeAssistant, config_entry: MockConfigEntry, netatmo_auth: AsyncMock
+) -> None:
+    """Test window events are handled."""
+    with selected_platforms([Platform.BINARY_SENSOR]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+        await hass.async_block_till_done()
+
+    assert hass.states.get("binary_sensor.window_hall_window").state == "off"
+    test_netatmo_event = async_capture_events(hass, NETATMO_EVENT)
+    assert not test_netatmo_event
+
+    fake_webhook_event = {
+        "event_type": "tag_open",
+        "camera_id": "12:34:56:00:f1:62",
+        "device_id": "12:34:56:00:f1:62",
+        "module_id": "12:34:56:00:86:99",
+        "event_id": "1234567890",
+        "message": "Window open",
+        "push_type": "NACamera-tag_open",
+    }
+
+    webhook_id = config_entry.data[CONF_WEBHOOK_ID]
+    await simulate_webhook(hass, webhook_id, fake_webhook_event)
+    assert hass.states.get("binary_sensor.window_hall_window").state == "on"
+
+    assert test_netatmo_event


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add binary sensors for NIS and NACamDoorTag devices, 
Device NIS:
reachable
monitoring: On/Off
sound: True if the siren souding (alert) (webhook with the event home_alarm)

Device NACamDoorTag:
reachable
opening : True if the window/door is open or webhook tag_open  is received
motion: True if webhook tag_big_move is received
vibration: True if webhook tag_small_move is received

After, I'll update sensors.py for these devices, if you are ok with these updates
First commit: binary sensors
Second commit: sensors

I have done this update for my heating

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ x] The code change is tested and works locally.
- [ x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ x] There is no commented out code in this PR.
- [ x] I have followed the [development checklist][dev-checklist]
- [ x] I have followed the [perfect PR recommendations][perfect-pr]
- [ x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
