### PR TITLE
Add config flow for select platform in Template

### DIFF
--- a/homeassistant/components/template/config_flow.py
+++ b/homeassistant/components/template/config_flow.py
@@ -41,6 +41,7 @@ from homeassistant.helpers.schema_config_entry_flow import (
 
 from .binary_sensor import async_create_preview_binary_sensor
 from .const import CONF_PRESS, CONF_TURN_OFF, CONF_TURN_ON, DOMAIN
+from .select import CONF_OPTIONS, CONF_SELECT_OPTION
 from .sensor import async_create_preview_sensor
 from .switch import async_create_preview_switch
 from .template_entity import TemplateEntity
@@ -91,6 +92,13 @@ def generate_schema(domain: str, flow_type: str) -> vol.Schema:
         schema |= {
             vol.Required(CONF_URL): selector.TemplateSelector(),
             vol.Optional(CONF_VERIFY_SSL, default=True): selector.BooleanSelector(),
+            vol.Optional(CONF_DEVICE_ID): selector.DeviceSelector(),
+        }
+
+    if domain == Platform.SELECT:
+        schema |= _SCHEMA_STATE | {
+            vol.Required(CONF_OPTIONS): selector.TemplateSelector(),
+            vol.Optional(CONF_SELECT_OPTION): selector.ActionSelector(),
             vol.Optional(CONF_DEVICE_ID): selector.DeviceSelector(),
         }
 
@@ -232,6 +240,7 @@ TEMPLATE_TYPES = [
     "binary_sensor",
     "button",
     "image",
+    "select",
     "sensor",
     "switch",
 ]
@@ -250,6 +259,10 @@ CONFIG_FLOW = {
     Platform.IMAGE: SchemaFlowFormStep(
         config_schema(Platform.IMAGE),
         validate_user_input=validate_user_input(Platform.IMAGE),
+    ),
+    Platform.SELECT: SchemaFlowFormStep(
+        config_schema(Platform.SELECT),
+        validate_user_input=validate_user_input(Platform.SELECT),
     ),
     Platform.SENSOR: SchemaFlowFormStep(
         config_schema(Platform.SENSOR),
@@ -278,6 +291,10 @@ OPTIONS_FLOW = {
     Platform.IMAGE: SchemaFlowFormStep(
         options_schema(Platform.IMAGE),
         validate_user_input=validate_user_input(Platform.IMAGE),
+    ),
+    Platform.SELECT: SchemaFlowFormStep(
+        options_schema(Platform.SELECT),
+        validate_user_input=validate_user_input(Platform.SELECT),
     ),
     Platform.SENSOR: SchemaFlowFormStep(
         options_schema(Platform.SENSOR),

--- a/homeassistant/components/template/config_flow.py
+++ b/homeassistant/components/template/config_flow.py
@@ -92,14 +92,12 @@ def generate_schema(domain: str, flow_type: str) -> vol.Schema:
         schema |= {
             vol.Required(CONF_URL): selector.TemplateSelector(),
             vol.Optional(CONF_VERIFY_SSL, default=True): selector.BooleanSelector(),
-            vol.Optional(CONF_DEVICE_ID): selector.DeviceSelector(),
         }
 
     if domain == Platform.SELECT:
         schema |= _SCHEMA_STATE | {
             vol.Required(CONF_OPTIONS): selector.TemplateSelector(),
             vol.Optional(CONF_SELECT_OPTION): selector.ActionSelector(),
-            vol.Optional(CONF_DEVICE_ID): selector.DeviceSelector(),
         }
 
     if domain == Platform.SENSOR:

--- a/homeassistant/components/template/select.py
+++ b/homeassistant/components/template/select.py
@@ -13,9 +13,17 @@ from homeassistant.components.select import (
     DOMAIN as SELECT_DOMAIN,
     SelectEntity,
 )
-from homeassistant.const import CONF_NAME, CONF_OPTIMISTIC, CONF_STATE, CONF_UNIQUE_ID
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    CONF_DEVICE_ID,
+    CONF_NAME,
+    CONF_OPTIMISTIC,
+    CONF_STATE,
+    CONF_UNIQUE_ID,
+)
 from homeassistant.core import HomeAssistant, callback
-import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers import config_validation as cv, selector
+from homeassistant.helpers.device import async_device_info_to_link_from_device_id
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.script import Script
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -31,6 +39,7 @@ from .trigger_entity import TriggerEntity
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_OPTIONS = "options"
 CONF_SELECT_OPTION = "select_option"
 
 DEFAULT_NAME = "Template Select"
@@ -49,6 +58,17 @@ SELECT_SCHEMA = (
     )
     .extend(TEMPLATE_ENTITY_AVAILABILITY_SCHEMA.schema)
     .extend(TEMPLATE_ENTITY_ICON_SCHEMA.schema)
+)
+
+
+SELECT_CONFIG_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_NAME): cv.template,
+        vol.Required(CONF_STATE): cv.template,
+        vol.Required(CONF_OPTIONS): cv.template,
+        vol.Optional(CONF_SELECT_OPTION): cv.SCRIPT_SCHEMA,
+        vol.Optional(CONF_DEVICE_ID): selector.DeviceSelector(),
+    }
 )
 
 
@@ -92,6 +112,18 @@ async def async_setup_platform(
     )
 
 
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Initialize config entry."""
+    _options = dict(config_entry.options)
+    _options.pop("template_type")
+    validated_config = SELECT_CONFIG_SCHEMA(_options)
+    async_add_entities([TemplateSelect(hass, validated_config, config_entry.entry_id)])
+
+
 class TemplateSelect(TemplateEntity, SelectEntity):
     """Representation of a template select."""
 
@@ -107,13 +139,18 @@ class TemplateSelect(TemplateEntity, SelectEntity):
         super().__init__(hass, config=config, unique_id=unique_id)
         assert self._attr_name is not None
         self._value_template = config[CONF_STATE]
-        self._command_select_option = Script(
-            hass, config[CONF_SELECT_OPTION], self._attr_name, DOMAIN
-        )
+        if (selection_option := config.get(CONF_SELECT_OPTION)) is not None:
+            self._command_select_option = Script(
+                hass, selection_option, self._attr_name, DOMAIN
+            )
         self._options_template = config[ATTR_OPTIONS]
-        self._attr_assumed_state = self._optimistic = config[CONF_OPTIMISTIC]
+        self._attr_assumed_state = self._optimistic = config.get(CONF_OPTIMISTIC, False)
         self._attr_options = []
         self._attr_current_option = None
+        self._attr_device_info = async_device_info_to_link_from_device_id(
+            hass,
+            config.get(CONF_DEVICE_ID),
+        )
 
     @callback
     def _async_setup_templates(self) -> None:
@@ -137,11 +174,12 @@ class TemplateSelect(TemplateEntity, SelectEntity):
         if self._optimistic:
             self._attr_current_option = option
             self.async_write_ha_state()
-        await self.async_run_script(
-            self._command_select_option,
-            run_variables={ATTR_OPTION: option},
-            context=self._context,
-        )
+        if self._command_select_option:
+            await self.async_run_script(
+                self._command_select_option,
+                run_variables={ATTR_OPTION: option},
+                context=self._context,
+            )
 
 
 class TriggerSelectEntity(TriggerEntity, SelectEntity):

--- a/homeassistant/components/template/strings.json
+++ b/homeassistant/components/template/strings.json
@@ -37,6 +37,19 @@
         },
         "title": "Template image"
       },
+      "select": {
+        "data": {
+          "device_id": "[%key:common::config_flow::data::device%]",
+          "name": "[%key:common::config_flow::data::name%]",
+          "state": "[%key:component::template::config::step::sensor::data::state%]",
+          "select_option": "Actions on select",
+          "options": "Available options"
+        },
+        "data_description": {
+          "device_id": "[%key:component::template::config::step::sensor::data_description::device_id%]"
+        },
+        "title": "Template select"
+      },
       "sensor": {
         "data": {
           "device_id": "[%key:common::config_flow::data::device%]",
@@ -57,6 +70,7 @@
           "binary_sensor": "Template a binary sensor",
           "button": "Template a button",
           "image": "Template a image",
+          "select": "Template a select",
           "sensor": "Template a sensor",
           "switch": "Template a switch"
         },
@@ -109,6 +123,19 @@
           "device_id": "[%key:component::template::config::step::sensor::data_description::device_id%]"
         },
         "title": "[%key:component::template::config::step::image::title%]"
+      },
+      "select": {
+        "data": {
+          "device_id": "[%key:common::config_flow::data::device%]",
+          "name": "[%key:common::config_flow::data::name%]",
+          "state": "[%key:component::template::config::step::sensor::data::state%]",
+          "select_option": "[%key:component::template::config::step::select::data::select_option%]",
+          "options": "[%key:component::template::config::step::select::data::options%]"
+        },
+        "data_description": {
+          "device_id": "[%key:component::template::config::step::sensor::data_description::device_id%]"
+        },
+        "title": "[%key:component::template::config::step::select::title%]"
       },
       "sensor": {
         "data": {

--- a/tests/components/template/snapshots/test_select.ambr
+++ b/tests/components/template/snapshots/test_select.ambr
@@ -1,0 +1,19 @@
+# serializer version: 1
+# name: test_setup_config_entry
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'My template',
+      'options': Wrapper([
+        'off',
+        'on',
+        'auto',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.my_template',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/template/test_config_flow.py
+++ b/tests/components/template/test_config_flow.py
@@ -92,6 +92,16 @@ from tests.typing import WebSocketGenerator
             {},
         ),
         (
+            "select",
+            {"state": "{{ states('select.one') }}"},
+            "on",
+            {"one": "on", "two": "off"},
+            {},
+            {"options": "{{ ['off', 'on', 'auto'] }}"},
+            {"options": "{{ ['off', 'on', 'auto'] }}"},
+            {},
+        ),
+        (
             "switch",
             {"value_template": "{{ states('switch.one') }}"},
             "on",
@@ -215,6 +225,12 @@ async def test_config_flow(
             },
             {"verify_ssl": True},
             {"verify_ssl": True},
+        ),
+        (
+            "select",
+            {"state": "{{ states('select.one') }}"},
+            {"options": "{{ ['off', 'on', 'auto'] }}"},
+            {"options": "{{ ['off', 'on', 'auto'] }}"},
         ),
     ],
 )
@@ -385,6 +401,16 @@ def get_suggested(schema, key):
                 "verify_ssl": True,
             },
             "url",
+        ),
+        (
+            "select",
+            {"state": "{{ states('select.one') }}"},
+            {"state": "{{ states('select.two') }}"},
+            ["on", "off"],
+            {"one": "on", "two": "off"},
+            {"options": "{{ ['off', 'on', 'auto'] }}"},
+            {"options": "{{ ['off', 'on', 'auto'] }}"},
+            "state",
         ),
         (
             "switch",
@@ -1129,6 +1155,12 @@ async def test_option_flow_sensor_preview_config_entry_removed(
             },
             {},
             {},
+        ),
+        (
+            "select",
+            {"state": "{{ states('select.one') }}"},
+            {"options": "{{ ['off', 'on', 'auto'] }}"},
+            {"options": "{{ ['off', 'on', 'auto'] }}"},
         ),
         (
             "switch",

--- a/tests/components/template/test_init.py
+++ b/tests/components/template/test_init.py
@@ -316,6 +316,18 @@ async def async_yaml_patch_helper(hass, filename):
         ),
         (
             {
+                "template_type": "select",
+                "name": "My template",
+                "state": "{{ 'on' }}",
+                "options": "{{ ['off', 'on', 'auto'] }}",
+            },
+            {
+                "state": "{{ 'on' }}",
+                "options": "{{ ['off', 'on', 'auto'] }}",
+            },
+        ),
+        (
+            {
                 "template_type": "switch",
                 "name": "My template",
                 "value_template": "{{ true }}",

--- a/tests/components/template/test_select.py
+++ b/tests/components/template/test_select.py
@@ -1,5 +1,7 @@
 """The tests for the Template select platform."""
 
+from syrupy.assertion import SnapshotAssertion
+
 from homeassistant import setup
 from homeassistant.components.input_select import (
     ATTR_OPTION as INPUT_SELECT_ATTR_OPTION,
@@ -14,15 +16,43 @@ from homeassistant.components.select import (
     DOMAIN as SELECT_DOMAIN,
     SERVICE_SELECT_OPTION as SELECT_SERVICE_SELECT_OPTION,
 )
+from homeassistant.components.template import DOMAIN
 from homeassistant.const import ATTR_ICON, CONF_ENTITY_ID, STATE_UNKNOWN
 from homeassistant.core import Context, HomeAssistant, ServiceCall
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from tests.common import assert_setup_component, async_capture_events
+from tests.common import MockConfigEntry, assert_setup_component, async_capture_events
 
 _TEST_SELECT = "select.template_select"
 # Represent for select's current_option
 _OPTION_INPUT_SELECT = "input_select.option"
+
+
+async def test_setup_config_entry(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the config flow."""
+
+    template_config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            "name": "My template",
+            "template_type": "select",
+            "state": "{{ 'on' }}",
+            "options": "{{ ['off', 'on', 'auto'] }}",
+        },
+        title="My template",
+    )
+    template_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(template_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("select.my_template")
+    assert state is not None
+    assert state == snapshot
 
 
 async def test_missing_optional_config(hass: HomeAssistant) -> None:
@@ -428,3 +458,43 @@ async def test_template_icon_with_trigger(hass: HomeAssistant) -> None:
     state = hass.states.get(_TEST_SELECT)
     assert state.state == "a"
     assert state.attributes[ATTR_ICON] == "mdi:greater"
+
+
+async def test_device_id(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test for device for select template."""
+
+    device_config_entry = MockConfigEntry()
+    device_config_entry.add_to_hass(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=device_config_entry.entry_id,
+        identifiers={("test", "identifier_test")},
+        connections={("mac", "30:31:32:33:34:35")},
+    )
+    await hass.async_block_till_done()
+    assert device_entry is not None
+    assert device_entry.id is not None
+
+    template_config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            "name": "My template",
+            "template_type": "select",
+            "state": "{{ 'on' }}",
+            "options": "{{ ['off', 'on', 'auto'] }}",
+            "device_id": device_entry.id,
+        },
+        title="My template",
+    )
+    template_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(template_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    template_entity = entity_registry.async_get("select.my_template")
+    assert template_entity is not None
+    assert template_entity.device_id == device_entry.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add config flow for platform select in Template.

This is another in a series of PRs that I intend to contribute to to bring the config of templates platforms to the UI, the focus will be on the simplest to the most complex configuration platforms (which will require leaving part of the more advanced features only in YAML) .

Migration of existing YAML is not implemented due to configuration maintenance via YAML for helpers.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33710

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
