### PR TITLE
Initial support for LIFX Ceiling SKY effect

### DIFF
--- a/homeassistant/components/lifx/const.py
+++ b/homeassistant/components/lifx/const.py
@@ -61,5 +61,6 @@ INFRARED_BRIGHTNESS_VALUES_MAP = {
 }
 DATA_LIFX_MANAGER = "lifx_manager"
 
+LIFX_CEILING_PRODUCT_IDS = {176, 177}
 
 _LOGGER = logging.getLogger(__package__)

--- a/homeassistant/components/lifx/icons.json
+++ b/homeassistant/components/lifx/icons.json
@@ -7,6 +7,7 @@
     "effect_move": "mdi:cube-send",
     "effect_flame": "mdi:fire",
     "effect_morph": "mdi:shape-outline",
+    "effect_sky": "mdi:clouds",
     "effect_stop": "mdi:stop"
   }
 }

--- a/homeassistant/components/lifx/light.py
+++ b/homeassistant/components/lifx/light.py
@@ -36,6 +36,7 @@ from .const import (
     DATA_LIFX_MANAGER,
     DOMAIN,
     INFRARED_BRIGHTNESS,
+    LIFX_CEILING_PRODUCT_IDS,
 )
 from .coordinator import FirmwareEffect, LIFXUpdateCoordinator
 from .entity import LIFXEntity
@@ -98,7 +99,7 @@ async def async_setup_entry(
         "set_hev_cycle_state",
     )
     if lifx_features(device)["matrix"]:
-        if device.product in {176, 177}:
+        if device.product in LIFX_CEILING_PRODUCT_IDS:
             entity: LIFXLight = LIFXCeiling(coordinator, manager, entry)
         else:
             entity = LIFXMatrix(coordinator, manager, entry)

--- a/homeassistant/components/lifx/light.py
+++ b/homeassistant/components/lifx/light.py
@@ -45,6 +45,7 @@ from .manager import (
     SERVICE_EFFECT_MORPH,
     SERVICE_EFFECT_MOVE,
     SERVICE_EFFECT_PULSE,
+    SERVICE_EFFECT_SKY,
     SERVICE_EFFECT_STOP,
     LIFXManager,
 )
@@ -97,7 +98,10 @@ async def async_setup_entry(
         "set_hev_cycle_state",
     )
     if lifx_features(device)["matrix"]:
-        entity: LIFXLight = LIFXMatrix(coordinator, manager, entry)
+        if device.product in {176, 177}:
+            entity: LIFXLight = LIFXCeiling(coordinator, manager, entry)
+        else:
+            entity = LIFXMatrix(coordinator, manager, entry)
     elif lifx_features(device)["extended_multizone"]:
         entity = LIFXExtendedMultiZone(coordinator, manager, entry)
     elif lifx_features(device)["multizone"]:
@@ -497,5 +501,18 @@ class LIFXMatrix(LIFXColor):
         SERVICE_EFFECT_FLAME,
         SERVICE_EFFECT_PULSE,
         SERVICE_EFFECT_MORPH,
+        SERVICE_EFFECT_STOP,
+    ]
+
+
+class LIFXCeiling(LIFXMatrix):
+    """Representation of a LIFX Ceiling device."""
+
+    _attr_effect_list = [
+        SERVICE_EFFECT_COLORLOOP,
+        SERVICE_EFFECT_FLAME,
+        SERVICE_EFFECT_PULSE,
+        SERVICE_EFFECT_MORPH,
+        SERVICE_EFFECT_SKY,
         SERVICE_EFFECT_STOP,
     ]

--- a/homeassistant/components/lifx/manager.py
+++ b/homeassistant/components/lifx/manager.py
@@ -410,21 +410,33 @@ class LIFXManager:
             await self.effects_conductor.start(effect, bulbs)
 
         elif service == SERVICE_EFFECT_SKY:
+            palette = kwargs.get(ATTR_PALETTE, None)
+            if palette is not None:
+                theme = Theme()
+                for hsbk in palette:
+                    theme.add_hsbk(hsbk[0], hsbk[1], hsbk[2], hsbk[3])
+
+            speed = kwargs.get(ATTR_SPEED, EFFECT_SKY_DEFAULT_SPEED)
+            sky_type = kwargs.get(ATTR_SKY_TYPE, EFFECT_SKY_DEFAULT_SKY_TYPE)
+
+            cloud_saturation_min = kwargs.get(
+                ATTR_CLOUD_SATURATION_MIN,
+                EFFECT_SKY_DEFAULT_CLOUD_SATURATION_MIN,
+            )
+            cloud_saturation_max = kwargs.get(
+                ATTR_CLOUD_SATURATION_MAX,
+                EFFECT_SKY_DEFAULT_CLOUD_SATURATION_MAX,
+            )
+
             await asyncio.gather(
                 *(
                     coordinator.async_set_matrix_effect(
                         effect=EFFECT_SKY,
-                        speed=kwargs.get(ATTR_SPEED, EFFECT_SKY_DEFAULT_SPEED),
-                        sky_type=kwargs.get(ATTR_SKY_TYPE, EFFECT_SKY_DEFAULT_SKY_TYPE),
-                        cloud_saturation_min=kwargs.get(
-                            ATTR_CLOUD_SATURATION_MIN,
-                            EFFECT_SKY_DEFAULT_CLOUD_SATURATION_MIN,
-                        ),
-                        cloud_saturation_max=kwargs.get(
-                            ATTR_CLOUD_SATURATION_MAX,
-                            EFFECT_SKY_DEFAULT_CLOUD_SATURATION_MAX,
-                        ),
-                        palette=kwargs.get(ATTR_PALETTE, None),
+                        speed=speed,
+                        sky_type=sky_type,
+                        cloud_saturation_min=cloud_saturation_min,
+                        cloud_saturation_max=cloud_saturation_max,
+                        palette=theme.colors,
                     )
                     for coordinator in coordinators
                 )

--- a/homeassistant/components/lifx/manager.py
+++ b/homeassistant/components/lifx/manager.py
@@ -41,9 +41,12 @@ SERVICE_EFFECT_FLAME = "effect_flame"
 SERVICE_EFFECT_MORPH = "effect_morph"
 SERVICE_EFFECT_MOVE = "effect_move"
 SERVICE_EFFECT_PULSE = "effect_pulse"
+SERVICE_EFFECT_SKY = "effect_sky"
 SERVICE_EFFECT_STOP = "effect_stop"
 
 ATTR_CHANGE = "change"
+ATTR_CLOUD_SATURATION_MIN = "cloud_saturation_min"
+ATTR_CLOUD_SATURATION_MAX = "cloud_saturation_max"
 ATTR_CYCLES = "cycles"
 ATTR_DIRECTION = "direction"
 ATTR_PALETTE = "palette"
@@ -52,6 +55,7 @@ ATTR_POWER_OFF = "power_off"
 ATTR_POWER_ON = "power_on"
 ATTR_SATURATION_MAX = "saturation_max"
 ATTR_SATURATION_MIN = "saturation_min"
+ATTR_SKY_TYPE = "sky_type"
 ATTR_SPEED = "speed"
 ATTR_SPREAD = "spread"
 
@@ -59,6 +63,7 @@ EFFECT_FLAME = "FLAME"
 EFFECT_MORPH = "MORPH"
 EFFECT_MOVE = "MOVE"
 EFFECT_OFF = "OFF"
+EFFECT_SKY = "SKY"
 
 EFFECT_FLAME_DEFAULT_SPEED = 3
 
@@ -71,6 +76,13 @@ EFFECT_MOVE_DIRECTION_RIGHT = "right"
 EFFECT_MOVE_DIRECTION_LEFT = "left"
 
 EFFECT_MOVE_DIRECTIONS = [EFFECT_MOVE_DIRECTION_LEFT, EFFECT_MOVE_DIRECTION_RIGHT]
+
+EFFECT_SKY_DEFAULT_SPEED = 50
+EFFECT_SKY_DEFAULT_SKY_TYPE = "Clouds"
+EFFECT_SKY_DEFAULT_CLOUD_SATURATION_MIN = 50
+EFFECT_SKY_DEFAULT_CLOUD_SATURATION_MAX = 180
+
+EFFECT_SKY_SKY_TYPES = ["Sunrise", "Sunset", "Clouds"]
 
 PULSE_MODE_BLINK = "blink"
 PULSE_MODE_BREATHE = "breathe"
@@ -137,13 +149,6 @@ LIFX_EFFECT_COLORLOOP_SCHEMA = cv.make_entity_service_schema(
 
 LIFX_EFFECT_STOP_SCHEMA = cv.make_entity_service_schema({})
 
-SERVICES = (
-    SERVICE_EFFECT_STOP,
-    SERVICE_EFFECT_PULSE,
-    SERVICE_EFFECT_MOVE,
-    SERVICE_EFFECT_COLORLOOP,
-)
-
 LIFX_EFFECT_FLAME_SCHEMA = cv.make_entity_service_schema(
     {
         **LIFX_EFFECT_SCHEMA,
@@ -183,6 +188,28 @@ LIFX_EFFECT_MOVE_SCHEMA = cv.make_entity_service_schema(
         ATTR_DIRECTION: vol.In(EFFECT_MOVE_DIRECTIONS),
         ATTR_THEME: vol.Optional(vol.In(ThemeLibrary().themes)),
     }
+)
+
+LIFX_EFFECT_SKY_SCHEMA = cv.make_entity_service_schema(
+    {
+        **LIFX_EFFECT_SCHEMA,
+        ATTR_SPEED: vol.All(vol.Coerce(int), vol.Clamp(min=1, max=86400)),
+        ATTR_SKY_TYPE: vol.In(EFFECT_SKY_SKY_TYPES),
+        ATTR_CLOUD_SATURATION_MIN: vol.All(vol.Coerce(int), vol.Clamp(min=0, max=255)),
+        ATTR_CLOUD_SATURATION_MAX: vol.All(vol.Coerce(int), vol.Clamp(min=0, max=255)),
+        ATTR_PALETTE: vol.All(cv.ensure_list, [HSBK_SCHEMA]),
+    }
+)
+
+
+SERVICES = (
+    SERVICE_EFFECT_COLORLOOP,
+    SERVICE_EFFECT_FLAME,
+    SERVICE_EFFECT_MORPH,
+    SERVICE_EFFECT_MOVE,
+    SERVICE_EFFECT_PULSE,
+    SERVICE_EFFECT_SKY,
+    SERVICE_EFFECT_STOP,
 )
 
 
@@ -259,6 +286,13 @@ class LIFXManager:
             SERVICE_EFFECT_MOVE,
             service_handler,
             schema=LIFX_EFFECT_MOVE_SCHEMA,
+        )
+
+        self.hass.services.async_register(
+            DOMAIN,
+            SERVICE_EFFECT_SKY,
+            service_handler,
+            schema=LIFX_EFFECT_SKY_SCHEMA,
         )
 
         self.hass.services.async_register(
@@ -374,6 +408,27 @@ class LIFXManager:
                 saturation_min=saturation_min,
             )
             await self.effects_conductor.start(effect, bulbs)
+
+        elif service == SERVICE_EFFECT_SKY:
+            await asyncio.gather(
+                *(
+                    coordinator.async_set_matrix_effect(
+                        effect=EFFECT_SKY,
+                        speed=kwargs.get(ATTR_SPEED, EFFECT_SKY_DEFAULT_SPEED),
+                        sky_type=kwargs.get(ATTR_SKY_TYPE, EFFECT_SKY_DEFAULT_SKY_TYPE),
+                        cloud_saturation_min=kwargs.get(
+                            ATTR_CLOUD_SATURATION_MIN,
+                            EFFECT_SKY_DEFAULT_CLOUD_SATURATION_MIN,
+                        ),
+                        cloud_saturation_max=kwargs.get(
+                            ATTR_CLOUD_SATURATION_MAX,
+                            EFFECT_SKY_DEFAULT_CLOUD_SATURATION_MAX,
+                        ),
+                        palette=kwargs.get(ATTR_PALETTE, None),
+                    )
+                    for coordinator in coordinators
+                )
+            )
 
         elif service == SERVICE_EFFECT_STOP:
             await self.effects_conductor.stop(bulbs)

--- a/homeassistant/components/lifx/services.yaml
+++ b/homeassistant/components/lifx/services.yaml
@@ -281,6 +281,49 @@ effect_morph:
       default: true
       selector:
         boolean:
+effect_sky:
+  target:
+    entity:
+      integration: lifx
+      domain: light
+  fields:
+    power_on:
+      default: true
+      selector:
+        boolean:
+    speed:
+      default: 50
+      selector:
+        number:
+          min: 1
+          max: 86400
+          step: 1
+          unit_of_measurement: seconds
+    sky_type:
+      default: "Clouds"
+      selector:
+        select:
+          options:
+            - "Clouds"
+            - "Sunrise"
+            - "Sunset"
+    cloud_saturation_min:
+      default: 50
+      selector:
+        number:
+          min: 0
+          max: 255
+    cloud_saturation_max:
+      default: 180
+      selector:
+        number:
+          min: 0
+          max: 255
+    palette:
+      example:
+        - "[[0, 100, 100, 3500], [60, 100, 100, 3500]]"
+      selector:
+        object:
 effect_stop:
   target:
     entity:

--- a/homeassistant/components/lifx/services.yaml
+++ b/homeassistant/components/lifx/services.yaml
@@ -293,6 +293,7 @@ effect_sky:
         boolean:
     speed:
       default: 50
+      example: 50
       selector:
         number:
           min: 1
@@ -301,6 +302,7 @@ effect_sky:
           unit_of_measurement: seconds
     sky_type:
       default: "Clouds"
+      example: "Clouds"
       selector:
         select:
           options:
@@ -309,19 +311,26 @@ effect_sky:
             - "Sunset"
     cloud_saturation_min:
       default: 50
+      example: 50
       selector:
         number:
           min: 0
           max: 255
     cloud_saturation_max:
       default: 180
+      example: 180
       selector:
         number:
           min: 0
           max: 255
     palette:
       example:
-        - "[[0, 100, 100, 3500], [60, 100, 100, 3500]]"
+        - "[200, 1, 1, 3500]"
+        - "[241, 1, 0.01, 3500]"
+        - "[189, 1, 0.08, 3500]"
+        - "[40, 1, 1, 3500]"
+        - "[40, 0.5, 1, 3500]"
+        - "[40, 0, 1, 6500]"
       selector:
         object:
 effect_stop:

--- a/homeassistant/components/lifx/strings.json
+++ b/homeassistant/components/lifx/strings.json
@@ -230,15 +230,15 @@
         },
         "sky_type": {
           "name": "Sky type",
-          "description": "(Optional, default: 'Clouds') The style of sky that will be animated by the effect."
+          "description": "The style of sky that will be animated by the effect."
         },
         "cloud_saturation_min": {
           "name": "Cloud saturation Minimum",
-          "description": "(Optional, default: 50) Minimum cloud saturation."
+          "description": "Minimum cloud saturation."
         },
         "cloud_saturation_max": {
           "name": "Cloud Saturation maximum",
-          "description": "(Optional, default: 180) Maximum cloud saturation."
+          "description": "Maximum cloud saturation."
         },
         "palette": {
           "name": "Palette",

--- a/homeassistant/components/lifx/strings.json
+++ b/homeassistant/components/lifx/strings.json
@@ -220,6 +220,36 @@
         }
       }
     },
+    "effect_sky": {
+      "name": "Sky effect",
+      "description": "Starts the firmware-based Sky effect on LIFX Ceiling.",
+      "fields": {
+        "speed": {
+          "name": "Speed",
+          "description": "How long the Sunrise and Sunset sky types will take to complete. For the Cloud sky type, it is the speed of the clouds across the device."
+        },
+        "sky_type": {
+          "name": "Sky type",
+          "description": "(Optional, default: 'Clouds') The style of sky that will be animated by the effect."
+        },
+        "cloud_saturation_min": {
+          "name": "Cloud saturation Minimum",
+          "description": "(Optional, default: 50) Minimum cloud saturation."
+        },
+        "cloud_saturation_max": {
+          "name": "Cloud Saturation maximum",
+          "description": "(Optional, default: 180) Maximum cloud saturation."
+        },
+        "palette": {
+          "name": "Palette",
+          "description": "List of 1 to 6 colors as hue (0-360), saturation (0-100), brightness (0-100) and kelvin (1500-9000) values to use for this effect."
+        },
+        "power_on": {
+          "name": "Power on",
+          "description": "[%key:component::lifx::services::effect_move::fields::power_on::description%]"
+        }
+      }
+    },
     "effect_stop": {
       "name": "Stop effect",
       "description": "Stops a running effect."

--- a/tests/components/lifx/__init__.py
+++ b/tests/components/lifx/__init__.py
@@ -172,6 +172,19 @@ def _mocked_tile() -> Light:
     bulb.effect = {"effect": "OFF"}
     bulb.get_tile_effect = MockLifxCommand(bulb)
     bulb.set_tile_effect = MockLifxCommand(bulb)
+    bulb.get64 = MockLifxCommand(bulb)
+    bulb.get_device_chain = MockLifxCommand(bulb)
+    return bulb
+
+
+def _mocked_ceiling() -> Light:
+    bulb = _mocked_bulb()
+    bulb.product = 176  # LIFX Ceiling
+    bulb.effect = {"effect": "OFF"}
+    bulb.get_tile_effect = MockLifxCommand(bulb)
+    bulb.set_tile_effect = MockLifxCommand(bulb)
+    bulb.get64 = MockLifxCommand(bulb)
+    bulb.get_device_chain = MockLifxCommand(bulb)
     return bulb
 
 

--- a/tests/components/lifx/test_light.py
+++ b/tests/components/lifx/test_light.py
@@ -887,7 +887,72 @@ async def test_sky_effect(hass: HomeAssistant) -> None:
         "effect": 5,
         "speed": 50,
         "palette": [],
-        "sky_type": "Clouds",
+        "sky_type": 2,
+        "cloud_saturation_min": 50,
+        "cloud_saturation_max": 180,
+    }
+    bulb.get_tile_effect.reset_mock()
+    bulb.set_tile_effect.reset_mock()
+    bulb.set_power.reset_mock()
+
+    bulb.power_level = 0
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_EFFECT_SKY,
+        {
+            ATTR_ENTITY_ID: entity_id,
+            ATTR_PALETTE: [
+                (200, 100, 1, 3500),
+                (241, 100, 1, 3500),
+                (189, 100, 8, 3500),
+                (40, 100, 100, 3500),
+                (40, 50, 100, 3500),
+                (0, 0, 100, 6500),
+            ],
+            ATTR_SKY_TYPE: "Sunrise",
+            ATTR_CLOUD_SATURATION_MAX: 180,
+            ATTR_CLOUD_SATURATION_MIN: 50,
+        },
+        blocking=True,
+    )
+
+    bulb.power_level = 65535
+    bulb.effect = {
+        "effect": "SKY",
+        "palette": [
+            (200, 100, 1, 3500),
+            (241, 100, 1, 3500),
+            (189, 100, 8, 3500),
+            (40, 100, 100, 3500),
+            (40, 50, 100, 3500),
+            (0, 0, 100, 6500),
+        ],
+        "sky_type": 0,
+        "cloud_saturation_min": 50,
+        "cloud_saturation_max": 180,
+    }
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=30))
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+
+    assert len(bulb.set_power.calls) == 1
+    assert len(bulb.set_tile_effect.calls) == 1
+    call_dict = bulb.set_tile_effect.calls[0][1]
+    call_dict.pop("callb")
+    assert call_dict == {
+        "effect": 5,
+        "speed": 50,
+        "palette": [
+            (36408, 65535, 65535, 3500),
+            (43872, 65535, 65535, 3500),
+            (34406, 65535, 5243, 3500),
+            (7281, 65535, 65535, 3500),
+            (7281, 32768, 65535, 3500),
+            (0, 0, 65535, 6500),
+        ],
+        "sky_type": 0,
         "cloud_saturation_min": 50,
         "cloud_saturation_max": 180,
     }

--- a/tests/components/lifx/test_light.py
+++ b/tests/components/lifx/test_light.py
@@ -11,15 +11,19 @@ from homeassistant.components.lifx import DOMAIN
 from homeassistant.components.lifx.const import ATTR_POWER
 from homeassistant.components.lifx.light import ATTR_INFRARED, ATTR_ZONES
 from homeassistant.components.lifx.manager import (
+    ATTR_CLOUD_SATURATION_MAX,
+    ATTR_CLOUD_SATURATION_MIN,
     ATTR_DIRECTION,
     ATTR_PALETTE,
     ATTR_SATURATION_MAX,
     ATTR_SATURATION_MIN,
+    ATTR_SKY_TYPE,
     ATTR_SPEED,
     ATTR_THEME,
     SERVICE_EFFECT_COLORLOOP,
     SERVICE_EFFECT_MORPH,
     SERVICE_EFFECT_MOVE,
+    SERVICE_EFFECT_SKY,
 )
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -62,6 +66,7 @@ from . import (
     _mocked_brightness_bulb,
     _mocked_bulb,
     _mocked_bulb_new_firmware,
+    _mocked_ceiling,
     _mocked_clean_bulb,
     _mocked_light_strip,
     _mocked_tile,
@@ -691,6 +696,7 @@ async def test_matrix_flame_morph_effects(hass: HomeAssistant) -> None:
 
     entity_id = "light.my_bulb"
 
+    # FLAME effect test
     await hass.services.async_call(
         LIGHT_DOMAIN,
         "turn_on",
@@ -707,11 +713,15 @@ async def test_matrix_flame_morph_effects(hass: HomeAssistant) -> None:
         "effect": 3,
         "speed": 3,
         "palette": [],
+        "sky_type": None,
+        "cloud_saturation_min": None,
+        "cloud_saturation_max": None,
     }
     bulb.get_tile_effect.reset_mock()
     bulb.set_tile_effect.reset_mock()
     bulb.set_power.reset_mock()
 
+    # MORPH effect tests
     bulb.power_level = 0
     await hass.services.async_call(
         DOMAIN,
@@ -750,6 +760,9 @@ async def test_matrix_flame_morph_effects(hass: HomeAssistant) -> None:
             (8920, 65535, 32768, 3500),
             (10558, 65535, 32768, 3500),
         ],
+        "sky_type": None,
+        "cloud_saturation_min": None,
+        "cloud_saturation_max": None,
     }
     bulb.get_tile_effect.reset_mock()
     bulb.set_tile_effect.reset_mock()
@@ -808,6 +821,75 @@ async def test_matrix_flame_morph_effects(hass: HomeAssistant) -> None:
             (43690, 65535, 65535, 3500),
             (54613, 65535, 65535, 3500),
         ],
+        "sky_type": None,
+        "cloud_saturation_min": None,
+        "cloud_saturation_max": None,
+    }
+    bulb.get_tile_effect.reset_mock()
+    bulb.set_tile_effect.reset_mock()
+    bulb.set_power.reset_mock()
+
+
+@pytest.mark.usefixtures("mock_discovery")
+async def test_sky_effect(hass: HomeAssistant) -> None:
+    """Test the firmware sky effect on a ceiling device."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=SERIAL
+    )
+    config_entry.add_to_hass(hass)
+    bulb = _mocked_ceiling()
+    bulb.power_level = 0
+    bulb.color = [65535, 65535, 65535, 65535]
+    with (
+        _patch_discovery(device=bulb),
+        _patch_config_flow_try_connect(device=bulb),
+        _patch_device(device=bulb),
+    ):
+        await async_setup_component(hass, lifx.DOMAIN, {lifx.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "light.my_bulb"
+
+    # SKY effect test
+    bulb.power_level = 0
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_EFFECT_SKY,
+        {
+            ATTR_ENTITY_ID: entity_id,
+            ATTR_PALETTE: [],
+            ATTR_SKY_TYPE: "Clouds",
+            ATTR_CLOUD_SATURATION_MAX: 180,
+            ATTR_CLOUD_SATURATION_MIN: 50,
+        },
+        blocking=True,
+    )
+
+    bulb.power_level = 65535
+    bulb.effect = {
+        "effect": "SKY",
+        "palette": [],
+        "sky_type": 2,
+        "cloud_saturation_min": 50,
+        "cloud_saturation_max": 180,
+    }
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=30))
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+
+    assert len(bulb.set_power.calls) == 1
+    assert len(bulb.set_tile_effect.calls) == 1
+    call_dict = bulb.set_tile_effect.calls[0][1]
+    call_dict.pop("callb")
+    assert call_dict == {
+        "effect": 5,
+        "speed": 50,
+        "palette": [],
+        "sky_type": "Clouds",
+        "cloud_saturation_min": 50,
+        "cloud_saturation_max": 180,
     }
     bulb.get_tile_effect.reset_mock()
     bulb.set_tile_effect.reset_mock()


### PR DESCRIPTION
## Proposed change

Add support for the SKY firmware effect on LIFX Ceiling devices. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: depends on #121824 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33712

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
