### PR TITLE
Correct deprecated telegram usage in dsmr

### DIFF
--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -16,7 +16,7 @@ from dsmr_parser.clients.rfxtrx_protocol import (
     create_rfxtrx_dsmr_reader,
     create_rfxtrx_tcp_dsmr_reader,
 )
-from dsmr_parser.objects import DSMRObject
+from dsmr_parser.objects import DSMRObject, Telegram
 import serial
 
 from homeassistant.components.sensor import (
@@ -380,7 +380,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
 
 
 def create_mbus_entity(
-    mbus: int, mtype: int, telegram: dict[str, DSMRObject]
+    mbus: int, mtype: int, telegram: Telegram
 ) -> DSMRSensorEntityDescription | None:
     """Create a new MBUS Entity."""
     if (
@@ -478,7 +478,7 @@ def rename_old_gas_to_mbus(
 
 
 def create_mbus_entities(
-    hass: HomeAssistant, telegram: dict[str, DSMRObject], entry: ConfigEntry
+    hass: HomeAssistant, telegram: Telegram, entry: ConfigEntry
 ) -> list[DSMREntity]:
     """Create MBUS Entities."""
     entities = []
@@ -523,7 +523,7 @@ async def async_setup_entry(
     add_entities_handler: Callable[..., None] | None
 
     @callback
-    def init_async_add_entities(telegram: dict[str, DSMRObject]) -> None:
+    def init_async_add_entities(telegram: Telegram) -> None:
         """Add the sensor entities after the first telegram was received."""
         nonlocal add_entities_handler
         assert add_entities_handler is not None
@@ -560,7 +560,7 @@ async def async_setup_entry(
     )
 
     @Throttle(min_time_between_updates)
-    def update_entities_telegram(telegram: dict[str, DSMRObject] | None) -> None:
+    def update_entities_telegram(telegram: Telegram | None) -> None:
         """Update entities with latest telegram and trigger state update."""
         nonlocal initialized
         # Make all device entities aware of new telegram
@@ -709,7 +709,7 @@ class DSMREntity(SensorEntity):
         self,
         entity_description: DSMRSensorEntityDescription,
         entry: ConfigEntry,
-        telegram: dict[str, DSMRObject],
+        telegram: Telegram,
         device_class: SensorDeviceClass,
         native_unit_of_measurement: str | None,
         serial_id: str = "",
@@ -720,7 +720,7 @@ class DSMREntity(SensorEntity):
         self._attr_device_class = device_class
         self._attr_native_unit_of_measurement = native_unit_of_measurement
         self._entry = entry
-        self.telegram: dict[str, DSMRObject] | None = telegram
+        self.telegram: Telegram | None = telegram
 
         device_serial = entry.data[CONF_SERIAL_ID]
         device_name = DEVICE_NAME_ELECTRICITY
@@ -750,7 +750,7 @@ class DSMREntity(SensorEntity):
             self._attr_unique_id = f"{device_serial}_{entity_description.key}"
 
     @callback
-    def update_data(self, telegram: dict[str, DSMRObject] | None) -> None:
+    def update_data(self, telegram: Telegram | None) -> None:
         """Update data."""
         self.telegram = telegram
         if self.hass and (

--- a/tests/components/dsmr/test_mbus_migration.py
+++ b/tests/components/dsmr/test_mbus_migration.py
@@ -9,7 +9,7 @@ from dsmr_parser.obis_references import (
     BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
     BELGIUM_MBUS1_METER_READING2,
 )
-from dsmr_parser.objects import CosemObject, MBusObject
+from dsmr_parser.objects import CosemObject, MBusObject, Telegram
 
 from homeassistant.components.dsmr.const import DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
@@ -65,20 +65,31 @@ async def test_migrate_gas_to_mbus(
     assert entity.unique_id == old_unique_id
     await hass.async_block_till_done()
 
-    telegram = {
-        BELGIUM_MBUS1_DEVICE_TYPE: CosemObject((0, 0), [{"value": "003", "unit": ""}]),
-        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER: CosemObject(
+    telegram = Telegram()
+    telegram.add(
+        BELGIUM_MBUS1_DEVICE_TYPE,
+        CosemObject((0, 0), [{"value": "003", "unit": ""}]),
+        "BELGIUM_MBUS1_DEVICE_TYPE",
+    )
+    telegram.add(
+        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+        CosemObject(
             (0, 1),
             [{"value": "37464C4F32313139303333373331", "unit": ""}],
         ),
-        BELGIUM_MBUS1_METER_READING2: MBusObject(
+        "BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER",
+    )
+    telegram.add(
+        BELGIUM_MBUS1_METER_READING2,
+        MBusObject(
             (0, 1),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642213)},
                 {"value": Decimal(745.695), "unit": "m3"},
             ],
         ),
-    }
+        "BELGIUM_MBUS1_METER_READING2",
+    )
 
     assert await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
@@ -171,20 +182,31 @@ async def test_migrate_gas_to_mbus_exists(
     )
     await hass.async_block_till_done()
 
-    telegram = {
-        BELGIUM_MBUS1_DEVICE_TYPE: CosemObject((0, 0), [{"value": "003", "unit": ""}]),
-        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER: CosemObject(
+    telegram = Telegram()
+    telegram.add(
+        BELGIUM_MBUS1_DEVICE_TYPE,
+        CosemObject((0, 0), [{"value": "003", "unit": ""}]),
+        "BELGIUM_MBUS1_DEVICE_TYPE",
+    )
+    telegram.add(
+        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+        CosemObject(
             (0, 1),
             [{"value": "37464C4F32313139303333373331", "unit": ""}],
         ),
-        BELGIUM_MBUS1_METER_READING2: MBusObject(
+        "BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER",
+    )
+    telegram.add(
+        BELGIUM_MBUS1_METER_READING2,
+        MBusObject(
             (0, 1),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642213)},
                 {"value": Decimal(745.695), "unit": "m3"},
             ],
         ),
-    }
+        "BELGIUM_MBUS1_METER_READING2",
+    )
 
     assert await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/dsmr/test_mbus_migration.py
+++ b/tests/components/dsmr/test_mbus_migration.py
@@ -66,15 +66,13 @@ async def test_migrate_gas_to_mbus(
     await hass.async_block_till_done()
 
     telegram = {
-        BELGIUM_MBUS1_DEVICE_TYPE: CosemObject(
-            BELGIUM_MBUS1_DEVICE_TYPE, [{"value": "003", "unit": ""}]
-        ),
+        BELGIUM_MBUS1_DEVICE_TYPE: CosemObject((0, 0), [{"value": "003", "unit": ""}]),
         BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER: CosemObject(
-            BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+            (0, 1),
             [{"value": "37464C4F32313139303333373331", "unit": ""}],
         ),
         BELGIUM_MBUS1_METER_READING2: MBusObject(
-            BELGIUM_MBUS1_METER_READING2,
+            (0, 1),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642213)},
                 {"value": Decimal(745.695), "unit": "m3"},
@@ -174,15 +172,13 @@ async def test_migrate_gas_to_mbus_exists(
     await hass.async_block_till_done()
 
     telegram = {
-        BELGIUM_MBUS1_DEVICE_TYPE: CosemObject(
-            BELGIUM_MBUS1_DEVICE_TYPE, [{"value": "003", "unit": ""}]
-        ),
+        BELGIUM_MBUS1_DEVICE_TYPE: CosemObject((0, 0), [{"value": "003", "unit": ""}]),
         BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER: CosemObject(
-            BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+            (0, 1),
             [{"value": "37464C4F32313139303333373331", "unit": ""}],
         ),
         BELGIUM_MBUS1_METER_READING2: MBusObject(
-            BELGIUM_MBUS1_METER_READING2,
+            (0, 1),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642213)},
                 {"value": Decimal(745.695), "unit": "m3"},

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -37,7 +37,7 @@ from dsmr_parser.obis_references import (
     GAS_METER_READING,
     HOURLY_GAS_METER_READING,
 )
-from dsmr_parser.objects import CosemObject, MBusObject
+from dsmr_parser.objects import CosemObject, MBusObject, Telegram
 import pytest
 
 from homeassistant.components.sensor import (
@@ -80,20 +80,31 @@ async def test_default_setup(
         "time_between_update": 0,
     }
 
-    telegram = {
-        CURRENT_ELECTRICITY_USAGE: CosemObject(
+    telegram = Telegram()
+    telegram.add(
+        CURRENT_ELECTRICITY_USAGE,
+        CosemObject(
             (0, 0),
             [{"value": Decimal("0.0"), "unit": UnitOfPower.WATT}],
         ),
-        ELECTRICITY_ACTIVE_TARIFF: CosemObject((0, 0), [{"value": "0001", "unit": ""}]),
-        GAS_METER_READING: MBusObject(
+        "CURRENT_ELECTRICITY_USAGE",
+    )
+    telegram.add(
+        ELECTRICITY_ACTIVE_TARIFF,
+        CosemObject((0, 0), [{"value": "0001", "unit": ""}]),
+        "ELECTRICITY_ACTIVE_TARIFF",
+    )
+    telegram.add(
+        GAS_METER_READING,
+        MBusObject(
             (0, 0),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642213)},
                 {"value": Decimal(745.695), "unit": UnitOfVolume.CUBIC_METERS},
             ],
         ),
-    }
+        "GAS_METER_READING",
+    )
 
     mock_entry = MockConfigEntry(
         domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data, options=entry_options
@@ -132,20 +143,31 @@ async def test_default_setup(
     )
     assert power_consumption.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "W"
 
-    telegram = {
-        CURRENT_ELECTRICITY_USAGE: CosemObject(
+    telegram = Telegram()
+    telegram.add(
+        CURRENT_ELECTRICITY_USAGE,
+        CosemObject(
             (0, 0),
             [{"value": Decimal("35.0"), "unit": UnitOfPower.WATT}],
         ),
-        ELECTRICITY_ACTIVE_TARIFF: CosemObject((0, 0), [{"value": "0001", "unit": ""}]),
-        GAS_METER_READING: MBusObject(
+        "CURRENT_ELECTRICITY_USAGE",
+    )
+    telegram.add(
+        ELECTRICITY_ACTIVE_TARIFF,
+        CosemObject((0, 0), [{"value": "0001", "unit": ""}]),
+        "ELECTRICITY_ACTIVE_TARIFF",
+    )
+    telegram.add(
+        GAS_METER_READING,
+        MBusObject(
             (0, 0),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642214)},
                 {"value": Decimal(745.701), "unit": UnitOfVolume.CUBIC_METERS},
             ],
         ),
-    }
+        "GAS_METER_READING",
+    )
 
     # simulate a telegram pushed from the smartmeter and parsed by dsmr_parser
     telegram_callback(telegram)
@@ -205,13 +227,20 @@ async def test_setup_only_energy(
         "time_between_update": 0,
     }
 
-    telegram = {
-        CURRENT_ELECTRICITY_USAGE: CosemObject(
+    telegram = Telegram()
+    telegram.add(
+        CURRENT_ELECTRICITY_USAGE,
+        CosemObject(
             (0, 0),
             [{"value": Decimal("35.0"), "unit": UnitOfPower.WATT}],
         ),
-        ELECTRICITY_ACTIVE_TARIFF: CosemObject((0, 0), [{"value": "0001", "unit": ""}]),
-    }
+        "CURRENT_ELECTRICITY_USAGE",
+    )
+    telegram.add(
+        ELECTRICITY_ACTIVE_TARIFF,
+        CosemObject((0, 0), [{"value": "0001", "unit": ""}]),
+        "ELECTRICITY_ACTIVE_TARIFF",
+    )
 
     mock_entry = MockConfigEntry(
         domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data, options=entry_options
@@ -254,16 +283,23 @@ async def test_v4_meter(
         "time_between_update": 0,
     }
 
-    telegram = {
-        HOURLY_GAS_METER_READING: MBusObject(
+    telegram = Telegram()
+    telegram.add(
+        HOURLY_GAS_METER_READING,
+        MBusObject(
             (0, 0),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642213)},
                 {"value": Decimal(745.695), "unit": "m3"},
             ],
         ),
-        ELECTRICITY_ACTIVE_TARIFF: CosemObject((0, 0), [{"value": "0001", "unit": ""}]),
-    }
+        "HOURLY_GAS_METER_READING",
+    )
+    telegram.add(
+        ELECTRICITY_ACTIVE_TARIFF,
+        CosemObject((0, 0), [{"value": "0001", "unit": ""}]),
+        "ELECTRICITY_ACTIVE_TARIFF",
+    )
 
     mock_entry = MockConfigEntry(
         domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data, options=entry_options
@@ -335,16 +371,23 @@ async def test_v5_meter(
         "time_between_update": 0,
     }
 
-    telegram = {
-        HOURLY_GAS_METER_READING: MBusObject(
+    telegram = Telegram()
+    telegram.add(
+        HOURLY_GAS_METER_READING,
+        MBusObject(
             (0, 0),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642213)},
                 {"value": value, "unit": "m3"},
             ],
         ),
-        ELECTRICITY_ACTIVE_TARIFF: CosemObject((0, 0), [{"value": "0001", "unit": ""}]),
-    }
+        "HOURLY_GAS_METER_READING",
+    )
+    telegram.add(
+        ELECTRICITY_ACTIVE_TARIFF,
+        CosemObject((0, 0), [{"value": "0001", "unit": ""}]),
+        "ELECTRICITY_ACTIVE_TARIFF",
+    )
 
     mock_entry = MockConfigEntry(
         domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data, options=entry_options
@@ -401,23 +444,34 @@ async def test_luxembourg_meter(
         "time_between_update": 0,
     }
 
-    telegram = {
-        HOURLY_GAS_METER_READING: MBusObject(
+    telegram = Telegram()
+    telegram.add(
+        HOURLY_GAS_METER_READING,
+        MBusObject(
             (0, 0),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642213)},
                 {"value": Decimal(745.695), "unit": "m3"},
             ],
         ),
-        ELECTRICITY_IMPORTED_TOTAL: CosemObject(
+        "HOURLY_GAS_METER_READING",
+    )
+    telegram.add(
+        ELECTRICITY_IMPORTED_TOTAL,
+        CosemObject(
             (0, 0),
             [{"value": Decimal(123.456), "unit": UnitOfEnergy.KILO_WATT_HOUR}],
         ),
-        ELECTRICITY_EXPORTED_TOTAL: CosemObject(
+        "ELECTRICITY_IMPORTED_TOTAL",
+    )
+    telegram.add(
+        ELECTRICITY_EXPORTED_TOTAL,
+        CosemObject(
             (0, 0),
             [{"value": Decimal(654.321), "unit": UnitOfEnergy.KILO_WATT_HOUR}],
         ),
-    }
+        "ELECTRICITY_EXPORTED_TOTAL",
+    )
 
     mock_entry = MockConfigEntry(
         domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data, options=entry_options
@@ -485,68 +539,127 @@ async def test_belgian_meter(
         "time_between_update": 0,
     }
 
-    telegram = {
-        BELGIUM_CURRENT_AVERAGE_DEMAND: CosemObject(
+    telegram = Telegram()
+    telegram.add(
+        BELGIUM_CURRENT_AVERAGE_DEMAND,
+        CosemObject(
             (0, 0),
             [{"value": Decimal(1.75), "unit": "kW"}],
         ),
-        BELGIUM_MAXIMUM_DEMAND_MONTH: MBusObject(
+        "BELGIUM_CURRENT_AVERAGE_DEMAND",
+    )
+    telegram.add(
+        BELGIUM_MAXIMUM_DEMAND_MONTH,
+        MBusObject(
             (0, 0),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642218)},
                 {"value": Decimal(4.11), "unit": "kW"},
             ],
         ),
-        BELGIUM_MBUS1_DEVICE_TYPE: CosemObject((0, 1), [{"value": "003", "unit": ""}]),
-        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER: CosemObject(
+        "BELGIUM_MAXIMUM_DEMAND_MONTH",
+    )
+    telegram.add(
+        BELGIUM_MBUS1_DEVICE_TYPE,
+        CosemObject((0, 1), [{"value": "003", "unit": ""}]),
+        "BELGIUM_MBUS1_DEVICE_TYPE",
+    )
+    telegram.add(
+        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+        CosemObject(
             (0, 1),
             [{"value": "37464C4F32313139303333373331", "unit": ""}],
         ),
-        BELGIUM_MBUS1_METER_READING2: MBusObject(
+        "BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER",
+    )
+    telegram.add(
+        BELGIUM_MBUS1_METER_READING2,
+        MBusObject(
             (0, 1),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642213)},
                 {"value": Decimal(745.695), "unit": "m3"},
             ],
         ),
-        BELGIUM_MBUS2_DEVICE_TYPE: CosemObject((0, 0), [{"value": "007", "unit": ""}]),
-        BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER: CosemObject(
+        "BELGIUM_MBUS1_METER_READING2",
+    )
+    telegram.add(
+        BELGIUM_MBUS2_DEVICE_TYPE,
+        CosemObject((0, 0), [{"value": "007", "unit": ""}]),
+        "BELGIUM_MBUS2_DEVICE_TYPE",
+    )
+    telegram.add(
+        BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER,
+        CosemObject(
             (0, 2),
             [{"value": "37464C4F32313139303333373332", "unit": ""}],
         ),
-        BELGIUM_MBUS2_METER_READING1: MBusObject(
+        "BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER",
+    )
+    telegram.add(
+        BELGIUM_MBUS2_METER_READING1,
+        MBusObject(
             (0, 2),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642214)},
                 {"value": Decimal(678.695), "unit": "m3"},
             ],
         ),
-        BELGIUM_MBUS3_DEVICE_TYPE: CosemObject((0, 0), [{"value": "003", "unit": ""}]),
-        BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER: CosemObject(
+        "BELGIUM_MBUS2_METER_READING1",
+    )
+    telegram.add(
+        BELGIUM_MBUS3_DEVICE_TYPE,
+        CosemObject((0, 0), [{"value": "003", "unit": ""}]),
+        "BELGIUM_MBUS3_DEVICE_TYPE",
+    )
+    telegram.add(
+        BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER,
+        CosemObject(
             (0, 3),
             [{"value": "37464C4F32313139303333373333", "unit": ""}],
         ),
-        BELGIUM_MBUS3_METER_READING2: MBusObject(
+        "BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER",
+    )
+    telegram.add(
+        BELGIUM_MBUS3_METER_READING2,
+        MBusObject(
             (0, 3),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642215)},
                 {"value": Decimal(12.12), "unit": "m3"},
             ],
         ),
-        BELGIUM_MBUS4_DEVICE_TYPE: CosemObject((0, 0), [{"value": "007", "unit": ""}]),
-        BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER: CosemObject(
+        "BELGIUM_MBUS3_METER_READING2",
+    )
+    telegram.add(
+        BELGIUM_MBUS4_DEVICE_TYPE,
+        CosemObject((0, 0), [{"value": "007", "unit": ""}]),
+        "BELGIUM_MBUS4_DEVICE_TYPE",
+    )
+    telegram.add(
+        BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER,
+        CosemObject(
             (0, 4),
             [{"value": "37464C4F32313139303333373334", "unit": ""}],
         ),
-        BELGIUM_MBUS4_METER_READING1: MBusObject(
+        "BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER",
+    )
+    telegram.add(
+        BELGIUM_MBUS4_METER_READING1,
+        MBusObject(
             (0, 4),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642216)},
                 {"value": Decimal(13.13), "unit": "m3"},
             ],
         ),
-        ELECTRICITY_ACTIVE_TARIFF: CosemObject((0, 0), [{"value": "0001", "unit": ""}]),
-    }
+        "BELGIUM_MBUS4_METER_READING1",
+    )
+    telegram.add(
+        ELECTRICITY_ACTIVE_TARIFF,
+        CosemObject((0, 0), [{"value": "0001", "unit": ""}]),
+        "ELECTRICITY_ACTIVE_TARIFF",
+    )
 
     mock_entry = MockConfigEntry(
         domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data, options=entry_options
@@ -660,56 +773,103 @@ async def test_belgian_meter_alt(
         "time_between_update": 0,
     }
 
-    telegram = {
-        BELGIUM_MBUS1_DEVICE_TYPE: CosemObject((0, 0), [{"value": "007", "unit": ""}]),
-        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER: CosemObject(
+    telegram = Telegram()
+    telegram.add(
+        BELGIUM_MBUS1_DEVICE_TYPE,
+        CosemObject((0, 0), [{"value": "007", "unit": ""}]),
+        "BELGIUM_MBUS1_DEVICE_TYPE",
+    )
+    telegram.add(
+        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+        CosemObject(
             (0, 1),
             [{"value": "37464C4F32313139303333373331", "unit": ""}],
         ),
-        BELGIUM_MBUS1_METER_READING1: MBusObject(
+        "BELGIUM_MBUS1_DEVICE_TYPE",
+    )
+    telegram.add(
+        BELGIUM_MBUS1_METER_READING1,
+        MBusObject(
             (0, 1),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642215)},
                 {"value": Decimal(123.456), "unit": "m3"},
             ],
         ),
-        BELGIUM_MBUS2_DEVICE_TYPE: CosemObject((0, 0), [{"value": "003", "unit": ""}]),
-        BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER: CosemObject(
+        "BELGIUM_MBUS1_METER_READING1",
+    )
+    telegram.add(
+        BELGIUM_MBUS2_DEVICE_TYPE,
+        CosemObject((0, 0), [{"value": "003", "unit": ""}]),
+        "BELGIUM_MBUS2_DEVICE_TYPE",
+    )
+    telegram.add(
+        BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER,
+        CosemObject(
             (0, 2),
             [{"value": "37464C4F32313139303333373332", "unit": ""}],
         ),
-        BELGIUM_MBUS2_METER_READING2: MBusObject(
+        "BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER",
+    )
+    telegram.add(
+        BELGIUM_MBUS2_METER_READING2,
+        MBusObject(
             (0, 2),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642216)},
                 {"value": Decimal(678.901), "unit": "m3"},
             ],
         ),
-        BELGIUM_MBUS3_DEVICE_TYPE: CosemObject((0, 0), [{"value": "007", "unit": ""}]),
-        BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER: CosemObject(
+        BELGIUM_MBUS2_METER_READING2,
+    )
+    telegram.add(
+        BELGIUM_MBUS3_DEVICE_TYPE,
+        CosemObject((0, 0), [{"value": "007", "unit": ""}]),
+        "BELGIUM_MBUS3_DEVICE_TYPE",
+    )
+    telegram.add(
+        BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER,
+        CosemObject(
             (0, 3),
             [{"value": "37464C4F32313139303333373333", "unit": ""}],
         ),
-        BELGIUM_MBUS3_METER_READING1: MBusObject(
+        "BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER",
+    )
+    telegram.add(
+        BELGIUM_MBUS3_METER_READING1,
+        MBusObject(
             (0, 3),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642217)},
                 {"value": Decimal(12.12), "unit": "m3"},
             ],
         ),
-        BELGIUM_MBUS4_DEVICE_TYPE: CosemObject((0, 0), [{"value": "003", "unit": ""}]),
-        BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER: CosemObject(
+        "BELGIUM_MBUS3_METER_READING1",
+    )
+    telegram.add(
+        BELGIUM_MBUS4_DEVICE_TYPE,
+        CosemObject((0, 0), [{"value": "003", "unit": ""}]),
+        "BELGIUM_MBUS4_DEVICE_TYPE",
+    )
+    telegram.add(
+        BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER,
+        CosemObject(
             (0, 4),
             [{"value": "37464C4F32313139303333373334", "unit": ""}],
         ),
-        BELGIUM_MBUS4_METER_READING2: MBusObject(
+        "BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER",
+    )
+    telegram.add(
+        BELGIUM_MBUS4_METER_READING2,
+        MBusObject(
             (0, 4),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642218)},
                 {"value": Decimal(13.13), "unit": "m3"},
             ],
         ),
-    }
+        "BELGIUM_MBUS4_METER_READING2",
+    )
 
     mock_entry = MockConfigEntry(
         domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data, options=entry_options
@@ -801,39 +961,78 @@ async def test_belgian_meter_mbus(
         "time_between_update": 0,
     }
 
-    telegram = {
-        ELECTRICITY_ACTIVE_TARIFF: CosemObject((0, 0), [{"value": "0003", "unit": ""}]),
-        BELGIUM_MBUS1_DEVICE_TYPE: CosemObject((0, 0), [{"value": "006", "unit": ""}]),
-        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER: CosemObject(
+    telegram = Telegram()
+    telegram.add(
+        ELECTRICITY_ACTIVE_TARIFF,
+        CosemObject((0, 0), [{"value": "0003", "unit": ""}]),
+        "ELECTRICITY_ACTIVE_TARIFF",
+    )
+    telegram.add(
+        BELGIUM_MBUS1_DEVICE_TYPE,
+        CosemObject((0, 0), [{"value": "006", "unit": ""}]),
+        "BELGIUM_MBUS1_DEVICE_TYPE",
+    )
+    telegram.add(
+        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+        CosemObject(
             (0, 1),
             [{"value": "37464C4F32313139303333373331", "unit": ""}],
         ),
-        BELGIUM_MBUS2_DEVICE_TYPE: CosemObject((0, 0), [{"value": "003", "unit": ""}]),
-        BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER: CosemObject(
+        "BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER",
+    )
+    telegram.add(
+        BELGIUM_MBUS2_DEVICE_TYPE,
+        CosemObject((0, 0), [{"value": "003", "unit": ""}]),
+        "BELGIUM_MBUS2_DEVICE_TYPE",
+    )
+    telegram.add(
+        BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER,
+        CosemObject(
             (0, 2),
             [{"value": "37464C4F32313139303333373332", "unit": ""}],
         ),
-        BELGIUM_MBUS3_DEVICE_TYPE: CosemObject((0, 0), [{"value": "007", "unit": ""}]),
-        BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER: CosemObject(
+        "BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER",
+    )
+    telegram.add(
+        BELGIUM_MBUS3_DEVICE_TYPE,
+        CosemObject((0, 0), [{"value": "007", "unit": ""}]),
+        "BELGIUM_MBUS3_DEVICE_TYPE",
+    )
+    telegram.add(
+        BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER,
+        CosemObject(
             (0, 3),
             [{"value": "37464C4F32313139303333373333", "unit": ""}],
         ),
-        BELGIUM_MBUS3_METER_READING2: MBusObject(
+        "BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER",
+    )
+    telegram.add(
+        BELGIUM_MBUS3_METER_READING2,
+        MBusObject(
             (0, 3),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642217)},
                 {"value": Decimal(12.12), "unit": "m3"},
             ],
         ),
-        BELGIUM_MBUS4_DEVICE_TYPE: CosemObject((0, 0), [{"value": "007", "unit": ""}]),
-        BELGIUM_MBUS4_METER_READING1: MBusObject(
+        "BELGIUM_MBUS3_METER_READING2",
+    )
+    telegram.add(
+        BELGIUM_MBUS4_DEVICE_TYPE,
+        CosemObject((0, 0), [{"value": "007", "unit": ""}]),
+        "BELGIUM_MBUS4_DEVICE_TYPE",
+    )
+    telegram.add(
+        BELGIUM_MBUS4_METER_READING1,
+        MBusObject(
             (0, 4),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642218)},
                 {"value": Decimal(13.13), "unit": "m3"},
             ],
         ),
-    }
+        "BELGIUM_MBUS4_METER_READING1",
+    )
 
     mock_entry = MockConfigEntry(
         domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data, options=entry_options
@@ -900,9 +1099,12 @@ async def test_belgian_meter_low(
         "time_between_update": 0,
     }
 
-    telegram = {
-        ELECTRICITY_ACTIVE_TARIFF: CosemObject((0, 0), [{"value": "0002", "unit": ""}])
-    }
+    telegram = Telegram()
+    telegram.add(
+        ELECTRICITY_ACTIVE_TARIFF,
+        CosemObject((0, 0), [{"value": "0002", "unit": ""}]),
+        "ELECTRICITY_ACTIVE_TARIFF",
+    )
 
     mock_entry = MockConfigEntry(
         domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data, options=entry_options
@@ -946,16 +1148,23 @@ async def test_swedish_meter(
         "time_between_update": 0,
     }
 
-    telegram = {
-        ELECTRICITY_IMPORTED_TOTAL: CosemObject(
+    telegram = Telegram()
+    telegram.add(
+        ELECTRICITY_IMPORTED_TOTAL,
+        CosemObject(
             (0, 0),
             [{"value": Decimal(123.456), "unit": UnitOfEnergy.KILO_WATT_HOUR}],
         ),
-        ELECTRICITY_EXPORTED_TOTAL: CosemObject(
+        "ELECTRICITY_IMPORTED_TOTAL",
+    )
+    telegram.add(
+        ELECTRICITY_EXPORTED_TOTAL,
+        CosemObject(
             (0, 0),
             [{"value": Decimal(654.321), "unit": UnitOfEnergy.KILO_WATT_HOUR}],
         ),
-    }
+        "ELECTRICITY_EXPORTED_TOTAL",
+    )
 
     mock_entry = MockConfigEntry(
         domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data, options=entry_options
@@ -1014,16 +1223,23 @@ async def test_easymeter(
         "time_between_update": 0,
     }
 
-    telegram = {
-        ELECTRICITY_IMPORTED_TOTAL: CosemObject(
+    telegram = Telegram()
+    telegram.add(
+        ELECTRICITY_IMPORTED_TOTAL,
+        CosemObject(
             (0, 0),
             [{"value": Decimal(54184.6316), "unit": UnitOfEnergy.KILO_WATT_HOUR}],
         ),
-        ELECTRICITY_EXPORTED_TOTAL: CosemObject(
+        "ELECTRICITY_IMPORTED_TOTAL",
+    )
+    telegram.add(
+        ELECTRICITY_EXPORTED_TOTAL,
+        CosemObject(
             (0, 0),
             [{"value": Decimal(19981.1069), "unit": UnitOfEnergy.KILO_WATT_HOUR}],
         ),
-    }
+        "ELECTRICITY_EXPORTED_TOTAL",
+    )
 
     mock_entry = MockConfigEntry(
         domain="dsmr",
@@ -1182,13 +1398,20 @@ async def test_reconnect(
         "time_between_update": 0,
     }
 
-    telegram = {
-        CURRENT_ELECTRICITY_USAGE: CosemObject(
+    telegram = Telegram()
+    telegram.add(
+        CURRENT_ELECTRICITY_USAGE,
+        CosemObject(
             (0, 0),
             [{"value": Decimal("35.0"), "unit": UnitOfPower.WATT}],
         ),
-        ELECTRICITY_ACTIVE_TARIFF: CosemObject((0, 0), [{"value": "0001", "unit": ""}]),
-    }
+        "CURRENT_ELECTRICITY_USAGE",
+    )
+    telegram.add(
+        ELECTRICITY_ACTIVE_TARIFF,
+        CosemObject((0, 0), [{"value": "0001", "unit": ""}]),
+        "ELECTRICITY_ACTIVE_TARIFF",
+    )
 
     # mock waiting coroutine while connection lasts
     closed = asyncio.Event()
@@ -1258,15 +1481,18 @@ async def test_gas_meter_providing_energy_reading(
         "time_between_update": 0,
     }
 
-    telegram = {
-        GAS_METER_READING: MBusObject(
+    telegram = Telegram()
+    telegram.add(
+        GAS_METER_READING,
+        MBusObject(
             (0, 0),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642213)},
                 {"value": Decimal(123.456), "unit": UnitOfEnergy.GIGA_JOULE},
             ],
         ),
-    }
+        "GAS_METER_READING",
+    )
 
     mock_entry = MockConfigEntry(
         domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data, options=entry_options

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -82,14 +82,12 @@ async def test_default_setup(
 
     telegram = {
         CURRENT_ELECTRICITY_USAGE: CosemObject(
-            CURRENT_ELECTRICITY_USAGE,
+            (0, 0),
             [{"value": Decimal("0.0"), "unit": UnitOfPower.WATT}],
         ),
-        ELECTRICITY_ACTIVE_TARIFF: CosemObject(
-            ELECTRICITY_ACTIVE_TARIFF, [{"value": "0001", "unit": ""}]
-        ),
+        ELECTRICITY_ACTIVE_TARIFF: CosemObject((0, 0), [{"value": "0001", "unit": ""}]),
         GAS_METER_READING: MBusObject(
-            GAS_METER_READING,
+            (0, 0),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642213)},
                 {"value": Decimal(745.695), "unit": UnitOfVolume.CUBIC_METERS},
@@ -136,14 +134,12 @@ async def test_default_setup(
 
     telegram = {
         CURRENT_ELECTRICITY_USAGE: CosemObject(
-            CURRENT_ELECTRICITY_USAGE,
+            (0, 0),
             [{"value": Decimal("35.0"), "unit": UnitOfPower.WATT}],
         ),
-        ELECTRICITY_ACTIVE_TARIFF: CosemObject(
-            ELECTRICITY_ACTIVE_TARIFF, [{"value": "0001", "unit": ""}]
-        ),
+        ELECTRICITY_ACTIVE_TARIFF: CosemObject((0, 0), [{"value": "0001", "unit": ""}]),
         GAS_METER_READING: MBusObject(
-            GAS_METER_READING,
+            (0, 0),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642214)},
                 {"value": Decimal(745.701), "unit": UnitOfVolume.CUBIC_METERS},
@@ -211,12 +207,10 @@ async def test_setup_only_energy(
 
     telegram = {
         CURRENT_ELECTRICITY_USAGE: CosemObject(
-            CURRENT_ELECTRICITY_USAGE,
+            (0, 0),
             [{"value": Decimal("35.0"), "unit": UnitOfPower.WATT}],
         ),
-        ELECTRICITY_ACTIVE_TARIFF: CosemObject(
-            ELECTRICITY_ACTIVE_TARIFF, [{"value": "0001", "unit": ""}]
-        ),
+        ELECTRICITY_ACTIVE_TARIFF: CosemObject((0, 0), [{"value": "0001", "unit": ""}]),
     }
 
     mock_entry = MockConfigEntry(
@@ -262,15 +256,13 @@ async def test_v4_meter(
 
     telegram = {
         HOURLY_GAS_METER_READING: MBusObject(
-            HOURLY_GAS_METER_READING,
+            (0, 0),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642213)},
                 {"value": Decimal(745.695), "unit": "m3"},
             ],
         ),
-        ELECTRICITY_ACTIVE_TARIFF: CosemObject(
-            ELECTRICITY_ACTIVE_TARIFF, [{"value": "0001", "unit": ""}]
-        ),
+        ELECTRICITY_ACTIVE_TARIFF: CosemObject((0, 0), [{"value": "0001", "unit": ""}]),
     }
 
     mock_entry = MockConfigEntry(
@@ -345,15 +337,13 @@ async def test_v5_meter(
 
     telegram = {
         HOURLY_GAS_METER_READING: MBusObject(
-            HOURLY_GAS_METER_READING,
+            (0, 0),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642213)},
                 {"value": value, "unit": "m3"},
             ],
         ),
-        ELECTRICITY_ACTIVE_TARIFF: CosemObject(
-            ELECTRICITY_ACTIVE_TARIFF, [{"value": "0001", "unit": ""}]
-        ),
+        ELECTRICITY_ACTIVE_TARIFF: CosemObject((0, 0), [{"value": "0001", "unit": ""}]),
     }
 
     mock_entry = MockConfigEntry(
@@ -413,18 +403,18 @@ async def test_luxembourg_meter(
 
     telegram = {
         HOURLY_GAS_METER_READING: MBusObject(
-            HOURLY_GAS_METER_READING,
+            (0, 0),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642213)},
                 {"value": Decimal(745.695), "unit": "m3"},
             ],
         ),
         ELECTRICITY_IMPORTED_TOTAL: CosemObject(
-            ELECTRICITY_IMPORTED_TOTAL,
+            (0, 0),
             [{"value": Decimal(123.456), "unit": UnitOfEnergy.KILO_WATT_HOUR}],
         ),
         ELECTRICITY_EXPORTED_TOTAL: CosemObject(
-            ELECTRICITY_EXPORTED_TOTAL,
+            (0, 0),
             [{"value": Decimal(654.321), "unit": UnitOfEnergy.KILO_WATT_HOUR}],
         ),
     }
@@ -497,75 +487,65 @@ async def test_belgian_meter(
 
     telegram = {
         BELGIUM_CURRENT_AVERAGE_DEMAND: CosemObject(
-            BELGIUM_CURRENT_AVERAGE_DEMAND,
+            (0, 0),
             [{"value": Decimal(1.75), "unit": "kW"}],
         ),
         BELGIUM_MAXIMUM_DEMAND_MONTH: MBusObject(
-            BELGIUM_MAXIMUM_DEMAND_MONTH,
+            (0, 0),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642218)},
                 {"value": Decimal(4.11), "unit": "kW"},
             ],
         ),
-        BELGIUM_MBUS1_DEVICE_TYPE: CosemObject(
-            BELGIUM_MBUS1_DEVICE_TYPE, [{"value": "003", "unit": ""}]
-        ),
+        BELGIUM_MBUS1_DEVICE_TYPE: CosemObject((0, 1), [{"value": "003", "unit": ""}]),
         BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER: CosemObject(
-            BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+            (0, 1),
             [{"value": "37464C4F32313139303333373331", "unit": ""}],
         ),
         BELGIUM_MBUS1_METER_READING2: MBusObject(
-            BELGIUM_MBUS1_METER_READING2,
+            (0, 1),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642213)},
                 {"value": Decimal(745.695), "unit": "m3"},
             ],
         ),
-        BELGIUM_MBUS2_DEVICE_TYPE: CosemObject(
-            BELGIUM_MBUS2_DEVICE_TYPE, [{"value": "007", "unit": ""}]
-        ),
+        BELGIUM_MBUS2_DEVICE_TYPE: CosemObject((0, 0), [{"value": "007", "unit": ""}]),
         BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER: CosemObject(
-            BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER,
+            (0, 2),
             [{"value": "37464C4F32313139303333373332", "unit": ""}],
         ),
         BELGIUM_MBUS2_METER_READING1: MBusObject(
-            BELGIUM_MBUS2_METER_READING1,
+            (0, 2),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642214)},
                 {"value": Decimal(678.695), "unit": "m3"},
             ],
         ),
-        BELGIUM_MBUS3_DEVICE_TYPE: CosemObject(
-            BELGIUM_MBUS3_DEVICE_TYPE, [{"value": "003", "unit": ""}]
-        ),
+        BELGIUM_MBUS3_DEVICE_TYPE: CosemObject((0, 0), [{"value": "003", "unit": ""}]),
         BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER: CosemObject(
-            BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER,
+            (0, 3),
             [{"value": "37464C4F32313139303333373333", "unit": ""}],
         ),
         BELGIUM_MBUS3_METER_READING2: MBusObject(
-            BELGIUM_MBUS3_METER_READING2,
+            (0, 3),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642215)},
                 {"value": Decimal(12.12), "unit": "m3"},
             ],
         ),
-        BELGIUM_MBUS4_DEVICE_TYPE: CosemObject(
-            BELGIUM_MBUS4_DEVICE_TYPE, [{"value": "007", "unit": ""}]
-        ),
+        BELGIUM_MBUS4_DEVICE_TYPE: CosemObject((0, 0), [{"value": "007", "unit": ""}]),
         BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER: CosemObject(
-            BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER,
+            (0, 4),
             [{"value": "37464C4F32313139303333373334", "unit": ""}],
         ),
         BELGIUM_MBUS4_METER_READING1: MBusObject(
-            BELGIUM_MBUS4_METER_READING1,
+            (0, 4),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642216)},
                 {"value": Decimal(13.13), "unit": "m3"},
             ],
         ),
-        ELECTRICITY_ACTIVE_TARIFF: CosemObject(
-            ELECTRICITY_ACTIVE_TARIFF, [{"value": "0001", "unit": ""}]
-        ),
+        ELECTRICITY_ACTIVE_TARIFF: CosemObject((0, 0), [{"value": "0001", "unit": ""}]),
     }
 
     mock_entry = MockConfigEntry(
@@ -681,57 +661,49 @@ async def test_belgian_meter_alt(
     }
 
     telegram = {
-        BELGIUM_MBUS1_DEVICE_TYPE: CosemObject(
-            BELGIUM_MBUS1_DEVICE_TYPE, [{"value": "007", "unit": ""}]
-        ),
+        BELGIUM_MBUS1_DEVICE_TYPE: CosemObject((0, 0), [{"value": "007", "unit": ""}]),
         BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER: CosemObject(
-            BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+            (0, 1),
             [{"value": "37464C4F32313139303333373331", "unit": ""}],
         ),
         BELGIUM_MBUS1_METER_READING1: MBusObject(
-            BELGIUM_MBUS1_METER_READING1,
+            (0, 1),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642215)},
                 {"value": Decimal(123.456), "unit": "m3"},
             ],
         ),
-        BELGIUM_MBUS2_DEVICE_TYPE: CosemObject(
-            BELGIUM_MBUS2_DEVICE_TYPE, [{"value": "003", "unit": ""}]
-        ),
+        BELGIUM_MBUS2_DEVICE_TYPE: CosemObject((0, 0), [{"value": "003", "unit": ""}]),
         BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER: CosemObject(
-            BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER,
+            (0, 2),
             [{"value": "37464C4F32313139303333373332", "unit": ""}],
         ),
         BELGIUM_MBUS2_METER_READING2: MBusObject(
-            BELGIUM_MBUS2_METER_READING2,
+            (0, 2),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642216)},
                 {"value": Decimal(678.901), "unit": "m3"},
             ],
         ),
-        BELGIUM_MBUS3_DEVICE_TYPE: CosemObject(
-            BELGIUM_MBUS3_DEVICE_TYPE, [{"value": "007", "unit": ""}]
-        ),
+        BELGIUM_MBUS3_DEVICE_TYPE: CosemObject((0, 0), [{"value": "007", "unit": ""}]),
         BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER: CosemObject(
-            BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER,
+            (0, 3),
             [{"value": "37464C4F32313139303333373333", "unit": ""}],
         ),
         BELGIUM_MBUS3_METER_READING1: MBusObject(
-            BELGIUM_MBUS3_METER_READING1,
+            (0, 3),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642217)},
                 {"value": Decimal(12.12), "unit": "m3"},
             ],
         ),
-        BELGIUM_MBUS4_DEVICE_TYPE: CosemObject(
-            BELGIUM_MBUS4_DEVICE_TYPE, [{"value": "003", "unit": ""}]
-        ),
+        BELGIUM_MBUS4_DEVICE_TYPE: CosemObject((0, 0), [{"value": "003", "unit": ""}]),
         BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER: CosemObject(
-            BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER,
+            (0, 4),
             [{"value": "37464C4F32313139303333373334", "unit": ""}],
         ),
         BELGIUM_MBUS4_METER_READING2: MBusObject(
-            BELGIUM_MBUS4_METER_READING2,
+            (0, 4),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642218)},
                 {"value": Decimal(13.13), "unit": "m3"},
@@ -830,42 +802,32 @@ async def test_belgian_meter_mbus(
     }
 
     telegram = {
-        ELECTRICITY_ACTIVE_TARIFF: CosemObject(
-            ELECTRICITY_ACTIVE_TARIFF, [{"value": "0003", "unit": ""}]
-        ),
-        BELGIUM_MBUS1_DEVICE_TYPE: CosemObject(
-            BELGIUM_MBUS1_DEVICE_TYPE, [{"value": "006", "unit": ""}]
-        ),
+        ELECTRICITY_ACTIVE_TARIFF: CosemObject((0, 0), [{"value": "0003", "unit": ""}]),
+        BELGIUM_MBUS1_DEVICE_TYPE: CosemObject((0, 0), [{"value": "006", "unit": ""}]),
         BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER: CosemObject(
-            BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+            (0, 1),
             [{"value": "37464C4F32313139303333373331", "unit": ""}],
         ),
-        BELGIUM_MBUS2_DEVICE_TYPE: CosemObject(
-            BELGIUM_MBUS2_DEVICE_TYPE, [{"value": "003", "unit": ""}]
-        ),
+        BELGIUM_MBUS2_DEVICE_TYPE: CosemObject((0, 0), [{"value": "003", "unit": ""}]),
         BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER: CosemObject(
-            BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER,
+            (0, 2),
             [{"value": "37464C4F32313139303333373332", "unit": ""}],
         ),
-        BELGIUM_MBUS3_DEVICE_TYPE: CosemObject(
-            BELGIUM_MBUS3_DEVICE_TYPE, [{"value": "007", "unit": ""}]
-        ),
+        BELGIUM_MBUS3_DEVICE_TYPE: CosemObject((0, 0), [{"value": "007", "unit": ""}]),
         BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER: CosemObject(
-            BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER,
+            (0, 3),
             [{"value": "37464C4F32313139303333373333", "unit": ""}],
         ),
         BELGIUM_MBUS3_METER_READING2: MBusObject(
-            BELGIUM_MBUS3_METER_READING2,
+            (0, 3),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642217)},
                 {"value": Decimal(12.12), "unit": "m3"},
             ],
         ),
-        BELGIUM_MBUS4_DEVICE_TYPE: CosemObject(
-            BELGIUM_MBUS4_DEVICE_TYPE, [{"value": "007", "unit": ""}]
-        ),
+        BELGIUM_MBUS4_DEVICE_TYPE: CosemObject((0, 0), [{"value": "007", "unit": ""}]),
         BELGIUM_MBUS4_METER_READING1: MBusObject(
-            BELGIUM_MBUS4_METER_READING1,
+            (0, 4),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642218)},
                 {"value": Decimal(13.13), "unit": "m3"},
@@ -939,9 +901,7 @@ async def test_belgian_meter_low(
     }
 
     telegram = {
-        ELECTRICITY_ACTIVE_TARIFF: CosemObject(
-            ELECTRICITY_ACTIVE_TARIFF, [{"value": "0002", "unit": ""}]
-        )
+        ELECTRICITY_ACTIVE_TARIFF: CosemObject((0, 0), [{"value": "0002", "unit": ""}])
     }
 
     mock_entry = MockConfigEntry(
@@ -988,11 +948,11 @@ async def test_swedish_meter(
 
     telegram = {
         ELECTRICITY_IMPORTED_TOTAL: CosemObject(
-            ELECTRICITY_IMPORTED_TOTAL,
+            (0, 0),
             [{"value": Decimal(123.456), "unit": UnitOfEnergy.KILO_WATT_HOUR}],
         ),
         ELECTRICITY_EXPORTED_TOTAL: CosemObject(
-            ELECTRICITY_EXPORTED_TOTAL,
+            (0, 0),
             [{"value": Decimal(654.321), "unit": UnitOfEnergy.KILO_WATT_HOUR}],
         ),
     }
@@ -1056,11 +1016,11 @@ async def test_easymeter(
 
     telegram = {
         ELECTRICITY_IMPORTED_TOTAL: CosemObject(
-            ELECTRICITY_IMPORTED_TOTAL,
+            (0, 0),
             [{"value": Decimal(54184.6316), "unit": UnitOfEnergy.KILO_WATT_HOUR}],
         ),
         ELECTRICITY_EXPORTED_TOTAL: CosemObject(
-            ELECTRICITY_EXPORTED_TOTAL,
+            (0, 0),
             [{"value": Decimal(19981.1069), "unit": UnitOfEnergy.KILO_WATT_HOUR}],
         ),
     }
@@ -1224,12 +1184,10 @@ async def test_reconnect(
 
     telegram = {
         CURRENT_ELECTRICITY_USAGE: CosemObject(
-            CURRENT_ELECTRICITY_USAGE,
+            (0, 0),
             [{"value": Decimal("35.0"), "unit": UnitOfPower.WATT}],
         ),
-        ELECTRICITY_ACTIVE_TARIFF: CosemObject(
-            ELECTRICITY_ACTIVE_TARIFF, [{"value": "0001", "unit": ""}]
-        ),
+        ELECTRICITY_ACTIVE_TARIFF: CosemObject((0, 0), [{"value": "0001", "unit": ""}]),
     }
 
     # mock waiting coroutine while connection lasts
@@ -1302,7 +1260,7 @@ async def test_gas_meter_providing_energy_reading(
 
     telegram = {
         GAS_METER_READING: MBusObject(
-            GAS_METER_READING,
+            (0, 0),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642213)},
                 {"value": Decimal(123.456), "unit": UnitOfEnergy.GIGA_JOULE},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Correct the use of deprecated dict instead of Telegram object. This is a prerequisite to being able to upgrade dsmr library to newer versions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
