### PR TITLE
Allow nightly Mealie versions to pass

### DIFF
--- a/homeassistant/components/mealie/__init__.py
+++ b/homeassistant/components/mealie/__init__.py
@@ -57,7 +57,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MealieConfigEntry) -> bo
 
     if not version.valid:
         LOGGER.warning(
-            "It seems like you are using the nightly version of Mealie. The integration could stop working with older nightlies, so please make sure your version is up-to-date"
+            "It seems like you are using the nightly version of Mealie, nightly versions could have changes that stop this integration working"
         )
     if version.valid and version < MIN_REQUIRED_MEALIE_VERSION:
         raise ConfigEntryError(

--- a/homeassistant/components/mealie/__init__.py
+++ b/homeassistant/components/mealie/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DOMAIN, MIN_REQUIRED_MEALIE_VERSION
+from .const import DOMAIN, LOGGER, MIN_REQUIRED_MEALIE_VERSION
 from .coordinator import (
     MealieConfigEntry,
     MealieData,
@@ -55,6 +55,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: MealieConfigEntry) -> bo
     except MealieConnectionError as error:
         raise ConfigEntryNotReady(error) from error
 
+    if not version.valid:
+        LOGGER.warning(
+            "It seems like you are using the nightly version of Mealie. The integration could stop working with older nightlies, so please make sure your version is up-to-date"
+        )
     if version.valid and version < MIN_REQUIRED_MEALIE_VERSION:
         raise ConfigEntryError(
             translation_domain=DOMAIN,

--- a/homeassistant/components/mealie/__init__.py
+++ b/homeassistant/components/mealie/__init__.py
@@ -55,7 +55,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MealieConfigEntry) -> bo
     except MealieConnectionError as error:
         raise ConfigEntryNotReady(error) from error
 
-    if not version.valid or version < MIN_REQUIRED_MEALIE_VERSION:
+    if version.valid and version < MIN_REQUIRED_MEALIE_VERSION:
         raise ConfigEntryError(
             translation_domain=DOMAIN,
             translation_key="version_error",

--- a/homeassistant/components/mealie/config_flow.py
+++ b/homeassistant/components/mealie/config_flow.py
@@ -55,7 +55,7 @@ class MealieConfigFlow(ConfigFlow, domain=DOMAIN):
         except Exception:  # noqa: BLE001
             LOGGER.exception("Unexpected error")
             return {"base": "unknown"}, None
-        if not version.valid or version < MIN_REQUIRED_MEALIE_VERSION:
+        if version.valid and version < MIN_REQUIRED_MEALIE_VERSION:
             return {"base": "mealie_version"}, None
         return {}, info.user_id
 

--- a/tests/components/mealie/test_config_flow.py
+++ b/tests/components/mealie/test_config_flow.py
@@ -91,7 +91,6 @@ async def test_flow_errors(
         ("v1.0.0beta-5"),
         ("v1.0.0-RC2"),
         ("v0.1.0"),
-        ("something"),
     ],
 )
 async def test_flow_version_error(

--- a/tests/components/mealie/test_init.py
+++ b/tests/components/mealie/test_init.py
@@ -90,12 +90,17 @@ async def test_setup_invalid(
     hass: HomeAssistant,
     mock_mealie_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test setup of Mealie entry with too old version of Mealie."""
     mock_mealie_client.get_about.return_value = About(version="nightly")
 
     await setup_integration(hass, mock_config_entry)
 
+    assert (
+        "It seems like you are using the nightly version of Mealie, nightly versions could have changes that stop this integration working"
+        in caplog.text
+    )
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
 

--- a/tests/components/mealie/test_init.py
+++ b/tests/components/mealie/test_init.py
@@ -86,6 +86,19 @@ async def test_setup_too_old(
     assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
+async def test_setup_invalid(
+    hass: HomeAssistant,
+    mock_mealie_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test setup of Mealie entry with too old version of Mealie."""
+    mock_mealie_client.get_about.return_value = About(version="nightly")
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+
 async def test_load_unload_entry(
     hass: HomeAssistant,
     mock_mealie_client: AsyncMock,

--- a/tests/components/mealie/test_init.py
+++ b/tests/components/mealie/test_init.py
@@ -70,7 +70,6 @@ async def test_setup_failure(
         ("v1.0.0beta-5"),
         ("v1.0.0-RC2"),
         ("v0.1.0"),
-        ("something"),
     ],
 )
 async def test_setup_too_old(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Where the Mealie version is invalid in AwesomeVersion allow integration to setup/load to cope with nightly builds.
Still checks valid versions and the "beta-" format.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
