### PR TITLE
Improve type hints in kulersky tests

### DIFF
--- a/tests/components/kulersky/test_light.py
+++ b/tests/components/kulersky/test_light.py
@@ -1,5 +1,6 @@
 """Test the Kuler Sky lights."""
 
+from collections.abc import AsyncGenerator
 from unittest.mock import MagicMock, patch
 
 import pykulersky
@@ -37,13 +38,15 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 @pytest.fixture
-async def mock_entry(hass):
+async def mock_entry() -> MockConfigEntry:
     """Create a mock light entity."""
     return MockConfigEntry(domain=DOMAIN)
 
 
 @pytest.fixture
-async def mock_light(hass, mock_entry):
+async def mock_light(
+    hass: HomeAssistant, mock_entry: MockConfigEntry
+) -> AsyncGenerator[MagicMock]:
     """Create a mock light entity."""
 
     light = MagicMock(spec=pykulersky.Light)
@@ -64,7 +67,7 @@ async def mock_light(hass, mock_entry):
         yield light
 
 
-async def test_init(hass: HomeAssistant, mock_light) -> None:
+async def test_init(hass: HomeAssistant, mock_light: MagicMock) -> None:
     """Test platform setup."""
     state = hass.states.get("light.bedroom")
     assert state.state == STATE_OFF
@@ -87,7 +90,9 @@ async def test_init(hass: HomeAssistant, mock_light) -> None:
     assert mock_light.disconnect.called
 
 
-async def test_remove_entry(hass: HomeAssistant, mock_light, mock_entry) -> None:
+async def test_remove_entry(
+    hass: HomeAssistant, mock_light: MagicMock, mock_entry: MockConfigEntry
+) -> None:
     """Test platform setup."""
     assert hass.data[DOMAIN][DATA_ADDRESSES] == {"AA:BB:CC:11:22:33"}
     assert DATA_DISCOVERY_SUBSCRIPTION in hass.data[DOMAIN]
@@ -99,7 +104,7 @@ async def test_remove_entry(hass: HomeAssistant, mock_light, mock_entry) -> None
 
 
 async def test_remove_entry_exceptions_caught(
-    hass: HomeAssistant, mock_light, mock_entry
+    hass: HomeAssistant, mock_light: MagicMock, mock_entry: MockConfigEntry
 ) -> None:
     """Assert that disconnect exceptions are caught."""
     mock_light.disconnect.side_effect = pykulersky.PykulerskyException("Mock error")
@@ -108,7 +113,7 @@ async def test_remove_entry_exceptions_caught(
     assert mock_light.disconnect.called
 
 
-async def test_update_exception(hass: HomeAssistant, mock_light) -> None:
+async def test_update_exception(hass: HomeAssistant, mock_light: MagicMock) -> None:
     """Test platform setup."""
 
     mock_light.get_color.side_effect = pykulersky.PykulerskyException
@@ -118,7 +123,7 @@ async def test_update_exception(hass: HomeAssistant, mock_light) -> None:
     assert state.state == STATE_UNAVAILABLE
 
 
-async def test_light_turn_on(hass: HomeAssistant, mock_light) -> None:
+async def test_light_turn_on(hass: HomeAssistant, mock_light: MagicMock) -> None:
     """Test KulerSkyLight turn_on."""
     mock_light.get_color.return_value = (255, 255, 255, 255)
     await hass.services.async_call(
@@ -175,7 +180,7 @@ async def test_light_turn_on(hass: HomeAssistant, mock_light) -> None:
     mock_light.set_color.assert_called_with(50, 41, 0, 50)
 
 
-async def test_light_turn_off(hass: HomeAssistant, mock_light) -> None:
+async def test_light_turn_off(hass: HomeAssistant, mock_light: MagicMock) -> None:
     """Test KulerSkyLight turn_on."""
     mock_light.get_color.return_value = (0, 0, 0, 0)
     await hass.services.async_call(
@@ -188,7 +193,7 @@ async def test_light_turn_off(hass: HomeAssistant, mock_light) -> None:
     mock_light.set_color.assert_called_with(0, 0, 0, 0)
 
 
-async def test_light_update(hass: HomeAssistant, mock_light) -> None:
+async def test_light_update(hass: HomeAssistant, mock_light: MagicMock) -> None:
     """Test KulerSkyLight update."""
     utcnow = dt_util.utcnow()
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
