### PR TITLE
Actionable Persistent Notifications

### DIFF
--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -102,11 +102,17 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             title = title_tpl.async_render(parse_result=False)
 
         notification_id = None
+        actions = None
         if data := service.data.get(ATTR_DATA):
             notification_id = data.get(pn.ATTR_NOTIFICATION_ID)
+            actions = data.get(pn.ATTR_ACTIONS)
 
         pn.async_create(
-            hass, message.async_render(parse_result=False), title, notification_id
+            hass,
+            message.async_render(parse_result=False),
+            title,
+            notification_id,
+            actions,
         )
 
     hass.services.async_register(

--- a/homeassistant/components/persistent_notification/services.yaml
+++ b/homeassistant/components/persistent_notification/services.yaml
@@ -9,6 +9,9 @@ create:
       example: Test notification
       selector:
         text:
+    actions:
+      selector:
+        object:
     notification_id:
       example: 1234
       selector:

--- a/homeassistant/components/persistent_notification/strings.json
+++ b/homeassistant/components/persistent_notification/strings.json
@@ -13,6 +13,10 @@
           "name": "Title",
           "description": "Optional title of the notification."
         },
+        "actions": {
+          "name": "Actions",
+          "description": "Optional actions to be presented to the user with the notification."
+        },
         "notification_id": {
           "name": "Notification ID",
           "description": "ID of the notification. This new notification will overwrite an existing notification with the same ID."


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Allow persistent_notifications to have actionable buttons in the same style as the mobile apps. 

![image](https://github.com/home-assistant/core/assets/32912880/a78ff764-08f9-4ef5-b8a1-57be19128da2)

The syntax is the same/similar as mobile apps, so that if `persistent_notification` is used in a notification group with mobile_apps, the desktop client can also trigger an action response.

When mobile apps trigger a response, they send a `mobile_app_notification_action` event, which didn't feel exactly right to use for a desktop client, so I chose to fire a `persistent_notification_action` event instead. I'm not sure what's the right choice, as this might make writing an automation to respond to the action slightly more difficult, as it may have to listen for two types of events, instead of just `mobile_app_notification_action`. 

![image](https://github.com/home-assistant/core/assets/32912880/714c1000-6abf-4301-aa75-62b49f40fea8)


I also considered instead of sending an event, a service call could just be baked into the notification itself, so that the frontend could call that service when it was clicked, but this felt like it might be annoying as the setup would be completely different from how the mobile apps are used. Perhaps in the future this could be extended with optional actions directly defined in the notification (instead of having to write an automation to catch the event), but starting this simple for now. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
