### PR TITLE
Add config flow to worldclock

### DIFF
--- a/homeassistant/components/worldclock/__init__.py
+++ b/homeassistant/components/worldclock/__init__.py
@@ -7,7 +7,7 @@ from .const import PLATFORMS
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up Worlc clock from a config entry."""
+    """Set up Worldclock from a config entry."""
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(update_listener))

--- a/homeassistant/components/worldclock/__init__.py
+++ b/homeassistant/components/worldclock/__init__.py
@@ -1,1 +1,25 @@
 """The worldclock component."""
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import PLATFORMS
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Worlc clock from a config entry."""
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    entry.async_on_unload(entry.add_update_listener(update_listener))
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload World clock config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle options update."""
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/homeassistant/components/worldclock/config_flow.py
+++ b/homeassistant/components/worldclock/config_flow.py
@@ -1,0 +1,86 @@
+"""Config flow for World clock."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, cast
+import zoneinfo
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_NAME, CONF_TIME_ZONE
+from homeassistant.helpers.schema_config_entry_flow import (
+    SchemaCommonFlowHandler,
+    SchemaConfigFlowHandler,
+    SchemaFlowFormStep,
+)
+from homeassistant.helpers.selector import (
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+    TextSelector,
+)
+
+from .const import CONF_TIME_FORMAT, DEFAULT_NAME, DEFAULT_TIME_STR_FORMAT, DOMAIN
+
+
+async def validate_duplicate(
+    handler: SchemaCommonFlowHandler, user_input: dict[str, Any]
+) -> dict[str, Any]:
+    """Validate already existing entry."""
+    handler.parent_handler._async_abort_entries_match({**handler.options, **user_input})  # noqa: SLF001
+
+    return user_input
+
+
+async def get_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
+    """Get available timezones."""
+    get_timezones: list[str] = list(
+        await handler.parent_handler.hass.async_add_executor_job(
+            zoneinfo.available_timezones
+        )
+    )
+    return vol.Schema(
+        {
+            vol.Required(CONF_NAME, default=DEFAULT_NAME): TextSelector(),
+            vol.Required(CONF_TIME_ZONE): SelectSelector(
+                SelectSelectorConfig(
+                    options=get_timezones, mode=SelectSelectorMode.DROPDOWN, sort=True
+                )
+            ),
+        }
+    ).extend(DATA_SCHEMA_OPTIONS.schema)
+
+
+DATA_SCHEMA_OPTIONS = vol.Schema(
+    {vol.Optional(CONF_TIME_FORMAT, default=DEFAULT_TIME_STR_FORMAT): TextSelector()}
+)
+
+
+CONFIG_FLOW = {
+    "user": SchemaFlowFormStep(
+        schema=get_schema,
+        validate_user_input=validate_duplicate,
+    ),
+    "import": SchemaFlowFormStep(
+        schema=get_schema,
+        validate_user_input=validate_duplicate,
+    ),
+}
+OPTIONS_FLOW = {
+    "init": SchemaFlowFormStep(
+        DATA_SCHEMA_OPTIONS,
+        validate_user_input=validate_duplicate,
+    )
+}
+
+
+class WorldclockConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
+    """Handle a config flow for Worldclock."""
+
+    config_flow = CONFIG_FLOW
+    options_flow = OPTIONS_FLOW
+
+    def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
+        """Return config entry title."""
+        return cast(str, options[CONF_NAME])

--- a/homeassistant/components/worldclock/config_flow.py
+++ b/homeassistant/components/worldclock/config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.schema_config_entry_flow import (
     SchemaFlowFormStep,
 )
 from homeassistant.helpers.selector import (
+    SelectOptionDict,
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
@@ -22,6 +23,18 @@ from homeassistant.helpers.selector import (
 )
 
 from .const import CONF_TIME_FORMAT, DEFAULT_NAME, DEFAULT_TIME_STR_FORMAT, DOMAIN
+
+TIME_STR_OPTIONS = [
+    SelectOptionDict(
+        value=DEFAULT_TIME_STR_FORMAT, label=f"14:05 ({DEFAULT_TIME_STR_FORMAT})"
+    ),
+    SelectOptionDict(value="%I:%M %p", label="11:05 am (%I:%M %p)"),
+    SelectOptionDict(value="%Y-%m-%d %H:%M", label="2024-01-01 14:05 (%Y-%m-%d %H:%M)"),
+    SelectOptionDict(
+        value="%a, %b %d, %Y %I:%M %p",
+        label="Monday, Jan 01, 2024 11:05 am (%a, %b %d, %Y %I:%M %p)",
+    ),
+]
 
 
 async def validate_duplicate(
@@ -53,7 +66,15 @@ async def get_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
 
 
 DATA_SCHEMA_OPTIONS = vol.Schema(
-    {vol.Optional(CONF_TIME_FORMAT, default=DEFAULT_TIME_STR_FORMAT): TextSelector()}
+    {
+        vol.Optional(CONF_TIME_FORMAT, default=DEFAULT_TIME_STR_FORMAT): SelectSelector(
+            SelectSelectorConfig(
+                options=TIME_STR_OPTIONS,
+                custom_value=True,
+                mode=SelectSelectorMode.DROPDOWN,
+            )
+        )
+    }
 )
 
 

--- a/homeassistant/components/worldclock/const.py
+++ b/homeassistant/components/worldclock/const.py
@@ -1,0 +1,11 @@
+"""Constants for world clock component."""
+
+from homeassistant.const import Platform
+
+DOMAIN = "worldclock"
+PLATFORMS = [Platform.SENSOR]
+
+CONF_TIME_FORMAT = "time_format"
+
+DEFAULT_NAME = "Worldclock Sensor"
+DEFAULT_TIME_STR_FORMAT = "%H:%M"

--- a/homeassistant/components/worldclock/manifest.json
+++ b/homeassistant/components/worldclock/manifest.json
@@ -2,6 +2,7 @@
   "domain": "worldclock",
   "name": "Worldclock",
   "codeowners": ["@fabaff"],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/worldclock",
   "iot_class": "local_push",
   "quality_scale": "internal"

--- a/homeassistant/components/worldclock/sensor.py
+++ b/homeassistant/components/worldclock/sensor.py
@@ -10,17 +10,16 @@ from homeassistant.components.sensor import (
     PLATFORM_SCHEMA as SENSOR_PLATFORM_SCHEMA,
     SensorEntity,
 )
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_NAME, CONF_TIME_ZONE
-from homeassistant.core import HomeAssistant
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 import homeassistant.util.dt as dt_util
 
-CONF_TIME_FORMAT = "time_format"
-
-DEFAULT_NAME = "Worldclock Sensor"
-DEFAULT_TIME_STR_FORMAT = "%H:%M"
+from .const import CONF_TIME_FORMAT, DEFAULT_NAME, DEFAULT_TIME_STR_FORMAT, DOMAIN
 
 PLATFORM_SCHEMA = SENSOR_PLATFORM_SCHEMA.extend(
     {
@@ -38,13 +37,44 @@ async def async_setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the World clock sensor."""
-    time_zone = dt_util.get_time_zone(config[CONF_TIME_ZONE])
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_IMPORT},
+            data=config,
+        )
+    )
+
+    async_create_issue(
+        hass,
+        HOMEASSISTANT_DOMAIN,
+        f"deprecated_yaml_{DOMAIN}",
+        breaks_in_ha_version="2025.2.0",
+        is_fixable=False,
+        issue_domain=DOMAIN,
+        severity=IssueSeverity.WARNING,
+        translation_key="deprecated_yaml",
+        translation_placeholders={
+            "domain": DOMAIN,
+            "integration_title": "Worldclock",
+        },
+    )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the World clock sensor entry."""
+    time_zone = await dt_util.async_get_time_zone(entry.options[CONF_TIME_ZONE])
     async_add_entities(
         [
             WorldClockSensor(
                 time_zone,
-                config[CONF_NAME],
-                config[CONF_TIME_FORMAT],
+                entry.options[CONF_NAME],
+                entry.options[CONF_TIME_FORMAT],
+                entry.entry_id,
             )
         ],
         True,
@@ -56,11 +86,14 @@ class WorldClockSensor(SensorEntity):
 
     _attr_icon = "mdi:clock"
 
-    def __init__(self, time_zone: tzinfo | None, name: str, time_format: str) -> None:
+    def __init__(
+        self, time_zone: tzinfo | None, name: str, time_format: str, unique_id: str
+    ) -> None:
         """Initialize the sensor."""
         self._attr_name = name
         self._time_zone = time_zone
         self._time_format = time_format
+        self._attr_unique_id = unique_id
 
     async def async_update(self) -> None:
         """Get the time and updates the states."""

--- a/homeassistant/components/worldclock/strings.json
+++ b/homeassistant/components/worldclock/strings.json
@@ -3,9 +3,6 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
     },
-    "error": {
-      "incorrect_time_format": "the provided time format is incorrect"
-    },
     "step": {
       "user": {
         "data": {
@@ -23,9 +20,6 @@
   "options": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
-    },
-    "error": {
-      "incorrect_time_format": "[%key:component::worldclock::config::error::incorrect_time_format%]"
     },
     "step": {
       "init": {

--- a/homeassistant/components/worldclock/strings.json
+++ b/homeassistant/components/worldclock/strings.json
@@ -1,0 +1,41 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
+    },
+    "error": {
+      "incorrect_time_format": "the provided time format is incorrect"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "name": "[%key:common::config_flow::data::name%]",
+          "time_zone": "Timezone",
+          "time_format": "Time format"
+        },
+        "data_description": {
+          "time_zone": "Select timezone from list",
+          "time_format": "Change the time format if needed, by default is represented by hours and minutes."
+        }
+      }
+    }
+  },
+  "options": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
+    },
+    "error": {
+      "incorrect_time_format": "[%key:component::worldclock::config::error::incorrect_time_format%]"
+    },
+    "step": {
+      "init": {
+        "data": {
+          "time_format": "[%key:component::worldclock::config::step::user::data::time_format%]"
+        },
+        "data_description": {
+          "time_format": "[%key:component::worldclock::config::step::user::data_description::time_format%]"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/worldclock/strings.json
+++ b/homeassistant/components/worldclock/strings.json
@@ -12,7 +12,7 @@
         },
         "data_description": {
           "time_zone": "Select timezone from list",
-          "time_format": "Change the time format if needed, by default is represented by hours and minutes."
+          "time_format": "Select a pre-defined format from the list or define your own format."
         }
       }
     }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -642,6 +642,7 @@ FLOWS = {
         "wled",
         "wolflink",
         "workday",
+        "worldclock",
         "ws66i",
         "wyoming",
         "xbox",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -6876,7 +6876,7 @@
     "worldclock": {
       "name": "Worldclock",
       "integration_type": "hub",
-      "config_flow": false,
+      "config_flow": true,
       "iot_class": "local_push"
     },
     "worldtidesinfo": {

--- a/tests/components/worldclock/conftest.py
+++ b/tests/components/worldclock/conftest.py
@@ -1,0 +1,66 @@
+"""Fixtures for the Worldclock integration."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.worldclock.const import (
+    CONF_TIME_FORMAT,
+    DEFAULT_NAME,
+    DEFAULT_TIME_STR_FORMAT,
+    DOMAIN,
+)
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_NAME, CONF_TIME_ZONE
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Automatically patch setup."""
+    with patch(
+        "homeassistant.components.worldclock.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        yield mock_setup_entry
+
+
+@pytest.fixture(name="get_config")
+async def get_config_to_integration_load() -> dict[str, Any]:
+    """Return configuration.
+
+    To override the config, tests can be marked with:
+    @pytest.mark.parametrize("get_config", [{...}])
+    """
+    return {
+        CONF_NAME: DEFAULT_NAME,
+        CONF_TIME_ZONE: "America/New_York",
+        CONF_TIME_FORMAT: DEFAULT_TIME_STR_FORMAT,
+    }
+
+
+@pytest.fixture(name="loaded_entry")
+async def load_integration(
+    hass: HomeAssistant, get_config: dict[str, Any]
+) -> MockConfigEntry:
+    """Set up the Worldclock integration in Home Assistant."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=DEFAULT_NAME,
+        source=SOURCE_USER,
+        options=get_config,
+        entry_id="1",
+    )
+
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    return config_entry

--- a/tests/components/worldclock/test_config_flow.py
+++ b/tests/components/worldclock/test_config_flow.py
@@ -1,0 +1,104 @@
+"""Test the Worldclock config flow."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from homeassistant import config_entries
+from homeassistant.components.worldclock.const import (
+    CONF_TIME_FORMAT,
+    DEFAULT_NAME,
+    DEFAULT_TIME_STR_FORMAT,
+    DOMAIN,
+)
+from homeassistant.const import CONF_NAME, CONF_TIME_ZONE
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
+
+
+async def test_form(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
+    """Test we get the form."""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["step_id"] == "user"
+    assert result["type"] is FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: DEFAULT_NAME,
+            CONF_TIME_ZONE: "America/New_York",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["version"] == 1
+    assert result["options"] == {
+        CONF_NAME: DEFAULT_NAME,
+        CONF_TIME_ZONE: "America/New_York",
+        CONF_TIME_FORMAT: DEFAULT_TIME_STR_FORMAT,
+    }
+
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_options_flow(hass: HomeAssistant, loaded_entry: MockConfigEntry) -> None:
+    """Test options flow."""
+
+    result = await hass.config_entries.options.async_init(loaded_entry.entry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_TIME_FORMAT: "%a, %b %d, %Y %I:%M %p",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        CONF_NAME: DEFAULT_NAME,
+        CONF_TIME_ZONE: "America/New_York",
+        CONF_TIME_FORMAT: "%a, %b %d, %Y %I:%M %p",
+    }
+
+    await hass.async_block_till_done()
+
+    # Check the entity was updated, no new entity was created
+    assert len(hass.states.async_all()) == 1
+
+    state = hass.states.get("sensor.worldclock_sensor")
+    assert state is not None
+
+
+async def test_entry_already_exist(
+    hass: HomeAssistant, loaded_entry: MockConfigEntry
+) -> None:
+    """Test abort when entry already exist."""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["step_id"] == "user"
+    assert result["type"] is FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: DEFAULT_NAME,
+            CONF_TIME_ZONE: "America/New_York",
+            CONF_TIME_FORMAT: DEFAULT_TIME_STR_FORMAT,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"

--- a/tests/components/worldclock/test_init.py
+++ b/tests/components/worldclock/test_init.py
@@ -1,0 +1,17 @@
+"""Test Worldclock component setup process."""
+
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_unload_entry(hass: HomeAssistant, loaded_entry: MockConfigEntry) -> None:
+    """Test unload an entry."""
+
+    assert loaded_entry.state is ConfigEntryState.LOADED
+    assert await hass.config_entries.async_unload(loaded_entry.entry_id)
+    await hass.async_block_till_done()
+    assert loaded_entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/worldclock/test_sensor.py
+++ b/tests/components/worldclock/test_sensor.py
@@ -2,9 +2,18 @@
 
 import pytest
 
-from homeassistant.core import HomeAssistant
+from homeassistant.components.worldclock.const import (
+    CONF_TIME_FORMAT,
+    DEFAULT_NAME,
+    DOMAIN,
+)
+from homeassistant.const import CONF_NAME, CONF_TIME_ZONE
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
+
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture
@@ -13,7 +22,9 @@ def time_zone():
     return dt_util.get_time_zone("America/New_York")
 
 
-async def test_time(hass: HomeAssistant, time_zone) -> None:
+async def test_time_imported_from_yaml(
+    hass: HomeAssistant, time_zone, issue_registry: ir.IssueRegistry
+) -> None:
     """Test the time at a different location."""
     config = {"sensor": {"platform": "worldclock", "time_zone": "America/New_York"}}
 
@@ -29,26 +40,42 @@ async def test_time(hass: HomeAssistant, time_zone) -> None:
 
     assert state.state == dt_util.now(time_zone=time_zone).strftime("%H:%M")
 
-
-async def test_time_format(hass: HomeAssistant, time_zone) -> None:
-    """Test time_format setting."""
-    time_format = "%a, %b %d, %Y %I:%M %p"
-    config = {
-        "sensor": {
-            "platform": "worldclock",
-            "time_zone": "America/New_York",
-            "time_format": time_format,
-        }
-    }
-
-    assert await async_setup_component(
-        hass,
-        "sensor",
-        config,
+    issue = issue_registry.async_get_issue(
+        HOMEASSISTANT_DOMAIN, f"deprecated_yaml_{DOMAIN}"
     )
-    await hass.async_block_till_done()
+    assert issue
+    assert issue.issue_domain == DOMAIN
+
+
+async def test_time_from_config_entry(
+    hass: HomeAssistant, time_zone, loaded_entry: MockConfigEntry
+) -> None:
+    """Test the time at a different location."""
 
     state = hass.states.get("sensor.worldclock_sensor")
     assert state is not None
 
-    assert state.state == dt_util.now(time_zone=time_zone).strftime(time_format)
+    assert state.state == dt_util.now(time_zone=time_zone).strftime("%H:%M")
+
+
+@pytest.mark.parametrize(
+    "get_config",
+    [
+        {
+            CONF_NAME: DEFAULT_NAME,
+            CONF_TIME_ZONE: "America/New_York",
+            CONF_TIME_FORMAT: "%a, %b %d, %Y %I:%M %p",
+        }
+    ],
+)
+async def test_time_format(
+    hass: HomeAssistant, time_zone, loaded_entry: MockConfigEntry
+) -> None:
+    """Test time_format setting."""
+
+    state = hass.states.get("sensor.worldclock_sensor")
+    assert state is not None
+
+    assert state.state == dt_util.now(time_zone=time_zone).strftime(
+        "%a, %b %d, %Y %I:%M %p"
+    )

--- a/tests/components/worldclock/test_sensor.py
+++ b/tests/components/worldclock/test_sensor.py
@@ -1,5 +1,7 @@
 """The test for the World clock sensor platform."""
 
+from datetime import tzinfo
+
 import pytest
 
 from homeassistant.components.worldclock.const import (
@@ -17,13 +19,13 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def time_zone():
+async def time_zone() -> tzinfo | None:
     """Fixture for time zone."""
-    return dt_util.get_time_zone("America/New_York")
+    return await dt_util.async_get_time_zone("America/New_York")
 
 
 async def test_time_imported_from_yaml(
-    hass: HomeAssistant, time_zone, issue_registry: ir.IssueRegistry
+    hass: HomeAssistant, time_zone: tzinfo | None, issue_registry: ir.IssueRegistry
 ) -> None:
     """Test the time at a different location."""
     config = {"sensor": {"platform": "worldclock", "time_zone": "America/New_York"}}
@@ -48,7 +50,7 @@ async def test_time_imported_from_yaml(
 
 
 async def test_time_from_config_entry(
-    hass: HomeAssistant, time_zone, loaded_entry: MockConfigEntry
+    hass: HomeAssistant, time_zone: tzinfo | None, loaded_entry: MockConfigEntry
 ) -> None:
     """Test the time at a different location."""
 
@@ -69,7 +71,7 @@ async def test_time_from_config_entry(
     ],
 )
 async def test_time_format(
-    hass: HomeAssistant, time_zone, loaded_entry: MockConfigEntry
+    hass: HomeAssistant, time_zone: tzinfo | None, loaded_entry: MockConfigEntry
 ) -> None:
     """Test time_format setting."""
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Worldclock is now configured via UI. Your YAML has been automatically imported from your `configuration.yaml` file and this part can now be removed.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add config flow to worldclock

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33702

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
