### PR TITLE
Write data to state after Broadlink entity added

### DIFF
--- a/homeassistant/components/broadlink/entity.py
+++ b/homeassistant/components/broadlink/entity.py
@@ -21,7 +21,7 @@ class BroadlinkEntity(Entity):
         """Call when the entity is added to hass."""
         self.async_on_remove(self._coordinator.async_add_listener(self._recv_data))
         if self._coordinator.data:
-            self._recv_data()
+            self._update_state(self._coordinator.data)
 
     async def async_update(self):
         """Update the state of the entity."""

--- a/homeassistant/components/broadlink/entity.py
+++ b/homeassistant/components/broadlink/entity.py
@@ -20,6 +20,8 @@ class BroadlinkEntity(Entity):
     async def async_added_to_hass(self):
         """Call when the entity is added to hass."""
         self.async_on_remove(self._coordinator.async_add_listener(self._recv_data))
+        if self._coordinator.data:
+            self._recv_data()
 
     async def async_update(self):
         """Update the state of the entity."""

--- a/tests/components/broadlink/__init__.py
+++ b/tests/components/broadlink/__init__.py
@@ -168,6 +168,31 @@ class BroadlinkDevice:
         }
 
 
+class BroadlinkMP1BG1Device(BroadlinkDevice):
+    """Mock device for MP1 and BG1 with special mocking of api return values."""
+
+    def get_mock_api(self):
+        """Return a mock device (API) with support for check_power calls."""
+        mock_api = super().get_mock_api()
+        mock_api.check_power.return_value = {"s1": 0, "s2": 0, "s3": 0, "s4": 0}
+        return mock_api
+
+
+class BroadlinkSP4BDevice(BroadlinkDevice):
+    """Mock device for SP4b with special mocking of api return values."""
+
+    def get_mock_api(self):
+        """Return a mock device (API) with support for get_state calls."""
+        mock_api = super().get_mock_api()
+        mock_api.get_state.return_value = {"pwr": 0}
+        return mock_api
+
+
 def get_device(name):
     """Get a device by name."""
+    dev_type = BROADLINK_DEVICES[name][5]
+    if dev_type in {0x4EB5}:
+        return BroadlinkMP1BG1Device(name, *BROADLINK_DEVICES[name])
+    if dev_type in {0x5115}:
+        return BroadlinkSP4BDevice(name, *BROADLINK_DEVICES[name])
     return BroadlinkDevice(name, *BROADLINK_DEVICES[name])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When a new entity is added or HA starts up the entity is available in the frontend but has no data. Only on the next coordinator update is the data shown in the UI.

This change fixes this by immediately calling the method which writes the entities state to the state machine after it was added. When the device is added `async_config_entry_first_refresh()` gets called so we can expect the data to be available when the first entities get added.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
