### PR TITLE
Bump pyloadapi to v1.3.2

### DIFF
--- a/homeassistant/components/pyload/coordinator.py
+++ b/homeassistant/components/pyload/coordinator.py
@@ -30,7 +30,7 @@ class PyLoadData:
     speed: float
     download: bool
     reconnect: bool
-    captcha: bool
+    captcha: bool | None = None
     free_space: int
 
 

--- a/homeassistant/components/pyload/manifest.json
+++ b/homeassistant/components/pyload/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "loggers": ["pyloadapi"],
   "quality_scale": "platinum",
-  "requirements": ["PyLoadAPI==1.2.0"]
+  "requirements": ["PyLoadAPI==1.3.2"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -60,7 +60,7 @@ PyFlume==0.6.5
 PyFronius==0.7.3
 
 # homeassistant.components.pyload
-PyLoadAPI==1.2.0
+PyLoadAPI==1.3.2
 
 # homeassistant.components.mvglive
 PyMVGLive==1.1.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -51,7 +51,7 @@ PyFlume==0.6.5
 PyFronius==0.7.3
 
 # homeassistant.components.pyload
-PyLoadAPI==1.2.0
+PyLoadAPI==1.3.2
 
 # homeassistant.components.met_eireann
 PyMetEireann==2021.8.0

--- a/tests/components/pyload/test_sensor.py
+++ b/tests/components/pyload/test_sensor.py
@@ -157,3 +157,25 @@ async def test_deprecated_yaml(
     assert issue_registry.async_get_issue(
         domain=HOMEASSISTANT_DOMAIN, issue_id=f"deprecated_yaml_{DOMAIN}"
     )
+
+
+async def test_pyload_pre_0_5_0(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_pyloadapi: AsyncMock,
+) -> None:
+    """Test setup of the pyload sensor platform."""
+    mock_pyloadapi.get_status.return_value = {
+        "pause": False,
+        "active": 1,
+        "queue": 6,
+        "total": 37,
+        "speed": 5405963.0,
+        "download": True,
+        "reconnect": False,
+    }
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bumps pyloadapi from v. 1.2.0 to 1.3.2.

This update changes the parameter captcha (currently unused in HA) from a mandatory to an optional parameter to ensure compatibility with pyLoad versions pre 0.5.0, where this parameter is not present in the json response.

**Change Log:** [`v1.2.0...v1.3.2`](https://github.com/tr4nt0r/pyloadapi/compare/v1.2.0...v1.3.2)
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #121152
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
