### PR TITLE
Remove filtering of user data in Habitica integration

### DIFF
--- a/homeassistant/components/habitica/const.py
+++ b/homeassistant/components/habitica/const.py
@@ -20,6 +20,4 @@ ATTR_DATA = "data"
 MANUFACTURER = "HabitRPG, Inc."
 NAME = "Habitica"
 
-ADDITIONAL_USER_FIELDS: set[str] = {"lastCron"}
-
 UNIT_TASKS = "tasks"

--- a/homeassistant/components/habitica/coordinator.py
+++ b/homeassistant/components/habitica/coordinator.py
@@ -17,7 +17,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import ADDITIONAL_USER_FIELDS, DOMAIN
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -46,10 +46,8 @@ class HabiticaDataUpdateCoordinator(DataUpdateCoordinator[HabiticaData]):
         self.api = habitipy
 
     async def _async_update_data(self) -> HabiticaData:
-        user_fields = set(self.async_contexts()) | ADDITIONAL_USER_FIELDS
-
         try:
-            user_response = await self.api.user.get(userFields=",".join(user_fields))
+            user_response = await self.api.user.get()
             tasks_response = await self.api.tasks.user.get()
             tasks_response.extend(await self.api.tasks.user.get(type="completedTodos"))
         except ClientResponseError as error:

--- a/homeassistant/components/habitica/entity.py
+++ b/homeassistant/components/habitica/entity.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from homeassistant.const import CONF_NAME, CONF_URL
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
@@ -22,10 +22,9 @@ class HabiticaBase(CoordinatorEntity[HabiticaDataUpdateCoordinator]):
         self,
         coordinator: HabiticaDataUpdateCoordinator,
         entity_description: EntityDescription,
-        context: Any = None,
     ) -> None:
         """Initialize a Habitica entity."""
-        super().__init__(coordinator, context)
+        super().__init__(coordinator)
         if TYPE_CHECKING:
             assert coordinator.config_entry.unique_id
         self.entity_description = entity_description

--- a/homeassistant/components/habitica/sensor.py
+++ b/homeassistant/components/habitica/sensor.py
@@ -26,7 +26,6 @@ from homeassistant.helpers.typing import StateType
 
 from . import HabiticaConfigEntry
 from .const import DOMAIN, UNIT_TASKS
-from .coordinator import HabiticaDataUpdateCoordinator
 from .entity import HabiticaBase
 from .util import entity_used_in
 
@@ -38,7 +37,6 @@ class HabitipySensorEntityDescription(SensorEntityDescription):
     """Habitipy Sensor Description."""
 
     value_fn: Callable[[dict[str, Any]], StateType]
-    ctx: str
 
 
 @dataclass(kw_only=True, frozen=True)
@@ -72,7 +70,6 @@ SENSOR_DESCRIPTIONS: tuple[HabitipySensorEntityDescription, ...] = (
         key=HabitipySensorEntity.DISPLAY_NAME,
         translation_key=HabitipySensorEntity.DISPLAY_NAME,
         value_fn=lambda user: user.get("profile", {}).get("name"),
-        ctx="profile",
     ),
     HabitipySensorEntityDescription(
         key=HabitipySensorEntity.HEALTH,
@@ -80,7 +77,6 @@ SENSOR_DESCRIPTIONS: tuple[HabitipySensorEntityDescription, ...] = (
         native_unit_of_measurement="HP",
         suggested_display_precision=0,
         value_fn=lambda user: user.get("stats", {}).get("hp"),
-        ctx="stats",
     ),
     HabitipySensorEntityDescription(
         key=HabitipySensorEntity.HEALTH_MAX,
@@ -88,7 +84,6 @@ SENSOR_DESCRIPTIONS: tuple[HabitipySensorEntityDescription, ...] = (
         native_unit_of_measurement="HP",
         entity_registry_enabled_default=False,
         value_fn=lambda user: user.get("stats", {}).get("maxHealth"),
-        ctx="stats",
     ),
     HabitipySensorEntityDescription(
         key=HabitipySensorEntity.MANA,
@@ -96,34 +91,29 @@ SENSOR_DESCRIPTIONS: tuple[HabitipySensorEntityDescription, ...] = (
         native_unit_of_measurement="MP",
         suggested_display_precision=0,
         value_fn=lambda user: user.get("stats", {}).get("mp"),
-        ctx="stats",
     ),
     HabitipySensorEntityDescription(
         key=HabitipySensorEntity.MANA_MAX,
         translation_key=HabitipySensorEntity.MANA_MAX,
         native_unit_of_measurement="MP",
         value_fn=lambda user: user.get("stats", {}).get("maxMP"),
-        ctx="stats",
     ),
     HabitipySensorEntityDescription(
         key=HabitipySensorEntity.EXPERIENCE,
         translation_key=HabitipySensorEntity.EXPERIENCE,
         native_unit_of_measurement="XP",
         value_fn=lambda user: user.get("stats", {}).get("exp"),
-        ctx="stats",
     ),
     HabitipySensorEntityDescription(
         key=HabitipySensorEntity.EXPERIENCE_MAX,
         translation_key=HabitipySensorEntity.EXPERIENCE_MAX,
         native_unit_of_measurement="XP",
         value_fn=lambda user: user.get("stats", {}).get("toNextLevel"),
-        ctx="stats",
     ),
     HabitipySensorEntityDescription(
         key=HabitipySensorEntity.LEVEL,
         translation_key=HabitipySensorEntity.LEVEL,
         value_fn=lambda user: user.get("stats", {}).get("lvl"),
-        ctx="stats",
     ),
     HabitipySensorEntityDescription(
         key=HabitipySensorEntity.GOLD,
@@ -131,7 +121,6 @@ SENSOR_DESCRIPTIONS: tuple[HabitipySensorEntityDescription, ...] = (
         native_unit_of_measurement="GP",
         suggested_display_precision=2,
         value_fn=lambda user: user.get("stats", {}).get("gp"),
-        ctx="stats",
     ),
     HabitipySensorEntityDescription(
         key=HabitipySensorEntity.CLASS,
@@ -139,7 +128,6 @@ SENSOR_DESCRIPTIONS: tuple[HabitipySensorEntityDescription, ...] = (
         value_fn=lambda user: user.get("stats", {}).get("class"),
         device_class=SensorDeviceClass.ENUM,
         options=["warrior", "healer", "wizard", "rogue"],
-        ctx="stats",
     ),
 )
 
@@ -225,18 +213,6 @@ class HabitipySensor(HabiticaBase, SensorEntity):
     """A generic Habitica sensor."""
 
     entity_description: HabitipySensorEntityDescription
-
-    def __init__(
-        self,
-        coordinator: HabiticaDataUpdateCoordinator,
-        entity_description: HabitipySensorEntityDescription,
-    ) -> None:
-        """Initialize a generic Habitica sensor."""
-        super().__init__(
-            coordinator,
-            entity_description,
-            context=entity_description.ctx,
-        )
 
     @property
     def native_value(self) -> StateType:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This removes currently not needed code from the Habitica integration. The filtering of userFields when fetching user data was not only dysfunctional but cannot be used anymore, since the Habitica API doesn't allow to filter for the field `needsCron`.  This field is required for the `Start my day` entity. Therefore the code is removed completely until this is fixed in the Habitica API. 

- https://github.com/HabitRPG/habitica/pull/15266


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
