### PR TITLE
Migrate resetting doorbird favorites to a button

### DIFF
--- a/homeassistant/components/doorbird/__init__.py
+++ b/homeassistant/components/doorbird/__init__.py
@@ -79,7 +79,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: DoorBirdConfigEntry) -> 
     name: str | None = door_station_config.get(CONF_NAME)
     events = entry.options.get(CONF_EVENTS, [])
     event_entity_ids: dict[str, str] = {}
-    door_station = ConfiguredDoorBird(device, name, custom_url, token, event_entity_ids)
+    door_station = ConfiguredDoorBird(
+        hass, device, name, custom_url, token, event_entity_ids
+    )
     door_bird_data = DoorBirdData(door_station, info, event_entity_ids)
     door_station.update_events(events)
     # Subscribe to doorbell or motion events
@@ -103,7 +105,7 @@ async def _async_register_events(
 ) -> bool:
     """Register events on device."""
     try:
-        await door_station.async_register_events(hass)
+        await door_station.async_register_events()
     except ClientResponseError:
         persistent_notification.async_create(
             hass,

--- a/homeassistant/components/doorbird/button.py
+++ b/homeassistant/components/doorbird/button.py
@@ -1,15 +1,15 @@
-"""Support for powering relays in a DoorBird video doorbell."""
+"""Support for relays and actions in a DoorBird video doorbell."""
 
 from collections.abc import Callable, Coroutine
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
-from doorbirdpy import DoorBird
-
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .device import ConfiguredDoorBird, async_reset_device_favorites
 from .entity import DoorBirdEntity
 from .models import DoorBirdConfigEntry, DoorBirdData
 
@@ -20,18 +20,25 @@ IR_RELAY = "__ir_light__"
 class DoorbirdButtonEntityDescription(ButtonEntityDescription):
     """Class to describe a Doorbird Button entity."""
 
-    press_action: Callable[[DoorBird, str], Coroutine[Any, Any, bool]]
+    press_action: Callable[[ConfiguredDoorBird, str], Coroutine[Any, Any, bool | None]]
 
 
 RELAY_ENTITY_DESCRIPTION = DoorbirdButtonEntityDescription(
     key="relay",
-    translation_key="relay",
-    press_action=lambda device, relay: device.energize_relay(relay),
+    press_action=lambda door_station, relay: door_station.device.energize_relay(relay),
 )
-IR_ENTITY_DESCRIPTION = DoorbirdButtonEntityDescription(
-    key="ir",
-    translation_key="ir",
-    press_action=lambda device, _: device.turn_light_on(),
+BUTTON_DESCRIPTIONS: tuple[DoorbirdButtonEntityDescription, ...] = (
+    DoorbirdButtonEntityDescription(
+        key="__ir_light__",
+        translation_key="ir",
+        press_action=lambda door_station, _: door_station.device.turn_light_on(),
+    ),
+    DoorbirdButtonEntityDescription(
+        key="reset_favorites",
+        translation_key="reset_favorites",
+        press_action=lambda door_station, _: async_reset_device_favorites(door_station),
+        entity_category=EntityCategory.CONFIG,
+    ),
 )
 
 
@@ -42,40 +49,39 @@ async def async_setup_entry(
 ) -> None:
     """Set up the DoorBird button platform."""
     door_bird_data = config_entry.runtime_data
-    relays = door_bird_data.door_station_info["RELAYS"]
-
+    relays: list[str] = door_bird_data.door_station_info["RELAYS"]
     entities = [
-        DoorBirdButton(door_bird_data, relay, RELAY_ENTITY_DESCRIPTION)
+        DoorBirdButton(
+            door_bird_data,
+            replace(RELAY_ENTITY_DESCRIPTION, name=f"Relay {relay}"),
+            relay,
+        )
         for relay in relays
     ]
-    entities.append(DoorBirdButton(door_bird_data, IR_RELAY, IR_ENTITY_DESCRIPTION))
-
+    entities.extend(
+        DoorBirdButton(door_bird_data, button_description)
+        for button_description in BUTTON_DESCRIPTIONS
+    )
     async_add_entities(entities)
 
 
 class DoorBirdButton(DoorBirdEntity, ButtonEntity):
-    """A relay in a DoorBird device."""
+    """A button for a DoorBird device."""
 
     entity_description: DoorbirdButtonEntityDescription
 
     def __init__(
         self,
         door_bird_data: DoorBirdData,
-        relay: str,
         entity_description: DoorbirdButtonEntityDescription,
+        relay: str | None = None,
     ) -> None:
-        """Initialize a relay in a DoorBird device."""
+        """Initialize a button for a DoorBird device."""
         super().__init__(door_bird_data)
-        self._relay = relay
+        self._relay = relay or ""
         self.entity_description = entity_description
-        if self._relay == IR_RELAY:
-            self._attr_name = "IR"
-        else:
-            self._attr_name = f"Relay {self._relay}"
-        self._attr_unique_id = f"{self._mac_addr}_{self._relay}"
+        self._attr_unique_id = f"{self._mac_addr}_{relay or entity_description.key}"
 
     async def async_press(self) -> None:
-        """Power the relay."""
-        await self.entity_description.press_action(
-            self._door_station.device, self._relay
-        )
+        """Call the press action."""
+        await self.entity_description.press_action(self._door_station, self._relay)

--- a/homeassistant/components/doorbird/strings.json
+++ b/homeassistant/components/doorbird/strings.json
@@ -38,6 +38,14 @@
     }
   },
   "entity": {
+    "button": {
+      "reset_favorites": {
+        "name": "Reset favorites"
+      },
+      "ir": {
+        "name": "IR"
+      }
+    },
     "camera": {
       "live": {
         "name": "live"

--- a/homeassistant/components/doorbird/view.py
+++ b/homeassistant/components/doorbird/view.py
@@ -9,7 +9,6 @@ from aiohttp import web
 from homeassistant.components.http import KEY_HASS, HomeAssistantView
 
 from .const import API_URL, DOMAIN
-from .device import async_reset_device_favorites
 from .util import get_door_station_by_token
 
 
@@ -37,11 +36,6 @@ class DoorBirdRequestView(HomeAssistantView):
             event_data = door_station.get_event_data(event)
         else:
             event_data = {}
-
-        if event == "clear":
-            await async_reset_device_favorites(hass, door_station)
-            message = f"HTTP Favorites cleared for {door_station.slug}"
-            return web.Response(text=message)
 
         #
         # This integration uses a multiple different events.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Previously resetting the device favorites required working out a complicated url. A button is now available to perform this operation.

## Proposed change

Note that there is no deprecation period needed here since this is an uncommon operation only used to cleanup when the Home Assistant url changes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33683

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
