### PR TITLE
 Home Connect unit tests for light platform

### DIFF
--- a/tests/components/home_connect/conftest.py
+++ b/tests/components/home_connect/conftest.py
@@ -152,15 +152,18 @@ def mock_appliance(request: pytest.FixtureRequest) -> MagicMock:
 
 
 @pytest.fixture(name="problematic_appliance")
-def mock_problematic_appliance() -> Mock:
+def mock_problematic_appliance(request: pytest.FixtureRequest) -> Mock:
     """Fixture to mock a problematic Appliance."""
     app = "Washer"
+    if hasattr(request, "param") and request.param:
+        app = request.param
+
     mock = Mock(
-        spec=HomeConnectAppliance,
+        autospec=HomeConnectAppliance,
         **MOCK_APPLIANCES_PROPERTIES.get(app),
     )
     mock.name = app
-    setattr(mock, "status", {})
+    type(mock).status = PropertyMock(return_value={})
     mock.get_programs_active.side_effect = HomeConnectError
     mock.get_programs_available.side_effect = HomeConnectError
     mock.start_program.side_effect = HomeConnectError

--- a/tests/components/home_connect/test_light.py
+++ b/tests/components/home_connect/test_light.py
@@ -1,0 +1,299 @@
+"""Tests for home_connect light entities."""
+
+from collections.abc import Awaitable, Callable, Generator
+from typing import Any
+from unittest.mock import MagicMock, Mock
+
+from homeconnect.api import HomeConnectError
+import pytest
+
+from homeassistant.components.home_connect.const import (
+    BSH_AMBIENT_LIGHT_BRIGHTNESS,
+    BSH_AMBIENT_LIGHT_CUSTOM_COLOR,
+    BSH_AMBIENT_LIGHT_ENABLED,
+    COOKING_LIGHTING,
+    COOKING_LIGHTING_BRIGHTNESS,
+)
+from homeassistant.components.light import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import (
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNKNOWN,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+
+from .conftest import get_all_appliances
+
+from tests.common import MockConfigEntry, load_json_object_fixture
+
+TEST_HC_APP = "Hood"
+
+SETTINGS_STATUS = {
+    setting.pop("key"): setting
+    for setting in load_json_object_fixture("home_connect/settings.json")
+    .get(TEST_HC_APP)
+    .get("data")
+    .get("settings")
+}
+
+
+@pytest.fixture
+def platforms() -> list[str]:
+    """Fixture to specify platforms to test."""
+    return [Platform.LIGHT]
+
+
+async def test_light(
+    bypass_throttle: Generator[None, Any, None],
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[], Awaitable[bool]],
+    setup_credentials: None,
+    get_appliances: Mock,
+) -> None:
+    """Test switch entities."""
+    get_appliances.side_effect = get_all_appliances
+    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert await integration_setup()
+    assert config_entry.state == ConfigEntryState.LOADED
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "status", "service", "service_data", "state", "appliance"),
+    [
+        (
+            "light.hood_light",
+            {
+                COOKING_LIGHTING: {
+                    "value": True,
+                },
+            },
+            SERVICE_TURN_ON,
+            {},
+            STATE_ON,
+            "Hood",
+        ),
+        (
+            "light.hood_light",
+            {
+                COOKING_LIGHTING: {
+                    "value": True,
+                },
+                COOKING_LIGHTING_BRIGHTNESS: {"value": 70},
+            },
+            SERVICE_TURN_ON,
+            {"brightness": 200},
+            STATE_ON,
+            "Hood",
+        ),
+        (
+            "light.hood_light",
+            {
+                COOKING_LIGHTING: {"value": False},
+                COOKING_LIGHTING_BRIGHTNESS: {"value": 70},
+            },
+            SERVICE_TURN_OFF,
+            {},
+            STATE_OFF,
+            "Hood",
+        ),
+        (
+            "light.hood_light",
+            {
+                COOKING_LIGHTING: {
+                    "value": None,
+                },
+                COOKING_LIGHTING_BRIGHTNESS: None,
+            },
+            SERVICE_TURN_ON,
+            {},
+            STATE_UNKNOWN,
+            "Hood",
+        ),
+        (
+            "light.hood_ambientlight",
+            {
+                BSH_AMBIENT_LIGHT_ENABLED: {
+                    "value": True,
+                },
+                BSH_AMBIENT_LIGHT_BRIGHTNESS: {"value": 70},
+            },
+            SERVICE_TURN_ON,
+            {"brightness": 200},
+            STATE_ON,
+            "Hood",
+        ),
+        (
+            "light.hood_ambientlight",
+            {
+                BSH_AMBIENT_LIGHT_ENABLED: {"value": False},
+                BSH_AMBIENT_LIGHT_BRIGHTNESS: {"value": 70},
+            },
+            SERVICE_TURN_OFF,
+            {},
+            STATE_OFF,
+            "Hood",
+        ),
+        (
+            "light.hood_ambientlight",
+            {
+                BSH_AMBIENT_LIGHT_ENABLED: {"value": True},
+                BSH_AMBIENT_LIGHT_CUSTOM_COLOR: {},
+            },
+            SERVICE_TURN_ON,
+            {},
+            STATE_ON,
+            "Hood",
+        ),
+    ],
+    indirect=["appliance"],
+)
+async def test_light_functionality(
+    entity_id: str,
+    status: dict,
+    service: str,
+    service_data: dict,
+    state: str,
+    appliance: Mock,
+    bypass_throttle: Generator[None, Any, None],
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[], Awaitable[bool]],
+    setup_credentials: None,
+    get_appliances: MagicMock,
+) -> None:
+    """Test light functionality."""
+    appliance.status.update(SETTINGS_STATUS)
+    get_appliances.return_value = [appliance]
+
+    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert await integration_setup()
+    assert config_entry.state == ConfigEntryState.LOADED
+
+    appliance.status.update(status)
+    service_data["entity_id"] = entity_id
+    await hass.services.async_call(
+        DOMAIN,
+        service,
+        service_data,
+        blocking=True,
+    )
+    assert hass.states.is_state(entity_id, state)
+
+
+@pytest.mark.parametrize(
+    (
+        "entity_id",
+        "status",
+        "service",
+        "service_data",
+        "mock_attr",
+        "attr_side_effect",
+        "problematic_appliance",
+    ),
+    [
+        (
+            "light.hood_light",
+            {
+                COOKING_LIGHTING: {
+                    "value": False,
+                },
+            },
+            SERVICE_TURN_ON,
+            {},
+            "set_setting",
+            [HomeConnectError, HomeConnectError],
+            "Hood",
+        ),
+        (
+            "light.hood_light",
+            {
+                COOKING_LIGHTING: {
+                    "value": True,
+                },
+                COOKING_LIGHTING_BRIGHTNESS: {"value": 70},
+            },
+            SERVICE_TURN_ON,
+            {"brightness": 200},
+            "set_setting",
+            [HomeConnectError, HomeConnectError],
+            "Hood",
+        ),
+        (
+            "light.hood_light",
+            {
+                COOKING_LIGHTING: {"value": False},
+            },
+            SERVICE_TURN_OFF,
+            {},
+            "set_setting",
+            [HomeConnectError, HomeConnectError],
+            "Hood",
+        ),
+        (
+            "light.hood_ambientlight",
+            {
+                BSH_AMBIENT_LIGHT_ENABLED: {
+                    "value": True,
+                },
+                BSH_AMBIENT_LIGHT_BRIGHTNESS: {"value": 70},
+            },
+            SERVICE_TURN_ON,
+            {},
+            "set_setting",
+            [HomeConnectError, HomeConnectError],
+            "Hood",
+        ),
+        (
+            "light.hood_ambientlight",
+            {
+                BSH_AMBIENT_LIGHT_ENABLED: {
+                    "value": True,
+                },
+                BSH_AMBIENT_LIGHT_BRIGHTNESS: {"value": 70},
+            },
+            SERVICE_TURN_ON,
+            {"brightness": 200},
+            "set_setting",
+            [HomeConnectError, None, HomeConnectError, HomeConnectError],
+            "Hood",
+        ),
+    ],
+    indirect=["problematic_appliance"],
+)
+async def test_switch_exception_handling(
+    entity_id: str,
+    status: dict,
+    service: str,
+    service_data: dict,
+    mock_attr: str,
+    attr_side_effect: list,
+    problematic_appliance: Mock,
+    bypass_throttle: Generator[None, Any, None],
+    hass: HomeAssistant,
+    integration_setup: Callable[[], Awaitable[bool]],
+    config_entry: MockConfigEntry,
+    setup_credentials: None,
+    get_appliances: MagicMock,
+) -> None:
+    """Test light exception handling."""
+    problematic_appliance.status.update(SETTINGS_STATUS)
+    problematic_appliance.set_setting.side_effect = attr_side_effect
+    get_appliances.return_value = [problematic_appliance]
+
+    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert await integration_setup()
+    assert config_entry.state == ConfigEntryState.LOADED
+
+    # Assert that an exception is called.
+    with pytest.raises(HomeConnectError):
+        getattr(problematic_appliance, mock_attr)()
+
+    problematic_appliance.status.update(status)
+    service_data["entity_id"] = entity_id
+    await hass.services.async_call(DOMAIN, service, service_data, blocking=True)
+    assert getattr(problematic_appliance, mock_attr).call_count == len(attr_side_effect)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adding unit test for the light platform.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
