### PR TITLE
Adjust type hints for unnecessary returns in tests

### DIFF
--- a/tests/components/androidtv/patchers.py
+++ b/tests/components/androidtv/patchers.py
@@ -37,7 +37,7 @@ class AdbDeviceTcpAsyncFake:
         """Try to connect to a device."""
         raise NotImplementedError
 
-    async def shell(self, cmd, *args, **kwargs):
+    async def shell(self, cmd, *args, **kwargs) -> bytes | str | None:
         """Send an ADB shell command."""
         return None
 

--- a/tests/components/enigma2/conftest.py
+++ b/tests/components/enigma2/conftest.py
@@ -78,7 +78,7 @@ class MockDevice:
                 }
             }
 
-    def get_version(self):
+    def get_version(self) -> str | None:
         """Return the version."""
         return None
 

--- a/tests/components/ipma/test_weather.py
+++ b/tests/components/ipma/test_weather.py
@@ -4,6 +4,7 @@ import datetime
 from unittest.mock import patch
 
 from freezegun.api import FrozenDateTimeFactory
+from pyipma.observation import Observation
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -43,7 +44,7 @@ TEST_CONFIG_HOURLY = {
 class MockBadLocation(MockLocation):
     """Mock Location with unresponsive api."""
 
-    async def observation(self, api):
+    async def observation(self, api) -> Observation | None:
         """Mock Observation."""
         return None
 

--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -61,7 +61,7 @@ def register_words_fixture():
 
 
 @pytest.fixture(name="config_addon")
-def config_addon_fixture():
+def config_addon_fixture() -> dict[str, Any] | None:
     """Add extra configuration items."""
     return None
 

--- a/tests/components/nest/test_api.py
+++ b/tests/components/nest/test_api.py
@@ -18,7 +18,7 @@ from homeassistant.components.nest.const import API_URL, OAUTH2_TOKEN, SDM_SCOPE
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
-from .common import CLIENT_ID, CLIENT_SECRET, PROJECT_ID, PlatformSetup
+from .common import CLIENT_ID, CLIENT_SECRET, PROJECT_ID, FakeSubscriber, PlatformSetup
 from .conftest import FAKE_REFRESH_TOKEN, FAKE_TOKEN
 
 from tests.test_util.aiohttp import AiohttpClientMocker
@@ -27,7 +27,7 @@ FAKE_UPDATED_TOKEN = "fake-updated-token"
 
 
 @pytest.fixture
-def subscriber() -> None:
+def subscriber() -> FakeSubscriber | None:
     """Disable default subscriber since tests use their own patch."""
     return None
 

--- a/tests/components/nest/test_init.py
+++ b/tests/components/nest/test_init.py
@@ -67,13 +67,15 @@ def warning_caplog(
 
 
 @pytest.fixture
-def subscriber_side_effect() -> None:
+def subscriber_side_effect() -> Any | None:
     """Fixture to inject failures into FakeSubscriber start."""
     return None
 
 
 @pytest.fixture
-def failing_subscriber(subscriber_side_effect: Any) -> YieldFixture[FakeSubscriber]:
+def failing_subscriber(
+    subscriber_side_effect: Any | None,
+) -> YieldFixture[FakeSubscriber]:
     """Fixture overriding default subscriber behavior to allow failure injection."""
     subscriber = FakeSubscriber()
     with patch(

--- a/tests/components/notify/test_legacy.py
+++ b/tests/components/notify/test_legacy.py
@@ -226,7 +226,11 @@ async def test_invalid_service(
 ) -> None:
     """Test service setup with an invalid service object or platform."""
 
-    def get_service(hass, config, discovery_info=None):
+    def get_service(
+        hass: HomeAssistant,
+        config: ConfigType,
+        discovery_info: DiscoveryInfoType | None = None,
+    ) -> notify.BaseNotificationService | None:
         """Return None for an invalid notify service."""
         return None
 

--- a/tests/components/rainbird/test_config_flow.py
+++ b/tests/components/rainbird/test_config_flow.py
@@ -40,7 +40,7 @@ def mock_responses() -> list[AiohttpClientMockResponse]:
 
 
 @pytest.fixture(autouse=True)
-async def config_entry_data() -> None:
+async def config_entry_data() -> dict[str, Any] | None:
     """Fixture to disable config entry setup for exercising config flow."""
     return None
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #115031

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
