### PR TITLE
Improve rate limit handling in Habitica integration

### DIFF
--- a/homeassistant/components/habitica/button.py
+++ b/homeassistant/components/habitica/button.py
@@ -113,7 +113,7 @@ class HabiticaButton(HabiticaBase, ButtonEntity):
                 translation_key="service_call_exception",
             ) from e
         else:
-            await self.coordinator.async_refresh()
+            await self.coordinator.async_request_refresh()
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/habitica/coordinator.py
+++ b/homeassistant/components/habitica/coordinator.py
@@ -15,6 +15,7 @@ from habitipy.aio import HabitipyAsync
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import ADDITIONAL_USER_FIELDS, DOMAIN
@@ -42,6 +43,12 @@ class HabiticaDataUpdateCoordinator(DataUpdateCoordinator[HabiticaData]):
             _LOGGER,
             name=DOMAIN,
             update_interval=timedelta(seconds=60),
+            request_refresh_debouncer=Debouncer(
+                hass,
+                _LOGGER,
+                cooldown=5,
+                immediate=False,
+            ),
         )
         self.api = habitipy
 

--- a/homeassistant/components/habitica/coordinator.py
+++ b/homeassistant/components/habitica/coordinator.py
@@ -85,4 +85,4 @@ class HabiticaDataUpdateCoordinator(DataUpdateCoordinator[HabiticaData]):
                 translation_key="service_call_exception",
             ) from e
         else:
-            await self.async_refresh()
+            await self.async_request_refresh()

--- a/homeassistant/components/habitica/todo.py
+++ b/homeassistant/components/habitica/todo.py
@@ -112,6 +112,18 @@ class BaseHabiticaListEntity(HabiticaBase, TodoListEntity):
                 translation_key=f"move_{self.entity_description.key}_item_failed",
                 translation_placeholders={"pos": str(pos)},
             ) from e
+        else:
+            # move tasks in the coordinator until we have fresh data
+            tasks = self.coordinator.data.tasks
+            new_pos = (
+                tasks.index(next(task for task in tasks if task["id"] == previous_uid))
+                + 1
+                if previous_uid
+                else 0
+            )
+            old_pos = tasks.index(next(task for task in tasks if task["id"] == uid))
+            tasks.insert(new_pos, tasks.pop(old_pos))
+            await self.coordinator.async_request_refresh()
 
     async def async_update_todo_item(self, item: TodoItem) -> None:
         """Update a Habitica todo."""

--- a/homeassistant/components/habitica/todo.py
+++ b/homeassistant/components/habitica/todo.py
@@ -133,18 +133,23 @@ class BaseHabiticaListEntity(HabiticaBase, TodoListEntity):
         else:
             date = None
 
-        try:
-            await self.coordinator.api.tasks[item.uid].put(
-                text=item.summary,
-                notes=item.description or "",
-                date=date,
-            )
-        except ClientResponseError as e:
-            raise ServiceValidationError(
-                translation_domain=DOMAIN,
-                translation_key=f"update_{self.entity_description.key}_item_failed",
-                translation_placeholders={"name": item.summary or ""},
-            ) from e
+        if (
+            item.summary != current_item.summary
+            or item.description != current_item.description
+            or item.due != current_item.due
+        ):
+            try:
+                await self.coordinator.api.tasks[item.uid].put(
+                    text=item.summary,
+                    notes=item.description or "",
+                    date=date,
+                )
+            except ClientResponseError as e:
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key=f"update_{self.entity_description.key}_item_failed",
+                    translation_placeholders={"name": item.summary or ""},
+                ) from e
 
         try:
             # Score up or down if item status changed

--- a/homeassistant/components/habitica/todo.py
+++ b/homeassistant/components/habitica/todo.py
@@ -84,7 +84,7 @@ class BaseHabiticaListEntity(HabiticaBase, TodoListEntity):
                     translation_key=f"delete_{self.entity_description.key}_failed",
                 ) from e
 
-        await self.coordinator.async_refresh()
+        await self.coordinator.async_request_refresh()
 
     async def async_move_todo_item(
         self, uid: str, previous_uid: str | None = None
@@ -186,7 +186,7 @@ class BaseHabiticaListEntity(HabiticaBase, TodoListEntity):
                 self.hass, message=msg, title="Habitica"
             )
 
-        await self.coordinator.async_refresh()
+        await self.coordinator.async_request_refresh()
 
 
 class HabiticaTodosListEntity(BaseHabiticaListEntity):
@@ -250,7 +250,7 @@ class HabiticaTodosListEntity(BaseHabiticaListEntity):
                 translation_placeholders={"name": item.summary or ""},
             ) from e
 
-        await self.coordinator.async_refresh()
+        await self.coordinator.async_request_refresh()
 
 
 class HabiticaDailiesListEntity(BaseHabiticaListEntity):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR makes some adjustments to improve the handling of rate limits in the Habitica integration. The Habitica API has a rate limit of 30 requests per 60s. The update coordinator consumes 3 requests per update. 
- Update coordinator will now skip the update if user is rate limited, instead of raising `UpdateFailed` and drawing all entities unavailable while rate limited.
- Update interval of coordinator raised to 60s.
- When updating a to-do item, it will now be checked if summary, description or date were changed. When only the status of a to-do item is changed, now one less request is sent to the Habitica API (4 instead of 5). 
- Check if the details or the status of a to-do item were actually changed before requesting a coordinator refresh
- Added a debouncer for the forced coordinator refresh in to-do lists and buttons/switches. In theory (if done within 5s) this should allow to perform up to 24 changes to to-do items before beeing rate limited. This reduces the responsiveness in the frontend a bit but shouldn't be too annoying.
- Due to the delayed coordinator refresh, the sort order is provisionally updated in the coordinator, otherwise subsequent position changes will be determined based on an outdated ordering of the to-do items

With these adjustments now it should be possible to make 6-7 changes (or up to 24 if done consecutively within 5s) in the to-do lists until the user is rate limited. (4 changes before)



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
