### PR TITLE
Improve type hints in iotawatt tests

### DIFF
--- a/tests/components/iotawatt/conftest.py
+++ b/tests/components/iotawatt/conftest.py
@@ -1,16 +1,18 @@
 """Test fixtures for IoTaWatt."""
 
-from unittest.mock import AsyncMock, patch
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from homeassistant.components.iotawatt import DOMAIN
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def entry(hass):
+def entry(hass: HomeAssistant) -> MockConfigEntry:
     """Mock config entry added to HA."""
     entry = MockConfigEntry(domain=DOMAIN, data={"host": "1.2.3.4"})
     entry.add_to_hass(hass)
@@ -18,7 +20,7 @@ def entry(hass):
 
 
 @pytest.fixture
-def mock_iotawatt(entry):
+def mock_iotawatt(entry: MockConfigEntry) -> Generator[MagicMock]:
     """Mock iotawatt."""
     with patch("homeassistant.components.iotawatt.coordinator.Iotawatt") as mock:
         instance = mock.return_value

--- a/tests/components/iotawatt/test_init.py
+++ b/tests/components/iotawatt/test_init.py
@@ -1,5 +1,7 @@
 """Test init."""
 
+from unittest.mock import MagicMock
+
 import httpx
 
 from homeassistant.config_entries import ConfigEntryState
@@ -8,8 +10,12 @@ from homeassistant.setup import async_setup_component
 
 from . import INPUT_SENSOR
 
+from tests.common import MockConfigEntry
 
-async def test_setup_unload(hass: HomeAssistant, mock_iotawatt, entry) -> None:
+
+async def test_setup_unload(
+    hass: HomeAssistant, mock_iotawatt: MagicMock, entry: MockConfigEntry
+) -> None:
     """Test we can setup and unload an entry."""
     mock_iotawatt.getSensors.return_value["sensors"]["my_sensor_key"] = INPUT_SENSOR
     assert await async_setup_component(hass, "iotawatt", {})
@@ -18,7 +24,7 @@ async def test_setup_unload(hass: HomeAssistant, mock_iotawatt, entry) -> None:
 
 
 async def test_setup_connection_failed(
-    hass: HomeAssistant, mock_iotawatt, entry
+    hass: HomeAssistant, mock_iotawatt: MagicMock, entry: MockConfigEntry
 ) -> None:
     """Test connection error during startup."""
     mock_iotawatt.connect.side_effect = httpx.ConnectError("")
@@ -27,7 +33,9 @@ async def test_setup_connection_failed(
     assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_setup_auth_failed(hass: HomeAssistant, mock_iotawatt, entry) -> None:
+async def test_setup_auth_failed(
+    hass: HomeAssistant, mock_iotawatt: MagicMock, entry: MockConfigEntry
+) -> None:
     """Test auth error during startup."""
     mock_iotawatt.connect.return_value = False
     assert await async_setup_component(hass, "iotawatt", {})

--- a/tests/components/iotawatt/test_sensor.py
+++ b/tests/components/iotawatt/test_sensor.py
@@ -1,6 +1,7 @@
 """Test setting up sensors."""
 
 from datetime import timedelta
+from unittest.mock import MagicMock
 
 from freezegun.api import FrozenDateTimeFactory
 
@@ -25,7 +26,7 @@ from tests.common import async_fire_time_changed
 
 
 async def test_sensor_type_input(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, mock_iotawatt
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, mock_iotawatt: MagicMock
 ) -> None:
     """Test input sensors work."""
     assert await async_setup_component(hass, "iotawatt", {})
@@ -60,7 +61,7 @@ async def test_sensor_type_input(
 
 
 async def test_sensor_type_output(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, mock_iotawatt
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, mock_iotawatt: MagicMock
 ) -> None:
     """Tests the sensor type of Output."""
     mock_iotawatt.getSensors.return_value["sensors"]["my_watthour_sensor_key"] = (


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
