### PR TITLE
Revert "Rename sensor to finished downloads in pyLoad integration"

### DIFF
--- a/homeassistant/components/pyload/strings.json
+++ b/homeassistant/components/pyload/strings.json
@@ -74,7 +74,7 @@
         "name": "Downloads in queue"
       },
       "total": {
-        "name": "Finished downloads"
+        "name": "Total downloads"
       },
       "free_space": {
         "name": "Free space"

--- a/tests/components/pyload/snapshots/test_sensor.ambr
+++ b/tests/components/pyload/snapshots/test_sensor.ambr
@@ -99,56 +99,6 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_sensor_update_exceptions[CannotConnect][sensor.pyload_finished_downloads-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.pyload_finished_downloads',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Finished downloads',
-    'platform': 'pyload',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': <PyLoadSensorEntity.TOTAL: 'total'>,
-    'unique_id': 'XXXXXXXXXXXXXX_total',
-    'unit_of_measurement': 'downloads',
-  })
-# ---
-# name: test_sensor_update_exceptions[CannotConnect][sensor.pyload_finished_downloads-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'pyLoad Finished downloads',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'downloads',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.pyload_finished_downloads',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
 # name: test_sensor_update_exceptions[CannotConnect][sensor.pyload_free_space-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -257,6 +207,56 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_sensor_update_exceptions[CannotConnect][sensor.pyload_total_downloads-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.pyload_total_downloads',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Total downloads',
+    'platform': 'pyload',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': <PyLoadSensorEntity.TOTAL: 'total'>,
+    'unique_id': 'XXXXXXXXXXXXXX_total',
+    'unit_of_measurement': 'downloads',
+  })
+# ---
+# name: test_sensor_update_exceptions[CannotConnect][sensor.pyload_total_downloads-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'pyLoad Total downloads',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'downloads',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.pyload_total_downloads',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_sensor_update_exceptions[InvalidAuth][sensor.pyload_active_downloads-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -351,56 +351,6 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.pyload_downloads_in_queue',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_sensor_update_exceptions[InvalidAuth][sensor.pyload_finished_downloads-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.pyload_finished_downloads',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Finished downloads',
-    'platform': 'pyload',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': <PyLoadSensorEntity.TOTAL: 'total'>,
-    'unique_id': 'XXXXXXXXXXXXXX_total',
-    'unit_of_measurement': 'downloads',
-  })
-# ---
-# name: test_sensor_update_exceptions[InvalidAuth][sensor.pyload_finished_downloads-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'pyLoad Finished downloads',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'downloads',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.pyload_finished_downloads',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -515,6 +465,56 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_sensor_update_exceptions[InvalidAuth][sensor.pyload_total_downloads-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.pyload_total_downloads',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Total downloads',
+    'platform': 'pyload',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': <PyLoadSensorEntity.TOTAL: 'total'>,
+    'unique_id': 'XXXXXXXXXXXXXX_total',
+    'unit_of_measurement': 'downloads',
+  })
+# ---
+# name: test_sensor_update_exceptions[InvalidAuth][sensor.pyload_total_downloads-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'pyLoad Total downloads',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'downloads',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.pyload_total_downloads',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_sensor_update_exceptions[ParserError][sensor.pyload_active_downloads-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -609,56 +609,6 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.pyload_downloads_in_queue',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_sensor_update_exceptions[ParserError][sensor.pyload_finished_downloads-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.pyload_finished_downloads',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Finished downloads',
-    'platform': 'pyload',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': <PyLoadSensorEntity.TOTAL: 'total'>,
-    'unique_id': 'XXXXXXXXXXXXXX_total',
-    'unit_of_measurement': 'downloads',
-  })
-# ---
-# name: test_sensor_update_exceptions[ParserError][sensor.pyload_finished_downloads-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'pyLoad Finished downloads',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'downloads',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.pyload_finished_downloads',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -773,6 +723,56 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_sensor_update_exceptions[ParserError][sensor.pyload_total_downloads-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.pyload_total_downloads',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Total downloads',
+    'platform': 'pyload',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': <PyLoadSensorEntity.TOTAL: 'total'>,
+    'unique_id': 'XXXXXXXXXXXXXX_total',
+    'unit_of_measurement': 'downloads',
+  })
+# ---
+# name: test_sensor_update_exceptions[ParserError][sensor.pyload_total_downloads-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'pyLoad Total downloads',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'downloads',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.pyload_total_downloads',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_setup[sensor.pyload_active_downloads-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -871,56 +871,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '6',
-  })
-# ---
-# name: test_setup[sensor.pyload_finished_downloads-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.pyload_finished_downloads',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Finished downloads',
-    'platform': 'pyload',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': <PyLoadSensorEntity.TOTAL: 'total'>,
-    'unique_id': 'XXXXXXXXXXXXXX_total',
-    'unit_of_measurement': 'downloads',
-  })
-# ---
-# name: test_setup[sensor.pyload_finished_downloads-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'pyLoad Finished downloads',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'downloads',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.pyload_finished_downloads',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '37',
   })
 # ---
 # name: test_setup[sensor.pyload_free_space-entry]
@@ -1029,5 +979,55 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '43.247704',
+  })
+# ---
+# name: test_setup[sensor.pyload_total_downloads-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.pyload_total_downloads',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Total downloads',
+    'platform': 'pyload',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': <PyLoadSensorEntity.TOTAL: 'total'>,
+    'unique_id': 'XXXXXXXXXXXXXX_total',
+    'unit_of_measurement': 'downloads',
+  })
+# ---
+# name: test_setup[sensor.pyload_total_downloads-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'pyLoad Total downloads',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'downloads',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.pyload_total_downloads',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '37',
   })
 # ---


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Revert "Rename sensor to finished downloads in pyLoad integration ( #120483)"

This reverts commit 8e598ec3ff9b6c96dfe633d5510762c4053279c3.

Changing the name of the entity was a mistake, the value simply does not represent the finished downloads, therefore i am reverting the renaming. Please don't ask why i renamed it in the first place because i really don't know.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
