### PR TITLE
Fix state for Matter Locks (including optional door sensor)

### DIFF
--- a/homeassistant/components/matter/binary_sensor.py
+++ b/homeassistant/components/matter/binary_sensor.py
@@ -145,4 +145,20 @@ DISCOVERY_SCHEMAS = [
         required_attributes=(clusters.BooleanState.Attributes.StateValue,),
         device_type=(device_types.RainSensor,),
     ),
+    MatterDiscoverySchema(
+        platform=Platform.BINARY_SENSOR,
+        entity_description=MatterBinarySensorEntityDescription(
+            key="LockDoorStateSensor",
+            device_class=BinarySensorDeviceClass.DOOR,
+            # pylint: disable=unnecessary-lambda
+            measurement_to_ha=lambda x: {
+                clusters.DoorLock.Enums.DoorStateEnum.kDoorOpen: True,
+                clusters.DoorLock.Enums.DoorStateEnum.kDoorJammed: True,
+                clusters.DoorLock.Enums.DoorStateEnum.kDoorForcedOpen: True,
+                clusters.DoorLock.Enums.DoorStateEnum.kDoorClosed: False,
+            }.get(x),
+        ),
+        entity_class=MatterBinarySensor,
+        required_attributes=(clusters.DoorLock.Attributes.DoorState,),
+    ),
 ]

--- a/homeassistant/components/matter/lock.py
+++ b/homeassistant/components/matter/lock.py
@@ -110,7 +110,7 @@ class MatterLock(MatterEntity, LockEntity):
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the lock with pin if needed."""
         if self._attr_is_locked:
-            # optimistically signal locking to state machine
+            # optimistically signal unlocking to state machine
             self._attr_is_unlocking = True
             self.async_write_ha_state()
             # the lock should acknowledge the command with an attribute update
@@ -134,7 +134,7 @@ class MatterLock(MatterEntity, LockEntity):
 
     async def async_open(self, **kwargs: Any) -> None:
         """Open the door latch."""
-        # optimistically signal locking to state machine
+        # optimistically signal opening to state machine
         self._attr_is_opening = True
         self.async_write_ha_state()
         # the lock should acknowledge the command with an attribute update

--- a/homeassistant/components/matter/lock.py
+++ b/homeassistant/components/matter/lock.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from chip.clusters import Objects as clusters
@@ -38,6 +39,7 @@ class MatterLock(MatterEntity, LockEntity):
     """Representation of a Matter lock."""
 
     features: int | None = None
+    _optimistic_timer: asyncio.TimerHandle | None = None
 
     @property
     def code_format(self) -> str | None:
@@ -90,9 +92,15 @@ class MatterLock(MatterEntity, LockEntity):
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the lock with pin if needed."""
-        # optimistically signal locking to state machine
-        self._attr_is_locking = True
-        self.async_write_ha_state()
+        if not self._attr_is_locked:
+            # optimistically signal locking to state machine
+            self._attr_is_locking = True
+            self.async_write_ha_state()
+            # the lock should acknowledge the command with an attribute update
+            # but bad things may happen, so guard against it with a timer.
+            self._optimistic_timer = self.hass.loop.call_later(
+                5, self._reset_optimistic_state
+            )
         code: str | None = kwargs.get(ATTR_CODE)
         code_bytes = code.encode() if code else None
         await self.send_device_command(
@@ -101,9 +109,15 @@ class MatterLock(MatterEntity, LockEntity):
 
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the lock with pin if needed."""
-        # optimistically signal unlocking to state machine
-        self._attr_is_unlocking = True
-        self.async_write_ha_state()
+        if self._attr_is_locked:
+            # optimistically signal locking to state machine
+            self._attr_is_unlocking = True
+            self.async_write_ha_state()
+            # the lock should acknowledge the command with an attribute update
+            # but bad things may happen, so guard against it with a timer.
+            self._optimistic_timer = self.hass.loop.call_later(
+                5, self._reset_optimistic_state
+            )
         code: str | None = kwargs.get(ATTR_CODE)
         code_bytes = code.encode() if code else None
         if self.supports_unbolt:
@@ -120,9 +134,14 @@ class MatterLock(MatterEntity, LockEntity):
 
     async def async_open(self, **kwargs: Any) -> None:
         """Open the door latch."""
-        # optimistically signal unlocking to state machine
-        self._attr_is_unlocking = True
+        # optimistically signal locking to state machine
+        self._attr_is_opening = True
         self.async_write_ha_state()
+        # the lock should acknowledge the command with an attribute update
+        # but bad things may happen, so guard against it with a timer.
+        self._optimistic_timer = self.hass.loop.call_later(
+            5, self._reset_optimistic_state
+        )
         code: str | None = kwargs.get(ATTR_CODE)
         code_bytes = code.encode() if code else None
         await self.send_device_command(
@@ -145,38 +164,38 @@ class MatterLock(MatterEntity, LockEntity):
         )
 
         # always reset the optimisically (un)locking state on state update
-        self._attr_is_locking = False
-        self._attr_is_unlocking = False
+        self._reset_optimistic_state(write_state=False)
 
         LOGGER.debug("Lock state: %s for %s", lock_state, self.entity_id)
 
+        if lock_state is clusters.DoorLock.Enums.DlLockState.kUnlatched:
+            self._attr_is_locked = False
+            self._attr_is_open = True
         if lock_state is clusters.DoorLock.Enums.DlLockState.kLocked:
             self._attr_is_locked = True
+            self._attr_is_open = False
         elif lock_state in (
             clusters.DoorLock.Enums.DlLockState.kUnlocked,
-            clusters.DoorLock.Enums.DlLockState.kUnlatched,
             clusters.DoorLock.Enums.DlLockState.kNotFullyLocked,
         ):
             self._attr_is_locked = False
+            self._attr_is_open = False
         else:
-            # According to the matter docs a null state can happen during device startup.
+            # Treat any other state as unknown.
+            # NOTE: A null state can happen during device startup.
             self._attr_is_locked = None
+            self._attr_is_open = None
 
-        if self.supports_door_position_sensor:
-            door_state = self.get_matter_attribute_value(
-                clusters.DoorLock.Attributes.DoorState
-            )
-
-            assert door_state is not None
-
-            LOGGER.debug("Door state: %s for %s", door_state, self.entity_id)
-
-            self._attr_is_jammed = (
-                door_state is clusters.DoorLock.Enums.DoorStateEnum.kDoorJammed
-            )
-            self._attr_is_open = (
-                door_state is clusters.DoorLock.Enums.DoorStateEnum.kDoorOpen
-            )
+    @callback
+    def _reset_optimistic_state(self, write_state: bool = True) -> None:
+        if self._optimistic_timer and not self._optimistic_timer.cancelled():
+            self._optimistic_timer.cancel()
+        self._optimistic_timer = None
+        self._attr_is_locking = False
+        self._attr_is_unlocking = False
+        self._attr_is_opening = False
+        if write_state:
+            self.async_write_ha_state()
 
 
 DISCOVERY_SCHEMAS = [


### PR DESCRIPTION
## Proposed change
After some back-and-forth with Nuki (the smart lock manufacturer) we came to the conclusion that a few assumption of translating the door lock state were wrong. This PR corrects that:

- Only signal state 'open' if the door lock state is 'unlatched'
- Only signal state 'locked' if the lock state is literally locked
- Only signal state 'unlocked' if the lock state is literally unlocked (or NotFullyLocked)
- Signal door lock state of 'unknown' (None) in all other cases 
- Treat the optional door sensor as separate binary sensor
- Do not connect the door sensor state to the lock state
- Use a timer to reset optimistic state of unlocking/locking/opening in case the lock does not send a notification

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
