### PR TITLE
Migrate doorbird to use entry.runtime_data

### DIFF
--- a/homeassistant/components/doorbird/__init__.py
+++ b/homeassistant/components/doorbird/__init__.py
@@ -10,7 +10,6 @@ from doorbirdpy import DoorBird
 import requests
 
 from homeassistant.components import persistent_notification
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
@@ -25,7 +24,7 @@ from homeassistant.helpers.typing import ConfigType
 
 from .const import CONF_EVENTS, DOMAIN, PLATFORMS
 from .device import ConfiguredDoorBird
-from .models import DoorBirdData
+from .models import DoorBirdConfigEntry, DoorBirdData
 from .view import DoorBirdRequestView
 
 _LOGGER = logging.getLogger(__name__)
@@ -33,8 +32,6 @@ _LOGGER = logging.getLogger(__name__)
 CONF_CUSTOM_URL = "hass_url_override"
 
 CONFIG_SCHEMA = cv.removed(DOMAIN, raise_if_present=False)
-
-type DoorBirdConfigEntry = ConfigEntry[DoorBirdData]
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/homeassistant/components/doorbird/__init__.py
+++ b/homeassistant/components/doorbird/__init__.py
@@ -34,16 +34,17 @@ CONF_CUSTOM_URL = "hass_url_override"
 
 CONFIG_SCHEMA = cv.removed(DOMAIN, raise_if_present=False)
 
+type DoorBirdConfigEntry = ConfigEntry[DoorBirdData]
+
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the DoorBird component."""
-    hass.data.setdefault(DOMAIN, {})
     # Provide an endpoint for the door stations to call to trigger events
     hass.http.register_view(DoorBirdRequestView)
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: DoorBirdConfigEntry) -> bool:
     """Set up DoorBird from a config entry."""
 
     _async_import_options_from_data_if_missing(hass, entry)
@@ -91,7 +92,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady
 
     entry.async_on_unload(entry.add_update_listener(_update_listener))
-    hass.data[DOMAIN][config_entry_id] = door_bird_data
+    entry.runtime_data = door_bird_data
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
@@ -102,12 +103,9 @@ def _init_door_bird_device(device: DoorBird) -> tuple[tuple[bool, int], dict[str
     return device.ready(), device.info()
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: DoorBirdConfigEntry) -> bool:
     """Unload a config entry."""
-    data: dict[str, DoorBirdData] = hass.data[DOMAIN]
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        data.pop(entry.entry_id)
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
 async def _async_register_events(
@@ -133,11 +131,9 @@ async def _async_register_events(
     return True
 
 
-async def _update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def _update_listener(hass: HomeAssistant, entry: DoorBirdConfigEntry) -> None:
     """Handle options update."""
-    config_entry_id = entry.entry_id
-    data: DoorBirdData = hass.data[DOMAIN][config_entry_id]
-    door_station = data.door_station
+    door_station = entry.runtime_data.door_station
     door_station.update_events(entry.options[CONF_EVENTS])
     # Subscribe to doorbell or motion events
     await _async_register_events(hass, door_station)
@@ -145,7 +141,7 @@ async def _update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
 
 @callback
 def _async_import_options_from_data_if_missing(
-    hass: HomeAssistant, entry: ConfigEntry
+    hass: HomeAssistant, entry: DoorBirdConfigEntry
 ) -> None:
     options = dict(entry.options)
     modified = False

--- a/homeassistant/components/doorbird/button.py
+++ b/homeassistant/components/doorbird/button.py
@@ -9,9 +9,8 @@ from homeassistant.components.button import ButtonEntity, ButtonEntityDescriptio
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import DoorBirdConfigEntry
 from .entity import DoorBirdEntity
-from .models import DoorBirdData
+from .models import DoorBirdConfigEntry, DoorBirdData
 
 IR_RELAY = "__ir_light__"
 

--- a/homeassistant/components/doorbird/button.py
+++ b/homeassistant/components/doorbird/button.py
@@ -6,11 +6,10 @@ from dataclasses import dataclass
 from doorbirdpy import DoorBird
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from . import DoorBirdConfigEntry
 from .entity import DoorBirdEntity
 from .models import DoorBirdData
 
@@ -38,12 +37,11 @@ IR_ENTITY_DESCRIPTION = DoorbirdButtonEntityDescription(
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: DoorBirdConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the DoorBird button platform."""
-    config_entry_id = config_entry.entry_id
-    door_bird_data: DoorBirdData = hass.data[DOMAIN][config_entry_id]
+    door_bird_data = config_entry.runtime_data
     relays = door_bird_data.door_station_info["RELAYS"]
 
     entities = [

--- a/homeassistant/components/doorbird/camera.py
+++ b/homeassistant/components/doorbird/camera.py
@@ -14,9 +14,8 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.dt as dt_util
 
-from . import DoorBirdConfigEntry
 from .entity import DoorBirdEntity
-from .models import DoorBirdData
+from .models import DoorBirdConfigEntry, DoorBirdData
 
 _LAST_VISITOR_INTERVAL = datetime.timedelta(minutes=2)
 _LAST_MOTION_INTERVAL = datetime.timedelta(seconds=30)

--- a/homeassistant/components/doorbird/camera.py
+++ b/homeassistant/components/doorbird/camera.py
@@ -9,13 +9,12 @@ import logging
 import aiohttp
 
 from homeassistant.components.camera import Camera, CameraEntityFeature
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.dt as dt_util
 
-from .const import DOMAIN
+from . import DoorBirdConfigEntry
 from .entity import DoorBirdEntity
 from .models import DoorBirdData
 
@@ -28,12 +27,11 @@ _TIMEOUT = 15  # seconds
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: DoorBirdConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the DoorBird camera platform."""
-    config_entry_id = config_entry.entry_id
-    door_bird_data: DoorBirdData = hass.data[DOMAIN][config_entry_id]
+    door_bird_data = config_entry.runtime_data
     device = door_bird_data.door_station.device
 
     async_add_entities(

--- a/homeassistant/components/doorbird/event.py
+++ b/homeassistant/components/doorbird/event.py
@@ -10,11 +10,10 @@ from homeassistant.components.event import (
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import DoorBirdConfigEntry
 from .const import DOMAIN
 from .device import DoorbirdEvent
 from .entity import DoorBirdEntity
-from .models import DoorBirdData
+from .models import DoorBirdConfigEntry, DoorBirdData
 
 EVENT_DESCRIPTIONS = {
     "doorbell": EventEntityDescription(

--- a/homeassistant/components/doorbird/event.py
+++ b/homeassistant/components/doorbird/event.py
@@ -7,10 +7,10 @@ from homeassistant.components.event import (
     EventEntity,
     EventEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import DoorBirdConfigEntry
 from .const import DOMAIN
 from .device import DoorbirdEvent
 from .entity import DoorBirdEntity
@@ -34,12 +34,11 @@ EVENT_DESCRIPTIONS = {
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: DoorBirdConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the DoorBird event platform."""
-    config_entry_id = config_entry.entry_id
-    door_bird_data: DoorBirdData = hass.data[DOMAIN][config_entry_id]
+    door_bird_data = config_entry.runtime_data
     async_add_entities(
         DoorBirdEventEntity(door_bird_data, doorbird_event, description)
         for doorbird_event in door_bird_data.door_station.event_descriptions
@@ -48,7 +47,7 @@ async def async_setup_entry(
 
 
 class DoorBirdEventEntity(DoorBirdEntity, EventEntity):
-    """A relay in a DoorBird device."""
+    """A doorbird event entity."""
 
     entity_description: EventEntityDescription
     _attr_has_entity_name = True

--- a/homeassistant/components/doorbird/logbook.py
+++ b/homeassistant/components/doorbird/logbook.py
@@ -13,7 +13,7 @@ from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import Event, HomeAssistant, callback
 
 from .const import DOMAIN
-from .models import DoorBirdData
+from .util import async_get_entries
 
 
 @callback
@@ -35,8 +35,8 @@ def async_describe_events(
             LOGBOOK_ENTRY_ENTITY_ID: event.data.get(ATTR_ENTITY_ID),
         }
 
-    domain_data: dict[str, DoorBirdData] = hass.data[DOMAIN]
-    for data in domain_data.values():
+    for entry in async_get_entries(hass):
+        data = entry.runtime_data
         for event in data.door_station.door_station_events:
             async_describe_event(
                 DOMAIN, f"{DOMAIN}_{event}", async_describe_logbook_event

--- a/homeassistant/components/doorbird/models.py
+++ b/homeassistant/components/doorbird/models.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from homeassistant.config_entries import ConfigEntry
+
 from .device import ConfiguredDoorBird
+
+type DoorBirdConfigEntry = ConfigEntry[DoorBirdData]
 
 
 @dataclass

--- a/homeassistant/components/doorbird/util.py
+++ b/homeassistant/components/doorbird/util.py
@@ -1,12 +1,12 @@
 """DoorBird integration utils."""
 
-from typing import Any
+from typing import Any, cast
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 
+from . import DoorBirdConfigEntry
 from .const import DOMAIN
 from .device import ConfiguredDoorBird
-from .models import DoorBirdData
 
 
 def get_mac_address_from_door_station_info(door_station_info: dict[str, Any]) -> str:
@@ -18,9 +18,18 @@ def get_door_station_by_token(
     hass: HomeAssistant, token: str
 ) -> ConfiguredDoorBird | None:
     """Get door station by token."""
-    domain_data: dict[str, DoorBirdData] = hass.data[DOMAIN]
-    for data in domain_data.values():
-        door_station = data.door_station
+    for entry in async_get_entries(hass):
+        door_station = entry.runtime_data.door_station
         if door_station.token == token:
             return door_station
     return None
+
+
+@callback
+def async_get_entries(hass: HomeAssistant) -> list[DoorBirdConfigEntry]:
+    """Get all the doorbird entries."""
+    entries = hass.config_entries.async_entries(
+        DOMAIN, include_ignore=True, include_disabled=True
+    )
+    active_entries = [entry for entry in entries if hasattr(entry, "runtime_data")]
+    return cast(list[DoorBirdConfigEntry], active_entries)

--- a/homeassistant/components/doorbird/util.py
+++ b/homeassistant/components/doorbird/util.py
@@ -4,9 +4,9 @@ from typing import Any, cast
 
 from homeassistant.core import HomeAssistant, callback
 
-from . import DoorBirdConfigEntry
 from .const import DOMAIN
 from .device import ConfiguredDoorBird
+from .models import DoorBirdConfigEntry
 
 
 def get_mac_address_from_door_station_info(door_station_info: dict[str, Any]) -> str:


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate doorbird to use entry.runtime_data

Note: integration lacks coverage. Codecov checks failing is expected 



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
