### PR TITLE
Improve type hints in zwave_js tests

### DIFF
--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -1,9 +1,11 @@
 """Provide common Z-Wave JS fixtures."""
 
 import asyncio
+from collections.abc import Generator
 import copy
 import io
 import json
+from typing import Any
 from unittest.mock import DEFAULT, AsyncMock, patch
 
 import pytest
@@ -20,13 +22,13 @@ from tests.common import MockConfigEntry, load_fixture
 
 
 @pytest.fixture(name="addon_info_side_effect")
-def addon_info_side_effect_fixture():
+def addon_info_side_effect_fixture() -> Any | None:
     """Return the add-on info side effect."""
     return None
 
 
 @pytest.fixture(name="addon_info")
-def mock_addon_info(addon_info_side_effect):
+def mock_addon_info(addon_info_side_effect: Any | None) -> Generator[AsyncMock]:
     """Mock Supervisor add-on info."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_get_addon_info",
@@ -44,13 +46,15 @@ def mock_addon_info(addon_info_side_effect):
 
 
 @pytest.fixture(name="addon_store_info_side_effect")
-def addon_store_info_side_effect_fixture():
+def addon_store_info_side_effect_fixture() -> Any | None:
     """Return the add-on store info side effect."""
     return None
 
 
 @pytest.fixture(name="addon_store_info")
-def mock_addon_store_info(addon_store_info_side_effect):
+def mock_addon_store_info(
+    addon_store_info_side_effect: Any | None,
+) -> Generator[AsyncMock]:
     """Mock Supervisor add-on info."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_get_addon_store_info",
@@ -66,7 +70,7 @@ def mock_addon_store_info(addon_store_info_side_effect):
 
 
 @pytest.fixture(name="addon_running")
-def mock_addon_running(addon_store_info, addon_info):
+def mock_addon_running(addon_store_info: AsyncMock, addon_info: AsyncMock) -> AsyncMock:
     """Mock add-on already running."""
     addon_store_info.return_value = {
         "available": True,
@@ -81,7 +85,9 @@ def mock_addon_running(addon_store_info, addon_info):
 
 
 @pytest.fixture(name="addon_installed")
-def mock_addon_installed(addon_store_info, addon_info):
+def mock_addon_installed(
+    addon_store_info: AsyncMock, addon_info: AsyncMock
+) -> AsyncMock:
     """Mock add-on already installed but not running."""
     addon_store_info.return_value = {
         "available": True,
@@ -96,23 +102,27 @@ def mock_addon_installed(addon_store_info, addon_info):
 
 
 @pytest.fixture(name="addon_not_installed")
-def mock_addon_not_installed(addon_store_info, addon_info):
+def mock_addon_not_installed(
+    addon_store_info: AsyncMock, addon_info: AsyncMock
+) -> AsyncMock:
     """Mock add-on not installed."""
     addon_store_info.return_value["available"] = True
     return addon_info
 
 
 @pytest.fixture(name="addon_options")
-def mock_addon_options(addon_info):
+def mock_addon_options(addon_info: AsyncMock):
     """Mock add-on options."""
     return addon_info.return_value["options"]
 
 
 @pytest.fixture(name="set_addon_options_side_effect")
-def set_addon_options_side_effect_fixture(addon_options):
+def set_addon_options_side_effect_fixture(
+    addon_options: dict[str, Any],
+) -> Any | None:
     """Return the set add-on options side effect."""
 
-    async def set_addon_options(hass: HomeAssistant, slug, options):
+    async def set_addon_options(hass: HomeAssistant, slug: str, options: dict) -> None:
         """Mock set add-on options."""
         addon_options.update(options["options"])
 
@@ -120,7 +130,9 @@ def set_addon_options_side_effect_fixture(addon_options):
 
 
 @pytest.fixture(name="set_addon_options")
-def mock_set_addon_options(set_addon_options_side_effect):
+def mock_set_addon_options(
+    set_addon_options_side_effect: Any | None,
+) -> Generator[AsyncMock]:
     """Mock set add-on options."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_set_addon_options",
@@ -130,7 +142,9 @@ def mock_set_addon_options(set_addon_options_side_effect):
 
 
 @pytest.fixture(name="install_addon_side_effect")
-def install_addon_side_effect_fixture(addon_store_info, addon_info):
+def install_addon_side_effect_fixture(
+    addon_store_info: AsyncMock, addon_info: AsyncMock
+) -> Any | None:
     """Return the install add-on side effect."""
 
     async def install_addon(hass: HomeAssistant, slug):
@@ -149,7 +163,7 @@ def install_addon_side_effect_fixture(addon_store_info, addon_info):
 
 
 @pytest.fixture(name="install_addon")
-def mock_install_addon(install_addon_side_effect):
+def mock_install_addon(install_addon_side_effect: Any | None) -> Generator[AsyncMock]:
     """Mock install add-on."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_install_addon",
@@ -159,7 +173,7 @@ def mock_install_addon(install_addon_side_effect):
 
 
 @pytest.fixture(name="update_addon")
-def mock_update_addon():
+def mock_update_addon() -> Generator[AsyncMock]:
     """Mock update add-on."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_update_addon"
@@ -168,7 +182,9 @@ def mock_update_addon():
 
 
 @pytest.fixture(name="start_addon_side_effect")
-def start_addon_side_effect_fixture(addon_store_info, addon_info):
+def start_addon_side_effect_fixture(
+    addon_store_info: AsyncMock, addon_info: AsyncMock
+) -> Any | None:
     """Return the start add-on options side effect."""
 
     async def start_addon(hass: HomeAssistant, slug):
@@ -186,7 +202,7 @@ def start_addon_side_effect_fixture(addon_store_info, addon_info):
 
 
 @pytest.fixture(name="start_addon")
-def mock_start_addon(start_addon_side_effect):
+def mock_start_addon(start_addon_side_effect: Any | None) -> Generator[AsyncMock]:
     """Mock start add-on."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_start_addon",
@@ -196,7 +212,7 @@ def mock_start_addon(start_addon_side_effect):
 
 
 @pytest.fixture(name="stop_addon")
-def stop_addon_fixture():
+def stop_addon_fixture() -> Generator[AsyncMock]:
     """Mock stop add-on."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_stop_addon"
@@ -205,13 +221,13 @@ def stop_addon_fixture():
 
 
 @pytest.fixture(name="restart_addon_side_effect")
-def restart_addon_side_effect_fixture():
+def restart_addon_side_effect_fixture() -> Any | None:
     """Return the restart add-on options side effect."""
     return None
 
 
 @pytest.fixture(name="restart_addon")
-def mock_restart_addon(restart_addon_side_effect):
+def mock_restart_addon(restart_addon_side_effect: Any | None) -> Generator[AsyncMock]:
     """Mock restart add-on."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_restart_addon",
@@ -221,7 +237,7 @@ def mock_restart_addon(restart_addon_side_effect):
 
 
 @pytest.fixture(name="uninstall_addon")
-def uninstall_addon_fixture():
+def uninstall_addon_fixture() -> Generator[AsyncMock]:
     """Mock uninstall add-on."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_uninstall_addon"
@@ -230,7 +246,7 @@ def uninstall_addon_fixture():
 
 
 @pytest.fixture(name="create_backup")
-def create_backup_fixture():
+def create_backup_fixture() -> Generator[AsyncMock]:
     """Mock create backup."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_create_backup"

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -1054,7 +1054,7 @@ async def test_usb_discovery_already_running(
     [CP2652_ZIGBEE_DISCOVERY_INFO],
 )
 async def test_abort_usb_discovery_aborts_specific_devices(
-    hass: HomeAssistant, supervisor, addon_options, discovery_info: dict[str, Any]
+    hass: HomeAssistant, supervisor, addon_options, discovery_info
 ) -> None:
     """Test usb discovery flow is aborted on specific devices."""
     result = await hass.config_entries.flow.async_init(
@@ -1984,6 +1984,7 @@ async def test_options_addon_running(
     set_addon_options,
     restart_addon,
     get_addon_discovery_info,
+    discovery_info,
     entry_data,
     old_addon_options,
     new_addon_options,
@@ -2105,6 +2106,7 @@ async def test_options_addon_running_no_changes(
     set_addon_options,
     restart_addon,
     get_addon_discovery_info,
+    discovery_info,
     entry_data,
     old_addon_options,
     new_addon_options,
@@ -2261,10 +2263,12 @@ async def test_options_different_device(
     set_addon_options,
     restart_addon,
     get_addon_discovery_info,
+    discovery_info,
     entry_data,
     old_addon_options,
     new_addon_options,
     disconnect_calls,
+    server_version_side_effect,
 ) -> None:
     """Test options flow and configuring a different device."""
     addon_options.update(old_addon_options)
@@ -2425,10 +2429,12 @@ async def test_options_addon_restart_failed(
     set_addon_options,
     restart_addon,
     get_addon_discovery_info,
+    discovery_info,
     entry_data,
     old_addon_options,
     new_addon_options,
     disconnect_calls,
+    restart_addon_side_effect,
 ) -> None:
     """Test options flow and add-on restart failure."""
     addon_options.update(old_addon_options)
@@ -2554,10 +2560,12 @@ async def test_options_addon_running_server_info_failure(
     set_addon_options,
     restart_addon,
     get_addon_discovery_info,
+    discovery_info,
     entry_data,
     old_addon_options,
     new_addon_options,
     disconnect_calls,
+    server_version_side_effect,
 ) -> None:
     """Test options flow and add-on already running with server info failure."""
     addon_options.update(old_addon_options)
@@ -2669,6 +2677,7 @@ async def test_options_addon_not_installed(
     set_addon_options,
     start_addon,
     get_addon_discovery_info,
+    discovery_info,
     entry_data,
     old_addon_options,
     new_addon_options,

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -4,7 +4,8 @@ import asyncio
 from collections.abc import Generator
 from copy import copy
 from ipaddress import ip_address
-from unittest.mock import DEFAULT, MagicMock, call, patch
+from typing import Any
+from unittest.mock import DEFAULT, AsyncMock, MagicMock, call, patch
 
 import aiohttp
 import pytest
@@ -59,7 +60,7 @@ CP2652_ZIGBEE_DISCOVERY_INFO = usb.UsbServiceInfo(
 
 
 @pytest.fixture(name="setup_entry")
-def setup_entry_fixture():
+def setup_entry_fixture() -> Generator[AsyncMock]:
     """Mock entry setup."""
     with patch(
         "homeassistant.components.zwave_js.async_setup_entry", return_value=True
@@ -68,7 +69,7 @@ def setup_entry_fixture():
 
 
 @pytest.fixture(name="supervisor")
-def mock_supervisor_fixture():
+def mock_supervisor_fixture() -> Generator[None]:
     """Mock Supervisor."""
     with patch(
         "homeassistant.components.zwave_js.config_flow.is_hassio", return_value=True
@@ -77,19 +78,21 @@ def mock_supervisor_fixture():
 
 
 @pytest.fixture(name="discovery_info")
-def discovery_info_fixture():
+def discovery_info_fixture() -> dict[str, Any]:
     """Return the discovery info from the supervisor."""
     return DEFAULT
 
 
 @pytest.fixture(name="discovery_info_side_effect")
-def discovery_info_side_effect_fixture():
+def discovery_info_side_effect_fixture() -> Any | None:
     """Return the discovery info from the supervisor."""
     return None
 
 
 @pytest.fixture(name="get_addon_discovery_info")
-def mock_get_addon_discovery_info(discovery_info, discovery_info_side_effect):
+def mock_get_addon_discovery_info(
+    discovery_info: dict[str, Any], discovery_info_side_effect: Any | None
+) -> Generator[AsyncMock]:
     """Mock get add-on discovery info."""
     with patch(
         "homeassistant.components.hassio.addon_manager.async_get_addon_discovery_info",
@@ -100,13 +103,15 @@ def mock_get_addon_discovery_info(discovery_info, discovery_info_side_effect):
 
 
 @pytest.fixture(name="server_version_side_effect")
-def server_version_side_effect_fixture():
+def server_version_side_effect_fixture() -> Any | None:
     """Return the server version side effect."""
     return None
 
 
 @pytest.fixture(name="get_server_version", autouse=True)
-def mock_get_server_version(server_version_side_effect, server_version_timeout):
+def mock_get_server_version(
+    server_version_side_effect: Any | None, server_version_timeout: int
+) -> Generator[AsyncMock]:
     """Mock server version."""
     version_info = VersionInfo(
         driver_version="mock-driver-version",
@@ -130,18 +135,18 @@ def mock_get_server_version(server_version_side_effect, server_version_timeout):
 
 
 @pytest.fixture(name="server_version_timeout")
-def mock_server_version_timeout():
+def mock_server_version_timeout() -> int:
     """Patch the timeout for getting server version."""
     return SERVER_VERSION_TIMEOUT
 
 
 @pytest.fixture(name="addon_setup_time", autouse=True)
-def mock_addon_setup_time():
+def mock_addon_setup_time() -> Generator[None]:
     """Mock add-on setup sleep time."""
     with patch(
         "homeassistant.components.zwave_js.config_flow.ADDON_SETUP_TIMEOUT", new=0
-    ) as addon_setup_time:
-        yield addon_setup_time
+    ):
+        yield
 
 
 @pytest.fixture(name="serial_port")
@@ -1049,7 +1054,7 @@ async def test_usb_discovery_already_running(
     [CP2652_ZIGBEE_DISCOVERY_INFO],
 )
 async def test_abort_usb_discovery_aborts_specific_devices(
-    hass: HomeAssistant, supervisor, addon_options, discovery_info
+    hass: HomeAssistant, supervisor, addon_options, discovery_info: dict[str, Any]
 ) -> None:
     """Test usb discovery flow is aborted on specific devices."""
     result = await hass.config_entries.flow.async_init(
@@ -1979,7 +1984,6 @@ async def test_options_addon_running(
     set_addon_options,
     restart_addon,
     get_addon_discovery_info,
-    discovery_info,
     entry_data,
     old_addon_options,
     new_addon_options,
@@ -2101,7 +2105,6 @@ async def test_options_addon_running_no_changes(
     set_addon_options,
     restart_addon,
     get_addon_discovery_info,
-    discovery_info,
     entry_data,
     old_addon_options,
     new_addon_options,
@@ -2258,12 +2261,10 @@ async def test_options_different_device(
     set_addon_options,
     restart_addon,
     get_addon_discovery_info,
-    discovery_info,
     entry_data,
     old_addon_options,
     new_addon_options,
     disconnect_calls,
-    server_version_side_effect,
 ) -> None:
     """Test options flow and configuring a different device."""
     addon_options.update(old_addon_options)
@@ -2424,12 +2425,10 @@ async def test_options_addon_restart_failed(
     set_addon_options,
     restart_addon,
     get_addon_discovery_info,
-    discovery_info,
     entry_data,
     old_addon_options,
     new_addon_options,
     disconnect_calls,
-    restart_addon_side_effect,
 ) -> None:
     """Test options flow and add-on restart failure."""
     addon_options.update(old_addon_options)
@@ -2555,12 +2554,10 @@ async def test_options_addon_running_server_info_failure(
     set_addon_options,
     restart_addon,
     get_addon_discovery_info,
-    discovery_info,
     entry_data,
     old_addon_options,
     new_addon_options,
     disconnect_calls,
-    server_version_side_effect,
 ) -> None:
     """Test options flow and add-on already running with server info failure."""
     addon_options.update(old_addon_options)
@@ -2672,7 +2669,6 @@ async def test_options_addon_not_installed(
     set_addon_options,
     start_addon,
     get_addon_discovery_info,
-    discovery_info,
     entry_data,
     old_addon_options,
     new_addon_options,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #115031

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
