### PR TITLE
Set DSMR Reader quality scale to Gold

### DIFF
--- a/homeassistant/components/dsmr_reader/manifest.json
+++ b/homeassistant/components/dsmr_reader/manifest.json
@@ -6,5 +6,6 @@
   "dependencies": ["mqtt"],
   "documentation": "https://www.home-assistant.io/integrations/dsmr_reader",
   "iot_class": "local_push",
-  "mqtt": ["dsmr/#"]
+  "mqtt": ["dsmr/#"],
+  "quality_scale": "gold"
 }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Going for a Gold status for the DSMR Reader integration.

Silver 🥈
- [x] Connection/configuration is handled via a component.
- [ ] Set an appropriate SCAN_INTERVAL (if a polling integration)
- [ ] Raise [PlatformNotReady](https://github.com/home-assistant/core/pull/integration_setup_failures.md#integrations-using-async_setup_platform) if unable to connect during platform setup (if appropriate)
- [ ] Handles expiration of auth credentials. Refresh if possible or print correct error and fail setup. If based on a config entry, should trigger a new config entry flow to re-authorize. ([docs](https://github.com/home-assistant/core/pull/config_entries_config_flow_handler.md#reauthentication))
- [x] Handles internet unavailable. Log a warning once when unavailable, log once when reconnected.
- [x] Handles device/service unavailable. Log a warning once when unavailable, log once when reconnected.
Operations like service calls and entity methods (e.g. Set HVAC Mode) have proper exception handling. Raise [ ] ServiceValidationError on invalid user input and raise HomeAssistantError for other failures such as a problem communicating with a device. [Read more](https://github.com/docs/core/platform/raising_exceptions) about raising exceptions.
- [x] Set available property to False if appropriate ([docs](https://github.com/home-assistant/core/pull/core/entity.md#generic-properties))
- [ ] Entities have unique ID (if available) ([docs](https://github.com/home-assistant/core/pull/entity_registry_index.md#unique-id-requirements))

Gold 🥇
This is a solid integration that is able to survive poor conditions and can be configured via the user interface.

- [x] Satisfying all Silver level requirements.
- [x]  Configurable via config entries.
- [x]  Don't allow configuring already configured device/service (example: no 2 entries for same hub)
- [x] Discoverable (if available)
- [x] Set unique ID in config flow (if available)
- [ ] Raise [ConfigEntryNotReady](https://github.com/home-assistant/core/pull/integration_setup_failures.md#integrations-using-async_setup_entry) if unable to connect during entry setup (if appropriate)
- [ ] Entities have device info (if available) ([docs](https://github.com/home-assistant/core/pull/device_registry_index.md#defining-devices))
- [x] Tests
- [x] Full test coverage for the config flow
- [x] Above average test coverage for all integration modules
- [x] Tests for fetching data from the integration and controlling it ([docs](https://github.com/home-assistant/core/pull/development_testing.md))
- [x] Has a code owner ([docs](https://github.com/home-assistant/core/pull/creating_integration_manifest.md#code-owners))
- [x] Entities only subscribe to updates inside async_added_to_hass and unsubscribe inside async_will_remove_from_hass ([docs](https://github.com/home-assistant/core/pull/core/entity.md#lifecycle-hooks))
- [x] Entities have correct device classes where appropriate ([docs](https://github.com/home-assistant/core/pull/core/entity.md#generic-properties))
- [x] Supports entities being disabled and leverages Entity.entity_registry_enabled_default to disable less popular entities ([docs](https://github.com/home-assistant/core/pull/core/entity.md#advanced-properties))
- [x] If the device/service API can remove entities, the integration should make sure to clean up the entity and device registry.
- [ ] When communicating with a device or service, the integration implements the diagnostics platform which redacts sensitive information.