### PR TITLE
Add config flow to Wake on LAN

### DIFF
--- a/homeassistant/components/wake_on_lan/__init__.py
+++ b/homeassistant/components/wake_on_lan/__init__.py
@@ -6,26 +6,13 @@ import logging
 import voluptuous as vol
 import wakeonlan
 
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import (
-    CONF_BROADCAST_ADDRESS,
-    CONF_BROADCAST_PORT,
-    CONF_MAC,
-    CONF_PLATFORM,
-    CONF_SCAN_INTERVAL,
-    Platform,
-)
-from homeassistant.core import (
-    DOMAIN as HOMEASSISTANT_DOMAIN,
-    HomeAssistant,
-    ServiceCall,
-)
-from homeassistant.helpers import issue_registry as ir
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_BROADCAST_ADDRESS, CONF_BROADCAST_PORT, CONF_MAC
+from homeassistant.core import HomeAssistant, ServiceCall
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN, PLATFORMS
-from .switch import PLATFORM_SCHEMA as SWITCH_PLATFORM_SCHEMA
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,7 +44,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         if broadcast_port is not None:
             service_kwargs["port"] = broadcast_port
 
-        _LOGGER.info(
+        _LOGGER.debug(
             "Send magic packet to mac %s (broadcast: %s, port: %s)",
             mac_address,
             broadcast_address,
@@ -74,47 +61,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         send_magic_packet,
         schema=WAKE_ON_LAN_SEND_MAGIC_PACKET_SCHEMA,
     )
-
-    if hass.config_entries.async_entries(DOMAIN):
-        # We skip import in case we already have config entries
-        return True
-
-    ir.async_create_issue(
-        hass,
-        HOMEASSISTANT_DOMAIN,
-        f"deprecated_yaml_{DOMAIN}",
-        breaks_in_ha_version="2025.2.0",
-        is_fixable=False,
-        issue_domain=DOMAIN,
-        learn_more_url="https://www.home-assistant.io/integrations/wake_on_lan/",
-        severity=ir.IssueSeverity.WARNING,
-        translation_key="deprecated_yaml",
-        translation_placeholders={
-            "domain": DOMAIN,
-            "integration_title": "Wake on LAN",
-        },
-    )
-
-    platforms_config: dict[Platform, list[ConfigType]] = {
-        domain: config[domain] for domain in PLATFORMS if domain in config
-    }
-    _LOGGER.debug("Importing YAML configuration %s", platforms_config)
-    for items in platforms_config.values():
-        for item in items:
-            if item[CONF_PLATFORM] == DOMAIN:
-                wol_config_item = SWITCH_PLATFORM_SCHEMA(item)
-                if CONF_PLATFORM in wol_config_item:
-                    del wol_config_item[CONF_PLATFORM]
-                if CONF_SCAN_INTERVAL in wol_config_item:
-                    del wol_config_item[CONF_SCAN_INTERVAL]
-                _LOGGER.debug("Resulting import config %s", wol_config_item)
-                hass.async_create_task(
-                    hass.config_entries.flow.async_init(
-                        DOMAIN,
-                        context={"source": SOURCE_IMPORT},
-                        data=wol_config_item,
-                    )
-                )
 
     return True
 

--- a/homeassistant/components/wake_on_lan/__init__.py
+++ b/homeassistant/components/wake_on_lan/__init__.py
@@ -6,12 +6,26 @@ import logging
 import voluptuous as vol
 import wakeonlan
 
-from homeassistant.const import CONF_BROADCAST_ADDRESS, CONF_BROADCAST_PORT, CONF_MAC
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.const import (
+    CONF_BROADCAST_ADDRESS,
+    CONF_BROADCAST_PORT,
+    CONF_MAC,
+    CONF_PLATFORM,
+    CONF_SCAN_INTERVAL,
+    Platform,
+)
+from homeassistant.core import (
+    DOMAIN as HOMEASSISTANT_DOMAIN,
+    HomeAssistant,
+    ServiceCall,
+)
+from homeassistant.helpers import issue_registry as ir
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DOMAIN
+from .const import DOMAIN, PLATFORMS
+from .switch import PLATFORM_SCHEMA as SWITCH_PLATFORM_SCHEMA
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -61,4 +75,63 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         schema=WAKE_ON_LAN_SEND_MAGIC_PACKET_SCHEMA,
     )
 
+    if hass.config_entries.async_entries(DOMAIN):
+        # We skip import in case we already have config entries
+        return True
+
+    ir.async_create_issue(
+        hass,
+        HOMEASSISTANT_DOMAIN,
+        f"deprecated_yaml_{DOMAIN}",
+        breaks_in_ha_version="2025.2.0",
+        is_fixable=False,
+        issue_domain=DOMAIN,
+        learn_more_url="https://www.home-assistant.io/integrations/wake_on_lan/",
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="deprecated_yaml",
+        translation_placeholders={
+            "domain": DOMAIN,
+            "integration_title": "Wake on LAN",
+        },
+    )
+
+    platforms_config: dict[Platform, list[ConfigType]] = {
+        domain: config[domain] for domain in PLATFORMS if domain in config
+    }
+    _LOGGER.debug("Importing YAML configuration %s", platforms_config)
+    for items in platforms_config.values():
+        for item in items:
+            if item[CONF_PLATFORM] == DOMAIN:
+                wol_config_item = SWITCH_PLATFORM_SCHEMA(item)
+                if CONF_PLATFORM in wol_config_item:
+                    del wol_config_item[CONF_PLATFORM]
+                if CONF_SCAN_INTERVAL in wol_config_item:
+                    del wol_config_item[CONF_SCAN_INTERVAL]
+                _LOGGER.debug("Resulting import config %s", wol_config_item)
+                hass.async_create_task(
+                    hass.config_entries.flow.async_init(
+                        DOMAIN,
+                        context={"source": SOURCE_IMPORT},
+                        data=wol_config_item,
+                    )
+                )
+
     return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up a Wake on LAN component entry."""
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    entry.async_on_unload(entry.add_update_listener(update_listener))
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle options update."""
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/homeassistant/components/wake_on_lan/button.py
+++ b/homeassistant/components/wake_on_lan/button.py
@@ -1,0 +1,87 @@
+"""Support for button entity in wake on lan."""
+
+from __future__ import annotations
+
+from functools import partial
+import logging
+from typing import Any
+
+import wakeonlan
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_BROADCAST_ADDRESS, CONF_BROADCAST_PORT, CONF_MAC
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Wake on LAN sensor entry."""
+    broadcast_address: str | None = entry.options.get(CONF_BROADCAST_ADDRESS)
+    broadcast_port: int | None = entry.options.get(CONF_BROADCAST_PORT)
+    mac_address: str = entry.options[CONF_MAC]
+    name: str = entry.title
+
+    async_add_entities(
+        [
+            WolSwitch(
+                name,
+                mac_address,
+                broadcast_address,
+                broadcast_port,
+            )
+        ]
+    )
+
+
+class WolSwitch(ButtonEntity):
+    """Representation of a wake on lan button."""
+
+    _attr_name = None
+
+    def __init__(
+        self,
+        name: str,
+        mac_address: str,
+        broadcast_address: str | None,
+        broadcast_port: int | None,
+    ) -> None:
+        """Initialize the WOL button."""
+        self._mac_address = mac_address
+        self._broadcast_address = broadcast_address
+        self._broadcast_port = broadcast_port
+        self._attr_unique_id = dr.format_mac(mac_address)
+        self._attr_device_info = dr.DeviceInfo(
+            connections={(dr.CONNECTION_NETWORK_MAC, self._attr_unique_id)},
+            identifiers={(DOMAIN, self._attr_unique_id)},
+            manufacturer="Wake on LAN",
+            name=name,
+        )
+
+    async def async_press(self) -> None:
+        """Press the button."""
+        service_kwargs: dict[str, Any] = {}
+        if self._broadcast_address is not None:
+            service_kwargs["ip_address"] = self._broadcast_address
+        if self._broadcast_port is not None:
+            service_kwargs["port"] = self._broadcast_port
+
+        _LOGGER.debug(
+            "Send magic packet to mac %s (broadcast: %s, port: %s)",
+            self._mac_address,
+            self._broadcast_address,
+            self._broadcast_port,
+        )
+
+        await self.hass.async_add_executor_job(
+            partial(wakeonlan.send_magic_packet, self._mac_address, **service_kwargs)
+        )

--- a/homeassistant/components/wake_on_lan/config_flow.py
+++ b/homeassistant/components/wake_on_lan/config_flow.py
@@ -1,0 +1,82 @@
+"""Config flow for Wake on lan integration."""
+
+from collections.abc import Mapping
+from typing import Any, cast
+
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_BROADCAST_ADDRESS,
+    CONF_BROADCAST_PORT,
+    CONF_HOST,
+    CONF_MAC,
+    CONF_NAME,
+)
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.schema_config_entry_flow import (
+    SchemaCommonFlowHandler,
+    SchemaConfigFlowHandler,
+    SchemaFlowFormStep,
+)
+from homeassistant.helpers.selector import (
+    ActionSelector,
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
+    TextSelector,
+)
+
+from .const import CONF_OFF_ACTION, DEFAULT_NAME, DOMAIN
+
+
+async def validate(
+    handler: SchemaCommonFlowHandler, user_input: dict[str, Any]
+) -> dict[str, Any]:
+    """Validate input."""
+    if CONF_BROADCAST_PORT in user_input:
+        # Convert float to int for broadcast port
+        user_input[CONF_BROADCAST_PORT] = int(user_input[CONF_BROADCAST_PORT])
+
+    user_input[CONF_MAC] = dr.format_mac(user_input[CONF_MAC])
+
+    # Mac address needs to be unique
+    handler.parent_handler._async_abort_entries_match({CONF_MAC: user_input[CONF_MAC]})  # noqa: SLF001
+
+    return user_input
+
+
+DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_MAC): TextSelector(),
+        vol.Optional(CONF_HOST): TextSelector(),
+        vol.Optional(CONF_OFF_ACTION): ActionSelector(),
+        vol.Optional(CONF_BROADCAST_ADDRESS): TextSelector(),
+        vol.Optional(CONF_BROADCAST_PORT): NumberSelector(
+            NumberSelectorConfig(min=0, max=65535, step=1, mode=NumberSelectorMode.BOX)
+        ),
+    }
+)
+
+
+CONFIG_FLOW = {
+    "user": SchemaFlowFormStep(schema=DATA_SCHEMA, validate_user_input=validate),
+    "import": SchemaFlowFormStep(schema=DATA_SCHEMA, validate_user_input=validate),
+}
+OPTIONS_FLOW = {
+    "init": SchemaFlowFormStep(DATA_SCHEMA, validate_user_input=validate),
+}
+
+
+class StatisticsConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
+    """Handle a config flow for Statistics."""
+
+    config_flow = CONFIG_FLOW
+    options_flow = OPTIONS_FLOW
+
+    def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
+        """Return config entry title."""
+        if CONF_NAME in options:
+            # Only if imported
+            return cast(str, options[CONF_NAME])
+        mac: str = options[CONF_MAC]
+        return f"{DEFAULT_NAME} {mac}"

--- a/homeassistant/components/wake_on_lan/config_flow.py
+++ b/homeassistant/components/wake_on_lan/config_flow.py
@@ -1,17 +1,11 @@
 """Config flow for Wake on lan integration."""
 
 from collections.abc import Mapping
-from typing import Any, cast
+from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.const import (
-    CONF_BROADCAST_ADDRESS,
-    CONF_BROADCAST_PORT,
-    CONF_HOST,
-    CONF_MAC,
-    CONF_NAME,
-)
+from homeassistant.const import CONF_BROADCAST_ADDRESS, CONF_BROADCAST_PORT, CONF_MAC
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.schema_config_entry_flow import (
     SchemaCommonFlowHandler,
@@ -19,14 +13,13 @@ from homeassistant.helpers.schema_config_entry_flow import (
     SchemaFlowFormStep,
 )
 from homeassistant.helpers.selector import (
-    ActionSelector,
     NumberSelector,
     NumberSelectorConfig,
     NumberSelectorMode,
     TextSelector,
 )
 
-from .const import CONF_OFF_ACTION, DEFAULT_NAME, DOMAIN
+from .const import DEFAULT_NAME, DOMAIN
 
 
 async def validate(
@@ -55,8 +48,6 @@ async def validate_options(
 
 DATA_SCHEMA = {vol.Required(CONF_MAC): TextSelector()}
 OPTIONS_SCHEMA = {
-    vol.Optional(CONF_HOST): TextSelector(),
-    vol.Optional(CONF_OFF_ACTION): ActionSelector(),
     vol.Optional(CONF_BROADCAST_ADDRESS): TextSelector(),
     vol.Optional(CONF_BROADCAST_PORT): NumberSelector(
         NumberSelectorConfig(min=0, max=65535, step=1, mode=NumberSelectorMode.BOX)
@@ -68,11 +59,7 @@ CONFIG_FLOW = {
     "user": SchemaFlowFormStep(
         schema=vol.Schema(DATA_SCHEMA).extend(OPTIONS_SCHEMA),
         validate_user_input=validate,
-    ),
-    "import": SchemaFlowFormStep(
-        schema=vol.Schema(DATA_SCHEMA).extend(OPTIONS_SCHEMA),
-        validate_user_input=validate,
-    ),
+    )
 }
 OPTIONS_FLOW = {
     "init": SchemaFlowFormStep(
@@ -89,8 +76,5 @@ class StatisticsConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
 
     def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
         """Return config entry title."""
-        if CONF_NAME in options:
-            # Only if imported
-            return cast(str, options[CONF_NAME])
         mac: str = options[CONF_MAC]
         return f"{DEFAULT_NAME} {mac}"

--- a/homeassistant/components/wake_on_lan/const.py
+++ b/homeassistant/components/wake_on_lan/const.py
@@ -1,3 +1,11 @@
 """Constants for the Wake-On-LAN component."""
 
+from homeassistant.const import Platform
+
 DOMAIN = "wake_on_lan"
+PLATFORMS = [Platform.SWITCH]
+
+CONF_OFF_ACTION = "turn_off"
+
+DEFAULT_NAME = "Wake on LAN"
+DEFAULT_PING_TIMEOUT = 1

--- a/homeassistant/components/wake_on_lan/const.py
+++ b/homeassistant/components/wake_on_lan/const.py
@@ -3,7 +3,7 @@
 from homeassistant.const import Platform
 
 DOMAIN = "wake_on_lan"
-PLATFORMS = [Platform.SWITCH]
+PLATFORMS = [Platform.BUTTON]
 
 CONF_OFF_ACTION = "turn_off"
 

--- a/homeassistant/components/wake_on_lan/manifest.json
+++ b/homeassistant/components/wake_on_lan/manifest.json
@@ -2,6 +2,7 @@
   "domain": "wake_on_lan",
   "name": "Wake on LAN",
   "codeowners": ["@ntilley905"],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/wake_on_lan",
   "iot_class": "local_push",
   "requirements": ["wakeonlan==2.1.0"]

--- a/homeassistant/components/wake_on_lan/strings.json
+++ b/homeassistant/components/wake_on_lan/strings.json
@@ -1,4 +1,48 @@
 {
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "mac": "MAC address",
+          "host": "Host",
+          "turn_off": "Turn off action",
+          "broadcast_address": "Broadcast address",
+          "broadcast_port": "Broadcast port"
+        },
+        "data_description": {
+          "host": "The IP address or hostname to check the state of the device (on/off).",
+          "turn_off": "Defines an action to run when the switch is turned off.",
+          "broadcast_address": "The IP address of the host to send the magic packet to. Defaults to `255.255.255.255` and is normally not changed.",
+          "broadcast_port": "The port to send the magic packet to. Defaults to `9` and is normally not changed."
+        }
+      }
+    }
+  },
+  "options": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
+    },
+    "step": {
+      "init": {
+        "data": {
+          "mac": "[%key:component::wake_on_lan::config::step::user::data::mac%]",
+          "host": "[%key:component::wake_on_lan::config::step::user::data::host%]",
+          "turn_off": "[%key:component::wake_on_lan::config::step::user::data::turn_off%]",
+          "broadcast_address": "[%key:component::wake_on_lan::config::step::user::data::broadcast_address%]",
+          "broadcast_port": "[%key:component::wake_on_lan::config::step::user::data::broadcast_port%]"
+        },
+        "data_description": {
+          "host": "[%key:component::wake_on_lan::config::step::user::data_description::host%]",
+          "turn_off": "[%key:component::wake_on_lan::config::step::user::data_description::turn_off%]",
+          "broadcast_address": "[%key:component::wake_on_lan::config::step::user::data_description::broadcast_address%]",
+          "broadcast_port": "[%key:component::wake_on_lan::config::step::user::data_description::broadcast_port%]"
+        }
+      }
+    }
+  },
   "services": {
     "send_magic_packet": {
       "name": "Send magic packet",

--- a/homeassistant/components/wake_on_lan/strings.json
+++ b/homeassistant/components/wake_on_lan/strings.json
@@ -7,14 +7,11 @@
       "user": {
         "data": {
           "mac": "MAC address",
-          "host": "Host",
-          "turn_off": "Turn off action",
           "broadcast_address": "Broadcast address",
           "broadcast_port": "Broadcast port"
         },
         "data_description": {
-          "host": "The IP address or hostname to check the state of the device (on/off).",
-          "turn_off": "Defines an action to run when the switch is turned off.",
+          "mac": "MAC address of the device to wake up.",
           "broadcast_address": "The IP address of the host to send the magic packet to. Defaults to `255.255.255.255` and is normally not changed.",
           "broadcast_port": "The port to send the magic packet to. Defaults to `9` and is normally not changed."
         }
@@ -28,15 +25,10 @@
     "step": {
       "init": {
         "data": {
-          "mac": "[%key:component::wake_on_lan::config::step::user::data::mac%]",
-          "host": "[%key:component::wake_on_lan::config::step::user::data::host%]",
-          "turn_off": "[%key:component::wake_on_lan::config::step::user::data::turn_off%]",
           "broadcast_address": "[%key:component::wake_on_lan::config::step::user::data::broadcast_address%]",
           "broadcast_port": "[%key:component::wake_on_lan::config::step::user::data::broadcast_port%]"
         },
         "data_description": {
-          "host": "[%key:component::wake_on_lan::config::step::user::data_description::host%]",
-          "turn_off": "[%key:component::wake_on_lan::config::step::user::data_description::turn_off%]",
           "broadcast_address": "[%key:component::wake_on_lan::config::step::user::data_description::broadcast_address%]",
           "broadcast_port": "[%key:component::wake_on_lan::config::step::user::data_description::broadcast_port%]"
         }
@@ -49,16 +41,16 @@
       "description": "Sends a 'magic packet' to wake up a device with 'Wake-On-LAN' capabilities.",
       "fields": {
         "mac": {
-          "name": "MAC address",
-          "description": "MAC address of the device to wake up."
+          "name": "[%key:component::wake_on_lan::config::step::user::data::mac%]",
+          "description": "[%key:component::wake_on_lan::config::step::user::data_description::mac%]"
         },
         "broadcast_address": {
-          "name": "Broadcast address",
-          "description": "Broadcast IP where to send the magic packet."
+          "name": "[%key:component::wake_on_lan::config::step::user::data::broadcast_address%]",
+          "description": "[%key:component::wake_on_lan::config::step::user::data_description::broadcast_address%]"
         },
         "broadcast_port": {
-          "name": "Broadcast port",
-          "description": "Port where to send the magic packet."
+          "name": "[%key:component::wake_on_lan::config::step::user::data::broadcast_port%]",
+          "description": "[%key:component::wake_on_lan::config::step::user::data_description::broadcast_port%]"
         }
       }
     }

--- a/homeassistant/components/wake_on_lan/switch.py
+++ b/homeassistant/components/wake_on_lan/switch.py
@@ -13,6 +13,7 @@ from homeassistant.components.switch import (
     PLATFORM_SCHEMA as SWITCH_PLATFORM_SCHEMA,
     SwitchEntity,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_BROADCAST_ADDRESS,
     CONF_BROADCAST_PORT,
@@ -27,14 +28,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.script import Script
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from .const import DOMAIN
+from .const import CONF_OFF_ACTION, DEFAULT_NAME, DEFAULT_PING_TIMEOUT, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
-
-CONF_OFF_ACTION = "turn_off"
-
-DEFAULT_NAME = "Wake on LAN"
-DEFAULT_PING_TIMEOUT = 1
 
 PLATFORM_SCHEMA = SWITCH_PLATFORM_SCHEMA.extend(
     {
@@ -48,21 +44,34 @@ PLATFORM_SCHEMA = SWITCH_PLATFORM_SCHEMA.extend(
 )
 
 
-def setup_platform(
+async def async_setup_platform(
     hass: HomeAssistant,
     config: ConfigType,
-    add_entities: AddEntitiesCallback,
+    async_add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
-    """Set up a wake on lan switch."""
-    broadcast_address: str | None = config.get(CONF_BROADCAST_ADDRESS)
-    broadcast_port: int | None = config.get(CONF_BROADCAST_PORT)
-    host: str | None = config.get(CONF_HOST)
-    mac_address: str = config[CONF_MAC]
-    name: str = config[CONF_NAME]
-    off_action: list[Any] | None = config.get(CONF_OFF_ACTION)
+    """Set up a wake on lan switch.
 
-    add_entities(
+    The YAML platform config is automatically
+    imported to a config entry, this method can be removed
+    when YAML support is removed.
+    """
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Wake on LAN sensor entry."""
+    broadcast_address: str | None = entry.options.get(CONF_BROADCAST_ADDRESS)
+    broadcast_port: int | None = entry.options.get(CONF_BROADCAST_PORT)
+    host: str | None = entry.options.get(CONF_HOST)
+    mac_address: str = entry.options[CONF_MAC]
+    name: str = entry.title
+    off_action: list[Any] | None = entry.options.get(CONF_OFF_ACTION)
+
+    async_add_entities(
         [
             WolSwitch(
                 hass,

--- a/homeassistant/components/wake_on_lan/switch.py
+++ b/homeassistant/components/wake_on_lan/switch.py
@@ -13,7 +13,6 @@ from homeassistant.components.switch import (
     PLATFORM_SCHEMA as SWITCH_PLATFORM_SCHEMA,
     SwitchEntity,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_BROADCAST_ADDRESS,
     CONF_BROADCAST_PORT,
@@ -50,26 +49,13 @@ async def async_setup_platform(
     async_add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
-    """Set up a wake on lan switch.
-
-    The YAML platform config is automatically
-    imported to a config entry, this method can be removed
-    when YAML support is removed.
-    """
-
-
-async def async_setup_entry(
-    hass: HomeAssistant,
-    entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
-) -> None:
-    """Set up the Wake on LAN sensor entry."""
-    broadcast_address: str | None = entry.options.get(CONF_BROADCAST_ADDRESS)
-    broadcast_port: int | None = entry.options.get(CONF_BROADCAST_PORT)
-    host: str | None = entry.options.get(CONF_HOST)
-    mac_address: str = entry.options[CONF_MAC]
-    name: str = entry.title
-    off_action: list[Any] | None = entry.options.get(CONF_OFF_ACTION)
+    """Set up a wake on lan switch."""
+    broadcast_address: str | None = config.get(CONF_BROADCAST_ADDRESS)
+    broadcast_port: int | None = config.get(CONF_BROADCAST_PORT)
+    host: str | None = config.get(CONF_HOST)
+    mac_address: str = config[CONF_MAC]
+    name: str = config[CONF_NAME]
+    off_action: list[Any] | None = config.get(CONF_OFF_ACTION)
 
     async_add_entities(
         [

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -619,6 +619,7 @@ FLOWS = {
         "volumio",
         "volvooncall",
         "vulcan",
+        "wake_on_lan",
         "wallbox",
         "waqi",
         "watttime",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -6725,7 +6725,7 @@
     "wake_on_lan": {
       "name": "Wake on LAN",
       "integration_type": "hub",
-      "config_flow": false,
+      "config_flow": true,
       "iot_class": "local_push"
     },
     "wallbox": {

--- a/tests/components/wake_on_lan/conftest.py
+++ b/tests/components/wake_on_lan/conftest.py
@@ -8,19 +8,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from homeassistant.components.wake_on_lan.const import CONF_OFF_ACTION, DOMAIN
+from homeassistant.components.wake_on_lan.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
-from homeassistant.const import (
-    CONF_BROADCAST_ADDRESS,
-    CONF_BROADCAST_PORT,
-    CONF_HOST,
-    CONF_MAC,
-)
+from homeassistant.const import CONF_BROADCAST_ADDRESS, CONF_BROADCAST_PORT, CONF_MAC
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
-DEFAULT_MAC = "00:01:02:03:04:05:06"
+DEFAULT_MAC = "00:01:02:03:04:05"
 
 
 @pytest.fixture
@@ -63,8 +58,6 @@ async def get_config_to_integration_load() -> dict[str, Any]:
     """
     return {
         CONF_MAC: DEFAULT_MAC,
-        CONF_HOST: "192.168.10.10",
-        CONF_OFF_ACTION: [{"service: wake_on_lan.send_magic_packet"}],
         CONF_BROADCAST_ADDRESS: "255.255.255.255",
         CONF_BROADCAST_PORT: 9,
     }

--- a/tests/components/wake_on_lan/conftest.py
+++ b/tests/components/wake_on_lan/conftest.py
@@ -3,13 +3,28 @@
 from __future__ import annotations
 
 from collections.abc import Generator
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from homeassistant.components.wake_on_lan.const import CONF_OFF_ACTION, DOMAIN
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import (
+    CONF_BROADCAST_ADDRESS,
+    CONF_BROADCAST_PORT,
+    CONF_HOST,
+    CONF_MAC,
+)
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+DEFAULT_MAC = "00:01:02:03:04:05:06"
+
 
 @pytest.fixture
-def mock_send_magic_packet() -> AsyncMock:
+def mock_send_magic_packet() -> Generator[AsyncMock]:
     """Mock magic packet."""
     with patch("wakeonlan.send_magic_packet") as mock_send:
         yield mock_send
@@ -27,3 +42,50 @@ def mock_subprocess_call(subprocess_call_return_value: int) -> Generator[MagicMo
     with patch("homeassistant.components.wake_on_lan.switch.sp.call") as mock_sp:
         mock_sp.return_value = subprocess_call_return_value
         yield mock_sp
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Automatically path uuid generator."""
+    with patch(
+        "homeassistant.components.wake_on_lan.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        yield mock_setup_entry
+
+
+@pytest.fixture(name="get_config")
+async def get_config_to_integration_load() -> dict[str, Any]:
+    """Return configuration.
+
+    To override the config, tests can be marked with:
+    @pytest.mark.parametrize("get_config", [{...}])
+    """
+    return {
+        CONF_MAC: DEFAULT_MAC,
+        CONF_HOST: "192.168.10.10",
+        CONF_OFF_ACTION: [{"service: wake_on_lan.send_magic_packet"}],
+        CONF_BROADCAST_ADDRESS: "255.255.255.255",
+        CONF_BROADCAST_PORT: 9,
+    }
+
+
+@pytest.fixture(name="loaded_entry")
+async def load_integration(
+    hass: HomeAssistant, get_config: dict[str, Any]
+) -> MockConfigEntry:
+    """Set up the Statistics integration in Home Assistant."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=f"Wake on LAN {DEFAULT_MAC}",
+        source=SOURCE_USER,
+        options=get_config,
+        entry_id="1",
+    )
+
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    return config_entry

--- a/tests/components/wake_on_lan/test_button.py
+++ b/tests/components/wake_on_lan/test_button.py
@@ -1,0 +1,54 @@
+"""The tests for the wake on lan button platform."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from freezegun.api import FrozenDateTimeFactory
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
+
+from tests.common import MockConfigEntry
+
+
+async def test_state(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    loaded_entry: MockConfigEntry,
+) -> None:
+    """Test button default state."""
+
+    state = hass.states.get("button.wake_on_lan_00_01_02_03_04_05")
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+    entry = entity_registry.async_get("button.wake_on_lan_00_01_02_03_04_05")
+    assert entry
+    assert entry.unique_id == "00:01:02:03:04:05"
+
+
+async def test_service_calls(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    loaded_entry: MockConfigEntry,
+    mock_send_magic_packet: AsyncMock,
+) -> None:
+    """Test service call."""
+
+    now = dt_util.parse_datetime("2021-01-09 12:00:00+00:00")
+    freezer.move_to(now)
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: "button.wake_on_lan_00_01_02_03_04_05"},
+        blocking=True,
+    )
+
+    assert (
+        hass.states.get("button.wake_on_lan_00_01_02_03_04_05").state == now.isoformat()
+    )

--- a/tests/components/wake_on_lan/test_config_flow.py
+++ b/tests/components/wake_on_lan/test_config_flow.py
@@ -15,8 +15,9 @@ from homeassistant.const import (
     CONF_NAME,
     STATE_OFF,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.setup import async_setup_component
 
 from .conftest import DEFAULT_MAC
@@ -122,7 +123,11 @@ async def test_entry_already_exist(
     assert result["reason"] == "already_configured"
 
 
-async def test_import(hass: HomeAssistant, mock_send_magic_packet: AsyncMock) -> None:
+async def test_import(
+    hass: HomeAssistant,
+    mock_send_magic_packet: AsyncMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
     """Test importing."""
 
     assert await async_setup_component(
@@ -150,3 +155,12 @@ async def test_import(hass: HomeAssistant, mock_send_magic_packet: AsyncMock) ->
         CONF_MAC: DEFAULT_MAC,
         CONF_NAME: "Test WOL",
     }
+
+    issue = issue_registry.async_get_issue(
+        HOMEASSISTANT_DOMAIN, f"deprecated_yaml_{DOMAIN}"
+    )
+    assert issue
+    assert (
+        issue.learn_more_url
+        == "https://www.home-assistant.io/integrations/wake_on_lan/"
+    )

--- a/tests/components/wake_on_lan/test_config_flow.py
+++ b/tests/components/wake_on_lan/test_config_flow.py
@@ -1,0 +1,152 @@
+"""Test the Scrape config flow."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from homeassistant import config_entries
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.components.wake_on_lan.const import CONF_OFF_ACTION, DOMAIN
+from homeassistant.const import (
+    CONF_BROADCAST_ADDRESS,
+    CONF_BROADCAST_PORT,
+    CONF_HOST,
+    CONF_MAC,
+    CONF_NAME,
+    STATE_OFF,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.setup import async_setup_component
+
+from .conftest import DEFAULT_MAC
+
+from tests.common import MockConfigEntry
+
+
+async def test_form(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
+    """Test we get the form."""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["step_id"] == "user"
+    assert result["type"] is FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_MAC: DEFAULT_MAC,
+            CONF_HOST: "192.168.10.10",
+            CONF_OFF_ACTION: [{"service: wake_on_lan.send_magic_packet"}],
+            CONF_BROADCAST_ADDRESS: "255.255.255.255",
+            CONF_BROADCAST_PORT: 9,
+        },
+    )
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["version"] == 1
+    assert result["options"] == {
+        CONF_MAC: DEFAULT_MAC,
+        CONF_HOST: "192.168.10.10",
+        CONF_OFF_ACTION: [{"service: wake_on_lan.send_magic_packet"}],
+        CONF_BROADCAST_ADDRESS: "255.255.255.255",
+        CONF_BROADCAST_PORT: 9,
+    }
+
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_options_flow(hass: HomeAssistant, loaded_entry: MockConfigEntry) -> None:
+    """Test options flow."""
+
+    result = await hass.config_entries.options.async_init(loaded_entry.entry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_HOST: "192.168.10.10",
+            CONF_OFF_ACTION: [{"service: wake_on_lan.send_magic_packet"}],
+            CONF_BROADCAST_ADDRESS: "255.255.255.255",
+            CONF_BROADCAST_PORT: 10,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        CONF_MAC: DEFAULT_MAC,
+        CONF_HOST: "192.168.10.10",
+        CONF_OFF_ACTION: [{"service: wake_on_lan.send_magic_packet"}],
+        CONF_BROADCAST_ADDRESS: "255.255.255.255",
+        CONF_BROADCAST_PORT: 10,
+    }
+
+    await hass.async_block_till_done()
+
+    # Check the entity was updated, no new entity was created
+    assert len(hass.states.async_all()) == 1
+
+    state = hass.states.get("switch.wake_on_lan_00_01_02_03_04_05_06")
+    assert state is not None
+
+
+async def test_entry_already_exist(
+    hass: HomeAssistant, loaded_entry: MockConfigEntry
+) -> None:
+    """Test abort when entry already exist."""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["step_id"] == "user"
+    assert result["type"] is FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_MAC: DEFAULT_MAC,
+            CONF_HOST: "192.168.10.10",
+            CONF_OFF_ACTION: [{"service: wake_on_lan.send_magic_packet"}],
+            CONF_BROADCAST_ADDRESS: "255.255.255.255",
+            CONF_BROADCAST_PORT: 9,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_import(hass: HomeAssistant, mock_send_magic_packet: AsyncMock) -> None:
+    """Test importing."""
+
+    assert await async_setup_component(
+        hass,
+        SWITCH_DOMAIN,
+        {
+            "switch": {
+                "platform": "wake_on_lan",
+                "name": "Test WOL",
+                "mac": DEFAULT_MAC,
+                "scan_interval": 60,
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_wol")
+    assert state.state == STATE_OFF
+
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    assert entry
+    assert entry.title == "Test WOL"
+    assert entry.data == {}
+    assert entry.options == {
+        CONF_MAC: DEFAULT_MAC,
+        CONF_NAME: "Test WOL",
+    }

--- a/tests/components/wake_on_lan/test_init.py
+++ b/tests/components/wake_on_lan/test_init.py
@@ -8,8 +8,20 @@ import pytest
 import voluptuous as vol
 
 from homeassistant.components.wake_on_lan import DOMAIN, SERVICE_SEND_MAGIC_PACKET
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+
+
+async def test_unload_entry(hass: HomeAssistant, loaded_entry: MockConfigEntry) -> None:
+    """Test unload an entry."""
+
+    assert loaded_entry.state is ConfigEntryState.LOADED
+    assert await hass.config_entries.async_unload(loaded_entry.entry_id)
+    await hass.async_block_till_done()
+    assert loaded_entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_send_magic_packet(hass: HomeAssistant) -> None:

--- a/tests/components/wake_on_lan/test_switch.py
+++ b/tests/components/wake_on_lan/test_switch.py
@@ -65,7 +65,7 @@ async def test_broadcast_config_ip_and_port(
     hass: HomeAssistant, mock_send_magic_packet: AsyncMock
 ) -> None:
     """Test with broadcast address and broadcast port config."""
-    mac = "00-01-02-03-04-05"
+    mac = "00:01:02:03:04:05"
     broadcast_address = "255.255.255.255"
     port = 999
 
@@ -104,7 +104,7 @@ async def test_broadcast_config_ip(
 ) -> None:
     """Test with only broadcast address."""
 
-    mac = "00-01-02-03-04-05"
+    mac = "00:01:02:03:04:05"
     broadcast_address = "255.255.255.255"
 
     assert await async_setup_component(
@@ -139,7 +139,7 @@ async def test_broadcast_config_port(
 ) -> None:
     """Test with only broadcast port config."""
 
-    mac = "00-01-02-03-04-05"
+    mac = "00:01:02:03:04:05"
     port = 999
 
     assert await async_setup_component(

--- a/tests/components/wake_on_lan/test_switch.py
+++ b/tests/components/wake_on_lan/test_switch.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     STATE_ON,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_mock_service
@@ -92,6 +93,7 @@ async def test_broadcast_config_ip_and_port(
         blocking=True,
     )
 
+    mac = dr.format_mac(mac)
     mock_send_magic_packet.assert_called_with(
         mac, ip_address=broadcast_address, port=port
     )
@@ -128,6 +130,7 @@ async def test_broadcast_config_ip(
         blocking=True,
     )
 
+    mac = dr.format_mac(mac)
     mock_send_magic_packet.assert_called_with(mac, ip_address=broadcast_address)
 
 
@@ -156,6 +159,7 @@ async def test_broadcast_config_port(
         blocking=True,
     )
 
+    mac = dr.format_mac(mac)
     mock_send_magic_packet.assert_called_with(mac, port=port)
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds config flow for Wake on LAN

This does not introduce an import from the existing schema.
It creates a `ButtonEntity` which is used only to send magic packets to the specified mac-address.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33660

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 