### PR TITLE
Add brand selection to support additional brands who use the same API for AquaCell integration

### DIFF
--- a/homeassistant/components/aquacell/__init__.py
+++ b/homeassistant/components/aquacell/__init__.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from aioaquacell import AquacellApi
+from aioaquacell.const import Brand
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
+from .const import CONF_BRAND
 from .coordinator import AquacellCoordinator
 
 PLATFORMS = [Platform.SENSOR]
@@ -20,7 +22,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: AquacellConfigEntry) -> 
     """Set up Aquacell from a config entry."""
     session = async_get_clientsession(hass)
 
-    aquacell_api = AquacellApi(session)
+    brand = entry.data.get(CONF_BRAND, Brand.AQUACELL)
+
+    aquacell_api = AquacellApi(session, brand)
 
     coordinator = AquacellCoordinator(hass, aquacell_api)
 

--- a/homeassistant/components/aquacell/const.py
+++ b/homeassistant/components/aquacell/const.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 DOMAIN = "aquacell"
 DATA_AQUACELL = "DATA_AQUACELL"
 
+CONF_BRAND = "brand"
 CONF_REFRESH_TOKEN = "refresh_token"
 CONF_REFRESH_TOKEN_CREATION_TIME = "refresh_token_creation_time"
 

--- a/homeassistant/components/aquacell/manifest.json
+++ b/homeassistant/components/aquacell/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "aquacell",
-  "name": "Aquacell",
+  "name": "AquaCell",
   "codeowners": ["@Jordi1990"],
   "config_flow": true,
   "dependencies": ["http", "network"],

--- a/homeassistant/components/aquacell/strings.json
+++ b/homeassistant/components/aquacell/strings.json
@@ -2,14 +2,9 @@
   "config": {
     "step": {
       "user": {
-        "description": "Select the brand of softener you have.",
+        "description": "Select the brand of the softener and fill in your softener mobile app credentials",
         "data": {
-          "hub": "Brand"
-        }
-      },
-      "cloud": {
-        "description": "Fill in your softener mobile app credentials",
-        "data": {
+          "brand": "Brand",
           "email": "[%key:common::config_flow::data::email%]",
           "password": "[%key:common::config_flow::data::password%]"
         }

--- a/homeassistant/components/aquacell/strings.json
+++ b/homeassistant/components/aquacell/strings.json
@@ -2,7 +2,13 @@
   "config": {
     "step": {
       "user": {
-        "description": "Fill in your Aquacell mobile app credentials",
+        "description": "Select the brand of softener you have.",
+        "data": {
+          "hub": "Brand"
+        }
+      },
+      "cloud": {
+        "description": "Fill in your softener mobile app credentials",
         "data": {
           "email": "[%key:common::config_flow::data::email%]",
           "password": "[%key:common::config_flow::data::password%]"

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -414,7 +414,7 @@
       "iot_class": "local_polling"
     },
     "aquacell": {
-      "name": "Aquacell",
+      "name": "AquaCell",
       "integration_type": "device",
       "config_flow": true,
       "iot_class": "cloud_polling"

--- a/tests/components/aquacell/__init__.py
+++ b/tests/components/aquacell/__init__.py
@@ -27,11 +27,10 @@ TEST_CONFIG_ENTRY_WITHOUT_BRAND = {
     CONF_REFRESH_TOKEN_CREATION_TIME: 0,
 }
 
-TEST_BRAND_INPUT = {CONF_BRAND: "aquacell"}
-
 TEST_USER_INPUT = {
     CONF_EMAIL: "test@test.com",
     CONF_PASSWORD: "test-password",
+    CONF_BRAND: "aquacell",
 }
 
 DSN = "DSN"

--- a/tests/components/aquacell/__init__.py
+++ b/tests/components/aquacell/__init__.py
@@ -1,6 +1,9 @@
 """Tests for the Aquacell integration."""
 
+from aioaquacell import Brand
+
 from homeassistant.components.aquacell.const import (
+    CONF_BRAND,
     CONF_REFRESH_TOKEN,
     CONF_REFRESH_TOKEN_CREATION_TIME,
 )
@@ -14,7 +17,17 @@ TEST_CONFIG_ENTRY = {
     CONF_PASSWORD: "test-password",
     CONF_REFRESH_TOKEN: "refresh-token",
     CONF_REFRESH_TOKEN_CREATION_TIME: 0,
+    CONF_BRAND: Brand.AQUACELL,
 }
+
+TEST_CONFIG_ENTRY_WITHOUT_BRAND = {
+    CONF_EMAIL: "test@test.com",
+    CONF_PASSWORD: "test-password",
+    CONF_REFRESH_TOKEN: "refresh-token",
+    CONF_REFRESH_TOKEN_CREATION_TIME: 0,
+}
+
+TEST_BRAND_INPUT = {CONF_BRAND: "aquacell"}
 
 TEST_USER_INPUT = {
     CONF_EMAIL: "test@test.com",

--- a/tests/components/aquacell/conftest.py
+++ b/tests/components/aquacell/conftest.py
@@ -13,7 +13,7 @@ from homeassistant.components.aquacell.const import (
 )
 from homeassistant.const import CONF_EMAIL
 
-from . import TEST_CONFIG_ENTRY
+from . import TEST_CONFIG_ENTRY, TEST_CONFIG_ENTRY_WITHOUT_BRAND
 
 from tests.common import MockConfigEntry, load_json_array_fixture
 
@@ -73,6 +73,20 @@ def mock_config_entry() -> MockConfigEntry:
         unique_id=TEST_CONFIG_ENTRY[CONF_EMAIL],
         data={
             **TEST_CONFIG_ENTRY,
+            CONF_REFRESH_TOKEN_CREATION_TIME: datetime.now().timestamp(),
+        },
+    )
+
+
+@pytest.fixture
+def mock_config_entry_without_brand() -> MockConfigEntry:
+    """Mock a config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="Aquacell",
+        unique_id=TEST_CONFIG_ENTRY[CONF_EMAIL],
+        data={
+            **TEST_CONFIG_ENTRY_WITHOUT_BRAND,
             CONF_REFRESH_TOKEN_CREATION_TIME: datetime.now().timestamp(),
         },
     )

--- a/tests/components/aquacell/test_config_flow.py
+++ b/tests/components/aquacell/test_config_flow.py
@@ -5,13 +5,17 @@ from unittest.mock import AsyncMock
 from aioaquacell import ApiException, AuthenticationFailed
 import pytest
 
-from homeassistant.components.aquacell.const import CONF_REFRESH_TOKEN, DOMAIN
+from homeassistant.components.aquacell.const import (
+    CONF_BRAND,
+    CONF_REFRESH_TOKEN,
+    DOMAIN,
+)
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from . import TEST_BRAND_INPUT, TEST_CONFIG_ENTRY, TEST_USER_INPUT
+from . import TEST_CONFIG_ENTRY, TEST_USER_INPUT
 
 from tests.common import MockConfigEntry
 
@@ -33,14 +37,6 @@ async def test_config_flow_already_configured(hass: HomeAssistant) -> None:
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        TEST_BRAND_INPUT,
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "cloud"
     assert result["errors"] == {}
 
     result = await hass.config_entries.flow.async_configure(
@@ -62,14 +58,6 @@ async def test_full_flow(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        TEST_BRAND_INPUT,
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "cloud"
     assert result["errors"] == {}
 
     result2 = await hass.config_entries.flow.async_configure(
@@ -83,6 +71,7 @@ async def test_full_flow(
     assert result2["data"][CONF_EMAIL] == TEST_CONFIG_ENTRY[CONF_EMAIL]
     assert result2["data"][CONF_PASSWORD] == TEST_CONFIG_ENTRY[CONF_PASSWORD]
     assert result2["data"][CONF_REFRESH_TOKEN] == TEST_CONFIG_ENTRY[CONF_REFRESH_TOKEN]
+    assert result2["data"][CONF_BRAND] == TEST_CONFIG_ENTRY[CONF_BRAND]
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -106,11 +95,6 @@ async def test_form_exceptions(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        TEST_BRAND_INPUT,
-    )
-
     mock_aquacell_api.authenticate.side_effect = exception
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"], TEST_USER_INPUT
@@ -132,4 +116,5 @@ async def test_form_exceptions(
     assert result3["data"][CONF_EMAIL] == TEST_CONFIG_ENTRY[CONF_EMAIL]
     assert result3["data"][CONF_PASSWORD] == TEST_CONFIG_ENTRY[CONF_PASSWORD]
     assert result3["data"][CONF_REFRESH_TOKEN] == TEST_CONFIG_ENTRY[CONF_REFRESH_TOKEN]
+    assert result3["data"][CONF_BRAND] == TEST_CONFIG_ENTRY[CONF_BRAND]
     assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/aquacell/test_config_flow.py
+++ b/tests/components/aquacell/test_config_flow.py
@@ -11,7 +11,7 @@ from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from . import TEST_CONFIG_ENTRY, TEST_USER_INPUT
+from . import TEST_BRAND_INPUT, TEST_CONFIG_ENTRY, TEST_USER_INPUT
 
 from tests.common import MockConfigEntry
 
@@ -33,6 +33,14 @@ async def test_config_flow_already_configured(hass: HomeAssistant) -> None:
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        TEST_BRAND_INPUT,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "cloud"
     assert result["errors"] == {}
 
     result = await hass.config_entries.flow.async_configure(
@@ -51,7 +59,17 @@ async def test_full_flow(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
+
     assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        TEST_BRAND_INPUT,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "cloud"
     assert result["errors"] == {}
 
     result2 = await hass.config_entries.flow.async_configure(
@@ -86,6 +104,11 @@ async def test_form_exceptions(
     """Test we handle form exceptions."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        TEST_BRAND_INPUT,
     )
 
     mock_aquacell_api.authenticate.side_effect = exception

--- a/tests/components/aquacell/test_init.py
+++ b/tests/components/aquacell/test_init.py
@@ -38,6 +38,18 @@ async def test_load_unload_entry(
     assert entry.state is ConfigEntryState.NOT_LOADED
 
 
+async def test_load_withoutbrand(
+    hass: HomeAssistant,
+    mock_aquacell_api: AsyncMock,
+    mock_config_entry_without_brand: MockConfigEntry,
+) -> None:
+    """Test load entry without brand."""
+    await setup_integration(hass, mock_config_entry_without_brand)
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+
+    assert entry.state is ConfigEntryState.LOADED
+
+
 async def test_coordinator_update_valid_refresh_token(
     hass: HomeAssistant,
     mock_aquacell_api: AsyncMock,

--- a/tests/components/aquacell/test_init.py
+++ b/tests/components/aquacell/test_init.py
@@ -45,9 +45,8 @@ async def test_load_withoutbrand(
 ) -> None:
     """Test load entry without brand."""
     await setup_integration(hass, mock_config_entry_without_brand)
-    entry = hass.config_entries.async_entries(DOMAIN)[0]
 
-    assert entry.state is ConfigEntryState.LOADED
+    assert mock_config_entry_without_brand.state is ConfigEntryState.LOADED
 
 
 async def test_coordinator_update_valid_refresh_token(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change expands the config flow to ask for which brand of softener you want to integrate, this is needed to tell the API which credentials to use when retrieving the data. This results in support for Harvey softeners. Harvey will be added as a new virtual integration in another PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#33725

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
