### PR TITLE
Add climate set_temperature device action

### DIFF
--- a/homeassistant/components/climate/const.py
+++ b/homeassistant/components/climate/const.py
@@ -137,6 +137,7 @@ ATTR_SWING_MODE = "swing_mode"
 ATTR_TARGET_TEMP_HIGH = "target_temp_high"
 ATTR_TARGET_TEMP_LOW = "target_temp_low"
 ATTR_TARGET_TEMP_STEP = "target_temp_step"
+ATTR_TEMPERATURE = "temperature"
 
 DEFAULT_MIN_TEMP = 7
 DEFAULT_MAX_TEMP = 35

--- a/homeassistant/components/climate/device_action.py
+++ b/homeassistant/components/climate/device_action.py
@@ -24,7 +24,7 @@ from homeassistant.helpers.typing import ConfigType, TemplateVarsType
 
 from . import DOMAIN, const
 
-ACTION_TYPES = {"set_hvac_mode", "set_preset_mode"}
+ACTION_TYPES = {"set_hvac_mode", "set_preset_mode", "set_temperature"}
 
 SET_HVAC_MODE_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
     {
@@ -151,8 +151,8 @@ async def async_get_action_capabilities(
             min_temp = get_capability(hass, entry.entity_id, const.ATTR_MIN_TEMP)
             max_temp = get_capability(hass, entry.entity_id, const.ATTR_MAX_TEMP)
         except HomeAssistantError:
-            min_temp = const.ATTR_MIN_TEMP
-            max_temp = const.ATTR_MAX_TEMP
+            min_temp = const.DEFAULT_MIN_TEMP
+            max_temp = const.DEFAULT_MAX_TEMP
         fields[vol.Required(const.ATTR_TEMPERATURE)] = vol.Range(min_temp, max_temp)
 
     return {"extra_fields": vol.Schema(fields)}

--- a/homeassistant/components/climate/device_action.py
+++ b/homeassistant/components/climate/device_action.py
@@ -46,6 +46,7 @@ SET_TEMPERATURE_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_TYPE): "set_temperature",
         vol.Required(CONF_ENTITY_ID): cv.entity_id_or_uuid,
+        vol.Required(const.ATTR_TEMPERATURE): int,
     }
 )
 
@@ -150,7 +151,8 @@ async def async_get_action_capabilities(
             min_temp = get_capability(hass, entry.entity_id, const.ATTR_MIN_TEMP)
             max_temp = get_capability(hass, entry.entity_id, const.ATTR_MAX_TEMP)
         except HomeAssistantError:
-            preset_modes = []
+            min_temp = const.ATTR_MIN_TEMP
+            max_temp = const.ATTR_MAX_TEMP
         fields[vol.Required(const.ATTR_TEMPERATURE)] = vol.Range(min_temp, max_temp)
 
     return {"extra_fields": vol.Schema(fields)}

--- a/homeassistant/components/climate/device_action.py
+++ b/homeassistant/components/climate/device_action.py
@@ -42,7 +42,18 @@ SET_PRESET_MODE_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
     }
 )
 
-_ACTION_SCHEMA = vol.Any(SET_HVAC_MODE_SCHEMA, SET_PRESET_MODE_SCHEMA)
+SET_TEMPERATURE_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): "set_temperature",
+        vol.Required(CONF_ENTITY_ID): cv.entity_id_or_uuid,
+    }
+)
+
+_ACTION_SCHEMA = vol.Any(
+    SET_HVAC_MODE_SCHEMA,
+    SET_PRESET_MODE_SCHEMA,
+    SET_TEMPERATURE_SCHEMA
+)
 
 
 async def async_validate_action_config(
@@ -75,6 +86,8 @@ async def async_get_actions(
         actions.append({**base_action, CONF_TYPE: "set_hvac_mode"})
         if supported_features & const.ClimateEntityFeature.PRESET_MODE:
             actions.append({**base_action, CONF_TYPE: "set_preset_mode"})
+        if supported_features & const.ClimateEntityFeature.TARGET_TEMPERATURE:
+            actions.append({**base_action, CONF_TYPE: "set_temperature"})
 
     return actions
 
@@ -94,6 +107,9 @@ async def async_call_action_from_config(
     elif config[CONF_TYPE] == "set_preset_mode":
         service = const.SERVICE_SET_PRESET_MODE
         service_data[const.ATTR_PRESET_MODE] = config[const.ATTR_PRESET_MODE]
+    elif config[CONF_TYPE] == "set_temperature":
+        service = const.SERVICE_SET_TEMPERATURE
+        service_data[const.ATTR_TEMPERATURE] = config[const.ATTR_TEMPERATURE]
 
     await hass.services.async_call(
         DOMAIN, service, service_data, blocking=True, context=context
@@ -127,5 +143,14 @@ async def async_get_action_capabilities(
         except HomeAssistantError:
             preset_modes = []
         fields[vol.Required(const.ATTR_PRESET_MODE)] = vol.In(preset_modes)
+    elif action_type == "set_temperature":
+        try:
+            entry = async_get_entity_registry_entry_or_raise(hass, entity_id_or_uuid)
+            # no default values b/c Climate entity provides defaults automatically
+            min_temp = get_capability(hass, entry.entity_id, const.ATTR_MIN_TEMP)
+            max_temp = get_capability(hass, entry.entity_id, const.ATTR_MAX_TEMP)
+        except HomeAssistantError:
+            preset_modes = []
+        fields[vol.Required(const.ATTR_TEMPERATURE)] = vol.Range(min_temp, max_temp)
 
     return {"extra_fields": vol.Schema(fields)}

--- a/homeassistant/components/climate/strings.json
+++ b/homeassistant/components/climate/strings.json
@@ -12,7 +12,8 @@
     },
     "action_type": {
       "set_hvac_mode": "Change HVAC mode on {entity_name}",
-      "set_preset_mode": "Change preset on {entity_name}"
+      "set_preset_mode": "Change preset on {entity_name}",
+      "set_temperature": "Set target temperature on {entity_name}"
     },
     "extra_fields": {
       "above": "[%key:common::device_automation::extra_fields::above%]",
@@ -20,7 +21,8 @@
       "for": "[%key:common::device_automation::extra_fields::for%]",
       "to": "[%key:common::device_automation::extra_fields::to%]",
       "preset_mode": "Preset mode",
-      "hvac_mode": "HVAC mode"
+      "hvac_mode": "HVAC mode",
+      "temperature": "Temperature"
     }
   },
   "entity_component": {

--- a/tests/components/climate/test_device_action.py
+++ b/tests/components/climate/test_device_action.py
@@ -39,12 +39,24 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
             0,
             ["set_hvac_mode", "set_preset_mode"],
         ),
+        (
+            False,
+            const.ClimateEntityFeature.TARGET_TEMPERATURE,
+            0,
+            ["set_hvac_mode", "set_temperature"],
+        ),
         (True, 0, 0, ["set_hvac_mode"]),
         (
             True,
             0,
             const.ClimateEntityFeature.PRESET_MODE,
             ["set_hvac_mode", "set_preset_mode"],
+        ),
+        (
+            True,
+            0,
+            const.ClimateEntityFeature.TARGET_TEMPERATURE,
+            ["set_hvac_mode", "set_temperature"],
         ),
     ],
 )

--- a/tests/components/climate/test_device_action.py
+++ b/tests/components/climate/test_device_action.py
@@ -342,6 +342,20 @@ async def test_action_legacy(
             ],
         ),
         (
+            False,
+            {const.ATTR_MIN_TEMP: 11, const.ATTR_MAX_TEMP: 31},
+            {},
+            "set_temperature",
+            [
+                {
+                    "name": "temperature",
+                    "valueMin": 11,
+                    "valueMax": 31,
+                    "required": True,
+                }
+            ],
+        ),
+        (
             True,
             {},
             {const.ATTR_HVAC_MODES: [HVACMode.COOL, HVACMode.OFF]},
@@ -366,6 +380,20 @@ async def test_action_legacy(
                     "options": [("home", "home"), ("away", "away")],
                     "required": True,
                     "type": "select",
+                }
+            ],
+        ),
+        (
+            True,
+            {},
+            {const.ATTR_MIN_TEMP: 11, const.ATTR_MAX_TEMP: 31},
+            "set_temperature",
+            [
+                {
+                    "name": "temperature",
+                    "valueMin": 11,
+                    "valueMax": 31,
+                    "required": True,
                 }
             ],
         ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

I have auto configured MQTT HVAC devices that work great from dashboard (thank you for a such great tools and integrations). When I attempted to add an automation with a timer schedule I found UI (or YAML editor) only accept `set_hvac_mode` action. No temperature, no fan mode, etc. In the same time HVAC's entity `supported_features=245` made me think HA knows the device can set temperature (well, it works from a Thermostat widget) but for some reason does not expose this to Automation.

This PR checks adds a new `set_temperature` device action if it is in supported features. It is done in a very similar way to `set_hvac_mode` and  `set_preset_mode` existing actions.

It is possible there is a good reason why `climate` component does not have `set_temperature`,  `set_fan_mode`, etc  automation actions - please explain an alternative approach to get such actions available in Automation.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # None
- This PR is related to issue: None
- Link to documentation pull request:  None

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
