### PR TITLE
Add HassGetCurrentDate and HassGetCurrentTime intents

### DIFF
--- a/homeassistant/components/conversation/manifest.json
+++ b/homeassistant/components/conversation/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/conversation",
   "integration_type": "system",
   "quality_scale": "internal",
-  "requirements": ["hassil==1.7.3", "home-assistant-intents==2024.7.3"]
+  "requirements": ["hassil==1.7.4", "home-assistant-intents==2024.7.10"]
 }

--- a/homeassistant/components/intent/__init__.py
+++ b/homeassistant/components/intent/__init__.py
@@ -381,7 +381,7 @@ class GetCurrentDateIntentHandler(intent.IntentHandler):
 
     async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         response = intent_obj.create_response()
-        response.async_set_speech_slots({"date": datetime.now()})
+        response.async_set_speech_slots({"date": datetime.now().date()})
         return response
 
 
@@ -393,7 +393,7 @@ class GetCurrentTimeIntentHandler(intent.IntentHandler):
 
     async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         response = intent_obj.create_response()
-        response.async_set_speech_slots({"time": datetime.now()})
+        response.async_set_speech_slots({"time": datetime.now().time()})
         return response
 
 

--- a/homeassistant/components/intent/__init__.py
+++ b/homeassistant/components/intent/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 import logging
 from typing import Any, Protocol
 
@@ -120,6 +121,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     intent.async_register(hass, PauseTimerIntentHandler())
     intent.async_register(hass, UnpauseTimerIntentHandler())
     intent.async_register(hass, TimerStatusIntentHandler())
+    intent.async_register(hass, GetCurrentDateIntentHandler())
+    intent.async_register(hass, GetCurrentTimeIntentHandler())
 
     return True
 
@@ -368,6 +371,30 @@ class SetPositionIntentHandler(intent.DynamicServiceIntentHandler):
             return (VALVE_DOMAIN, SERVICE_SET_VALVE_POSITION)
 
         raise intent.IntentHandleError(f"Domain not supported: {state.domain}")
+
+
+class GetCurrentDateIntentHandler(intent.IntentHandler):
+    """Gets the current date."""
+
+    intent_type = intent.INTENT_GET_CURRENT_DATE
+    description = "Gets the current date"
+
+    async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
+        response = intent_obj.create_response()
+        response.async_set_speech_slots({"date": datetime.now()})
+        return response
+
+
+class GetCurrentTimeIntentHandler(intent.IntentHandler):
+    """Gets the current time."""
+
+    intent_type = intent.INTENT_GET_CURRENT_TIME
+    description = "Gets the current time"
+
+    async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
+        response = intent_obj.create_response()
+        response.async_set_speech_slots({"time": datetime.now()})
+        return response
 
 
 async def _async_process_intent(

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -54,6 +54,8 @@ INTENT_DECREASE_TIMER = "HassDecreaseTimer"
 INTENT_PAUSE_TIMER = "HassPauseTimer"
 INTENT_UNPAUSE_TIMER = "HassUnpauseTimer"
 INTENT_TIMER_STATUS = "HassTimerStatus"
+INTENT_GET_CURRENT_DATE = "HassGetCurrentDate"
+INTENT_GET_CURRENT_TIME = "HassGetCurrentTime"
 
 SLOT_SCHEMA = vol.Schema({}, extra=vol.ALLOW_EXTRA)
 

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -277,6 +277,8 @@ class AssistAPI(API):
         intent.INTENT_GET_STATE,
         intent.INTENT_NEVERMIND,
         intent.INTENT_TOGGLE,
+        intent.INTENT_GET_CURRENT_DATE,
+        intent.INTENT_GET_CURRENT_TIME,
     }
 
     def __init__(self, hass: HomeAssistant) -> None:

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -30,10 +30,10 @@ ha-av==10.1.1
 ha-ffmpeg==3.2.0
 habluetooth==3.1.3
 hass-nabucasa==0.81.1
-hassil==1.7.3
+hassil==1.7.4
 home-assistant-bluetooth==1.12.2
 home-assistant-frontend==20240710.0
-home-assistant-intents==2024.7.3
+home-assistant-intents==2024.7.10
 httpx==0.27.0
 ifaddr==0.2.0
 Jinja2==3.1.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1059,7 +1059,7 @@ hass-nabucasa==0.81.1
 hass-splunk==0.1.1
 
 # homeassistant.components.conversation
-hassil==1.7.3
+hassil==1.7.4
 
 # homeassistant.components.jewish_calendar
 hdate==0.10.9
@@ -1096,7 +1096,7 @@ holidays==0.52
 home-assistant-frontend==20240710.0
 
 # homeassistant.components.conversation
-home-assistant-intents==2024.7.3
+home-assistant-intents==2024.7.10
 
 # homeassistant.components.home_connect
 homeconnect==0.7.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -870,7 +870,7 @@ habluetooth==3.1.3
 hass-nabucasa==0.81.1
 
 # homeassistant.components.conversation
-hassil==1.7.3
+hassil==1.7.4
 
 # homeassistant.components.jewish_calendar
 hdate==0.10.9
@@ -898,7 +898,7 @@ holidays==0.52
 home-assistant-frontend==20240710.0
 
 # homeassistant.components.conversation
-home-assistant-intents==2024.7.3
+home-assistant-intents==2024.7.10
 
 # homeassistant.components.home_connect
 homeconnect==0.7.2

--- a/tests/components/conversation/test_default_agent_intents.py
+++ b/tests/components/conversation/test_default_agent_intents.py
@@ -1,7 +1,9 @@
 """Test intents for the default agent."""
 
+from datetime import datetime
 from unittest.mock import patch
 
+from freezegun import freeze_time
 import pytest
 
 from homeassistant.components import (
@@ -413,3 +415,28 @@ async def test_todo_add_item_fr(
         assert mock_handle.call_args.args
         intent_obj = mock_handle.call_args.args[0]
         assert intent_obj.slots.get("item", {}).get("value", "").strip() == "farine"
+
+
+@freeze_time(datetime(year=2013, month=9, day=17, hour=1, minute=2))
+async def test_date_time(
+    hass: HomeAssistant,
+    init_components,
+) -> None:
+    """Test the date and time intents."""
+    result = await conversation.async_converse(
+        hass, "what is the date", None, Context(), None
+    )
+    await hass.async_block_till_done()
+
+    response = result.response
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.speech["plain"]["speech"] == "September 17th, 2013"
+
+    result = await conversation.async_converse(
+        hass, "what time is it", None, Context(), None
+    )
+    await hass.async_block_till_done()
+
+    response = result.response
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.speech["plain"]["speech"] == "1:02 AM"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
* Adds support for `HassGetCurrentDate` and `HassGetCurrentTime` (see: https://github.com/home-assistant/intents/pull/2300)
* Bumps intents to 2024.7.10: https://github.com/home-assistant/intents/compare/2024.7.3...2024.7.10
* Bumps hassil to 1.7.4: https://github.com/home-assistant/hassil/compare/1.7.1...1.7.4

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
