### PR TITLE
Add button group support

### DIFF
--- a/homeassistant/components/group/button.py
+++ b/homeassistant/components/group/button.py
@@ -104,7 +104,7 @@ class ButtonGroup(GroupEntity, ButtonEntity):
         name: str,
         entity_ids: list[str],
     ) -> None:
-        """Initialize an event group."""
+        """Initialize a button group."""
         self._entity_ids = entity_ids
         self._attr_name = name
         self._attr_extra_state_attributes = {ATTR_ENTITY_ID: entity_ids}

--- a/homeassistant/components/group/button.py
+++ b/homeassistant/components/group/button.py
@@ -122,7 +122,7 @@ class ButtonGroup(GroupEntity, ButtonEntity):
 
     @callback
     def async_update_group_state(self) -> None:
-        """Query all members and determine the switch group state."""
+        """Query all members and determine the button group state."""
         # Set group as unavailable if all members are unavailable or missing
         self._attr_available = any(
             state.state != STATE_UNAVAILABLE

--- a/homeassistant/components/group/button.py
+++ b/homeassistant/components/group/button.py
@@ -1,0 +1,131 @@
+"""Platform allowing several button entities to be grouped into one single button."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components.button import (
+    DOMAIN,
+    PLATFORM_SCHEMA as BUTTON_PLATFORM_SCHEMA,
+    SERVICE_PRESS,
+    ButtonEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_ENTITIES,
+    CONF_NAME,
+    CONF_UNIQUE_ID,
+    STATE_UNAVAILABLE,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv, entity_registry as er
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
+from .entity import GroupEntity
+
+DEFAULT_NAME = "Button group"
+
+# No limit on parallel updates to enable a group calling another group
+PARALLEL_UPDATES = 0
+
+PLATFORM_SCHEMA = BUTTON_PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_ENTITIES): cv.entities_domain(DOMAIN),
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_UNIQUE_ID): cv.string,
+    }
+)
+
+
+async def async_setup_platform(
+    _: HomeAssistant,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    __: DiscoveryInfoType | None = None,
+) -> None:
+    """Set up the button group platform."""
+    async_add_entities(
+        [
+            ButtonGroup(
+                config.get(CONF_UNIQUE_ID),
+                config[CONF_NAME],
+                config[CONF_ENTITIES],
+            )
+        ]
+    )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Initialize button group config entry."""
+    registry = er.async_get(hass)
+    entities = er.async_validate_entity_ids(
+        registry, config_entry.options[CONF_ENTITIES]
+    )
+    async_add_entities(
+        [
+            ButtonGroup(
+                config_entry.entry_id,
+                config_entry.title,
+                entities,
+            )
+        ]
+    )
+
+
+@callback
+def async_create_preview_button(
+    hass: HomeAssistant, name: str, validated_config: dict[str, Any]
+) -> ButtonGroup:
+    """Create a preview button."""
+    return ButtonGroup(
+        None,
+        name,
+        validated_config[CONF_ENTITIES],
+    )
+
+
+class ButtonGroup(GroupEntity, ButtonEntity):
+    """Representation of an button group."""
+
+    _attr_available = False
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        unique_id: str | None,
+        name: str,
+        entity_ids: list[str],
+    ) -> None:
+        """Initialize an event group."""
+        self._entity_ids = entity_ids
+        self._attr_name = name
+        self._attr_extra_state_attributes = {ATTR_ENTITY_ID: entity_ids}
+        self._attr_unique_id = unique_id
+
+    async def async_press(self) -> None:
+        """Forward the press to all buttons in the group."""
+        await self.hass.services.async_call(
+            DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: self._entity_ids},
+            blocking=True,
+            context=self._context,
+        )
+
+    @callback
+    def async_update_group_state(self) -> None:
+        """Query all members and determine the switch group state."""
+        # Set group as unavailable if all members are unavailable or missing
+        self._attr_available = any(
+            state.state != STATE_UNAVAILABLE
+            for entity_id in self._entity_ids
+            if (state := self.hass.states.get(entity_id)) is not None
+        )

--- a/homeassistant/components/group/config_flow.py
+++ b/homeassistant/components/group/config_flow.py
@@ -23,6 +23,7 @@ from homeassistant.helpers.schema_config_entry_flow import (
 )
 
 from .binary_sensor import CONF_ALL, async_create_preview_binary_sensor
+from .button import async_create_preview_button
 from .const import CONF_HIDE_MEMBERS, CONF_IGNORE_NON_NUMERIC, DOMAIN
 from .cover import async_create_preview_cover
 from .entity import GroupEntity
@@ -146,6 +147,7 @@ async def light_switch_options_schema(
 
 GROUP_TYPES = [
     "binary_sensor",
+    "button",
     "cover",
     "event",
     "fan",
@@ -184,6 +186,11 @@ CONFIG_FLOW = {
         BINARY_SENSOR_CONFIG_SCHEMA,
         preview="group",
         validate_user_input=set_group_type("binary_sensor"),
+    ),
+    "button": SchemaFlowFormStep(
+        basic_group_config_schema("button"),
+        preview="group",
+        validate_user_input=set_group_type("button"),
     ),
     "cover": SchemaFlowFormStep(
         basic_group_config_schema("cover"),
@@ -234,6 +241,10 @@ OPTIONS_FLOW = {
         binary_sensor_options_schema,
         preview="group",
     ),
+    "button": SchemaFlowFormStep(
+        partial(basic_group_options_schema, "button"),
+        preview="group",
+    ),
     "cover": SchemaFlowFormStep(
         partial(basic_group_options_schema, "cover"),
         preview="group",
@@ -275,6 +286,7 @@ CREATE_PREVIEW_ENTITY: dict[
     Callable[[HomeAssistant, str, dict[str, Any]], GroupEntity | MediaPlayerGroup],
 ] = {
     "binary_sensor": async_create_preview_binary_sensor,
+    "button": async_create_preview_button,
     "cover": async_create_preview_cover,
     "event": async_create_preview_event,
     "fan": async_create_preview_fan,

--- a/homeassistant/components/group/strings.json
+++ b/homeassistant/components/group/strings.json
@@ -7,6 +7,7 @@
         "description": "Groups allow you to create a new entity that represents multiple entities of the same type.",
         "menu_options": {
           "binary_sensor": "Binary sensor group",
+          "button": "Button group",
           "cover": "Cover group",
           "event": "Event group",
           "fan": "Fan group",
@@ -24,6 +25,14 @@
           "all": "All entities",
           "entities": "Members",
           "hide_members": "Hide members",
+          "name": "[%key:common::config_flow::data::name%]"
+        }
+      },
+      "button": {
+        "title": "[%key:component::group::config::step::user::title%]",
+        "data": {
+          "entities": "[%key:component::group::config::step::binary_sensor::data::entities%]",
+          "hide_members": "[%key:component::group::config::step::binary_sensor::data::hide_members%]",
           "name": "[%key:common::config_flow::data::name%]"
         }
       },
@@ -105,6 +114,12 @@
         "description": "[%key:component::group::config::step::binary_sensor::description%]",
         "data": {
           "all": "[%key:component::group::config::step::binary_sensor::data::all%]",
+          "entities": "[%key:component::group::config::step::binary_sensor::data::entities%]",
+          "hide_members": "[%key:component::group::config::step::binary_sensor::data::hide_members%]"
+        }
+      },
+      "button": {
+        "data": {
           "entities": "[%key:component::group::config::step::binary_sensor::data::entities%]",
           "hide_members": "[%key:component::group::config::step::binary_sensor::data::hide_members%]"
         }

--- a/tests/components/group/test_button.py
+++ b/tests/components/group/test_button.py
@@ -1,0 +1,122 @@
+"""The tests for the group button platform."""
+
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.components.group import DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+
+
+async def test_default_state(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test button group default state."""
+    hass.states.async_set("button.notify_light", "2021-01-01T23:59:59.123+00:00")
+    await async_setup_component(
+        hass,
+        BUTTON_DOMAIN,
+        {
+            BUTTON_DOMAIN: {
+                "platform": DOMAIN,
+                "entities": ["button.notify_light", "button.self_destruct"],
+                "name": "Button group",
+                "unique_id": "unique_identifier",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    state = hass.states.get("button.button_group")
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes.get(ATTR_ENTITY_ID) == [
+        "button.notify_light",
+        "button.self_destruct",
+    ]
+
+    entry = entity_registry.async_get("button.button_group")
+    assert entry
+    assert entry.unique_id == "unique_identifier"
+
+
+async def test_state_reporting(hass: HomeAssistant) -> None:
+    """Test the state reporting.
+
+    The group state is unavailable if all group members are unavailable.
+    Otherwise, the group state represents the last time the grouped button was pressed.
+    """
+    await async_setup_component(
+        hass,
+        BUTTON_DOMAIN,
+        {
+            BUTTON_DOMAIN: {
+                "platform": DOMAIN,
+                "entities": ["button.test1", "button.test2"],
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    # Initial state with no group member in the state machine -> unavailable
+    assert hass.states.get("button.button_group").state == STATE_UNAVAILABLE
+
+    # All group members unavailable -> unavailable
+    hass.states.async_set("button.test1", STATE_UNAVAILABLE)
+    hass.states.async_set("button.test2", STATE_UNAVAILABLE)
+    await hass.async_block_till_done()
+    assert hass.states.get("button.button_group").state == STATE_UNAVAILABLE
+
+    # All group members available, but no group member pressed -> unknown
+    hass.states.async_set("button.test1", "2021-01-01T23:59:59.123+00:00")
+    hass.states.async_set("button.test2", "2022-02-02T23:59:59.123+00:00")
+    await hass.async_block_till_done()
+    assert hass.states.get("button.button_group").state == STATE_UNKNOWN
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_service_calls(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+) -> None:
+    """Test service calls."""
+    await async_setup_component(
+        hass,
+        BUTTON_DOMAIN,
+        {
+            BUTTON_DOMAIN: [
+                {"platform": "demo"},
+                {
+                    "platform": DOMAIN,
+                    "entities": [
+                        "button.push",
+                        "button.self_destruct",
+                    ],
+                },
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("button.button_group").state == STATE_UNKNOWN
+    assert hass.states.get("button.push").state == STATE_UNKNOWN
+
+    now = dt_util.parse_datetime("2021-01-09 12:00:00+00:00")
+    freezer.move_to(now)
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: "button.button_group"},
+        blocking=True,
+    )
+
+    assert hass.states.get("button.button_group").state == now.isoformat()
+    assert hass.states.get("button.push").state == now.isoformat()

--- a/tests/components/group/test_config_flow.py
+++ b/tests/components/group/test_config_flow.py
@@ -29,6 +29,7 @@ from tests.typing import WebSocketGenerator
     [
         ("binary_sensor", "on", "on", {}, {}, {"all": False}, {}),
         ("binary_sensor", "on", "on", {}, {"all": True}, {"all": True}, {}),
+        ("button", STATE_UNKNOWN, "2021-01-01T23:59:59.123+00:00", {}, {}, {}, {}),
         ("cover", "open", "open", {}, {}, {}, {}),
         (
             "event",
@@ -135,6 +136,7 @@ async def test_config_flow(
     ("group_type", "extra_input"),
     [
         ("binary_sensor", {"all": False}),
+        ("button", {}),
         ("cover", {}),
         ("event", {}),
         ("fan", {}),
@@ -212,6 +214,7 @@ def get_suggested(schema, key):
     ("group_type", "member_state", "extra_options", "options_options"),
     [
         ("binary_sensor", "on", {"all": False}, {}),
+        ("button", "2021-01-01T23:59:59.123+00:00", {}, {}),
         ("cover", "open", {}, {}),
         ("event", "2021-01-01T23:59:59.123+00:00", {}, {}),
         ("fan", "on", {}, {}),
@@ -396,6 +399,7 @@ async def test_all_options(
     ("group_type", "extra_input"),
     [
         ("binary_sensor", {"all": False}),
+        ("button", {}),
         ("cover", {}),
         ("event", {}),
         ("fan", {}),
@@ -491,6 +495,7 @@ SENSOR_ATTRS = [{"icon": "mdi:calculator"}, {"max_entity_id": "sensor.input_two"
     ("domain", "extra_user_input", "input_states", "group_state", "extra_attributes"),
     [
         ("binary_sensor", {"all": True}, ["on", "off"], "off", [{}, {}]),
+        ("button", {}, ["", ""], "unknown", [{}, {}]),
         ("cover", {}, ["open", "closed"], "open", COVER_ATTRS),
         ("event", {}, ["", ""], "unknown", EVENT_ATTRS),
         ("fan", {}, ["on", "off"], "on", FAN_ATTRS),
@@ -600,6 +605,7 @@ async def test_config_flow_preview(
     ),
     [
         ("binary_sensor", {"all": True}, {"all": False}, ["on", "off"], "on", [{}, {}]),
+        ("button", {}, {}, ["", ""], "unknown", [{}, {}]),
         ("cover", {}, {}, ["open", "closed"], "open", COVER_ATTRS),
         ("event", {}, {}, ["", ""], "unknown", EVENT_ATTRS),
         ("fan", {}, {}, ["on", "off"], "on", FAN_ATTRS),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support for button entities to groups.


![CleanShot 2024-07-10 at 22 50 52@2x](https://github.com/home-assistant/core/assets/195327/9bba4c30-4fbb-4d89-91e4-03fd77494505)

![CleanShot 2024-07-10 at 22 51 10@2x](https://github.com/home-assistant/core/assets/195327/eff0e23c-f9b4-4d88-a85d-f875afc4980d)

![CleanShot 2024-07-10 at 22 51 22@2x](https://github.com/home-assistant/core/assets/195327/5c96e77b-95d8-4dd4-88bd-b4f34047ae4c)

![CleanShot 2024-07-10 at 22 51 34@2x](https://github.com/home-assistant/core/assets/195327/d1d42f1a-491f-4177-835f-1c17f5eb8d52)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33681

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
