### PR TITLE
Add Motionblinds Bluetooth full test coverage

### DIFF
--- a/tests/components/motionblinds_ble/__init__.py
+++ b/tests/components/motionblinds_ble/__init__.py
@@ -4,23 +4,23 @@ from motionblindsble.const import MotionBlindType
 
 from homeassistant.components.bluetooth.models import BluetoothServiceInfoBleak
 from homeassistant.components.motionblinds_ble import async_setup_entry
-from homeassistant.components.motionblinds_ble.const import CONF_LOCAL_NAME
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 from tests.components.bluetooth import generate_advertisement_data, generate_ble_device
 
 FIXTURE_MAC = "CCCC"
-FIXTURE_NAME = f"MOTION_{FIXTURE_MAC.upper()}"
+FIXTURE_DISPLAY_NAME = f"Motionblind {FIXTURE_MAC.upper()}"
+FIXTURE_LOCAL_NAME = f"MOTION_{FIXTURE_MAC.upper()}"
 FIXTURE_ADDRESS = "cc:cc:cc:cc:cc:cc"
 FIXTURE_BLIND_TYPE = MotionBlindType.ROLLER.name.lower()
 
 FIXTURE_SERVICE_INFO = BluetoothServiceInfoBleak(
-    name=FIXTURE_NAME,
+    name=FIXTURE_LOCAL_NAME,
     address=FIXTURE_ADDRESS,
     device=generate_ble_device(
         address=FIXTURE_ADDRESS,
-        name=FIXTURE_NAME,
+        name=FIXTURE_LOCAL_NAME,
     ),
     rssi=-61,
     manufacturer_data={000: b"test"},
@@ -53,4 +53,4 @@ async def setup_integration(
     await async_setup_entry(hass, mock_config_entry)
     await hass.async_block_till_done()
 
-    return str(mock_config_entry.data[CONF_LOCAL_NAME]).lower().replace(" ", "_")
+    return FIXTURE_DISPLAY_NAME.lower().replace(" ", "_")

--- a/tests/components/motionblinds_ble/__init__.py
+++ b/tests/components/motionblinds_ble/__init__.py
@@ -1,7 +1,5 @@
 """Tests for the Motionblinds Bluetooth integration."""
 
-from unittest.mock import patch
-
 from motionblindsble.const import MotionBlindType
 
 from homeassistant.components.motionblinds_ble import async_setup_entry
@@ -11,7 +9,7 @@ from homeassistant.components.motionblinds_ble.const import (
     CONF_MAC_CODE,
     DOMAIN,
 )
-from homeassistant.const import CONF_ADDRESS, Platform
+from homeassistant.const import CONF_ADDRESS
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
 
@@ -30,7 +28,6 @@ FIXTURE_SERVICE_INFO = BluetoothServiceInfo(
 
 async def setup_platform(
     hass: HomeAssistant,
-    platforms: list[Platform],
     blind_type: MotionBlindType = MotionBlindType.ROLLER,
 ) -> tuple[MockConfigEntry, str]:
     """Mock a fully setup config entry."""
@@ -48,10 +45,9 @@ async def setup_platform(
     )
     config_entry.add_to_hass(hass)
 
-    with patch("homeassistant.components.motionblinds_ble.PLATFORMS", platforms):
-        assert await hass.config_entries.async_setup(config_entry.entry_id)
-        await async_setup_entry(hass, config_entry)
-        await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await async_setup_entry(hass, config_entry)
+    await hass.async_block_till_done()
 
     return (
         config_entry,

--- a/tests/components/motionblinds_ble/__init__.py
+++ b/tests/components/motionblinds_ble/__init__.py
@@ -1,20 +1,43 @@
 """Tests for the Motionblinds Bluetooth integration."""
 
+from motionblindsble.const import MotionBlindType
+
+from homeassistant.components.bluetooth.models import BluetoothServiceInfoBleak
 from homeassistant.components.motionblinds_ble import async_setup_entry
 from homeassistant.components.motionblinds_ble.const import CONF_LOCAL_NAME
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
 
 from tests.common import MockConfigEntry
+from tests.components.bluetooth import generate_advertisement_data, generate_ble_device
 
-FIXTURE_SERVICE_INFO = BluetoothServiceInfo(
-    name="MOTION_CCCC",
-    address="cc:cc:cc:cc:cc:cc",
-    rssi=-63,
-    service_data={},
-    manufacturer_data={},
-    service_uuids=[],
+FIXTURE_MAC = "CCCC"
+FIXTURE_NAME = f"MOTION_{FIXTURE_MAC.upper()}"
+FIXTURE_ADDRESS = "cc:cc:cc:cc:cc:cc"
+FIXTURE_BLIND_TYPE = MotionBlindType.ROLLER.name.lower()
+
+FIXTURE_SERVICE_INFO = BluetoothServiceInfoBleak(
+    name=FIXTURE_NAME,
+    address=FIXTURE_ADDRESS,
+    device=generate_ble_device(
+        address=FIXTURE_ADDRESS,
+        name=FIXTURE_NAME,
+    ),
+    rssi=-61,
+    manufacturer_data={000: b"test"},
+    service_data={
+        "test": bytearray(b"0000"),
+    },
+    service_uuids=[
+        "test",
+    ],
     source="local",
+    advertisement=generate_advertisement_data(
+        manufacturer_data={000: b"test"},
+        service_uuids=["test"],
+    ),
+    connectable=True,
+    time=0,
+    tx_power=-127,
 )
 
 

--- a/tests/components/motionblinds_ble/__init__.py
+++ b/tests/components/motionblinds_ble/__init__.py
@@ -1,15 +1,7 @@
 """Tests for the Motionblinds Bluetooth integration."""
 
-from motionblindsble.const import MotionBlindType
-
 from homeassistant.components.motionblinds_ble import async_setup_entry
-from homeassistant.components.motionblinds_ble.const import (
-    CONF_BLIND_TYPE,
-    CONF_LOCAL_NAME,
-    CONF_MAC_CODE,
-    DOMAIN,
-)
-from homeassistant.const import CONF_ADDRESS
+from homeassistant.components.motionblinds_ble.const import CONF_LOCAL_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
 
@@ -28,28 +20,14 @@ FIXTURE_SERVICE_INFO = BluetoothServiceInfo(
 
 async def setup_integration(
     hass: HomeAssistant,
-    blind_type: MotionBlindType = MotionBlindType.ROLLER,
-) -> tuple[MockConfigEntry, str]:
+    mock_config_entry: MockConfigEntry,
+) -> str:
     """Mock a fully setup config entry."""
 
-    config_entry = MockConfigEntry(
-        title="mock_title",
-        domain=DOMAIN,
-        unique_id="cc:cc:cc:cc:cc:cc",
-        data={
-            CONF_ADDRESS: "cc:cc:cc:cc:cc:cc",
-            CONF_LOCAL_NAME: "Motionblind CCCC",
-            CONF_MAC_CODE: "CCCC",
-            CONF_BLIND_TYPE: blind_type.name.lower(),
-        },
-    )
-    config_entry.add_to_hass(hass)
+    mock_config_entry.add_to_hass(hass)
 
-    assert await hass.config_entries.async_setup(config_entry.entry_id)
-    await async_setup_entry(hass, config_entry)
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await async_setup_entry(hass, mock_config_entry)
     await hass.async_block_till_done()
 
-    return (
-        config_entry,
-        str(config_entry.data[CONF_LOCAL_NAME]).lower().replace(" ", "_"),
-    )
+    return str(mock_config_entry.data[CONF_LOCAL_NAME]).lower().replace(" ", "_")

--- a/tests/components/motionblinds_ble/__init__.py
+++ b/tests/components/motionblinds_ble/__init__.py
@@ -22,7 +22,7 @@ async def setup_platform(
     hass: HomeAssistant,
     platforms: list[Platform],
     blind_type: MotionBlindType = MotionBlindType.ROLLER,
-) -> MockConfigEntry:
+) -> tuple[MockConfigEntry, str]:
     """Mock a fully setup config entry."""
 
     config_entry = MockConfigEntry(

--- a/tests/components/motionblinds_ble/__init__.py
+++ b/tests/components/motionblinds_ble/__init__.py
@@ -26,7 +26,7 @@ FIXTURE_SERVICE_INFO = BluetoothServiceInfo(
 )
 
 
-async def setup_platform(
+async def setup_integration(
     hass: HomeAssistant,
     blind_type: MotionBlindType = MotionBlindType.ROLLER,
 ) -> tuple[MockConfigEntry, str]:

--- a/tests/components/motionblinds_ble/__init__.py
+++ b/tests/components/motionblinds_ble/__init__.py
@@ -1,50 +1,14 @@
 """Tests for the Motionblinds Bluetooth integration."""
 
-from motionblindsble.const import MotionBlindType
-
-from homeassistant.components.bluetooth.models import BluetoothServiceInfoBleak
 from homeassistant.components.motionblinds_ble import async_setup_entry
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
-from tests.components.bluetooth import generate_advertisement_data, generate_ble_device
-
-FIXTURE_MAC = "CCCC"
-FIXTURE_DISPLAY_NAME = f"Motionblind {FIXTURE_MAC.upper()}"
-FIXTURE_LOCAL_NAME = f"MOTION_{FIXTURE_MAC.upper()}"
-FIXTURE_ADDRESS = "cc:cc:cc:cc:cc:cc"
-FIXTURE_BLIND_TYPE = MotionBlindType.ROLLER.name.lower()
-
-FIXTURE_SERVICE_INFO = BluetoothServiceInfoBleak(
-    name=FIXTURE_LOCAL_NAME,
-    address=FIXTURE_ADDRESS,
-    device=generate_ble_device(
-        address=FIXTURE_ADDRESS,
-        name=FIXTURE_LOCAL_NAME,
-    ),
-    rssi=-61,
-    manufacturer_data={000: b"test"},
-    service_data={
-        "test": bytearray(b"0000"),
-    },
-    service_uuids=[
-        "test",
-    ],
-    source="local",
-    advertisement=generate_advertisement_data(
-        manufacturer_data={000: b"test"},
-        service_uuids=["test"],
-    ),
-    connectable=True,
-    time=0,
-    tx_power=-127,
-)
 
 
 async def setup_integration(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-) -> str:
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
     """Mock a fully setup config entry."""
 
     mock_config_entry.add_to_hass(hass)
@@ -52,5 +16,3 @@ async def setup_integration(
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await async_setup_entry(hass, mock_config_entry)
     await hass.async_block_till_done()
-
-    return FIXTURE_DISPLAY_NAME.lower().replace(" ", "_")

--- a/tests/components/motionblinds_ble/__init__.py
+++ b/tests/components/motionblinds_ble/__init__.py
@@ -11,7 +11,6 @@ from homeassistant.components.motionblinds_ble.const import (
     CONF_MAC_CODE,
     DOMAIN,
 )
-from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_ADDRESS, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
@@ -53,7 +52,6 @@ async def setup_platform(
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await async_setup_entry(hass, config_entry)
         await hass.async_block_till_done()
-        assert config_entry.state is ConfigEntryState.LOADED
 
     return (
         config_entry,

--- a/tests/components/motionblinds_ble/__init__.py
+++ b/tests/components/motionblinds_ble/__init__.py
@@ -1,6 +1,5 @@
 """Tests for the Motionblinds Bluetooth integration."""
 
-from homeassistant.components.motionblinds_ble import async_setup_entry
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -14,5 +13,4 @@ async def setup_integration(
     mock_config_entry.add_to_hass(hass)
 
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await async_setup_entry(hass, mock_config_entry)
     await hass.async_block_till_done()

--- a/tests/components/motionblinds_ble/__init__.py
+++ b/tests/components/motionblinds_ble/__init__.py
@@ -1,1 +1,50 @@
 """Tests for the Motionblinds Bluetooth integration."""
+
+from unittest.mock import patch
+
+from motionblindsble.const import MotionBlindType
+
+from homeassistant.components.motionblinds_ble import async_setup_entry
+from homeassistant.components.motionblinds_ble.const import (
+    CONF_BLIND_TYPE,
+    CONF_LOCAL_NAME,
+    CONF_MAC_CODE,
+    DOMAIN,
+)
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_ADDRESS, Platform
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def setup_platform(
+    hass: HomeAssistant,
+    platforms: list[Platform],
+    blind_type: MotionBlindType = MotionBlindType.ROLLER,
+) -> MockConfigEntry:
+    """Mock a fully setup config entry."""
+
+    config_entry = MockConfigEntry(
+        title="mock_title",
+        domain=DOMAIN,
+        unique_id="cc:cc:cc:cc:cc:cc",
+        data={
+            CONF_ADDRESS: "cc:cc:cc:cc:cc:cc",
+            CONF_LOCAL_NAME: "Motionblind CCCC",
+            CONF_MAC_CODE: "CCCC",
+            CONF_BLIND_TYPE: blind_type.name.lower(),
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.motionblinds_ble.PLATFORMS", platforms):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await async_setup_entry(hass, config_entry)
+        await hass.async_block_till_done()
+        assert config_entry.state is ConfigEntryState.LOADED
+
+    return (
+        config_entry,
+        str(config_entry.data[CONF_LOCAL_NAME]).lower().replace(" ", "_"),
+    )

--- a/tests/components/motionblinds_ble/__init__.py
+++ b/tests/components/motionblinds_ble/__init__.py
@@ -18,15 +18,13 @@ from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
 
 from tests.common import MockConfigEntry
 
-SERVICE_INFO = BluetoothServiceInfo(
+FIXTURE_SERVICE_INFO = BluetoothServiceInfo(
     name="MOTION_CCCC",
     address="cc:cc:cc:cc:cc:cc",
     rssi=-63,
     service_data={},
-    manufacturer_data={
-        1062: b"\x02\x07d\x02\x05\x01\x02\x08\x00\x02\t\x01\x04\x06\x10\x00\x01"
-    },
-    service_uuids=["98bd0001-0b0e-421a-84e5-ddbf75dc6de4"],
+    manufacturer_data={},
+    service_uuids=[],
     source="local",
 )
 

--- a/tests/components/motionblinds_ble/__init__.py
+++ b/tests/components/motionblinds_ble/__init__.py
@@ -14,8 +14,21 @@ from homeassistant.components.motionblinds_ble.const import (
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_ADDRESS, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
 
 from tests.common import MockConfigEntry
+
+SERVICE_INFO = BluetoothServiceInfo(
+    name="MOTION_CCCC",
+    address="cc:cc:cc:cc:cc:cc",
+    rssi=-63,
+    service_data={},
+    manufacturer_data={
+        1062: b"\x02\x07d\x02\x05\x01\x02\x08\x00\x02\t\x01\x04\x06\x10\x00\x01"
+    },
+    service_uuids=["98bd0001-0b0e-421a-84e5-ddbf75dc6de4"],
+    source="local",
+)
 
 
 async def setup_platform(

--- a/tests/components/motionblinds_ble/conftest.py
+++ b/tests/components/motionblinds_ble/conftest.py
@@ -26,15 +26,15 @@ def blind_type() -> MotionBlindType:
 
 
 @pytest.fixture
-def mac() -> str:
+def mac_code() -> str:
     """MAC code fixture."""
     return "CCCC"
 
 
 @pytest.fixture
-def display_name(mac: str) -> str:
+def display_name(mac_code: str) -> str:
     """Display name fixture."""
-    return f"Motionblind {mac.upper()}"
+    return f"Motionblind {mac_code.upper()}"
 
 
 @pytest.fixture
@@ -44,13 +44,13 @@ def name(display_name: str) -> str:
 
 
 @pytest.fixture
-def local_name(mac: str) -> str:
+def local_name(mac_code: str) -> str:
     """Local name fixture."""
-    return f"MOTION_{mac.upper()}"
+    return f"MOTION_{mac_code.upper()}"
 
 
 @pytest.fixture
-def address(mac: str) -> str:
+def address(mac_code: str) -> str:
     """Address fixture."""
     return "cc:cc:cc:cc:cc:cc"
 

--- a/tests/components/motionblinds_ble/conftest.py
+++ b/tests/components/motionblinds_ble/conftest.py
@@ -119,6 +119,16 @@ def mock_config_entry(
     )
 
 
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.motionblinds_ble.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        yield mock_setup_entry
+
+
 @pytest.fixture(name="motionblinds_ble_connect", autouse=True)
 def motion_blinds_connect_fixture(
     enable_bluetooth: None, local_name: str, address: str
@@ -139,10 +149,6 @@ def motion_blinds_connect_fixture(
         patch(
             "homeassistant.components.motionblinds_ble.config_flow.bluetooth.async_get_scanner",
             return_value=bleak_scanner,
-        ),
-        patch(
-            "homeassistant.components.motionblinds_ble.async_setup_entry",
-            return_value=True,
         ),
     ):
         yield bleak_scanner, device

--- a/tests/components/motionblinds_ble/conftest.py
+++ b/tests/components/motionblinds_ble/conftest.py
@@ -20,15 +20,15 @@ from tests.components.bluetooth import generate_advertisement_data, generate_ble
 
 
 @pytest.fixture
-def blind_type() -> MotionBlindType:
-    """Blind type fixture."""
-    return MotionBlindType.ROLLER
+def address() -> str:
+    """Address fixture."""
+    return "cc:cc:cc:cc:cc:cc"
 
 
 @pytest.fixture
-def mac_code() -> str:
+def mac_code(address: str) -> str:
     """MAC code fixture."""
-    return "CCCC"
+    return "".join(address.split(":")[-3:-1]).upper()
 
 
 @pytest.fixture
@@ -50,9 +50,9 @@ def local_name(mac_code: str) -> str:
 
 
 @pytest.fixture
-def address(mac_code: str) -> str:
-    """Address fixture."""
-    return "cc:cc:cc:cc:cc:cc"
+def blind_type() -> MotionBlindType:
+    """Blind type fixture."""
+    return MotionBlindType.ROLLER
 
 
 @pytest.fixture

--- a/tests/components/motionblinds_ble/conftest.py
+++ b/tests/components/motionblinds_ble/conftest.py
@@ -14,11 +14,9 @@ from homeassistant.components.motionblinds_ble.const import (
 )
 from homeassistant.const import CONF_ADDRESS
 
-from tests.common import MockConfigEntry
+from . import FIXTURE_ADDRESS, FIXTURE_NAME
 
-TEST_MAC = "abcd"
-TEST_NAME = f"MOTION_{TEST_MAC.upper()}"
-TEST_ADDRESS = "test_adress"
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture
@@ -70,8 +68,8 @@ def motion_blinds_connect_fixture(
 ) -> Generator[tuple[AsyncMock, Mock]]:
     """Mock motion blinds ble connection and entry setup."""
     device = Mock()
-    device.name = TEST_NAME
-    device.address = TEST_ADDRESS
+    device.name = FIXTURE_NAME
+    device.address = FIXTURE_ADDRESS
 
     bleak_scanner = AsyncMock()
     bleak_scanner.discover.return_value = [device]

--- a/tests/components/motionblinds_ble/conftest.py
+++ b/tests/components/motionblinds_ble/conftest.py
@@ -90,16 +90,10 @@ def mock_motion_device(
 ) -> Generator[AsyncMock]:
     """Mock a MotionDevice."""
 
-    with (
-        patch(
-            "homeassistant.components.motionblinds_ble.MotionDevice",
-            autospec=True,
-        ) as mock_device,
-        patch(
-            "homeassistant.components.motionblinds_ble.MotionDevice",
-            new=mock_device,
-        ),
-    ):
+    with patch(
+        "homeassistant.components.motionblinds_ble.MotionDevice",
+        autospec=True,
+    ) as mock_device:
         device = mock_device.return_value
         device.ble_device = Mock()
         device.display_name = display_name

--- a/tests/components/motionblinds_ble/conftest.py
+++ b/tests/components/motionblinds_ble/conftest.py
@@ -3,11 +3,44 @@
 from collections.abc import Generator
 from unittest.mock import AsyncMock, Mock, patch
 
+from motionblindsble.const import MotionBlindType
 import pytest
+
+from homeassistant.components.motionblinds_ble.const import (
+    CONF_BLIND_TYPE,
+    CONF_LOCAL_NAME,
+    CONF_MAC_CODE,
+    DOMAIN,
+)
+from homeassistant.const import CONF_ADDRESS
+
+from tests.common import MockConfigEntry
 
 TEST_MAC = "abcd"
 TEST_NAME = f"MOTION_{TEST_MAC.upper()}"
 TEST_ADDRESS = "test_adress"
+
+
+@pytest.fixture
+def blind_type() -> MotionBlindType:
+    """Blind type fixture."""
+    return MotionBlindType.ROLLER
+
+
+@pytest.fixture
+def mock_config_entry(blind_type: MotionBlindType) -> MockConfigEntry:
+    """Config entry fixture."""
+    return MockConfigEntry(
+        title="mock_title",
+        domain=DOMAIN,
+        unique_id="cc:cc:cc:cc:cc:cc",
+        data={
+            CONF_ADDRESS: "cc:cc:cc:cc:cc:cc",
+            CONF_LOCAL_NAME: "Motionblind CCCC",
+            CONF_MAC_CODE: "CCCC",
+            CONF_BLIND_TYPE: blind_type.name.lower(),
+        },
+    )
 
 
 @pytest.fixture(name="motionblinds_ble_connect", autouse=True)

--- a/tests/components/motionblinds_ble/conftest.py
+++ b/tests/components/motionblinds_ble/conftest.py
@@ -129,8 +129,8 @@ def mock_setup_entry() -> Generator[AsyncMock]:
         yield mock_setup_entry
 
 
-@pytest.fixture(name="motionblinds_ble_connect", autouse=True)
-def motion_blinds_connect_fixture(
+@pytest.fixture
+def motionblinds_ble_connect(
     enable_bluetooth: None, local_name: str, address: str
 ) -> Generator[tuple[AsyncMock, Mock]]:
     """Mock motion blinds ble connection and entry setup."""

--- a/tests/components/motionblinds_ble/conftest.py
+++ b/tests/components/motionblinds_ble/conftest.py
@@ -28,6 +28,27 @@ def blind_type() -> MotionBlindType:
 
 
 @pytest.fixture
+def mock_motion_device(blind_type) -> Generator[AsyncMock]:
+    """Mock a MotionDevice."""
+
+    with (
+        patch(
+            "homeassistant.components.motionblinds_ble.MotionDevice",
+            autospec=True,
+        ) as mock_device,
+        patch(
+            "homeassistant.components.motionblinds_ble.MotionDevice",
+            new=mock_device,
+        ),
+    ):
+        device = mock_device.return_value
+        device.ble_device = Mock()
+        device.display_name = ""
+        device.blind_type = blind_type
+        yield device
+
+
+@pytest.fixture
 def mock_config_entry(blind_type: MotionBlindType) -> MockConfigEntry:
     """Config entry fixture."""
     return MockConfigEntry(

--- a/tests/components/motionblinds_ble/conftest.py
+++ b/tests/components/motionblinds_ble/conftest.py
@@ -102,16 +102,18 @@ def mock_motion_device(
 
 
 @pytest.fixture
-def mock_config_entry(blind_type: MotionBlindType) -> MockConfigEntry:
+def mock_config_entry(
+    blind_type: MotionBlindType, address: str, display_name: str, mac_code: str
+) -> MockConfigEntry:
     """Config entry fixture."""
     return MockConfigEntry(
         title="mock_title",
         domain=DOMAIN,
-        unique_id="cc:cc:cc:cc:cc:cc",
+        unique_id=address,
         data={
-            CONF_ADDRESS: "cc:cc:cc:cc:cc:cc",
-            CONF_LOCAL_NAME: "Motionblind CCCC",
-            CONF_MAC_CODE: "CCCC",
+            CONF_ADDRESS: address,
+            CONF_LOCAL_NAME: display_name,
+            CONF_MAC_CODE: mac_code,
             CONF_BLIND_TYPE: blind_type.name.lower(),
         },
     )

--- a/tests/components/motionblinds_ble/conftest.py
+++ b/tests/components/motionblinds_ble/conftest.py
@@ -14,7 +14,7 @@ from homeassistant.components.motionblinds_ble.const import (
 )
 from homeassistant.const import CONF_ADDRESS
 
-from . import FIXTURE_ADDRESS, FIXTURE_NAME
+from . import FIXTURE_ADDRESS, FIXTURE_DISPLAY_NAME, FIXTURE_LOCAL_NAME
 
 from tests.common import MockConfigEntry
 
@@ -41,7 +41,7 @@ def mock_motion_device(blind_type) -> Generator[AsyncMock]:
     ):
         device = mock_device.return_value
         device.ble_device = Mock()
-        device.display_name = ""
+        device.display_name = FIXTURE_DISPLAY_NAME
         device.blind_type = blind_type
         yield device
 
@@ -68,7 +68,7 @@ def motion_blinds_connect_fixture(
 ) -> Generator[tuple[AsyncMock, Mock]]:
     """Mock motion blinds ble connection and entry setup."""
     device = Mock()
-    device.name = FIXTURE_NAME
+    device.name = FIXTURE_LOCAL_NAME
     device.address = FIXTURE_ADDRESS
 
     bleak_scanner = AsyncMock()

--- a/tests/components/motionblinds_ble/test_button.py
+++ b/tests/components/motionblinds_ble/test_button.py
@@ -1,0 +1,39 @@
+"""Tests for Motionblinds BLE buttons."""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.components.motionblinds_ble.const import (
+    ATTR_CONNECT,
+    ATTR_DISCONNECT,
+    ATTR_FAVORITE,
+)
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+
+from . import setup_platform
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize(("button"), [ATTR_CONNECT, ATTR_DISCONNECT, ATTR_FAVORITE])
+async def test_button(hass: HomeAssistant, button: str) -> None:
+    """Test states of the button."""
+
+    _, name = await setup_platform(hass, [Platform.BUTTON])
+
+    with patch(
+        f"homeassistant.components.motionblinds_ble.MotionDevice.{button}"
+    ) as command:
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: f"button.{name}_{button}"},
+            blocking=True,
+        )
+        command.assert_called_once()
+
+    await hass.async_block_till_done()

--- a/tests/components/motionblinds_ble/test_button.py
+++ b/tests/components/motionblinds_ble/test_button.py
@@ -13,14 +13,14 @@ from homeassistant.components.motionblinds_ble.const import (
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 
-from . import setup_platform
+from . import setup_integration
 
 
 @pytest.mark.parametrize(("button"), [ATTR_CONNECT, ATTR_DISCONNECT, ATTR_FAVORITE])
 async def test_button(hass: HomeAssistant, button: str) -> None:
     """Test states of the button."""
 
-    _, name = await setup_platform(hass)
+    _, name = await setup_integration(hass)
 
     with patch(
         f"homeassistant.components.motionblinds_ble.MotionDevice.{button}"

--- a/tests/components/motionblinds_ble/test_button.py
+++ b/tests/components/motionblinds_ble/test_button.py
@@ -18,6 +18,7 @@ from . import setup_integration
 from tests.common import MockConfigEntry
 
 
+@pytest.mark.usefixtures("motionblinds_ble_connect")
 @pytest.mark.parametrize(
     ("button"),
     [

--- a/tests/components/motionblinds_ble/test_button.py
+++ b/tests/components/motionblinds_ble/test_button.py
@@ -15,12 +15,16 @@ from homeassistant.core import HomeAssistant
 
 from . import setup_integration
 
+from tests.common import MockConfigEntry
+
 
 @pytest.mark.parametrize(("button"), [ATTR_CONNECT, ATTR_DISCONNECT, ATTR_FAVORITE])
-async def test_button(hass: HomeAssistant, button: str) -> None:
+async def test_button(
+    mock_config_entry: MockConfigEntry, hass: HomeAssistant, button: str
+) -> None:
     """Test states of the button."""
 
-    _, name = await setup_integration(hass)
+    name = await setup_integration(hass, mock_config_entry)
 
     with patch(
         f"homeassistant.components.motionblinds_ble.MotionDevice.{button}"

--- a/tests/components/motionblinds_ble/test_button.py
+++ b/tests/components/motionblinds_ble/test_button.py
@@ -10,7 +10,7 @@ from homeassistant.components.motionblinds_ble.const import (
     ATTR_DISCONNECT,
     ATTR_FAVORITE,
 )
-from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 
 from . import setup_platform
@@ -20,7 +20,7 @@ from . import setup_platform
 async def test_button(hass: HomeAssistant, button: str) -> None:
     """Test states of the button."""
 
-    _, name = await setup_platform(hass, [Platform.BUTTON])
+    _, name = await setup_platform(hass)
 
     with patch(
         f"homeassistant.components.motionblinds_ble.MotionDevice.{button}"

--- a/tests/components/motionblinds_ble/test_button.py
+++ b/tests/components/motionblinds_ble/test_button.py
@@ -19,11 +19,11 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.parametrize(
-    ("button", "name"),
+    ("button"),
     [
-        (ATTR_CONNECT, "mock_title_connect"),
-        (ATTR_DISCONNECT, "disconnect"),
-        (ATTR_FAVORITE, "favorite"),
+        ATTR_CONNECT,
+        ATTR_DISCONNECT,
+        ATTR_FAVORITE,
     ],
 )
 async def test_button(
@@ -31,11 +31,10 @@ async def test_button(
     mock_motion_device: Mock,
     hass: HomeAssistant,
     button: str,
-    name: str,
 ) -> None:
     """Test states of the button."""
 
-    await setup_integration(hass, mock_config_entry)
+    name = await setup_integration(hass, mock_config_entry)
 
     command = AsyncMock()
     setattr(mock_motion_device, button, command)
@@ -43,7 +42,7 @@ async def test_button(
     await hass.services.async_call(
         BUTTON_DOMAIN,
         SERVICE_PRESS,
-        {ATTR_ENTITY_ID: f"button.{name}"},
+        {ATTR_ENTITY_ID: f"button.{name}_{button}"},
         blocking=True,
     )
     command.assert_called_once()

--- a/tests/components/motionblinds_ble/test_button.py
+++ b/tests/components/motionblinds_ble/test_button.py
@@ -1,6 +1,6 @@
 """Tests for Motionblinds BLE buttons."""
 
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import Mock
 
 import pytest
 
@@ -37,13 +37,10 @@ async def test_button(
 
     await setup_integration(hass, mock_config_entry)
 
-    command = AsyncMock()
-    setattr(mock_motion_device, button, command)
-
     await hass.services.async_call(
         BUTTON_DOMAIN,
         SERVICE_PRESS,
         {ATTR_ENTITY_ID: f"button.{name}_{button}"},
         blocking=True,
     )
-    command.assert_called_once()
+    getattr(mock_motion_device, button).assert_called_once()

--- a/tests/components/motionblinds_ble/test_button.py
+++ b/tests/components/motionblinds_ble/test_button.py
@@ -29,12 +29,13 @@ from tests.common import MockConfigEntry
 async def test_button(
     mock_config_entry: MockConfigEntry,
     mock_motion_device: Mock,
+    name: str,
     hass: HomeAssistant,
     button: str,
 ) -> None:
     """Test states of the button."""
 
-    name = await setup_integration(hass, mock_config_entry)
+    await setup_integration(hass, mock_config_entry)
 
     command = AsyncMock()
     setattr(mock_motion_device, button, command)

--- a/tests/components/motionblinds_ble/test_button.py
+++ b/tests/components/motionblinds_ble/test_button.py
@@ -1,6 +1,5 @@
 """Tests for Motionblinds BLE buttons."""
 
-import logging
 from unittest.mock import patch
 
 import pytest
@@ -15,8 +14,6 @@ from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 
 from . import setup_platform
-
-_LOGGER = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize(("button"), [ATTR_CONNECT, ATTR_DISCONNECT, ATTR_FAVORITE])

--- a/tests/components/motionblinds_ble/test_config_flow.py
+++ b/tests/components/motionblinds_ble/test_config_flow.py
@@ -14,8 +14,8 @@ from homeassistant.data_entry_flow import FlowResultType
 from . import (
     FIXTURE_ADDRESS,
     FIXTURE_BLIND_TYPE,
+    FIXTURE_LOCAL_NAME,
     FIXTURE_MAC,
-    FIXTURE_NAME,
     FIXTURE_SERVICE_INFO,
 )
 
@@ -47,7 +47,7 @@ async def test_config_flow_manual_success(hass: HomeAssistant) -> None:
     assert result["title"] == f"Motionblind {FIXTURE_MAC.upper()}"
     assert result["data"] == {
         CONF_ADDRESS: FIXTURE_ADDRESS,
-        const.CONF_LOCAL_NAME: FIXTURE_NAME,
+        const.CONF_LOCAL_NAME: FIXTURE_LOCAL_NAME,
         const.CONF_MAC_CODE: FIXTURE_MAC.upper(),
         const.CONF_BLIND_TYPE: FIXTURE_BLIND_TYPE,
     }
@@ -92,7 +92,7 @@ async def test_config_flow_manual_error_invalid_mac(hass: HomeAssistant) -> None
     assert result["title"] == f"Motionblind {FIXTURE_MAC.upper()}"
     assert result["data"] == {
         CONF_ADDRESS: FIXTURE_ADDRESS,
-        const.CONF_LOCAL_NAME: FIXTURE_NAME,
+        const.CONF_LOCAL_NAME: FIXTURE_LOCAL_NAME,
         const.CONF_MAC_CODE: FIXTURE_MAC.upper(),
         const.CONF_BLIND_TYPE: FIXTURE_BLIND_TYPE,
     }
@@ -160,7 +160,7 @@ async def test_config_flow_manual_error_could_not_find_motor(
     assert result["errors"] == {"base": const.ERROR_COULD_NOT_FIND_MOTOR}
 
     # Recover
-    motionblinds_ble_connect[1].name = FIXTURE_NAME
+    motionblinds_ble_connect[1].name = FIXTURE_LOCAL_NAME
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {const.CONF_MAC_CODE: FIXTURE_MAC},
@@ -177,7 +177,7 @@ async def test_config_flow_manual_error_could_not_find_motor(
     assert result["title"] == f"Motionblind {FIXTURE_MAC.upper()}"
     assert result["data"] == {
         CONF_ADDRESS: FIXTURE_ADDRESS,
-        const.CONF_LOCAL_NAME: FIXTURE_NAME,
+        const.CONF_LOCAL_NAME: FIXTURE_LOCAL_NAME,
         const.CONF_MAC_CODE: FIXTURE_MAC.upper(),
         const.CONF_BLIND_TYPE: FIXTURE_BLIND_TYPE,
     }
@@ -228,7 +228,7 @@ async def test_config_flow_bluetooth_success(hass: HomeAssistant) -> None:
     assert result["title"] == f"Motionblind {FIXTURE_MAC.upper()}"
     assert result["data"] == {
         CONF_ADDRESS: FIXTURE_ADDRESS,
-        const.CONF_LOCAL_NAME: FIXTURE_NAME,
+        const.CONF_LOCAL_NAME: FIXTURE_LOCAL_NAME,
         const.CONF_MAC_CODE: FIXTURE_MAC.upper(),
         const.CONF_BLIND_TYPE: FIXTURE_BLIND_TYPE,
     }

--- a/tests/components/motionblinds_ble/test_config_flow.py
+++ b/tests/components/motionblinds_ble/test_config_flow.py
@@ -22,6 +22,7 @@ async def test_config_flow_manual_success(
     mac: str,
     address: str,
     local_name: str,
+    display_name: str,
 ) -> None:
     """Successful flow manually initialized by the user."""
     result = await hass.config_entries.flow.async_init(
@@ -43,7 +44,7 @@ async def test_config_flow_manual_success(
         {const.CONF_BLIND_TYPE: blind_type.name.lower()},
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == f"Motionblind {mac.upper()}"
+    assert result["title"] == display_name
     assert result["data"] == {
         CONF_ADDRESS: address,
         const.CONF_LOCAL_NAME: local_name,
@@ -59,6 +60,7 @@ async def test_config_flow_manual_error_invalid_mac(
     mac: str,
     address: str,
     local_name: str,
+    display_name: str,
     blind_type: MotionBlindType,
 ) -> None:
     """Invalid MAC code error flow manually initialized by the user."""
@@ -94,7 +96,7 @@ async def test_config_flow_manual_error_invalid_mac(
         {const.CONF_BLIND_TYPE: blind_type.name.lower()},
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == f"Motionblind {mac.upper()}"
+    assert result["title"] == display_name
     assert result["data"] == {
         CONF_ADDRESS: address,
         const.CONF_LOCAL_NAME: local_name,
@@ -146,6 +148,7 @@ async def test_config_flow_manual_error_could_not_find_motor(
     motionblinds_ble_connect: tuple[AsyncMock, Mock],
     mac: str,
     local_name: str,
+    display_name: str,
     address: str,
     blind_type: MotionBlindType,
 ) -> None:
@@ -181,10 +184,10 @@ async def test_config_flow_manual_error_could_not_find_motor(
     # Finish flow
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {const.CONF_BLIND_TYPE: MotionBlindType.ROLLER.name.lower()},
+        {const.CONF_BLIND_TYPE: blind_type.name.lower()},
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == f"Motionblind {mac.upper()}"
+    assert result["title"] == display_name
     assert result["data"] == {
         CONF_ADDRESS: address,
         const.CONF_LOCAL_NAME: local_name,
@@ -224,6 +227,7 @@ async def test_config_flow_bluetooth_success(
     service_info: BluetoothServiceInfoBleak,
     address: str,
     local_name: str,
+    display_name: str,
     blind_type: MotionBlindType,
 ) -> None:
     """Successful bluetooth discovery flow."""
@@ -242,7 +246,7 @@ async def test_config_flow_bluetooth_success(
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == f"Motionblind {mac.upper()}"
+    assert result["title"] == display_name
     assert result["data"] == {
         CONF_ADDRESS: address,
         const.CONF_LOCAL_NAME: local_name,

--- a/tests/components/motionblinds_ble/test_config_flow.py
+++ b/tests/components/motionblinds_ble/test_config_flow.py
@@ -23,7 +23,9 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.usefixtures("motionblinds_ble_connect")
-async def test_config_flow_manual_success(hass: HomeAssistant) -> None:
+async def test_config_flow_manual_success(
+    hass: HomeAssistant, blind_type: MotionBlindType
+) -> None:
     """Successful flow manually initialized by the user."""
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -41,7 +43,7 @@ async def test_config_flow_manual_success(hass: HomeAssistant) -> None:
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {const.CONF_BLIND_TYPE: MotionBlindType.ROLLER.name.lower()},
+        {const.CONF_BLIND_TYPE: blind_type.name.lower()},
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == f"Motionblind {FIXTURE_MAC.upper()}"

--- a/tests/components/motionblinds_ble/test_config_flow.py
+++ b/tests/components/motionblinds_ble/test_config_flow.py
@@ -16,10 +16,10 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.usefixtures("motionblinds_ble_connect")
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_config_flow_manual_success(
     hass: HomeAssistant,
     blind_type: MotionBlindType,
-    mock_setup_entry: AsyncMock,
     mac_code: str,
     address: str,
     local_name: str,
@@ -56,9 +56,9 @@ async def test_config_flow_manual_success(
 
 
 @pytest.mark.usefixtures("motionblinds_ble_connect")
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_config_flow_manual_error_invalid_mac(
     hass: HomeAssistant,
-    mock_setup_entry: AsyncMock,
     mac_code: str,
     address: str,
     local_name: str,
@@ -146,10 +146,10 @@ async def test_config_flow_manual_error_no_bluetooth_adapter(
     assert result["reason"] == const.ERROR_NO_BLUETOOTH_ADAPTER
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_config_flow_manual_error_could_not_find_motor(
     hass: HomeAssistant,
     motionblinds_ble_connect: tuple[AsyncMock, Mock],
-    mock_setup_entry: AsyncMock,
     mac_code: str,
     local_name: str,
     display_name: str,
@@ -231,7 +231,6 @@ async def test_config_flow_bluetooth_success(
     hass: HomeAssistant,
     mac_code: str,
     service_info: BluetoothServiceInfoBleak,
-    mock_setup_entry: AsyncMock,
     address: str,
     local_name: str,
     display_name: str,
@@ -263,10 +262,10 @@ async def test_config_flow_bluetooth_success(
     assert result["options"] == {}
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_options_flow(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_setup_entry: AsyncMock,
 ) -> None:
     """Test the options flow."""
     mock_config_entry.add_to_hass(hass)

--- a/tests/components/motionblinds_ble/test_config_flow.py
+++ b/tests/components/motionblinds_ble/test_config_flow.py
@@ -6,43 +6,20 @@ from motionblindsble.const import MotionBlindType
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components.bluetooth.models import BluetoothServiceInfoBleak
 from homeassistant.components.motionblinds_ble import const
 from homeassistant.const import CONF_ADDRESS
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from .conftest import TEST_ADDRESS, TEST_MAC, TEST_NAME
+from . import (
+    FIXTURE_ADDRESS,
+    FIXTURE_BLIND_TYPE,
+    FIXTURE_MAC,
+    FIXTURE_NAME,
+    FIXTURE_SERVICE_INFO,
+)
 
 from tests.common import MockConfigEntry
-from tests.components.bluetooth import generate_advertisement_data, generate_ble_device
-
-TEST_BLIND_TYPE = MotionBlindType.ROLLER.name.lower()
-
-BLIND_SERVICE_INFO = BluetoothServiceInfoBleak(
-    name=TEST_NAME,
-    address=TEST_ADDRESS,
-    device=generate_ble_device(
-        address="cc:cc:cc:cc:cc:cc",
-        name=TEST_NAME,
-    ),
-    rssi=-61,
-    manufacturer_data={000: b"test"},
-    service_data={
-        "test": bytearray(b"0000"),
-    },
-    service_uuids=[
-        "test",
-    ],
-    source="local",
-    advertisement=generate_advertisement_data(
-        manufacturer_data={000: b"test"},
-        service_uuids=["test"],
-    ),
-    connectable=True,
-    time=0,
-    tx_power=-127,
-)
 
 
 @pytest.mark.usefixtures("motionblinds_ble_connect")
@@ -57,7 +34,7 @@ async def test_config_flow_manual_success(hass: HomeAssistant) -> None:
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {const.CONF_MAC_CODE: TEST_MAC},
+        {const.CONF_MAC_CODE: FIXTURE_MAC},
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "confirm"
@@ -67,12 +44,12 @@ async def test_config_flow_manual_success(hass: HomeAssistant) -> None:
         {const.CONF_BLIND_TYPE: MotionBlindType.ROLLER.name.lower()},
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == f"Motionblind {TEST_MAC.upper()}"
+    assert result["title"] == f"Motionblind {FIXTURE_MAC.upper()}"
     assert result["data"] == {
-        CONF_ADDRESS: TEST_ADDRESS,
-        const.CONF_LOCAL_NAME: TEST_NAME,
-        const.CONF_MAC_CODE: TEST_MAC.upper(),
-        const.CONF_BLIND_TYPE: TEST_BLIND_TYPE,
+        CONF_ADDRESS: FIXTURE_ADDRESS,
+        const.CONF_LOCAL_NAME: FIXTURE_NAME,
+        const.CONF_MAC_CODE: FIXTURE_MAC.upper(),
+        const.CONF_BLIND_TYPE: FIXTURE_BLIND_TYPE,
     }
     assert result["options"] == {}
 
@@ -101,7 +78,7 @@ async def test_config_flow_manual_error_invalid_mac(hass: HomeAssistant) -> None
     # Recover
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {const.CONF_MAC_CODE: TEST_MAC},
+        {const.CONF_MAC_CODE: FIXTURE_MAC},
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "confirm"
@@ -112,12 +89,12 @@ async def test_config_flow_manual_error_invalid_mac(hass: HomeAssistant) -> None
         {const.CONF_BLIND_TYPE: MotionBlindType.ROLLER.name.lower()},
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == f"Motionblind {TEST_MAC.upper()}"
+    assert result["title"] == f"Motionblind {FIXTURE_MAC.upper()}"
     assert result["data"] == {
-        CONF_ADDRESS: TEST_ADDRESS,
-        const.CONF_LOCAL_NAME: TEST_NAME,
-        const.CONF_MAC_CODE: TEST_MAC.upper(),
-        const.CONF_BLIND_TYPE: TEST_BLIND_TYPE,
+        CONF_ADDRESS: FIXTURE_ADDRESS,
+        const.CONF_LOCAL_NAME: FIXTURE_NAME,
+        const.CONF_MAC_CODE: FIXTURE_MAC.upper(),
+        const.CONF_BLIND_TYPE: FIXTURE_BLIND_TYPE,
     }
     assert result["options"] == {}
 
@@ -153,7 +130,7 @@ async def test_config_flow_manual_error_no_bluetooth_adapter(
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {const.CONF_MAC_CODE: TEST_MAC},
+            {const.CONF_MAC_CODE: FIXTURE_MAC},
         )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == const.ERROR_NO_BLUETOOTH_ADAPTER
@@ -176,17 +153,17 @@ async def test_config_flow_manual_error_could_not_find_motor(
     motionblinds_ble_connect[1].name = "WRONG_NAME"
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {const.CONF_MAC_CODE: TEST_MAC},
+        {const.CONF_MAC_CODE: FIXTURE_MAC},
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": const.ERROR_COULD_NOT_FIND_MOTOR}
 
     # Recover
-    motionblinds_ble_connect[1].name = TEST_NAME
+    motionblinds_ble_connect[1].name = FIXTURE_NAME
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {const.CONF_MAC_CODE: TEST_MAC},
+        {const.CONF_MAC_CODE: FIXTURE_MAC},
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "confirm"
@@ -197,12 +174,12 @@ async def test_config_flow_manual_error_could_not_find_motor(
         {const.CONF_BLIND_TYPE: MotionBlindType.ROLLER.name.lower()},
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == f"Motionblind {TEST_MAC.upper()}"
+    assert result["title"] == f"Motionblind {FIXTURE_MAC.upper()}"
     assert result["data"] == {
-        CONF_ADDRESS: TEST_ADDRESS,
-        const.CONF_LOCAL_NAME: TEST_NAME,
-        const.CONF_MAC_CODE: TEST_MAC.upper(),
-        const.CONF_BLIND_TYPE: TEST_BLIND_TYPE,
+        CONF_ADDRESS: FIXTURE_ADDRESS,
+        const.CONF_LOCAL_NAME: FIXTURE_NAME,
+        const.CONF_MAC_CODE: FIXTURE_MAC.upper(),
+        const.CONF_BLIND_TYPE: FIXTURE_BLIND_TYPE,
     }
     assert result["options"] == {}
 
@@ -224,7 +201,7 @@ async def test_config_flow_manual_error_no_devices_found(
     motionblinds_ble_connect[0].discover.return_value = []
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {const.CONF_MAC_CODE: TEST_MAC},
+        {const.CONF_MAC_CODE: FIXTURE_MAC},
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == const.ERROR_NO_DEVICES_FOUND
@@ -236,7 +213,7 @@ async def test_config_flow_bluetooth_success(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN,
         context={"source": config_entries.SOURCE_BLUETOOTH},
-        data=BLIND_SERVICE_INFO,
+        data=FIXTURE_SERVICE_INFO,
     )
 
     assert result["type"] is FlowResultType.FORM
@@ -248,12 +225,12 @@ async def test_config_flow_bluetooth_success(hass: HomeAssistant) -> None:
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == f"Motionblind {TEST_MAC.upper()}"
+    assert result["title"] == f"Motionblind {FIXTURE_MAC.upper()}"
     assert result["data"] == {
-        CONF_ADDRESS: TEST_ADDRESS,
-        const.CONF_LOCAL_NAME: TEST_NAME,
-        const.CONF_MAC_CODE: TEST_MAC.upper(),
-        const.CONF_BLIND_TYPE: TEST_BLIND_TYPE,
+        CONF_ADDRESS: FIXTURE_ADDRESS,
+        const.CONF_LOCAL_NAME: FIXTURE_NAME,
+        const.CONF_MAC_CODE: FIXTURE_MAC.upper(),
+        const.CONF_BLIND_TYPE: FIXTURE_BLIND_TYPE,
     }
     assert result["options"] == {}
 

--- a/tests/components/motionblinds_ble/test_config_flow.py
+++ b/tests/components/motionblinds_ble/test_config_flow.py
@@ -19,7 +19,7 @@ from tests.common import MockConfigEntry
 async def test_config_flow_manual_success(
     hass: HomeAssistant,
     blind_type: MotionBlindType,
-    mac: str,
+    mac_code: str,
     address: str,
     local_name: str,
     display_name: str,
@@ -34,7 +34,7 @@ async def test_config_flow_manual_success(
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {const.CONF_MAC_CODE: mac},
+        {const.CONF_MAC_CODE: mac_code},
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "confirm"
@@ -48,7 +48,7 @@ async def test_config_flow_manual_success(
     assert result["data"] == {
         CONF_ADDRESS: address,
         const.CONF_LOCAL_NAME: local_name,
-        const.CONF_MAC_CODE: mac.upper(),
+        const.CONF_MAC_CODE: mac_code,
         const.CONF_BLIND_TYPE: blind_type.name.lower(),
     }
     assert result["options"] == {}
@@ -57,7 +57,7 @@ async def test_config_flow_manual_success(
 @pytest.mark.usefixtures("motionblinds_ble_connect")
 async def test_config_flow_manual_error_invalid_mac(
     hass: HomeAssistant,
-    mac: str,
+    mac_code: str,
     address: str,
     local_name: str,
     display_name: str,
@@ -85,7 +85,7 @@ async def test_config_flow_manual_error_invalid_mac(
     # Recover
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {const.CONF_MAC_CODE: mac},
+        {const.CONF_MAC_CODE: mac_code},
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "confirm"
@@ -100,7 +100,7 @@ async def test_config_flow_manual_error_invalid_mac(
     assert result["data"] == {
         CONF_ADDRESS: address,
         const.CONF_LOCAL_NAME: local_name,
-        const.CONF_MAC_CODE: mac.upper(),
+        const.CONF_MAC_CODE: mac_code,
         const.CONF_BLIND_TYPE: blind_type.name.lower(),
     }
     assert result["options"] == {}
@@ -108,7 +108,7 @@ async def test_config_flow_manual_error_invalid_mac(
 
 @pytest.mark.usefixtures("motionblinds_ble_connect")
 async def test_config_flow_manual_error_no_bluetooth_adapter(
-    hass: HomeAssistant, mac: str
+    hass: HomeAssistant, mac_code: str
 ) -> None:
     """No Bluetooth adapter error flow manually initialized by the user."""
 
@@ -137,7 +137,7 @@ async def test_config_flow_manual_error_no_bluetooth_adapter(
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {const.CONF_MAC_CODE: mac},
+            {const.CONF_MAC_CODE: mac_code},
         )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == const.ERROR_NO_BLUETOOTH_ADAPTER
@@ -146,7 +146,7 @@ async def test_config_flow_manual_error_no_bluetooth_adapter(
 async def test_config_flow_manual_error_could_not_find_motor(
     hass: HomeAssistant,
     motionblinds_ble_connect: tuple[AsyncMock, Mock],
-    mac: str,
+    mac_code: str,
     local_name: str,
     display_name: str,
     address: str,
@@ -166,7 +166,7 @@ async def test_config_flow_manual_error_could_not_find_motor(
     motionblinds_ble_connect[1].name = "WRONG_NAME"
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {const.CONF_MAC_CODE: mac},
+        {const.CONF_MAC_CODE: mac_code},
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
@@ -176,7 +176,7 @@ async def test_config_flow_manual_error_could_not_find_motor(
     motionblinds_ble_connect[1].name = local_name
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {const.CONF_MAC_CODE: mac},
+        {const.CONF_MAC_CODE: mac_code},
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "confirm"
@@ -191,14 +191,14 @@ async def test_config_flow_manual_error_could_not_find_motor(
     assert result["data"] == {
         CONF_ADDRESS: address,
         const.CONF_LOCAL_NAME: local_name,
-        const.CONF_MAC_CODE: mac.upper(),
+        const.CONF_MAC_CODE: mac_code,
         const.CONF_BLIND_TYPE: blind_type.name.lower(),
     }
     assert result["options"] == {}
 
 
 async def test_config_flow_manual_error_no_devices_found(
-    hass: HomeAssistant, motionblinds_ble_connect: tuple[AsyncMock, Mock], mac: str
+    hass: HomeAssistant, motionblinds_ble_connect: tuple[AsyncMock, Mock], mac_code: str
 ) -> None:
     """No devices found error flow manually initialized by the user."""
 
@@ -214,7 +214,7 @@ async def test_config_flow_manual_error_no_devices_found(
     motionblinds_ble_connect[0].discover.return_value = []
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {const.CONF_MAC_CODE: mac},
+        {const.CONF_MAC_CODE: mac_code},
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == const.ERROR_NO_DEVICES_FOUND
@@ -223,7 +223,7 @@ async def test_config_flow_manual_error_no_devices_found(
 @pytest.mark.usefixtures("motionblinds_ble_connect")
 async def test_config_flow_bluetooth_success(
     hass: HomeAssistant,
-    mac: str,
+    mac_code: str,
     service_info: BluetoothServiceInfoBleak,
     address: str,
     local_name: str,
@@ -250,7 +250,7 @@ async def test_config_flow_bluetooth_success(
     assert result["data"] == {
         CONF_ADDRESS: address,
         const.CONF_LOCAL_NAME: local_name,
-        const.CONF_MAC_CODE: mac.upper(),
+        const.CONF_MAC_CODE: mac_code,
         const.CONF_BLIND_TYPE: blind_type.name.lower(),
     }
     assert result["options"] == {}

--- a/tests/components/motionblinds_ble/test_config_flow.py
+++ b/tests/components/motionblinds_ble/test_config_flow.py
@@ -258,22 +258,16 @@ async def test_config_flow_bluetooth_success(hass: HomeAssistant) -> None:
     assert result["options"] == {}
 
 
-async def test_options_flow(hass: HomeAssistant) -> None:
+async def test_options_flow(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
     """Test the options flow."""
-    entry = MockConfigEntry(
-        domain=const.DOMAIN,
-        unique_id="0123456789",
-        data={
-            const.CONF_BLIND_TYPE: MotionBlindType.ROLLER,
-        },
-    )
-    entry.add_to_hass(hass)
+    mock_config_entry.add_to_hass(hass)
 
-    await hass.config_entries.async_setup(entry.entry_id)
-
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "init"

--- a/tests/components/motionblinds_ble/test_config_flow.py
+++ b/tests/components/motionblinds_ble/test_config_flow.py
@@ -19,6 +19,7 @@ from tests.common import MockConfigEntry
 async def test_config_flow_manual_success(
     hass: HomeAssistant,
     blind_type: MotionBlindType,
+    mock_setup_entry: AsyncMock,
     mac_code: str,
     address: str,
     local_name: str,
@@ -57,6 +58,7 @@ async def test_config_flow_manual_success(
 @pytest.mark.usefixtures("motionblinds_ble_connect")
 async def test_config_flow_manual_error_invalid_mac(
     hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
     mac_code: str,
     address: str,
     local_name: str,
@@ -108,7 +110,8 @@ async def test_config_flow_manual_error_invalid_mac(
 
 @pytest.mark.usefixtures("motionblinds_ble_connect")
 async def test_config_flow_manual_error_no_bluetooth_adapter(
-    hass: HomeAssistant, mac_code: str
+    hass: HomeAssistant,
+    mac_code: str,
 ) -> None:
     """No Bluetooth adapter error flow manually initialized by the user."""
 
@@ -146,6 +149,7 @@ async def test_config_flow_manual_error_no_bluetooth_adapter(
 async def test_config_flow_manual_error_could_not_find_motor(
     hass: HomeAssistant,
     motionblinds_ble_connect: tuple[AsyncMock, Mock],
+    mock_setup_entry: AsyncMock,
     mac_code: str,
     local_name: str,
     display_name: str,
@@ -198,7 +202,9 @@ async def test_config_flow_manual_error_could_not_find_motor(
 
 
 async def test_config_flow_manual_error_no_devices_found(
-    hass: HomeAssistant, motionblinds_ble_connect: tuple[AsyncMock, Mock], mac_code: str
+    hass: HomeAssistant,
+    motionblinds_ble_connect: tuple[AsyncMock, Mock],
+    mac_code: str,
 ) -> None:
     """No devices found error flow manually initialized by the user."""
 
@@ -225,6 +231,7 @@ async def test_config_flow_bluetooth_success(
     hass: HomeAssistant,
     mac_code: str,
     service_info: BluetoothServiceInfoBleak,
+    mock_setup_entry: AsyncMock,
     address: str,
     local_name: str,
     display_name: str,
@@ -257,7 +264,9 @@ async def test_config_flow_bluetooth_success(
 
 
 async def test_options_flow(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_setup_entry: AsyncMock,
 ) -> None:
     """Test the options flow."""
     mock_config_entry.add_to_hass(hass)

--- a/tests/components/motionblinds_ble/test_cover.py
+++ b/tests/components/motionblinds_ble/test_cover.py
@@ -47,6 +47,7 @@ from tests.common import MockConfigEntry
 )
 async def test_cover_service(
     mock_config_entry: MockConfigEntry,
+    name: str,
     hass: HomeAssistant,
     service: str,
     method: str,
@@ -54,7 +55,7 @@ async def test_cover_service(
 ) -> None:
     """Test cover service."""
 
-    name = await setup_integration(hass, mock_config_entry)
+    await setup_integration(hass, mock_config_entry)
 
     with patch(
         f"homeassistant.components.motionblinds_ble.MotionDevice.{method}"
@@ -80,13 +81,14 @@ async def test_cover_service(
 async def test_cover_update_running(
     mock_config_entry: MockConfigEntry,
     mock_motion_device: Mock,
+    name: str,
     hass: HomeAssistant,
     running_type: str | None,
     state: str,
 ) -> None:
     """Test updating running status."""
 
-    name = await setup_integration(hass, mock_config_entry)
+    await setup_integration(hass, mock_config_entry)
 
     async_update_running = mock_motion_device.register_running_callback.call_args[0][0]
 
@@ -106,6 +108,7 @@ async def test_cover_update_running(
 async def test_cover_update_position(
     mock_config_entry: MockConfigEntry,
     mock_motion_device: Mock,
+    name: str,
     hass: HomeAssistant,
     position: int,
     tilt: int,
@@ -113,7 +116,7 @@ async def test_cover_update_position(
 ) -> None:
     """Test updating cover position and tilt."""
 
-    name = await setup_integration(hass, mock_config_entry)
+    await setup_integration(hass, mock_config_entry)
 
     async_update_position = mock_motion_device.register_position_callback.call_args[0][
         0

--- a/tests/components/motionblinds_ble/test_cover.py
+++ b/tests/components/motionblinds_ble/test_cover.py
@@ -1,7 +1,7 @@
 """Tests for Motionblinds BLE covers."""
 
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from motionblindsble.const import MotionBlindType, MotionRunningType
 from motionblindsble.device import MotionDevice
@@ -83,17 +83,19 @@ async def test_cover_service(
 )
 async def test_cover_update_running(
     mock_config_entry: MockConfigEntry,
+    mock_motion_device: Mock,
     hass: HomeAssistant,
     running_type: str | None,
     state: str,
 ) -> None:
     """Test updating running status."""
 
-    name = await setup_integration(hass, mock_config_entry)
+    await setup_integration(hass, mock_config_entry)
 
-    device: MotionDevice = hass.data[DOMAIN][mock_config_entry.entry_id]
-    device.update_running(running_type)
-    assert hass.states.get(f"cover.{name}").state == state
+    async_update_running = mock_motion_device.register_running_callback.call_args[0][0]
+
+    async_update_running(running_type)
+    assert hass.states.get("cover.motionblinds_ble_cc_cc_cc_cc_cc_cc").state == state
 
 
 @pytest.mark.parametrize(

--- a/tests/components/motionblinds_ble/test_cover.py
+++ b/tests/components/motionblinds_ble/test_cover.py
@@ -4,7 +4,6 @@ from typing import Any
 from unittest.mock import Mock, patch
 
 from motionblindsble.const import MotionBlindType, MotionRunningType
-from motionblindsble.device import MotionDevice
 import pytest
 
 from homeassistant.components.cover import (
@@ -24,7 +23,6 @@ from homeassistant.components.cover import (
     STATE_OPEN,
     STATE_OPENING,
 )
-from homeassistant.components.motionblinds_ble.const import DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 
@@ -109,6 +107,7 @@ async def test_cover_update_running(
 )
 async def test_cover_update_position(
     mock_config_entry: MockConfigEntry,
+    mock_motion_device: Mock,
     hass: HomeAssistant,
     position: int,
     tilt: int,
@@ -116,8 +115,11 @@ async def test_cover_update_position(
 ) -> None:
     """Test updating cover position and tilt."""
 
-    name = await setup_integration(hass, mock_config_entry)
+    await setup_integration(hass, mock_config_entry)
 
-    device: MotionDevice = hass.data[DOMAIN][mock_config_entry.entry_id]
-    device.update_position(position, tilt)
-    assert hass.states.get(f"cover.{name}").state == state
+    async_update_position = mock_motion_device.register_position_callback.call_args[0][
+        0
+    ]
+
+    async_update_position(position, tilt)
+    assert hass.states.get("cover.motionblinds_ble_cc_cc_cc_cc_cc_cc").state == state

--- a/tests/components/motionblinds_ble/test_cover.py
+++ b/tests/components/motionblinds_ble/test_cover.py
@@ -28,7 +28,7 @@ from homeassistant.components.motionblinds_ble.const import DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 
-from . import setup_platform
+from . import setup_integration
 
 
 @pytest.mark.parametrize(
@@ -49,7 +49,7 @@ async def test_cover_service(
 ) -> None:
     """Test cover service."""
 
-    _, name = await setup_platform(hass, blind_type=MotionBlindType.VENETIAN)
+    _, name = await setup_integration(hass, blind_type=MotionBlindType.VENETIAN)
 
     with patch(
         f"homeassistant.components.motionblinds_ble.MotionDevice.{method}"
@@ -79,7 +79,9 @@ async def test_cover_update_running(
 ) -> None:
     """Test updating running status."""
 
-    config_entry, name = await setup_platform(hass, blind_type=MotionBlindType.VENETIAN)
+    config_entry, name = await setup_integration(
+        hass, blind_type=MotionBlindType.VENETIAN
+    )
 
     device: MotionDevice = hass.data[DOMAIN][config_entry.entry_id]
     device.update_running(running_type)
@@ -100,7 +102,9 @@ async def test_cover_update_position(
 ) -> None:
     """Test updating cover position and tilt."""
 
-    config_entry, name = await setup_platform(hass, blind_type=MotionBlindType.VENETIAN)
+    config_entry, name = await setup_integration(
+        hass, blind_type=MotionBlindType.VENETIAN
+    )
 
     device: MotionDevice = hass.data[DOMAIN][config_entry.entry_id]
     device.update_position(position, tilt)

--- a/tests/components/motionblinds_ble/test_cover.py
+++ b/tests/components/motionblinds_ble/test_cover.py
@@ -30,7 +30,10 @@ from homeassistant.core import HomeAssistant
 
 from . import setup_integration
 
+from tests.common import MockConfigEntry
 
+
+@pytest.mark.parametrize("blind_type", [MotionBlindType.VENETIAN])
 @pytest.mark.parametrize(
     ("service", "method", "kwargs"),
     [
@@ -45,11 +48,15 @@ from . import setup_integration
     ],
 )
 async def test_cover_service(
-    hass: HomeAssistant, service: str, method: str, kwargs: dict[str, Any]
+    mock_config_entry: MockConfigEntry,
+    hass: HomeAssistant,
+    service: str,
+    method: str,
+    kwargs: dict[str, Any],
 ) -> None:
     """Test cover service."""
 
-    _, name = await setup_integration(hass, blind_type=MotionBlindType.VENETIAN)
+    name = await setup_integration(hass, mock_config_entry)
 
     with patch(
         f"homeassistant.components.motionblinds_ble.MotionDevice.{method}"
@@ -75,15 +82,16 @@ async def test_cover_service(
     ],
 )
 async def test_cover_update_running(
-    hass: HomeAssistant, running_type: str | None, state: str
+    mock_config_entry: MockConfigEntry,
+    hass: HomeAssistant,
+    running_type: str | None,
+    state: str,
 ) -> None:
     """Test updating running status."""
 
-    config_entry, name = await setup_integration(
-        hass, blind_type=MotionBlindType.VENETIAN
-    )
+    name = await setup_integration(hass, mock_config_entry)
 
-    device: MotionDevice = hass.data[DOMAIN][config_entry.entry_id]
+    device: MotionDevice = hass.data[DOMAIN][mock_config_entry.entry_id]
     device.update_running(running_type)
     assert hass.states.get(f"cover.{name}").state == state
 
@@ -98,14 +106,16 @@ async def test_cover_update_running(
     ],
 )
 async def test_cover_update_position(
-    hass: HomeAssistant, position: int, tilt: int, state: str
+    mock_config_entry: MockConfigEntry,
+    hass: HomeAssistant,
+    position: int,
+    tilt: int,
+    state: str,
 ) -> None:
     """Test updating cover position and tilt."""
 
-    config_entry, name = await setup_integration(
-        hass, blind_type=MotionBlindType.VENETIAN
-    )
+    name = await setup_integration(hass, mock_config_entry)
 
-    device: MotionDevice = hass.data[DOMAIN][config_entry.entry_id]
+    device: MotionDevice = hass.data[DOMAIN][mock_config_entry.entry_id]
     device.update_position(position, tilt)
     assert hass.states.get(f"cover.{name}").state == state

--- a/tests/components/motionblinds_ble/test_cover.py
+++ b/tests/components/motionblinds_ble/test_cover.py
@@ -1,7 +1,7 @@
 """Tests for Motionblinds BLE covers."""
 
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 from motionblindsble.const import MotionBlindType, MotionRunningType
 import pytest
@@ -47,6 +47,7 @@ from tests.common import MockConfigEntry
 )
 async def test_cover_service(
     mock_config_entry: MockConfigEntry,
+    mock_motion_device: Mock,
     name: str,
     hass: HomeAssistant,
     service: str,
@@ -57,16 +58,13 @@ async def test_cover_service(
 
     await setup_integration(hass, mock_config_entry)
 
-    with patch(
-        f"homeassistant.components.motionblinds_ble.MotionDevice.{method}"
-    ) as func:
-        await hass.services.async_call(
-            COVER_DOMAIN,
-            service,
-            {ATTR_ENTITY_ID: f"cover.{name}", **kwargs},
-            blocking=True,
-        )
-        func.assert_called_once()
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        service,
+        {ATTR_ENTITY_ID: f"cover.{name}", **kwargs},
+        blocking=True,
+    )
+    getattr(mock_motion_device, method).assert_called_once()
 
 
 @pytest.mark.parametrize(

--- a/tests/components/motionblinds_ble/test_cover.py
+++ b/tests/components/motionblinds_ble/test_cover.py
@@ -67,8 +67,6 @@ async def test_cover_service(
         )
         func.assert_called_once()
 
-    await hass.async_block_till_done()
-
 
 @pytest.mark.parametrize(
     ("running_type", "state"),
@@ -88,12 +86,12 @@ async def test_cover_update_running(
 ) -> None:
     """Test updating running status."""
 
-    await setup_integration(hass, mock_config_entry)
+    name = await setup_integration(hass, mock_config_entry)
 
     async_update_running = mock_motion_device.register_running_callback.call_args[0][0]
 
     async_update_running(running_type)
-    assert hass.states.get("cover.motionblinds_ble_cc_cc_cc_cc_cc_cc").state == state
+    assert hass.states.get(f"cover.{name}").state == state
 
 
 @pytest.mark.parametrize(
@@ -115,11 +113,11 @@ async def test_cover_update_position(
 ) -> None:
     """Test updating cover position and tilt."""
 
-    await setup_integration(hass, mock_config_entry)
+    name = await setup_integration(hass, mock_config_entry)
 
     async_update_position = mock_motion_device.register_position_callback.call_args[0][
         0
     ]
 
     async_update_position(position, tilt)
-    assert hass.states.get("cover.motionblinds_ble_cc_cc_cc_cc_cc_cc").state == state
+    assert hass.states.get(f"cover.{name}").state == state

--- a/tests/components/motionblinds_ble/test_cover.py
+++ b/tests/components/motionblinds_ble/test_cover.py
@@ -1,0 +1,113 @@
+"""Tests for Motionblinds BLE covers."""
+
+from typing import Any
+from unittest.mock import patch
+
+from motionblindsble.const import MotionBlindType, MotionRunningType
+from motionblindsble.device import MotionDevice
+import pytest
+
+from homeassistant.components.cover import (
+    ATTR_POSITION,
+    ATTR_TILT_POSITION,
+    DOMAIN as COVER_DOMAIN,
+    SERVICE_CLOSE_COVER,
+    SERVICE_CLOSE_COVER_TILT,
+    SERVICE_OPEN_COVER,
+    SERVICE_OPEN_COVER_TILT,
+    SERVICE_SET_COVER_POSITION,
+    SERVICE_SET_COVER_TILT_POSITION,
+    SERVICE_STOP_COVER,
+    SERVICE_STOP_COVER_TILT,
+    STATE_CLOSED,
+    STATE_CLOSING,
+    STATE_OPEN,
+    STATE_OPENING,
+)
+from homeassistant.components.motionblinds_ble.const import DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+
+from . import setup_platform
+
+
+@pytest.mark.parametrize(
+    ("service", "method", "kwargs"),
+    [
+        (SERVICE_OPEN_COVER, "open", {}),
+        (SERVICE_CLOSE_COVER, "close", {}),
+        (SERVICE_OPEN_COVER_TILT, "open_tilt", {}),
+        (SERVICE_CLOSE_COVER_TILT, "close_tilt", {}),
+        (SERVICE_SET_COVER_POSITION, "position", {ATTR_POSITION: 5}),
+        (SERVICE_SET_COVER_TILT_POSITION, "tilt", {ATTR_TILT_POSITION: 10}),
+        (SERVICE_STOP_COVER, "stop", {}),
+        (SERVICE_STOP_COVER_TILT, "stop", {}),
+    ],
+)
+async def test_cover_service(
+    hass: HomeAssistant, service: str, method: str, kwargs: dict[str, Any]
+) -> None:
+    """Test cover service."""
+
+    _, name = await setup_platform(
+        hass, [Platform.COVER], blind_type=MotionBlindType.VENETIAN
+    )
+
+    with patch(
+        f"homeassistant.components.motionblinds_ble.MotionDevice.{method}"
+    ) as func:
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            service,
+            {ATTR_ENTITY_ID: f"cover.{name}", **kwargs},
+            blocking=True,
+        )
+        func.assert_called_once()
+
+    await hass.async_block_till_done()
+
+
+@pytest.mark.parametrize(
+    ("running_type", "state"),
+    [
+        (None, "unknown"),
+        (MotionRunningType.STILL, "unknown"),
+        (MotionRunningType.OPENING, STATE_OPENING),
+        (MotionRunningType.CLOSING, STATE_CLOSING),
+    ],
+)
+async def test_cover_update_running(
+    hass: HomeAssistant, running_type: str | None, state: str
+) -> None:
+    """Test updating running status."""
+
+    config_entry, name = await setup_platform(
+        hass, [Platform.COVER], blind_type=MotionBlindType.VENETIAN
+    )
+
+    device: MotionDevice = hass.data[DOMAIN][config_entry.entry_id]
+    device.update_running(running_type)
+    assert hass.states.get(f"cover.{name}").state == state
+
+
+@pytest.mark.parametrize(
+    ("position", "tilt", "state"),
+    [
+        (None, None, "unknown"),
+        (0, 0, STATE_OPEN),
+        (50, 90, STATE_OPEN),
+        (100, 180, STATE_CLOSED),
+    ],
+)
+async def test_cover_update_position(
+    hass: HomeAssistant, position: int, tilt: int, state: str
+) -> None:
+    """Test updating cover position and tilt."""
+
+    config_entry, name = await setup_platform(
+        hass, [Platform.COVER], blind_type=MotionBlindType.VENETIAN
+    )
+
+    device: MotionDevice = hass.data[DOMAIN][config_entry.entry_id]
+    device.update_position(position, tilt)
+    assert hass.states.get(f"cover.{name}").state == state

--- a/tests/components/motionblinds_ble/test_cover.py
+++ b/tests/components/motionblinds_ble/test_cover.py
@@ -25,7 +25,7 @@ from homeassistant.components.cover import (
     STATE_OPENING,
 )
 from homeassistant.components.motionblinds_ble.const import DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 
 from . import setup_platform
@@ -49,9 +49,7 @@ async def test_cover_service(
 ) -> None:
     """Test cover service."""
 
-    _, name = await setup_platform(
-        hass, [Platform.COVER], blind_type=MotionBlindType.VENETIAN
-    )
+    _, name = await setup_platform(hass, blind_type=MotionBlindType.VENETIAN)
 
     with patch(
         f"homeassistant.components.motionblinds_ble.MotionDevice.{method}"
@@ -81,9 +79,7 @@ async def test_cover_update_running(
 ) -> None:
     """Test updating running status."""
 
-    config_entry, name = await setup_platform(
-        hass, [Platform.COVER], blind_type=MotionBlindType.VENETIAN
-    )
+    config_entry, name = await setup_platform(hass, blind_type=MotionBlindType.VENETIAN)
 
     device: MotionDevice = hass.data[DOMAIN][config_entry.entry_id]
     device.update_running(running_type)
@@ -104,9 +100,7 @@ async def test_cover_update_position(
 ) -> None:
     """Test updating cover position and tilt."""
 
-    config_entry, name = await setup_platform(
-        hass, [Platform.COVER], blind_type=MotionBlindType.VENETIAN
-    )
+    config_entry, name = await setup_platform(hass, blind_type=MotionBlindType.VENETIAN)
 
     device: MotionDevice = hass.data[DOMAIN][config_entry.entry_id]
     device.update_position(position, tilt)

--- a/tests/components/motionblinds_ble/test_entity.py
+++ b/tests/components/motionblinds_ble/test_entity.py
@@ -26,7 +26,6 @@ from tests.common import MockConfigEntry
 @pytest.mark.parametrize(
     ("platform", "entity"),
     [
-        (Platform.COVER, None),
         (Platform.BUTTON, ATTR_CONNECT),
         (Platform.BUTTON, ATTR_DISCONNECT),
         (Platform.BUTTON, ATTR_FAVORITE),
@@ -49,11 +48,7 @@ async def test_entity_update(
     await hass.services.async_call(
         HA_DOMAIN,
         SERVICE_UPDATE_ENTITY,
-        {
-            ATTR_ENTITY_ID: f"{platform.name.lower()}.{name}"
-            if platform is Platform.COVER
-            else f"{platform.name.lower()}.{name}_{entity}"
-        },
+        {ATTR_ENTITY_ID: f"{platform.name.lower()}.{name}_{entity}"},
         blocking=True,
     )
     getattr(mock_motion_device, "status_query").assert_called_once_with()

--- a/tests/components/motionblinds_ble/test_entity.py
+++ b/tests/components/motionblinds_ble/test_entity.py
@@ -18,7 +18,7 @@ from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from . import setup_platform
+from . import setup_integration
 
 
 @pytest.mark.parametrize(
@@ -37,7 +37,7 @@ async def test_entity_update(
     """Test updating entity using homeassistant.update_entity."""
 
     await async_setup_component(hass, HA_DOMAIN, {})
-    _, name = await setup_platform(hass)
+    _, name = await setup_integration(hass)
 
     with patch(
         "homeassistant.components.motionblinds_ble.entity.MotionDevice.status_query"

--- a/tests/components/motionblinds_ble/test_entity.py
+++ b/tests/components/motionblinds_ble/test_entity.py
@@ -1,6 +1,6 @@
 """Tests for Motionblinds BLE entities."""
 
-from unittest.mock import patch
+from unittest.mock import Mock
 
 import pytest
 
@@ -35,6 +35,7 @@ from tests.common import MockConfigEntry
 )
 async def test_entity_update(
     mock_config_entry: MockConfigEntry,
+    mock_motion_device: Mock,
     name: str,
     hass: HomeAssistant,
     platform: Platform,
@@ -45,17 +46,14 @@ async def test_entity_update(
     await async_setup_component(hass, HA_DOMAIN, {})
     await setup_integration(hass, mock_config_entry)
 
-    with patch(
-        "homeassistant.components.motionblinds_ble.entity.MotionDevice.status_query"
-    ) as status_query:
-        await hass.services.async_call(
-            HA_DOMAIN,
-            SERVICE_UPDATE_ENTITY,
-            {
-                ATTR_ENTITY_ID: f"{platform.name.lower()}.{name}"
-                if platform is Platform.COVER
-                else f"{platform.name.lower()}.{name}_{entity}"
-            },
-            blocking=True,
-        )
-        status_query.assert_called_once()
+    await hass.services.async_call(
+        HA_DOMAIN,
+        SERVICE_UPDATE_ENTITY,
+        {
+            ATTR_ENTITY_ID: f"{platform.name.lower()}.{name}"
+            if platform is Platform.COVER
+            else f"{platform.name.lower()}.{name}_{entity}"
+        },
+        blocking=True,
+    )
+    getattr(mock_motion_device, "status_query").assert_called_once_with()

--- a/tests/components/motionblinds_ble/test_entity.py
+++ b/tests/components/motionblinds_ble/test_entity.py
@@ -20,6 +20,8 @@ from homeassistant.setup import async_setup_component
 
 from . import setup_integration
 
+from tests.common import MockConfigEntry
+
 
 @pytest.mark.parametrize(
     ("platform", "entity"),
@@ -32,12 +34,15 @@ from . import setup_integration
     ],
 )
 async def test_entity_update(
-    hass: HomeAssistant, platform: Platform, entity: str
+    mock_config_entry: MockConfigEntry,
+    hass: HomeAssistant,
+    platform: Platform,
+    entity: str,
 ) -> None:
     """Test updating entity using homeassistant.update_entity."""
 
     await async_setup_component(hass, HA_DOMAIN, {})
-    _, name = await setup_integration(hass)
+    name = await setup_integration(hass, mock_config_entry)
 
     with patch(
         "homeassistant.components.motionblinds_ble.entity.MotionDevice.status_query"

--- a/tests/components/motionblinds_ble/test_entity.py
+++ b/tests/components/motionblinds_ble/test_entity.py
@@ -35,6 +35,7 @@ from tests.common import MockConfigEntry
 )
 async def test_entity_update(
     mock_config_entry: MockConfigEntry,
+    name: str,
     hass: HomeAssistant,
     platform: Platform,
     entity: str,
@@ -42,7 +43,7 @@ async def test_entity_update(
     """Test updating entity using homeassistant.update_entity."""
 
     await async_setup_component(hass, HA_DOMAIN, {})
-    name = await setup_integration(hass, mock_config_entry)
+    await setup_integration(hass, mock_config_entry)
 
     with patch(
         "homeassistant.components.motionblinds_ble.entity.MotionDevice.status_query"

--- a/tests/components/motionblinds_ble/test_entity.py
+++ b/tests/components/motionblinds_ble/test_entity.py
@@ -37,7 +37,7 @@ async def test_entity_update(
     """Test updating entity using homeassistant.update_entity."""
 
     await async_setup_component(hass, HA_DOMAIN, {})
-    _, name = await setup_platform(hass, [platform])
+    _, name = await setup_platform(hass)
 
     with patch(
         "homeassistant.components.motionblinds_ble.entity.MotionDevice.status_query"

--- a/tests/components/motionblinds_ble/test_entity.py
+++ b/tests/components/motionblinds_ble/test_entity.py
@@ -8,7 +8,12 @@ from homeassistant.components.homeassistant import (
     DOMAIN as HA_DOMAIN,
     SERVICE_UPDATE_ENTITY,
 )
-from homeassistant.components.motionblinds_ble import PLATFORMS
+from homeassistant.components.motionblinds_ble.const import (
+    ATTR_CONNECT,
+    ATTR_DISCONNECT,
+    ATTR_FAVORITE,
+    ATTR_SPEED,
+)
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -16,12 +21,23 @@ from homeassistant.setup import async_setup_component
 from . import setup_platform
 
 
-@pytest.mark.parametrize("platform", PLATFORMS)
-async def test_entity_update(hass: HomeAssistant, platform: Platform) -> None:
+@pytest.mark.parametrize(
+    ("platform", "entity"),
+    [
+        (Platform.COVER, None),
+        (Platform.BUTTON, ATTR_CONNECT),
+        (Platform.BUTTON, ATTR_DISCONNECT),
+        (Platform.BUTTON, ATTR_FAVORITE),
+        (Platform.SELECT, ATTR_SPEED),
+    ],
+)
+async def test_entity_update(
+    hass: HomeAssistant, platform: Platform, entity: str
+) -> None:
     """Test updating entity using homeassistant.update_entity."""
 
     await async_setup_component(hass, HA_DOMAIN, {})
-    _, name = await setup_platform(hass, [Platform.COVER])
+    _, name = await setup_platform(hass, [platform])
 
     with patch(
         "homeassistant.components.motionblinds_ble.entity.MotionDevice.status_query"
@@ -29,7 +45,11 @@ async def test_entity_update(hass: HomeAssistant, platform: Platform) -> None:
         await hass.services.async_call(
             HA_DOMAIN,
             SERVICE_UPDATE_ENTITY,
-            {ATTR_ENTITY_ID: f"{platform.name}.{name}"},
+            {
+                ATTR_ENTITY_ID: f"{platform.name.lower()}.{name}"
+                if platform is Platform.COVER
+                else f"{platform.name.lower()}.{name}_{entity}"
+            },
             blocking=True,
         )
         status_query.assert_called_once()

--- a/tests/components/motionblinds_ble/test_entity.py
+++ b/tests/components/motionblinds_ble/test_entity.py
@@ -1,0 +1,35 @@
+"""Tests for Motionblinds BLE entities."""
+
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.homeassistant import (
+    DOMAIN as HA_DOMAIN,
+    SERVICE_UPDATE_ENTITY,
+)
+from homeassistant.components.motionblinds_ble import PLATFORMS
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from . import setup_platform
+
+
+@pytest.mark.parametrize("platform", PLATFORMS)
+async def test_entity_update(hass: HomeAssistant, platform: Platform) -> None:
+    """Test updating entity using homeassistant.update_entity."""
+
+    await async_setup_component(hass, HA_DOMAIN, {})
+    _, name = await setup_platform(hass, [Platform.COVER])
+
+    with patch(
+        "homeassistant.components.motionblinds_ble.entity.MotionDevice.status_query"
+    ) as status_query:
+        await hass.services.async_call(
+            HA_DOMAIN,
+            SERVICE_UPDATE_ENTITY,
+            {ATTR_ENTITY_ID: f"{platform.name}.{name}"},
+            blocking=True,
+        )
+        status_query.assert_called_once()

--- a/tests/components/motionblinds_ble/test_init.py
+++ b/tests/components/motionblinds_ble/test_init.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from homeassistant.components.motionblinds_ble import options_update_listener
 from homeassistant.core import HomeAssistant
 
-from . import FIXTURE_SERVICE_INFO, setup_platform
+from . import FIXTURE_SERVICE_INFO, setup_integration
 
 from tests.components.bluetooth import inject_bluetooth_service_info
 
@@ -13,7 +13,7 @@ from tests.components.bluetooth import inject_bluetooth_service_info
 async def test_options_update_listener(hass: HomeAssistant) -> None:
     """Test options_update_listener."""
 
-    config_entry, _ = await setup_platform(hass)
+    config_entry, _ = await setup_integration(hass)
 
     with (
         patch(
@@ -31,7 +31,7 @@ async def test_options_update_listener(hass: HomeAssistant) -> None:
 async def test_update_ble_device(hass: HomeAssistant) -> None:
     """Test async_update_ble_device."""
 
-    await setup_platform(hass)
+    await setup_integration(hass)
 
     with patch(
         "homeassistant.components.motionblinds_ble.MotionDevice.set_ble_device"

--- a/tests/components/motionblinds_ble/test_init.py
+++ b/tests/components/motionblinds_ble/test_init.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from homeassistant.components.motionblinds_ble import PLATFORMS, options_update_listener
 from homeassistant.core import HomeAssistant
 
-from . import SERVICE_INFO, setup_platform
+from . import FIXTURE_SERVICE_INFO, setup_platform
 
 from tests.components.bluetooth import inject_bluetooth_service_info
 
@@ -36,5 +36,5 @@ async def test_update_ble_device(hass: HomeAssistant) -> None:
     with patch(
         "homeassistant.components.motionblinds_ble.MotionDevice.set_ble_device"
     ) as mock_set_ble_device:
-        inject_bluetooth_service_info(hass, SERVICE_INFO)
+        inject_bluetooth_service_info(hass, FIXTURE_SERVICE_INFO)
         mock_set_ble_device.assert_called_once()

--- a/tests/components/motionblinds_ble/test_init.py
+++ b/tests/components/motionblinds_ble/test_init.py
@@ -7,13 +7,16 @@ from homeassistant.core import HomeAssistant
 
 from . import FIXTURE_SERVICE_INFO, setup_integration
 
+from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
 
 
-async def test_options_update_listener(hass: HomeAssistant) -> None:
+async def test_options_update_listener(
+    mock_config_entry: MockConfigEntry, hass: HomeAssistant
+) -> None:
     """Test options_update_listener."""
 
-    config_entry, _ = await setup_integration(hass)
+    await setup_integration(hass, mock_config_entry)
 
     with (
         patch(
@@ -23,15 +26,17 @@ async def test_options_update_listener(hass: HomeAssistant) -> None:
             "homeassistant.components.motionblinds_ble.MotionDevice.set_permanent_connection"
         ) as set_permanent_connection,
     ):
-        await options_update_listener(hass, config_entry)
+        await options_update_listener(hass, mock_config_entry)
         mock_set_custom_disconnect_time.assert_called_once()
         set_permanent_connection.assert_called_once()
 
 
-async def test_update_ble_device(hass: HomeAssistant) -> None:
+async def test_update_ble_device(
+    mock_config_entry: MockConfigEntry, hass: HomeAssistant
+) -> None:
     """Test async_update_ble_device."""
 
-    await setup_integration(hass)
+    await setup_integration(hass, mock_config_entry)
 
     with patch(
         "homeassistant.components.motionblinds_ble.MotionDevice.set_ble_device"

--- a/tests/components/motionblinds_ble/test_init.py
+++ b/tests/components/motionblinds_ble/test_init.py
@@ -2,10 +2,11 @@
 
 from unittest.mock import patch
 
+from homeassistant.components.bluetooth.models import BluetoothServiceInfoBleak
 from homeassistant.components.motionblinds_ble import options_update_listener
 from homeassistant.core import HomeAssistant
 
-from . import FIXTURE_SERVICE_INFO, setup_integration
+from . import setup_integration
 
 from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
@@ -32,7 +33,9 @@ async def test_options_update_listener(
 
 
 async def test_update_ble_device(
-    mock_config_entry: MockConfigEntry, hass: HomeAssistant
+    mock_config_entry: MockConfigEntry,
+    hass: HomeAssistant,
+    service_info: BluetoothServiceInfoBleak,
 ) -> None:
     """Test async_update_ble_device."""
 
@@ -41,5 +44,5 @@ async def test_update_ble_device(
     with patch(
         "homeassistant.components.motionblinds_ble.MotionDevice.set_ble_device"
     ) as mock_set_ble_device:
-        inject_bluetooth_service_info(hass, FIXTURE_SERVICE_INFO)
+        inject_bluetooth_service_info(hass, service_info)
         mock_set_ble_device.assert_called_once()

--- a/tests/components/motionblinds_ble/test_init.py
+++ b/tests/components/motionblinds_ble/test_init.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch
 
-from homeassistant.components.motionblinds_ble import PLATFORMS, options_update_listener
+from homeassistant.components.motionblinds_ble import options_update_listener
 from homeassistant.core import HomeAssistant
 
 from . import FIXTURE_SERVICE_INFO, setup_platform
@@ -13,7 +13,7 @@ from tests.components.bluetooth import inject_bluetooth_service_info
 async def test_options_update_listener(hass: HomeAssistant) -> None:
     """Test options_update_listener."""
 
-    config_entry, _ = await setup_platform(hass, PLATFORMS)
+    config_entry, _ = await setup_platform(hass)
 
     with (
         patch(
@@ -31,7 +31,7 @@ async def test_options_update_listener(hass: HomeAssistant) -> None:
 async def test_update_ble_device(hass: HomeAssistant) -> None:
     """Test async_update_ble_device."""
 
-    await setup_platform(hass, PLATFORMS)
+    await setup_platform(hass)
 
     with patch(
         "homeassistant.components.motionblinds_ble.MotionDevice.set_ble_device"

--- a/tests/components/motionblinds_ble/test_init.py
+++ b/tests/components/motionblinds_ble/test_init.py
@@ -1,0 +1,40 @@
+"""Tests for Motionblinds BLE init."""
+
+from unittest.mock import patch
+
+from homeassistant.components.motionblinds_ble import PLATFORMS, options_update_listener
+from homeassistant.core import HomeAssistant
+
+from . import SERVICE_INFO, setup_platform
+
+from tests.components.bluetooth import inject_bluetooth_service_info
+
+
+async def test_options_update_listener(hass: HomeAssistant) -> None:
+    """Test options_update_listener."""
+
+    config_entry, _ = await setup_platform(hass, PLATFORMS)
+
+    with (
+        patch(
+            "homeassistant.components.motionblinds_ble.MotionDevice.set_custom_disconnect_time"
+        ) as mock_set_custom_disconnect_time,
+        patch(
+            "homeassistant.components.motionblinds_ble.MotionDevice.set_permanent_connection"
+        ) as set_permanent_connection,
+    ):
+        await options_update_listener(hass, config_entry)
+        mock_set_custom_disconnect_time.assert_called_once()
+        set_permanent_connection.assert_called_once()
+
+
+async def test_update_ble_device(hass: HomeAssistant) -> None:
+    """Test async_update_ble_device."""
+
+    await setup_platform(hass, PLATFORMS)
+
+    with patch(
+        "homeassistant.components.motionblinds_ble.MotionDevice.set_ble_device"
+    ) as mock_set_ble_device:
+        inject_bluetooth_service_info(hass, SERVICE_INFO)
+        mock_set_ble_device.assert_called_once()

--- a/tests/components/motionblinds_ble/test_select.py
+++ b/tests/components/motionblinds_ble/test_select.py
@@ -16,14 +16,14 @@ from homeassistant.components.select import (
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_OPTION
 from homeassistant.core import HomeAssistant
 
-from . import setup_platform
+from . import setup_integration
 
 
 @pytest.mark.parametrize(("select", "args"), [(ATTR_SPEED, MotionSpeedLevel.HIGH)])
 async def test_select(hass: HomeAssistant, select: str, args: Any) -> None:
     """Test select."""
 
-    _, name = await setup_platform(hass)
+    _, name = await setup_integration(hass)
 
     with patch(
         f"homeassistant.components.motionblinds_ble.MotionDevice.{select}"
@@ -51,7 +51,7 @@ async def test_select_update(
 ) -> None:
     """Test select state update."""
 
-    config_entry, name = await setup_platform(hass)
+    config_entry, name = await setup_integration(hass)
 
     device: MotionDevice = hass.data[DOMAIN][config_entry.entry_id]
     update_func(device)(value)

--- a/tests/components/motionblinds_ble/test_select.py
+++ b/tests/components/motionblinds_ble/test_select.py
@@ -24,11 +24,15 @@ from tests.common import MockConfigEntry
 
 @pytest.mark.parametrize(("select", "args"), [(ATTR_SPEED, MotionSpeedLevel.HIGH)])
 async def test_select(
-    mock_config_entry: MockConfigEntry, hass: HomeAssistant, select: str, args: Any
+    mock_config_entry: MockConfigEntry,
+    name: str,
+    hass: HomeAssistant,
+    select: str,
+    args: Any,
 ) -> None:
     """Test select."""
 
-    name = await setup_integration(hass, mock_config_entry)
+    await setup_integration(hass, mock_config_entry)
 
     with patch(
         f"homeassistant.components.motionblinds_ble.MotionDevice.{select}"
@@ -60,6 +64,7 @@ async def test_select(
 async def test_select_update(
     mock_config_entry: MockConfigEntry,
     mock_motion_device: Mock,
+    name: str,
     hass: HomeAssistant,
     select: str,
     register_callback: Callable[[MotionDevice], Callable[..., None]],
@@ -67,7 +72,7 @@ async def test_select_update(
 ) -> None:
     """Test select state update."""
 
-    name = await setup_integration(hass, mock_config_entry)
+    await setup_integration(hass, mock_config_entry)
 
     update_func = register_callback(mock_motion_device).call_args[0][0]
 

--- a/tests/components/motionblinds_ble/test_select.py
+++ b/tests/components/motionblinds_ble/test_select.py
@@ -2,13 +2,12 @@
 
 from enum import Enum
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from motionblindsble.const import MotionSpeedLevel
-from motionblindsble.device import MotionDevice
 import pytest
 
-from homeassistant.components.motionblinds_ble.const import ATTR_SPEED, DOMAIN
+from homeassistant.components.motionblinds_ble.const import ATTR_SPEED
 from homeassistant.components.select import (
     DOMAIN as SELECT_DOMAIN,
     SERVICE_SELECT_OPTION,
@@ -47,22 +46,28 @@ async def test_select(
 
 
 @pytest.mark.parametrize(
-    ("select", "update_func", "value"),
-    [(ATTR_SPEED, lambda device: device.update_speed, MotionSpeedLevel.HIGH)],
+    ("select", "register_callback", "value"),
+    [
+        (
+            ATTR_SPEED,
+            lambda device: device.register_speed_callback,
+            MotionSpeedLevel.HIGH,
+        )
+    ],
 )
 async def test_select_update(
     mock_config_entry: MockConfigEntry,
+    mock_motion_device: Mock,
     hass: HomeAssistant,
     select: str,
-    update_func,
+    register_callback,
     value: type[Enum],
 ) -> None:
     """Test select state update."""
 
-    name = await setup_integration(hass, mock_config_entry)
+    await setup_integration(hass, mock_config_entry)
 
-    device: MotionDevice = hass.data[DOMAIN][mock_config_entry.entry_id]
-    update_func(device)(value)
-    assert hass.states.get(f"select.{name}_{select}").state == str(value.value)
+    update_func = register_callback(mock_motion_device).call_args[0][0]
 
-    await hass.async_block_till_done()
+    update_func(value)
+    assert hass.states.get(f"select.{select}").state == str(value.value)

--- a/tests/components/motionblinds_ble/test_select.py
+++ b/tests/components/motionblinds_ble/test_select.py
@@ -67,9 +67,9 @@ async def test_select_update(
 ) -> None:
     """Test select state update."""
 
-    await setup_integration(hass, mock_config_entry)
+    name = await setup_integration(hass, mock_config_entry)
 
     update_func = register_callback(mock_motion_device).call_args[0][0]
 
     update_func(value)
-    assert hass.states.get(f"select.{select}").state == str(value.value)
+    assert hass.states.get(f"select.{name}_{select}").state == str(value.value)

--- a/tests/components/motionblinds_ble/test_select.py
+++ b/tests/components/motionblinds_ble/test_select.py
@@ -13,7 +13,7 @@ from homeassistant.components.select import (
     DOMAIN as SELECT_DOMAIN,
     SERVICE_SELECT_OPTION,
 )
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_OPTION, Platform
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_OPTION
 from homeassistant.core import HomeAssistant
 
 from . import setup_platform
@@ -23,7 +23,7 @@ from . import setup_platform
 async def test_select(hass: HomeAssistant, select: str, args: Any) -> None:
     """Test select."""
 
-    _, name = await setup_platform(hass, [Platform.SELECT])
+    _, name = await setup_platform(hass)
 
     with patch(
         f"homeassistant.components.motionblinds_ble.MotionDevice.{select}"
@@ -51,7 +51,7 @@ async def test_select_update(
 ) -> None:
     """Test select state update."""
 
-    config_entry, name = await setup_platform(hass, [Platform.SELECT])
+    config_entry, name = await setup_platform(hass)
 
     device: MotionDevice = hass.data[DOMAIN][config_entry.entry_id]
     update_func(device)(value)

--- a/tests/components/motionblinds_ble/test_select.py
+++ b/tests/components/motionblinds_ble/test_select.py
@@ -1,0 +1,60 @@
+"""Tests for Motionblinds BLE selects."""
+
+from enum import Enum
+from typing import Any
+from unittest.mock import patch
+
+from motionblindsble.const import MotionSpeedLevel
+from motionblindsble.device import MotionDevice
+import pytest
+
+from homeassistant.components.motionblinds_ble.const import ATTR_SPEED, DOMAIN
+from homeassistant.components.select import (
+    DOMAIN as SELECT_DOMAIN,
+    SERVICE_SELECT_OPTION,
+)
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_OPTION, Platform
+from homeassistant.core import HomeAssistant
+
+from . import setup_platform
+
+
+@pytest.mark.parametrize(("select", "args"), [(ATTR_SPEED, MotionSpeedLevel.HIGH)])
+async def test_select(hass: HomeAssistant, select: str, args: Any) -> None:
+    """Test select."""
+
+    _, name = await setup_platform(hass, [Platform.SELECT])
+
+    with patch(
+        f"homeassistant.components.motionblinds_ble.MotionDevice.{select}"
+    ) as command:
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: f"select.{name}_{select}",
+                ATTR_OPTION: MotionSpeedLevel.HIGH.value,
+            },
+            blocking=True,
+        )
+        command.assert_called_once_with(args)
+
+    await hass.async_block_till_done()
+
+
+@pytest.mark.parametrize(
+    ("select", "update_func", "value"),
+    [(ATTR_SPEED, lambda device: device.update_speed, MotionSpeedLevel.HIGH)],
+)
+async def test_select_update(
+    hass: HomeAssistant, select: str, update_func, value: type[Enum]
+) -> None:
+    """Test select state update."""
+
+    config_entry, name = await setup_platform(hass, [Platform.SELECT])
+
+    device: MotionDevice = hass.data[DOMAIN][config_entry.entry_id]
+    update_func(device)(value)
+    assert hass.states.get(f"select.{name}_{select}").state == str(value.value)
+
+    await hass.async_block_till_done()

--- a/tests/components/motionblinds_ble/test_select.py
+++ b/tests/components/motionblinds_ble/test_select.py
@@ -1,10 +1,12 @@
 """Tests for Motionblinds BLE selects."""
 
+from collections.abc import Callable
 from enum import Enum
 from typing import Any
 from unittest.mock import Mock, patch
 
 from motionblindsble.const import MotionSpeedLevel
+from motionblindsble.device import MotionDevice
 import pytest
 
 from homeassistant.components.motionblinds_ble.const import ATTR_SPEED
@@ -60,7 +62,7 @@ async def test_select_update(
     mock_motion_device: Mock,
     hass: HomeAssistant,
     select: str,
-    register_callback,
+    register_callback: Callable[[MotionDevice], Callable[..., None]],
     value: type[Enum],
 ) -> None:
     """Test select state update."""

--- a/tests/components/motionblinds_ble/test_select.py
+++ b/tests/components/motionblinds_ble/test_select.py
@@ -18,12 +18,16 @@ from homeassistant.core import HomeAssistant
 
 from . import setup_integration
 
+from tests.common import MockConfigEntry
+
 
 @pytest.mark.parametrize(("select", "args"), [(ATTR_SPEED, MotionSpeedLevel.HIGH)])
-async def test_select(hass: HomeAssistant, select: str, args: Any) -> None:
+async def test_select(
+    mock_config_entry: MockConfigEntry, hass: HomeAssistant, select: str, args: Any
+) -> None:
     """Test select."""
 
-    _, name = await setup_integration(hass)
+    name = await setup_integration(hass, mock_config_entry)
 
     with patch(
         f"homeassistant.components.motionblinds_ble.MotionDevice.{select}"
@@ -47,13 +51,17 @@ async def test_select(hass: HomeAssistant, select: str, args: Any) -> None:
     [(ATTR_SPEED, lambda device: device.update_speed, MotionSpeedLevel.HIGH)],
 )
 async def test_select_update(
-    hass: HomeAssistant, select: str, update_func, value: type[Enum]
+    mock_config_entry: MockConfigEntry,
+    hass: HomeAssistant,
+    select: str,
+    update_func,
+    value: type[Enum],
 ) -> None:
     """Test select state update."""
 
-    config_entry, name = await setup_integration(hass)
+    name = await setup_integration(hass, mock_config_entry)
 
-    device: MotionDevice = hass.data[DOMAIN][config_entry.entry_id]
+    device: MotionDevice = hass.data[DOMAIN][mock_config_entry.entry_id]
     update_func(device)(value)
     assert hass.states.get(f"select.{name}_{select}").state == str(value.value)
 

--- a/tests/components/motionblinds_ble/test_select.py
+++ b/tests/components/motionblinds_ble/test_select.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from enum import Enum
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 from motionblindsble.const import MotionSpeedLevel
 from motionblindsble.device import MotionDevice
@@ -25,6 +25,7 @@ from tests.common import MockConfigEntry
 @pytest.mark.parametrize(("select", "args"), [(ATTR_SPEED, MotionSpeedLevel.HIGH)])
 async def test_select(
     mock_config_entry: MockConfigEntry,
+    mock_motion_device: Mock,
     name: str,
     hass: HomeAssistant,
     select: str,
@@ -34,21 +35,16 @@ async def test_select(
 
     await setup_integration(hass, mock_config_entry)
 
-    with patch(
-        f"homeassistant.components.motionblinds_ble.MotionDevice.{select}"
-    ) as command:
-        await hass.services.async_call(
-            SELECT_DOMAIN,
-            SERVICE_SELECT_OPTION,
-            {
-                ATTR_ENTITY_ID: f"select.{name}_{select}",
-                ATTR_OPTION: MotionSpeedLevel.HIGH.value,
-            },
-            blocking=True,
-        )
-        command.assert_called_once_with(args)
-
-    await hass.async_block_till_done()
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: f"select.{name}_{select}",
+            ATTR_OPTION: MotionSpeedLevel.HIGH.value,
+        },
+        blocking=True,
+    )
+    getattr(mock_motion_device, select).assert_called_once_with(args)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/motionblinds_ble/test_sensor.py
+++ b/tests/components/motionblinds_ble/test_sensor.py
@@ -17,7 +17,6 @@ from homeassistant.components.motionblinds_ble.const import (
     DOMAIN,
 )
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
 from . import setup_platform
@@ -94,9 +93,7 @@ async def test_sensor(
 ) -> None:
     """Test sensors."""
 
-    config_entry, name = await setup_platform(
-        hass, [Platform.SENSOR], blind_type=MotionBlindType.CURTAIN
-    )
+    config_entry, name = await setup_platform(hass, blind_type=MotionBlindType.CURTAIN)
     device: MotionDevice = hass.data[DOMAIN][config_entry.entry_id]
 
     assert hass.states.get(f"{SENSOR_DOMAIN}.{name}_{sensor}").state == initial_value

--- a/tests/components/motionblinds_ble/test_sensor.py
+++ b/tests/components/motionblinds_ble/test_sensor.py
@@ -24,7 +24,7 @@ from . import setup_platform
 
 
 @pytest.mark.parametrize(
-    ("sensor", "update_func", "initial", "input", "output"),
+    ("sensor", "update_func", "initial_value", "args", "expected_value"),
     [
         (
             "connection_status",
@@ -88,9 +88,9 @@ async def test_sensor(
     hass: HomeAssistant,
     sensor: str,
     update_func: Callable[[MotionDevice], Callable[..., None]],
-    initial: str,
-    input: list[Any],
-    output: str,
+    initial_value: str,
+    args: list[Any],
+    expected_value: str,
 ) -> None:
     """Test sensors."""
 
@@ -99,8 +99,8 @@ async def test_sensor(
     )
     device: MotionDevice = hass.data[DOMAIN][config_entry.entry_id]
 
-    assert hass.states.get(f"{SENSOR_DOMAIN}.{name}_{sensor}").state == initial
-    update_func(device)(*input)
-    assert hass.states.get(f"{SENSOR_DOMAIN}.{name}_{sensor}").state == output
+    assert hass.states.get(f"{SENSOR_DOMAIN}.{name}_{sensor}").state == initial_value
+    update_func(device)(*args)
+    assert hass.states.get(f"{SENSOR_DOMAIN}.{name}_{sensor}").state == expected_value
 
     await hass.async_block_till_done()

--- a/tests/components/motionblinds_ble/test_sensor.py
+++ b/tests/components/motionblinds_ble/test_sensor.py
@@ -1,0 +1,1 @@
+"""Tests for Motionblinds BLE sensors."""

--- a/tests/components/motionblinds_ble/test_sensor.py
+++ b/tests/components/motionblinds_ble/test_sensor.py
@@ -98,9 +98,9 @@ async def test_sensor(
 ) -> None:
     """Test sensors."""
 
-    await setup_integration(hass, mock_config_entry)
+    name = await setup_integration(hass, mock_config_entry)
 
-    assert hass.states.get(f"{SENSOR_DOMAIN}.{sensor}").state == initial_value
+    assert hass.states.get(f"{SENSOR_DOMAIN}.{name}_{sensor}").state == initial_value
     update_func = register_callback(mock_motion_device).call_args[0][0]
     update_func(*args)
-    assert hass.states.get(f"{SENSOR_DOMAIN}.{sensor}").state == expected_value
+    assert hass.states.get(f"{SENSOR_DOMAIN}.{name}_{sensor}").state == expected_value

--- a/tests/components/motionblinds_ble/test_sensor.py
+++ b/tests/components/motionblinds_ble/test_sensor.py
@@ -89,6 +89,7 @@ from tests.common import MockConfigEntry
 async def test_sensor(
     mock_config_entry: MockConfigEntry,
     mock_motion_device: Mock,
+    name: str,
     hass: HomeAssistant,
     sensor: str,
     register_callback: Callable[[MotionDevice], Callable[..., None]],
@@ -98,7 +99,7 @@ async def test_sensor(
 ) -> None:
     """Test sensors."""
 
-    name = await setup_integration(hass, mock_config_entry)
+    await setup_integration(hass, mock_config_entry)
 
     assert hass.states.get(f"{SENSOR_DOMAIN}.{name}_{sensor}").state == initial_value
     update_func = register_callback(mock_motion_device).call_args[0][0]

--- a/tests/components/motionblinds_ble/test_sensor.py
+++ b/tests/components/motionblinds_ble/test_sensor.py
@@ -1,5 +1,8 @@
 """Tests for Motionblinds BLE sensors."""
 
+from collections.abc import Callable
+from typing import Any
+
 from motionblindsble.const import (
     MotionBlindType,
     MotionCalibrationType,
@@ -94,10 +97,10 @@ async def test_sensor(
     hass: HomeAssistant,
     sensor: str,
     sensor_str: str,
-    update_func,
-    initial,
-    input,
-    output,
+    update_func: Callable[[MotionDevice], Callable[..., None]],
+    initial: str,
+    input: list[Any],
+    output: str,
 ) -> None:
     """Test sensors."""
 

--- a/tests/components/motionblinds_ble/test_sensor.py
+++ b/tests/components/motionblinds_ble/test_sensor.py
@@ -21,7 +21,10 @@ from homeassistant.core import HomeAssistant
 
 from . import setup_integration
 
+from tests.common import MockConfigEntry
 
+
+@pytest.mark.parametrize("blind_type", [MotionBlindType.CURTAIN])
 @pytest.mark.parametrize(
     ("sensor", "update_func", "initial_value", "args", "expected_value"),
     [
@@ -84,6 +87,7 @@ from . import setup_integration
     ],
 )
 async def test_sensor(
+    mock_config_entry: MockConfigEntry,
     hass: HomeAssistant,
     sensor: str,
     update_func: Callable[[MotionDevice], Callable[..., None]],
@@ -93,10 +97,8 @@ async def test_sensor(
 ) -> None:
     """Test sensors."""
 
-    config_entry, name = await setup_integration(
-        hass, blind_type=MotionBlindType.CURTAIN
-    )
-    device: MotionDevice = hass.data[DOMAIN][config_entry.entry_id]
+    name = await setup_integration(hass, mock_config_entry)
+    device: MotionDevice = hass.data[DOMAIN][mock_config_entry.entry_id]
 
     assert hass.states.get(f"{SENSOR_DOMAIN}.{name}_{sensor}").state == initial_value
     update_func(device)(*args)

--- a/tests/components/motionblinds_ble/test_sensor.py
+++ b/tests/components/motionblinds_ble/test_sensor.py
@@ -19,7 +19,7 @@ from homeassistant.components.motionblinds_ble.const import (
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.core import HomeAssistant
 
-from . import setup_platform
+from . import setup_integration
 
 
 @pytest.mark.parametrize(
@@ -93,7 +93,9 @@ async def test_sensor(
 ) -> None:
     """Test sensors."""
 
-    config_entry, name = await setup_platform(hass, blind_type=MotionBlindType.CURTAIN)
+    config_entry, name = await setup_integration(
+        hass, blind_type=MotionBlindType.CURTAIN
+    )
     device: MotionDevice = hass.data[DOMAIN][config_entry.entry_id]
 
     assert hass.states.get(f"{SENSOR_DOMAIN}.{name}_{sensor}").state == initial_value

--- a/tests/components/motionblinds_ble/test_sensor.py
+++ b/tests/components/motionblinds_ble/test_sensor.py
@@ -1,1 +1,113 @@
 """Tests for Motionblinds BLE sensors."""
+
+from motionblindsble.const import (
+    MotionBlindType,
+    MotionCalibrationType,
+    MotionConnectionType,
+)
+from motionblindsble.device import MotionDevice
+import pytest
+
+from homeassistant.components.motionblinds_ble.const import (
+    ATTR_BATTERY,
+    ATTR_CALIBRATION,
+    ATTR_CONNECTION,
+    ATTR_SIGNAL_STRENGTH,
+    DOMAIN,
+)
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from . import setup_platform
+
+
+@pytest.mark.parametrize(
+    ("sensor", "sensor_str", "update_func", "initial", "input", "output"),
+    [
+        (
+            ATTR_CONNECTION,
+            "none",
+            lambda device: device.update_connection,
+            MotionConnectionType.DISCONNECTED.value,
+            [MotionConnectionType.CONNECTING],
+            MotionConnectionType.CONNECTING.value,
+        ),
+        (
+            ATTR_BATTERY,
+            ATTR_BATTERY,
+            lambda device: device.update_battery,
+            "unknown",
+            [25, True, False],
+            "25",
+        ),
+        (  # Battery unknown
+            ATTR_BATTERY,
+            ATTR_BATTERY,
+            lambda device: device.update_battery,
+            "unknown",
+            [None, False, False],
+            "unknown",
+        ),
+        (  # Wired
+            ATTR_BATTERY,
+            ATTR_BATTERY,
+            lambda device: device.update_battery,
+            "unknown",
+            [255, False, True],
+            "255",
+        ),
+        (  # Almost full
+            ATTR_BATTERY,
+            ATTR_BATTERY,
+            lambda device: device.update_battery,
+            "unknown",
+            [99, False, False],
+            "99",
+        ),
+        (  # Almost empty
+            ATTR_BATTERY,
+            ATTR_BATTERY,
+            lambda device: device.update_battery,
+            "unknown",
+            [1, False, False],
+            "1",
+        ),
+        (
+            ATTR_CALIBRATION,
+            "none_2",
+            lambda device: device.update_calibration,
+            "unknown",
+            [MotionCalibrationType.CALIBRATING],
+            MotionCalibrationType.CALIBRATING.value,
+        ),
+        (
+            ATTR_SIGNAL_STRENGTH,
+            ATTR_SIGNAL_STRENGTH,
+            lambda device: device.update_signal_strength,
+            "unknown",
+            [-50],
+            "-50",
+        ),
+    ],
+)
+async def test_sensor(
+    hass: HomeAssistant,
+    sensor: str,
+    sensor_str: str,
+    update_func,
+    initial,
+    input,
+    output,
+) -> None:
+    """Test sensors."""
+
+    config_entry, name = await setup_platform(
+        hass, [Platform.SENSOR], blind_type=MotionBlindType.CURTAIN
+    )
+    device: MotionDevice = hass.data[DOMAIN][config_entry.entry_id]
+
+    assert hass.states.get(f"sensor.{name}_{sensor_str}").state == initial
+    update_func(device)(*input)
+    assert hass.states.get(f"sensor.{name}_{sensor_str}").state == output
+
+    await hass.async_block_till_done()

--- a/tests/components/motionblinds_ble/test_sensor.py
+++ b/tests/components/motionblinds_ble/test_sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from typing import Any
+from unittest.mock import Mock
 
 from motionblindsble.const import (
     MotionBlindType,
@@ -14,7 +15,6 @@ import pytest
 from homeassistant.components.motionblinds_ble.const import (
     ATTR_BATTERY,
     ATTR_SIGNAL_STRENGTH,
-    DOMAIN,
 )
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.core import HomeAssistant
@@ -26,60 +26,60 @@ from tests.common import MockConfigEntry
 
 @pytest.mark.parametrize("blind_type", [MotionBlindType.CURTAIN])
 @pytest.mark.parametrize(
-    ("sensor", "update_func", "initial_value", "args", "expected_value"),
+    ("sensor", "register_callback", "initial_value", "args", "expected_value"),
     [
         (
             "connection_status",
-            lambda device: device.update_connection,
+            lambda device: device.register_connection_callback,
             MotionConnectionType.DISCONNECTED.value,
             [MotionConnectionType.CONNECTING],
             MotionConnectionType.CONNECTING.value,
         ),
         (
             ATTR_BATTERY,
-            lambda device: device.update_battery,
+            lambda device: device.register_battery_callback,
             "unknown",
             [25, True, False],
             "25",
         ),
         (  # Battery unknown
             ATTR_BATTERY,
-            lambda device: device.update_battery,
+            lambda device: device.register_battery_callback,
             "unknown",
             [None, False, False],
             "unknown",
         ),
         (  # Wired
             ATTR_BATTERY,
-            lambda device: device.update_battery,
+            lambda device: device.register_battery_callback,
             "unknown",
             [255, False, True],
             "255",
         ),
         (  # Almost full
             ATTR_BATTERY,
-            lambda device: device.update_battery,
+            lambda device: device.register_battery_callback,
             "unknown",
             [99, False, False],
             "99",
         ),
         (  # Almost empty
             ATTR_BATTERY,
-            lambda device: device.update_battery,
+            lambda device: device.register_battery_callback,
             "unknown",
             [1, False, False],
             "1",
         ),
         (
             "calibration_status",
-            lambda device: device.update_calibration,
+            lambda device: device.register_calibration_callback,
             "unknown",
             [MotionCalibrationType.CALIBRATING],
             MotionCalibrationType.CALIBRATING.value,
         ),
         (
             ATTR_SIGNAL_STRENGTH,
-            lambda device: device.update_signal_strength,
+            lambda device: device.register_signal_strength_callback,
             "unknown",
             [-50],
             "-50",
@@ -88,20 +88,19 @@ from tests.common import MockConfigEntry
 )
 async def test_sensor(
     mock_config_entry: MockConfigEntry,
+    mock_motion_device: Mock,
     hass: HomeAssistant,
     sensor: str,
-    update_func: Callable[[MotionDevice], Callable[..., None]],
+    register_callback: Callable[[MotionDevice], Callable[..., None]],
     initial_value: str,
     args: list[Any],
     expected_value: str,
 ) -> None:
     """Test sensors."""
 
-    name = await setup_integration(hass, mock_config_entry)
-    device: MotionDevice = hass.data[DOMAIN][mock_config_entry.entry_id]
+    await setup_integration(hass, mock_config_entry)
 
-    assert hass.states.get(f"{SENSOR_DOMAIN}.{name}_{sensor}").state == initial_value
-    update_func(device)(*args)
-    assert hass.states.get(f"{SENSOR_DOMAIN}.{name}_{sensor}").state == expected_value
-
-    await hass.async_block_till_done()
+    assert hass.states.get(f"{SENSOR_DOMAIN}.{sensor}").state == initial_value
+    update_func = register_callback(mock_motion_device).call_args[0][0]
+    update_func(*args)
+    assert hass.states.get(f"{SENSOR_DOMAIN}.{sensor}").state == expected_value


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Full test coverage for the Motionblinds Bluetooth integration

```bash
---------- coverage: platform linux, python 3.12.2-final-0 -----------
Name                                                       Stmts   Miss  Cover   Missing
----------------------------------------------------------------------------------------
homeassistant/components/motionblinds_ble/__init__.py         52      0   100%
homeassistant/components/motionblinds_ble/button.py           28      0   100%
homeassistant/components/motionblinds_ble/config_flow.py     102      0   100%
homeassistant/components/motionblinds_ble/const.py            20      0   100%
homeassistant/components/motionblinds_ble/cover.py            89      0   100%
homeassistant/components/motionblinds_ble/entity.py           25      0   100%
homeassistant/components/motionblinds_ble/select.py           34      0   100%
homeassistant/components/motionblinds_ble/sensor.py           64      0   100%
----------------------------------------------------------------------------------------
TOTAL                                                        414      0   100%
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
