### PR TITLE
Ignore offline devices in ViCare integration

### DIFF
--- a/homeassistant/components/vicare/__init__.py
+++ b/homeassistant/components/vicare/__init__.py
@@ -116,5 +116,6 @@ def get_supported_devices(
     return [
         device_config
         for device_config in devices
-        if device_config.getModel() not in UNSUPPORTED_DEVICES
+        if device_config.isOnline()
+        and device_config.getModel() not in UNSUPPORTED_DEVICES
     ]

--- a/homeassistant/components/vicare/strings.json
+++ b/homeassistant/components/vicare/strings.json
@@ -380,12 +380,6 @@
       "message": "Unable to deactivate ViCare program {program}"
     }
   },
-  "issues": {
-    "device_offline": {
-      "title": "Device {model} is offline",
-      "description": "The device {model} is currently not reachable. If the device is turned off on purpose, you can ignore the message and reload the integration once it's turned on again."
-    }
-  },
   "services": {
     "set_vicare_mode": {
       "name": "Set ViCare mode",

--- a/homeassistant/components/vicare/strings.json
+++ b/homeassistant/components/vicare/strings.json
@@ -383,7 +383,7 @@
   "issues": {
     "device_offline": {
       "title": "Device {model} is offline",
-      "description": "The device {model} is currently not reachable. If the device is turned off on purpose, you can ignore the message and reload the integration once it's turned on again."
+      "description": "The device {model} is currently not reachable. If the device is turned off on purpose, you can ignore the message and reload the integration once the device is turned on again."
     }
   },
   "services": {

--- a/homeassistant/components/vicare/strings.json
+++ b/homeassistant/components/vicare/strings.json
@@ -383,7 +383,7 @@
   "issues": {
     "device_offline": {
       "title": "Device {model} is offline",
-      "description": "The device {model} is currently not reachable. If the device is turned off on purpose, you can ignore the message and reload the integration once the device is turned on again."
+      "description": "The device {model} is currently not reachable. If the device is turned off on purpose, you can ignore the message and reload the integration once it's turned on again."
     }
   },
   "services": {

--- a/homeassistant/components/vicare/strings.json
+++ b/homeassistant/components/vicare/strings.json
@@ -380,6 +380,12 @@
       "message": "Unable to deactivate ViCare program {program}"
     }
   },
+  "issues": {
+    "device_offline": {
+      "title": "Device {model} is offline",
+      "description": "The device {model} is currently not reachable. If the device is turned off on purpose, you can ignore the message and reload the integration once it's turned on again."
+    }
+  },
   "services": {
     "set_vicare_mode": {
       "name": "Set ViCare mode",

--- a/tests/components/vicare/conftest.py
+++ b/tests/components/vicare/conftest.py
@@ -40,7 +40,7 @@ class MockPyViCare:
                     ),
                     f"deviceId{idx}",
                     f"model{idx}",
-                    f"online{idx}",
+                    "Online",
                 )
             )
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Entities are created based on API responses in ViCare, thus when the device is offline we cannot determine if we should create an entity or not. Therefore we skip offline devices completely for now.

~~Repair issue is created on offline devices.~~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #https://github.com/home-assistant/core/issues/121429
- This PR is related to issue:
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
