### PR TITLE
Set quality scale to platinum for Motionblinds Bluetooth

### DIFF
--- a/homeassistant/components/motionblinds_ble/manifest.json
+++ b/homeassistant/components/motionblinds_ble/manifest.json
@@ -14,5 +14,6 @@
   "integration_type": "device",
   "iot_class": "assumed_state",
   "loggers": ["motionblindsble"],
+  "quality_scale": "platinum",
   "requirements": ["motionblindsble==0.1.2"]
 }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Set Motionblinds Bluetooth quality scale to platinum

```python

 tests/components/motionblinds_ble/test_button.py ✓✓✓                     7% ▊         
 tests/components/motionblinds_ble/test_config_flow.py ✓✓✓✓✓✓✓           23% ██▍       
 tests/components/motionblinds_ble/test_cover.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓        60% ██████▏   
 tests/components/motionblinds_ble/test_diagnostics.py ✓                 63% ██████▍   
 tests/components/motionblinds_ble/test_entity.py ✓✓✓✓                   72% ███████▎  
 tests/components/motionblinds_ble/test_init.py ✓✓                       77% ███████▋  
 tests/components/motionblinds_ble/test_select.py ✓✓                     81% ████████▎ 
 tests/components/motionblinds_ble/test_sensor.py ✓✓✓✓✓✓✓✓              100% ██████████

---------- coverage: platform linux, python 3.12.2-final-0 -----------
Name                                                       Stmts   Miss  Cover
------------------------------------------------------------------------------
homeassistant/components/motionblinds_ble/__init__.py         52      0   100%
homeassistant/components/motionblinds_ble/button.py           28      0   100%
homeassistant/components/motionblinds_ble/config_flow.py     102      0   100%
homeassistant/components/motionblinds_ble/const.py            20      0   100%
homeassistant/components/motionblinds_ble/cover.py            89      0   100%
homeassistant/components/motionblinds_ble/diagnostics.py      14      0   100%
homeassistant/components/motionblinds_ble/entity.py           25      0   100%
homeassistant/components/motionblinds_ble/select.py           34      0   100%
homeassistant/components/motionblinds_ble/sensor.py           64      0   100%
------------------------------------------------------------------------------
TOTAL                                                        428      0   100%

------------------------------- snapshot report summary -------------------------------
1 snapshot passed.

Results (6.28s):
      43 passed

```

# Silver 🥈

This integration is able to cope when things go wrong. It will not print any exceptions nor will it fill the log with retry attempts.

- [x] Connection/configuration is handled via a component.
- [x] ~~Set an appropriate SCAN_INTERVAL (if a polling integration),~~
    - No polling integration
- [x] ~~Raise [PlatformNotReady](https://developers.home-assistant.io/docs/integration_setup_failures#integrations-using-async_setup_platform) if unable to connect during platform setup (if appropriate)~~
    - No connection required during platform setup
- [x] ~~Handles expiration of auth credentials. Refresh if possible or print correct error and fail setup. If based on a config entry,
 should trigger a new config entry flow to re-authorize. ([docs](https://developers.home-assistant.io/docs/config_entries_config_flow_handler#reauthentication))~~
    - No authentication credentials
- [x] ~~Handles internet unavailable. Log a warning once when unavailable, log once when reconnected.~~
    - No internet is used
- [x] ~~Handles device/service unavailable. Log a warning once when unavailable, log once when reconnected. (Same as above)
Operations like service calls and entity methods (e.g. Set HVAC Mode) have proper exception handling. Raise ServiceValidationError on invalid user input and raise HomeAssistantError for other failures such as a problem communicating with a device. [Read more](https://developers.home-assistant.io/docs/core/platform/raising_exceptions) about raising exceptions.~~
    - Since it is a Bluetooth device that requires a connection, the device cannot become unavailable
- [x] ~~Set available property to False if appropriate ([docs](https://developers.home-assistant.io/docs/core/entity#generic-properties))~~
    - Home Assistant can always read the state and control the underlying device
- [x] Entities have unique ID (if available) ([docs](https://developers.home-assistant.io/docs/entity_registry_index#unique-id-requirements))

# Gold 🥇

This is a solid integration that is able to survive poor conditions and can be configured via the user interface.

- [x] Satisfying all Silver level requirements.
**Configurable via config entries.**
    - [x] Don't allow configuring already configured device/service (example: no 2 entries for same hub)
    - [x] Discoverable (if available)
    - [x] ~~Set unique ID in config flow (if available)~~
    - [x] ~~Raise [ConfigEntryNotReady](https://developers.home-assistant.io/docs/integration_setup_failures#integrations-using-async_setup_entry) if unable to connect during entry setup (if appropriate)~~
- [x] Entities have device info (if available) ([docs](https://developers.home-assistant.io/docs/device_registry_index#defining-devices))
**Tests**
   - [x] Full test coverage for the config flow
   - [x] Above average test coverage for all integration modules
100% test coverage
   - [x] Tests for fetching data from the integration and controlling it ([docs](https://developers.home-assistant.io/docs/development_testing))
- [x] Has a code owner ([docs](https://developers.home-assistant.io/docs/creating_integration_manifest#code-owners))
- [x] Entities only subscribe to updates inside async_added_to_hass and unsubscribe inside async_will_remove_from_hass ([docs](https://developers.home-assistant.io/docs/core/entity#lifecycle-hooks))
- [x] Entities have correct device classes where appropriate ([docs](https://developers.home-assistant.io/docs/core/entity#generic-properties))
- [x] Supports entities being disabled and leverages Entity.entity_registry_enabled_default to disable less popular entities ([docs](https://developers.home-assistant.io/docs/core/entity#advanced-properties))
- [x] ~~If the device/service API can remove entities, the integration should make sure to clean up the entity and device registry.~~
    - Device cannot remove entities
- [x] When communicating with a device or service, the integration implements the diagnostics platform which redacts sensitive information.


# Platinum 🏆

Best of the best. The integration is completely async, meaning it's super fast. Integrations that reach platinum level will require approval by the code owner for each PR.

- [x] Satisfying all Gold level requirements.
- [x] Set appropriate PARALLEL_UPDATES constant ([docs](https://developers.home-assistant.io/docs/integration_fetching_data#request-parallelism))
- [x] Support config entry unloading (called when config entry is removed)
- [x] Integration + dependency are async ([docs](https://developers.home-assistant.io/docs/asyncio_working_with_async))
- [x] ~~Uses aiohttp or httpx and allows passing in websession (if making HTTP requests)~~
    - Integration does not use HTTP
- [x] ~~[Handles expired credentials](https://developers.home-assistant.io/docs/integration_setup_failures#handling-expired-credentials) (if appropriate)
Re-authentication if cookie expires, initiates reauth flow if it fails~~
    - No credentials required


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
