### PR TITLE
Fix homekit linked doorbell and motion firing on reload

### DIFF
--- a/homeassistant/components/homekit/type_cameras.py
+++ b/homeassistant/components/homekit/type_cameras.py
@@ -233,8 +233,7 @@ class Camera(HomeAccessory, PyhapCamera):  # type: ignore[misc]
                 self._char_motion_detected = serv_motion.configure_char(
                     CHAR_MOTION_DETECTED, value=False
                 )
-                if not self.motion_is_event:
-                    self._async_update_motion_state(state)
+                self._async_update_motion_state(None, state)
 
         self._char_doorbell_detected = None
         self._char_doorbell_detected_switch = None
@@ -264,9 +263,7 @@ class Camera(HomeAccessory, PyhapCamera):  # type: ignore[misc]
         )
         serv_speaker = self.add_preload_service(SERV_SPEAKER)
         serv_speaker.configure_char(CHAR_MUTE, value=0)
-
-        if not self.doorbell_is_event:
-            self._async_update_doorbell_state(state)
+        self._async_update_doorbell_state(None, state)
 
     @pyhap_callback  # type: ignore[misc]
     @callback
@@ -304,20 +301,21 @@ class Camera(HomeAccessory, PyhapCamera):  # type: ignore[misc]
         self, event: Event[EventStateChangedData]
     ) -> None:
         """Handle state change event listener callback."""
-        if not state_changed_event_is_same_state(event):
-            self._async_update_motion_state(event.data["new_state"])
+        if not state_changed_event_is_same_state(event) and (
+            new_state := event.data["new_state"]
+        ):
+            self._async_update_motion_state(event.data["old_state"], new_state)
 
     @callback
-    def _async_update_motion_state(self, new_state: State | None) -> None:
+    def _async_update_motion_state(
+        self, old_state: State | None, new_state: State
+    ) -> None:
         """Handle link motion sensor state change to update HomeKit value."""
-        if not new_state:
-            return
-
         state = new_state.state
         char = self._char_motion_detected
         assert char is not None
         if self.motion_is_event:
-            if state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+            if old_state is None or state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
                 return
             _LOGGER.debug(
                 "%s: Set linked motion %s sensor to True/False",
@@ -348,16 +346,20 @@ class Camera(HomeAccessory, PyhapCamera):  # type: ignore[misc]
         if not state_changed_event_is_same_state(event) and (
             new_state := event.data["new_state"]
         ):
-            self._async_update_doorbell_state(new_state)
+            self._async_update_doorbell_state(event.data["old_state"], new_state)
 
     @callback
-    def _async_update_doorbell_state(self, new_state: State) -> None:
+    def _async_update_doorbell_state(
+        self, old_state: State | None, new_state: State
+    ) -> None:
         """Handle link doorbell sensor state change to update HomeKit value."""
         assert self._char_doorbell_detected
         assert self._char_doorbell_detected_switch
         state = new_state.state
         if state == STATE_ON or (
-            self.doorbell_is_event and state not in (STATE_UNKNOWN, STATE_UNAVAILABLE)
+            self.doorbell_is_event
+            and old_state is not None
+            and state not in (STATE_UNKNOWN, STATE_UNAVAILABLE)
         ):
             self._char_doorbell_detected.set_value(DOORBELL_SINGLE_PRESS)
             self._char_doorbell_detected_switch.set_value(DOORBELL_SINGLE_PRESS)

--- a/homeassistant/components/homekit/type_cameras.py
+++ b/homeassistant/components/homekit/type_cameras.py
@@ -315,7 +315,11 @@ class Camera(HomeAccessory, PyhapCamera):  # type: ignore[misc]
         char = self._char_motion_detected
         assert char is not None
         if self.motion_is_event:
-            if old_state is None or state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+            if (
+                old_state is None
+                or old_state.state == STATE_UNAVAILABLE
+                or state in (STATE_UNKNOWN, STATE_UNAVAILABLE)
+            ):
                 return
             _LOGGER.debug(
                 "%s: Set linked motion %s sensor to True/False",
@@ -359,6 +363,7 @@ class Camera(HomeAccessory, PyhapCamera):  # type: ignore[misc]
         if state == STATE_ON or (
             self.doorbell_is_event
             and old_state is not None
+            and old_state.state != STATE_UNAVAILABLE
             and state not in (STATE_UNKNOWN, STATE_UNAVAILABLE)
         ):
             self._char_doorbell_detected.set_value(DOORBELL_SINGLE_PRESS)

--- a/tests/components/homekit/test_type_cameras.py
+++ b/tests/components/homekit/test_type_cameras.py
@@ -31,7 +31,13 @@ from homeassistant.components.homekit.const import (
 )
 from homeassistant.components.homekit.type_cameras import Camera
 from homeassistant.components.homekit.type_switches import Switch
-from homeassistant.const import ATTR_DEVICE_CLASS, STATE_OFF, STATE_ON, STATE_UNKNOWN
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
@@ -897,6 +903,35 @@ async def test_camera_with_linked_motion_event(hass: HomeAssistant, run_driver) 
     hass.states.async_set(
         motion_entity_id,
         dt_util.utcnow().isoformat(),
+        {ATTR_DEVICE_CLASS: EventDeviceClass.MOTION},
+    )
+    await hass.async_block_till_done()
+    assert broker.mock_calls
+
+    # Now go unavailable
+    broker.reset_mock()
+    hass.states.async_set(
+        motion_entity_id,
+        STATE_UNAVAILABLE,
+        {ATTR_DEVICE_CLASS: EventDeviceClass.MOTION},
+    )
+    await hass.async_block_till_done()
+    assert not broker.mock_calls
+
+    # Going from unavailable to a state should not fire an event
+    hass.states.async_set(
+        motion_entity_id,
+        dt_util.utcnow().isoformat(),
+        {ATTR_DEVICE_CLASS: EventDeviceClass.MOTION},
+    )
+    await hass.async_block_till_done()
+    assert not broker.mock_calls
+
+    # But a another update does
+    broker.reset_mock()
+    hass.states.async_set(
+        motion_entity_id,
+        dt_util.utcnow().isoformat(),
         {ATTR_DEVICE_CLASS: EventDeviceClass.MOTION, "other": "attr"},
     )
     await hass.async_block_till_done()
@@ -1170,13 +1205,22 @@ async def test_camera_with_linked_doorbell_event(
     await hass.async_block_till_done()
     hass.states.async_set(
         doorbell_entity_id,
-        dt_util.utcnow().isoformat(),
+        STATE_UNAVAILABLE,
         {ATTR_DEVICE_CLASS: EventDeviceClass.DOORBELL},
     )
     await hass.async_block_till_done()
     # Ensure re-adding does not fire an event
     assert not broker.mock_calls
     broker.reset_mock()
+
+    # going from unavailable to a state should not fire an event
+    hass.states.async_set(
+        doorbell_entity_id,
+        dt_util.utcnow().isoformat(),
+        {ATTR_DEVICE_CLASS: EventDeviceClass.DOORBELL},
+    )
+    await hass.async_block_till_done()
+    assert not broker.mock_calls
 
     # But a second update does
     hass.states.async_set(

--- a/tests/components/homekit/test_type_cameras.py
+++ b/tests/components/homekit/test_type_cameras.py
@@ -883,6 +883,25 @@ async def test_camera_with_linked_motion_event(hass: HomeAssistant, run_driver) 
     await hass.async_block_till_done()
     assert char.value is False
 
+    # Ensure re-adding does not fire an event
+    hass.states.async_set(
+        motion_entity_id,
+        dt_util.utcnow().isoformat(),
+        {ATTR_DEVICE_CLASS: EventDeviceClass.MOTION, "other": "attr"},
+    )
+    await hass.async_block_till_done()
+    assert not broker.mock_calls
+
+    # But a second update does
+    broker.reset_mock()
+    hass.states.async_set(
+        motion_entity_id,
+        dt_util.utcnow().isoformat(),
+        {ATTR_DEVICE_CLASS: EventDeviceClass.MOTION, "other": "attr"},
+    )
+    await hass.async_block_till_done()
+    assert broker.mock_calls
+
 
 async def test_camera_with_a_missing_linked_motion_sensor(
     hass: HomeAssistant, run_driver
@@ -1147,6 +1166,26 @@ async def test_camera_with_linked_doorbell_event(
     await hass.async_block_till_done()
     assert char.value is None
     assert char2.value is None
+
+    await hass.async_block_till_done()
+    hass.states.async_set(
+        doorbell_entity_id,
+        dt_util.utcnow().isoformat(),
+        {ATTR_DEVICE_CLASS: EventDeviceClass.DOORBELL},
+    )
+    await hass.async_block_till_done()
+    # Ensure re-adding does not fire an event
+    assert not broker.mock_calls
+    broker.reset_mock()
+
+    # But a second update does
+    hass.states.async_set(
+        doorbell_entity_id,
+        dt_util.utcnow().isoformat(),
+        {ATTR_DEVICE_CLASS: EventDeviceClass.DOORBELL},
+    )
+    await hass.async_block_till_done()
+    assert broker.mock_calls
 
 
 async def test_camera_with_a_missing_linked_doorbell_sensor(


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When an integration is reloaded, the event entity is added and removed from the state machine which caused the doorbell or motion sensor to fire again. This was not a problem at startup because the entity is added before HomeKit is started. When the previous state was None, we should not fire.

This is only a problem in dev since event entity support is new in dev for HomeKit

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
