### PR TITLE
Use async_connect in newly bumped 0.5.8 UPB library

### DIFF
--- a/homeassistant/components/upb/__init__.py
+++ b/homeassistant/components/upb/__init__.py
@@ -26,7 +26,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     file = config_entry.data[CONF_FILE_PATH]
 
     upb = upb_lib.UpbPim({"url": url, "UPStartExportFile": file})
-    upb.connect()
+    await upb.async_connect()
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][config_entry.entry_id] = {"upb": upb}
 

--- a/homeassistant/components/upb/config_flow.py
+++ b/homeassistant/components/upb/config_flow.py
@@ -40,7 +40,7 @@ async def _validate_input(data):
 
     upb = upb_lib.UpbPim({"url": url, "UPStartExportFile": file_path})
 
-    upb.connect(_connected_callback)
+    await upb.async_connect(_connected_callback)
 
     if not upb.config_ok:
         _LOGGER.error("Missing or invalid UPB file: %s", file_path)

--- a/homeassistant/components/upb/manifest.json
+++ b/homeassistant/components/upb/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/upb",
   "iot_class": "local_push",
   "loggers": ["upb_lib"],
-  "requirements": ["upb-lib==0.5.7"]
+  "requirements": ["upb-lib==0.5.8"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2818,7 +2818,7 @@ unifiled==0.11
 universal-silabs-flasher==0.0.21
 
 # homeassistant.components.upb
-upb-lib==0.5.7
+upb-lib==0.5.8
 
 # homeassistant.components.upcloud
 upcloud-api==2.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2192,7 +2192,7 @@ unifi-discovery==1.2.0
 universal-silabs-flasher==0.0.21
 
 # homeassistant.components.upb
-upb-lib==0.5.7
+upb-lib==0.5.8
 
 # homeassistant.components.upcloud
 upcloud-api==2.5.1

--- a/tests/components/upb/test_config_flow.py
+++ b/tests/components/upb/test_config_flow.py
@@ -1,7 +1,7 @@
 """Test the UPB Control config flow."""
 
 from asyncio import TimeoutError
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import AsyncMock, PropertyMock, patch
 
 from homeassistant import config_entries
 from homeassistant.components.upb.const import DOMAIN
@@ -15,11 +15,11 @@ def mocked_upb(sync_complete=True, config_ok=True):
     def _upb_lib_connect(callback):
         callback()
 
-    upb_mock = MagicMock()
+    upb_mock = AsyncMock()
     type(upb_mock).network_id = PropertyMock(return_value="42")
     type(upb_mock).config_ok = PropertyMock(return_value=config_ok)
     if sync_complete:
-        upb_mock.connect.side_effect = _upb_lib_connect
+        upb_mock.async_connect.side_effect = _upb_lib_connect
     return patch(
         "homeassistant.components.upb.config_flow.upb_lib.UpbPim", return_value=upb_mock
     )


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This fixes the problem where the reading of the UPB file was generating an error due to the `connect` call not being properly async. What would happen is that the actual connect was deferred and hence the reading of the config file was deferred as well. The problem arose that the return from connect was checked before the connect (and reading of config file) had actually happened.

The fix is to add a proper async_connect to the UPB library and use that.

https://github.com/gwww/upb-lib/compare/0.5.7...0.5.8

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #https://github.com/home-assistant/core/issues/121568
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
