### PR TITLE
Add notify entity to mobile app

### DIFF
--- a/homeassistant/components/mobile_app/__init__.py
+++ b/homeassistant/components/mobile_app/__init__.py
@@ -49,7 +49,12 @@ from .http_api import RegistrationsView
 from .util import async_create_cloud_hook
 from .webhook import handle_webhook
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.DEVICE_TRACKER, Platform.SENSOR]
+PLATFORMS = [
+    Platform.BINARY_SENSOR,
+    Platform.DEVICE_TRACKER,
+    Platform.NOTIFY,
+    Platform.SENSOR,
+]
 
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 

--- a/homeassistant/components/mobile_app/notify.py
+++ b/homeassistant/components/mobile_app/notify.py
@@ -16,10 +16,15 @@ from homeassistant.components.notify import (
     ATTR_TITLE,
     ATTR_TITLE_DEFAULT,
     BaseNotificationService,
+    NotifyEntity,
+    NotifyEntityFeature,
 )
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_DEVICE_ID, CONF_WEBHOOK_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 import homeassistant.util.dt as dt_util
 
@@ -42,6 +47,8 @@ from .const import (
     DATA_PUSH_CHANNEL,
     DOMAIN,
 )
+from .helpers import device_info
+from .push_notification import PushChannel
 from .util import supports_push
 
 _LOGGER = logging.getLogger(__name__)
@@ -124,81 +131,144 @@ class MobileAppNotificationService(BaseNotificationService):
             data[ATTR_DATA] = kwargs.get(ATTR_DATA)
 
         local_push_channels = self.hass.data[DOMAIN][DATA_PUSH_CHANNEL]
-
         for target in targets:
             registration = self.hass.data[DOMAIN][DATA_CONFIG_ENTRIES][target].data
+            send_remote_message = partial(
+                _async_send_remote_message_target, self.hass, target, registration
+            )
 
             if target in local_push_channels:
                 local_push_channels[target].async_send_notification(
-                    data,
-                    partial(
-                        self._async_send_remote_message_target, target, registration
-                    ),
+                    data, send_remote_message
                 )
                 continue
 
             # Test if local push only.
             if ATTR_PUSH_URL not in registration[ATTR_APP_DATA]:
                 raise HomeAssistantError(
-                    "Device not connected to local push notifications"
+                    translation_domain=DOMAIN,
+                    translation_key="not_connected_local_push",
                 )
 
-            await self._async_send_remote_message_target(target, registration, data)
+            await send_remote_message(data)
 
-    async def _async_send_remote_message_target(self, target, registration, data):
-        """Send a message to a target."""
-        app_data = registration[ATTR_APP_DATA]
-        push_token = app_data[ATTR_PUSH_TOKEN]
-        push_url = app_data[ATTR_PUSH_URL]
 
-        target_data = dict(data)
-        target_data[ATTR_PUSH_TOKEN] = push_token
+async def _async_send_remote_message_target(hass, target, registration, data):
+    """Send a message to a target."""
+    app_data = registration[ATTR_APP_DATA]
+    push_token = app_data[ATTR_PUSH_TOKEN]
+    push_url = app_data[ATTR_PUSH_URL]
 
-        reg_info = {
-            ATTR_APP_ID: registration[ATTR_APP_ID],
-            ATTR_APP_VERSION: registration[ATTR_APP_VERSION],
-            ATTR_WEBHOOK_ID: target,
-        }
-        if ATTR_OS_VERSION in registration:
-            reg_info[ATTR_OS_VERSION] = registration[ATTR_OS_VERSION]
+    target_data = dict(data)
+    target_data[ATTR_PUSH_TOKEN] = push_token
 
-        target_data["registration_info"] = reg_info
+    reg_info = {
+        ATTR_APP_ID: registration[ATTR_APP_ID],
+        ATTR_APP_VERSION: registration[ATTR_APP_VERSION],
+        ATTR_WEBHOOK_ID: target,
+    }
+    if ATTR_OS_VERSION in registration:
+        reg_info[ATTR_OS_VERSION] = registration[ATTR_OS_VERSION]
 
-        try:
-            async with asyncio.timeout(10):
-                response = await async_get_clientsession(self._hass).post(
-                    push_url, json=target_data
-                )
-                result = await response.json()
+    target_data["registration_info"] = reg_info
 
-            if response.status in (
-                HTTPStatus.OK,
-                HTTPStatus.CREATED,
-                HTTPStatus.ACCEPTED,
-            ):
-                log_rate_limits(self.hass, registration[ATTR_DEVICE_NAME], result)
-                return
-
-            fallback_error = result.get("errorMessage", "Unknown error")
-            fallback_message = (
-                f"Internal server error, please try again later: {fallback_error}"
+    try:
+        async with asyncio.timeout(10):
+            response = await async_get_clientsession(hass).post(
+                push_url, json=target_data
             )
-            message = result.get("message", fallback_message)
+            result = await response.json()
 
-            if "message" in result:
-                if message[-1] not in [".", "?", "!"]:
-                    message += "."
-                message += " This message is generated externally to Home Assistant."
+        if response.status in (
+            HTTPStatus.OK,
+            HTTPStatus.CREATED,
+            HTTPStatus.ACCEPTED,
+        ):
+            log_rate_limits(hass, registration[ATTR_DEVICE_NAME], result)
+            return
 
-            if response.status == HTTPStatus.TOO_MANY_REQUESTS:
-                _LOGGER.warning(message)
-                log_rate_limits(
-                    self.hass, registration[ATTR_DEVICE_NAME], result, logging.WARNING
-                )
-            else:
-                _LOGGER.error(message)
+        fallback_error = result.get("errorMessage", "Unknown error")
+        fallback_message = (
+            f"Internal server error, please try again later: {fallback_error}"
+        )
+        message = result.get("message", fallback_message)
 
-        except TimeoutError:
-            _LOGGER.error("Timeout sending notification to %s", push_url)
-        except aiohttp.ClientError as err:
-            _LOGGER.error("Error sending notification to %s: %r", push_url, err)
+        if "message" in result:
+            if message[-1] not in [".", "?", "!"]:
+                message += "."
+            message += " This message is generated externally to Home Assistant."
+
+        if response.status == HTTPStatus.TOO_MANY_REQUESTS:
+            _LOGGER.warning(message)
+            log_rate_limits(
+                hass, registration[ATTR_DEVICE_NAME], result, logging.WARNING
+            )
+        else:
+            _LOGGER.error(message)
+
+    except TimeoutError:
+        _LOGGER.error("Timeout sending notification to %s", push_url)
+    except aiohttp.ClientError as err:
+        _LOGGER.error("Error sending notification to %s: %r", push_url, err)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the demo entity platform."""
+    registration = config_entry.data
+
+    if not supports_push(hass, registration[CONF_WEBHOOK_ID]):
+        _LOGGER.debug("Target does not support push")
+        return
+
+    async_add_entities([MobileAppNotifyEntity(dict(registration))])
+
+
+class MobileAppNotifyEntity(NotifyEntity):
+    """Implement demo notification platform."""
+
+    _attr_has_entity_name = True
+    _attr_name = None
+    _attr_supported_features = NotifyEntityFeature.TITLE
+
+    def __init__(
+        self,
+        registration: dict,
+    ) -> None:
+        """Initialize the Demo button entity."""
+        self._registration = registration
+        self._attr_unique_id = registration[ATTR_DEVICE_ID]
+        self._attr_device_info = device_info(registration)
+
+    async def async_send_message(self, message: str, title: str | None = None) -> None:
+        """Send a message to a user."""
+
+        data = {ATTR_MESSAGE: message}
+
+        # Remove default title from notifications.
+        if title is not None and title != ATTR_TITLE_DEFAULT:
+            data[ATTR_TITLE] = title
+
+        target = self._registration[CONF_WEBHOOK_ID]
+        push_channels: dict[str, PushChannel] = self.hass.data[DOMAIN][
+            DATA_PUSH_CHANNEL
+        ]
+        send_remote_message = partial(
+            _async_send_remote_message_target, self.hass, target, self._registration
+        )
+
+        if push_channel := push_channels.get(target):
+            push_channel.async_send_notification(data, send_remote_message)
+            return
+
+        # Test if local push only.
+        if ATTR_PUSH_URL not in self._registration[ATTR_APP_DATA]:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="not_connected_local_push",
+            )
+
+        await send_remote_message(data)

--- a/homeassistant/components/mobile_app/strings.json
+++ b/homeassistant/components/mobile_app/strings.json
@@ -18,5 +18,10 @@
       "message": "Message",
       "title": "Title"
     }
+  },
+  "exceptions": {
+    "not_connected_local_push": {
+      "message": "Device not connected to local push notifications."
+    }
   }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add notify entity support to mobile_app. Currently the notify entity's doesn't support data blocks, thus legacy notify platform remain supported.

Note: Diff looks larger than it is. Turn on "Hide white space", to see a more easilty reviewable change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to discussion: https://github.com/home-assistant/architecture/discussions/1041 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
