### PR TITLE
Add button platform to Habitica integration

### DIFF
--- a/homeassistant/components/habitica/__init__.py
+++ b/homeassistant/components/habitica/__init__.py
@@ -82,7 +82,7 @@ INSTANCE_LIST_SCHEMA = vol.All(
 )
 CONFIG_SCHEMA = vol.Schema({DOMAIN: INSTANCE_LIST_SCHEMA}, extra=vol.ALLOW_EXTRA)
 
-PLATFORMS = [Platform.SENSOR, Platform.TODO]
+PLATFORMS = [Platform.BUTTON, Platform.SENSOR, Platform.TODO]
 
 SERVICE_API_CALL_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/habitica/button.py
+++ b/homeassistant/components/habitica/button.py
@@ -37,6 +37,7 @@ class HabitipyButtonEntity(StrEnum):
     RUN_CRON = "run_cron"
     BUY_HEALTH_POTION = "buy_health_potion"
     ALLOCATE_ALL_STAT_POINTS = "allocate_all_stat_points"
+    REVIVE = "revive"
 
 
 BUTTON_DESCRIPTIONS: tuple[HabiticaButtonEntityDescription, ...] = (
@@ -65,6 +66,12 @@ BUTTON_DESCRIPTIONS: tuple[HabiticaButtonEntityDescription, ...] = (
             lambda data: data.user["preferences"].get("automaticAllocation") is True
             and data.user["stats"]["points"] > 0
         ),
+    ),
+    HabiticaButtonEntityDescription(
+        key=HabitipyButtonEntity.REVIVE,
+        translation_key=HabitipyButtonEntity.REVIVE,
+        press_fn=(lambda coordinator: coordinator.api["user"]["revive"].post()),
+        available_fn=(lambda data: data.user["stats"]["hp"] == 0),
     ),
 )
 
@@ -130,6 +137,8 @@ class HabiticaButton(CoordinatorEntity[HabiticaDataUpdateCoordinator], ButtonEnt
                 translation_domain=DOMAIN,
                 translation_key="service_call_exception",
             ) from e
+        else:
+            await self.coordinator.async_refresh()
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/habitica/button.py
+++ b/homeassistant/components/habitica/button.py
@@ -1,0 +1,139 @@
+"""Habitica button platform."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from http import HTTPStatus
+from typing import TYPE_CHECKING, Any
+
+from aiohttp import ClientResponseError
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.const import CONF_NAME, CONF_URL
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import HabiticaConfigEntry
+from .const import DOMAIN, MANUFACTURER, NAME
+from .coordinator import HabiticaData, HabiticaDataUpdateCoordinator
+
+
+@dataclass(kw_only=True, frozen=True)
+class HabiticaButtonEntityDescription(ButtonEntityDescription):
+    """Describes Habitica button entity."""
+
+    press_fn: Callable[[HabiticaDataUpdateCoordinator], Any]
+    available_fn: Callable[[HabiticaData], bool] | None = None
+
+
+class HabitipyButtonEntity(StrEnum):
+    """Habitica button entities."""
+
+    RUN_CRON = "run_cron"
+    BUY_HEALTH_POTION = "buy_health_potion"
+    ALLOCATE_ALL_STAT_POINTS = "allocate_all_stat_points"
+
+
+BUTTON_DESCRIPTIONS: tuple[HabiticaButtonEntityDescription, ...] = (
+    HabiticaButtonEntityDescription(
+        key=HabitipyButtonEntity.RUN_CRON,
+        translation_key=HabitipyButtonEntity.RUN_CRON,
+        press_fn=lambda coordinator: coordinator.api.cron.post(),
+        available_fn=lambda data: data.user["needsCron"],
+    ),
+    HabiticaButtonEntityDescription(
+        key=HabitipyButtonEntity.BUY_HEALTH_POTION,
+        translation_key=HabitipyButtonEntity.BUY_HEALTH_POTION,
+        press_fn=(
+            lambda coordinator: coordinator.api["user"]["buy-health-potion"].post()
+        ),
+        available_fn=(
+            lambda data: data.user["stats"]["gp"] >= 25
+            and data.user["stats"]["hp"] < 50
+        ),
+    ),
+    HabiticaButtonEntityDescription(
+        key=HabitipyButtonEntity.ALLOCATE_ALL_STAT_POINTS,
+        translation_key=HabitipyButtonEntity.ALLOCATE_ALL_STAT_POINTS,
+        press_fn=(lambda coordinator: coordinator.api["user"]["allocate-now"].post()),
+        available_fn=(
+            lambda data: data.user["preferences"].get("automaticAllocation") is True
+            and data.user["stats"]["points"] > 0
+        ),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: HabiticaConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up buttons from a config entry."""
+
+    coordinator = entry.runtime_data
+
+    async_add_entities(
+        HabiticaButton(coordinator, description) for description in BUTTON_DESCRIPTIONS
+    )
+
+
+class HabiticaButton(CoordinatorEntity[HabiticaDataUpdateCoordinator], ButtonEntity):
+    """Representation of a Habitica button."""
+
+    _attr_has_entity_name = True
+    entity_description: HabiticaButtonEntityDescription
+
+    def __init__(
+        self,
+        coordinator: HabiticaDataUpdateCoordinator,
+        entity_description: HabiticaButtonEntityDescription,
+    ) -> None:
+        """Initialize a Habitica button."""
+        super().__init__(coordinator)
+        if TYPE_CHECKING:
+            assert coordinator.config_entry.unique_id
+        self.entity_description = entity_description
+        self._attr_unique_id = (
+            f"{coordinator.config_entry.unique_id}_{entity_description.key}"
+        )
+        self._attr_device_info = DeviceInfo(
+            entry_type=DeviceEntryType.SERVICE,
+            manufacturer=MANUFACTURER,
+            model=NAME,
+            name=coordinator.config_entry.data[CONF_NAME],
+            configuration_url=coordinator.config_entry.data[CONF_URL],
+            identifiers={(DOMAIN, coordinator.config_entry.unique_id)},
+        )
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        try:
+            await self.entity_description.press_fn(self.coordinator)
+        except ClientResponseError as e:
+            if e.status == HTTPStatus.TOO_MANY_REQUESTS:
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="setup_rate_limit_exception",
+                ) from e
+            if e.status == HTTPStatus.UNAUTHORIZED:
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="service_call_unallowed",
+                ) from e
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="service_call_exception",
+            ) from e
+
+    @property
+    def available(self) -> bool:
+        """Is entity available."""
+        if self.entity_description.available_fn:
+            return self.entity_description.available_fn(self.coordinator.data)
+        return True

--- a/homeassistant/components/habitica/button.py
+++ b/homeassistant/components/habitica/button.py
@@ -61,7 +61,7 @@ BUTTON_DESCRIPTIONS: tuple[HabiticaButtonEntityDescription, ...] = (
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.ALLOCATE_ALL_STAT_POINTS,
         translation_key=HabitipyButtonEntity.ALLOCATE_ALL_STAT_POINTS,
-        press_fn=(lambda coordinator: coordinator.api["user"]["allocate-now"].post()),
+        press_fn=lambda coordinator: coordinator.api["user"]["allocate-now"].post(),
         available_fn=(
             lambda data: data.user["preferences"].get("automaticAllocation") is True
             and data.user["stats"]["points"] > 0
@@ -70,8 +70,8 @@ BUTTON_DESCRIPTIONS: tuple[HabiticaButtonEntityDescription, ...] = (
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.REVIVE,
         translation_key=HabitipyButtonEntity.REVIVE,
-        press_fn=(lambda coordinator: coordinator.api["user"]["revive"].post()),
-        available_fn=(lambda data: data.user["stats"]["hp"] == 0),
+        press_fn=lambda coordinator: coordinator.api["user"]["revive"].post(),
+        available_fn=lambda data: data.user["stats"]["hp"] == 0,
     ),
 )
 
@@ -143,6 +143,8 @@ class HabiticaButton(CoordinatorEntity[HabiticaDataUpdateCoordinator], ButtonEnt
     @property
     def available(self) -> bool:
         """Is entity available."""
+        if not super().available:
+            return False
         if self.entity_description.available_fn:
             return self.entity_description.available_fn(self.coordinator.data)
         return True

--- a/homeassistant/components/habitica/icons.json
+++ b/homeassistant/components/habitica/icons.json
@@ -17,6 +17,9 @@
       },
       "allocate_all_stat_points": {
         "default": "mdi:chart-box-outline"
+      },
+      "revive": {
+        "default": "mdi:grave-stone"
       }
     },
     "sensor": {

--- a/homeassistant/components/habitica/icons.json
+++ b/homeassistant/components/habitica/icons.json
@@ -8,6 +8,17 @@
         "default": "mdi:calendar-month"
       }
     },
+    "button": {
+      "run_cron": {
+        "default": "mdi:weather-sunset"
+      },
+      "buy_health_potion": {
+        "default": "mdi:flask-round-bottom"
+      },
+      "allocate_all_stat_points": {
+        "default": "mdi:chart-box-outline"
+      }
+    },
     "sensor": {
       "display_name": {
         "default": "mdi:account-circle"

--- a/homeassistant/components/habitica/strings.json
+++ b/homeassistant/components/habitica/strings.json
@@ -20,6 +20,17 @@
     }
   },
   "entity": {
+    "button": {
+      "run_cron": {
+        "name": "Start my day"
+      },
+      "buy_health_potion": {
+        "name": "Buy a health potion"
+      },
+      "allocate_all_stat_points": {
+        "name": "Allocate all stat points"
+      }
+    },
     "sensor": {
       "display_name": {
         "name": "Display name"
@@ -94,6 +105,12 @@
     },
     "setup_rate_limit_exception": {
       "message": "Currently rate limited, try again later"
+    },
+    "service_call_unallowed": {
+      "message": "Unable to carry out this action, because the required conditions are not met"
+    },
+    "service_call_exception": {
+      "message": "Unable to connect to Habitica, try again later"
     }
   },
   "issues": {

--- a/homeassistant/components/habitica/strings.json
+++ b/homeassistant/components/habitica/strings.json
@@ -29,6 +29,9 @@
       },
       "allocate_all_stat_points": {
         "name": "Allocate all stat points"
+      },
+      "revive": {
+        "name": "Revive from death"
       }
     },
     "sensor": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This adds the button platform to the Habitica integration. It allows to carry out the following actions from 
within Home Assistant:

- Start the day: runs the cron that allocates points, damage for unfinished dailies and resets them, available when time for day change is reached 
- Buy a health potion: available if health is less than max and enough gold is available to buy
- Allocate all stat points: available if there are points to allocate and the user has selected an has chosen a method for automatic stat point allocation after reaching lvl 10
- Revive from death: available if user is dead

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33620

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
