### PR TITLE
Add binary sensors to TotalConnect

### DIFF
--- a/homeassistant/components/totalconnect/binary_sensor.py
+++ b/homeassistant/components/totalconnect/binary_sensor.py
@@ -113,7 +113,7 @@ LOCATION_BINARY_SENSORS: tuple[TotalConnectAlarmBinarySensorEntityDescription, .
     ),
     TotalConnectAlarmBinarySensorEntityDescription(
         key="police",
-        device_class=BinarySensorDeviceClass.SAFETY,
+        translation_key="police",
         is_on_fn=lambda location: location.arming_state.is_triggered_police(),
     ),
 )

--- a/homeassistant/components/totalconnect/binary_sensor.py
+++ b/homeassistant/components/totalconnect/binary_sensor.py
@@ -101,6 +101,21 @@ LOCATION_BINARY_SENSORS: tuple[TotalConnectAlarmBinarySensorEntityDescription, .
         entity_category=EntityCategory.DIAGNOSTIC,
         is_on_fn=lambda location: location.is_ac_loss(),
     ),
+    TotalConnectAlarmBinarySensorEntityDescription(
+        key="smoke",
+        device_class=BinarySensorDeviceClass.SMOKE,
+        is_on_fn=lambda location: location.arming_state.is_triggered_fire(),
+    ),
+    TotalConnectAlarmBinarySensorEntityDescription(
+        key="carbon_monoxide",
+        device_class=BinarySensorDeviceClass.CO,
+        is_on_fn=lambda location: location.arming_state.is_triggered_gas(),
+    ),
+    TotalConnectAlarmBinarySensorEntityDescription(
+        key="police",
+        device_class=BinarySensorDeviceClass.SAFETY,
+        is_on_fn=lambda location: location.arming_state.is_triggered_police(),
+    ),
 )
 
 

--- a/homeassistant/components/totalconnect/icons.json
+++ b/homeassistant/components/totalconnect/icons.json
@@ -1,4 +1,14 @@
 {
+  "entity": {
+    "binary_sensor": {
+      "police": {
+        "default": "mdi:police-badge-outline",
+        "state": {
+          "on": "mdi:police-badge"
+        }
+      }
+    }
+  },
   "services": {
     "arm_away_instant": "mdi:shield-lock",
     "arm_home_instant": "mdi:shield-home"

--- a/homeassistant/components/totalconnect/strings.json
+++ b/homeassistant/components/totalconnect/strings.json
@@ -58,7 +58,11 @@
     },
     "binary_sensor": {
       "police": {
-        "name": "Police or Safety Emergency"
+        "name": "Police or Safety Emergency",
+        "state": {
+          "off": "No emergency",
+          "on": "Police or Safety Emergency"
+        }
       }
     },
     "button": {

--- a/homeassistant/components/totalconnect/strings.json
+++ b/homeassistant/components/totalconnect/strings.json
@@ -56,6 +56,11 @@
         "name": "Partition {partition_id}"
       }
     },
+    "binary_sensor": {
+      "police": {
+        "name": "Police or Safety Emergency"
+      }
+    },
     "button": {
       "clear_bypass": {
         "name": "Clear bypass"

--- a/homeassistant/components/totalconnect/strings.json
+++ b/homeassistant/components/totalconnect/strings.json
@@ -58,10 +58,10 @@
     },
     "binary_sensor": {
       "police": {
-        "name": "Police or Safety Emergency",
+        "name": "Police Emergency",
         "state": {
-          "off": "No emergency",
-          "on": "Police or Safety Emergency"
+          "off": "No Emergency",
+          "on": "Police Emergency"
         }
       }
     },

--- a/homeassistant/components/totalconnect/strings.json
+++ b/homeassistant/components/totalconnect/strings.json
@@ -58,10 +58,10 @@
     },
     "binary_sensor": {
       "police": {
-        "name": "Police Emergency",
+        "name": "Police emergency",
         "state": {
-          "off": "No Emergency",
-          "on": "Police Emergency"
+          "off": "No emergency",
+          "on": "Police emergency"
         }
       }
     },

--- a/tests/components/totalconnect/snapshots/test_binary_sensor.ambr
+++ b/tests/components/totalconnect/snapshots/test_binary_sensor.ambr
@@ -895,6 +895,53 @@
     'state': 'off',
   })
 # ---
+# name: test_entity_registry[binary_sensor.test_police_or_safety_emergency-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_police_or_safety_emergency',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Police or Safety Emergency',
+    'platform': 'totalconnect',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'police',
+    'unique_id': '123456_police',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entity_registry[binary_sensor.test_police_or_safety_emergency-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'test Police or Safety Emergency',
+      'location_id': '123456',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_police_or_safety_emergency',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_entity_registry[binary_sensor.test_power-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/totalconnect/snapshots/test_binary_sensor.ambr
+++ b/tests/components/totalconnect/snapshots/test_binary_sensor.ambr
@@ -919,7 +919,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Police Emergency',
+    'original_name': 'Police emergency',
     'platform': 'totalconnect',
     'previous_unique_id': None,
     'supported_features': 0,
@@ -931,7 +931,7 @@
 # name: test_entity_registry[binary_sensor.test_police_emergency-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'test Police Emergency',
+      'friendly_name': 'test Police emergency',
       'location_id': '123456',
     }),
     'context': <ANY>,

--- a/tests/components/totalconnect/snapshots/test_binary_sensor.ambr
+++ b/tests/components/totalconnect/snapshots/test_binary_sensor.ambr
@@ -847,6 +847,54 @@
     'state': 'off',
   })
 # ---
+# name: test_entity_registry[binary_sensor.test_carbon_monoxide-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_carbon_monoxide',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CO: 'carbon_monoxide'>,
+    'original_icon': None,
+    'original_name': 'Carbon monoxide',
+    'platform': 'totalconnect',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '123456_carbon_monoxide',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entity_registry[binary_sensor.test_carbon_monoxide-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'carbon_monoxide',
+      'friendly_name': 'test Carbon monoxide',
+      'location_id': '123456',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_carbon_monoxide',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_entity_registry[binary_sensor.test_power-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -889,6 +937,102 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.test_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entity_registry[binary_sensor.test_safety-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_safety',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.SAFETY: 'safety'>,
+    'original_icon': None,
+    'original_name': 'Safety',
+    'platform': 'totalconnect',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '123456_police',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entity_registry[binary_sensor.test_safety-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'safety',
+      'friendly_name': 'test Safety',
+      'location_id': '123456',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_safety',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entity_registry[binary_sensor.test_smoke-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_smoke',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.SMOKE: 'smoke'>,
+    'original_icon': None,
+    'original_name': 'Smoke',
+    'platform': 'totalconnect',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '123456_smoke',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entity_registry[binary_sensor.test_smoke-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'smoke',
+      'friendly_name': 'test Smoke',
+      'location_id': '123456',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_smoke',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/totalconnect/snapshots/test_binary_sensor.ambr
+++ b/tests/components/totalconnect/snapshots/test_binary_sensor.ambr
@@ -895,6 +895,53 @@
     'state': 'off',
   })
 # ---
+# name: test_entity_registry[binary_sensor.test_police_emergency-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_police_emergency',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Police Emergency',
+    'platform': 'totalconnect',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'police',
+    'unique_id': '123456_police',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entity_registry[binary_sensor.test_police_emergency-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'test Police Emergency',
+      'location_id': '123456',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_police_emergency',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_entity_registry[binary_sensor.test_police_or_safety_emergency-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/totalconnect/snapshots/test_binary_sensor.ambr
+++ b/tests/components/totalconnect/snapshots/test_binary_sensor.ambr
@@ -942,53 +942,6 @@
     'state': 'off',
   })
 # ---
-# name: test_entity_registry[binary_sensor.test_police_or_safety_emergency-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'binary_sensor',
-    'entity_category': None,
-    'entity_id': 'binary_sensor.test_police_or_safety_emergency',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Police or Safety Emergency',
-    'platform': 'totalconnect',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': 'police',
-    'unique_id': '123456_police',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_entity_registry[binary_sensor.test_police_or_safety_emergency-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'test Police or Safety Emergency',
-      'location_id': '123456',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.test_police_or_safety_emergency',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
 # name: test_entity_registry[binary_sensor.test_power-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -1031,54 +984,6 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.test_power',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_entity_registry[binary_sensor.test_safety-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'binary_sensor',
-    'entity_category': None,
-    'entity_id': 'binary_sensor.test_safety',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <BinarySensorDeviceClass.SAFETY: 'safety'>,
-    'original_icon': None,
-    'original_name': 'Safety',
-    'platform': 'totalconnect',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': '123456_police',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_entity_registry[binary_sensor.test_safety-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'safety',
-      'friendly_name': 'test Safety',
-      'location_id': '123456',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.test_safety',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,


### PR DESCRIPTION
## Proposed change
Adds binary sensors showing when the alarm location is triggered by fire/smoke, carbon monoxide or police.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # n/a
- This PR is related to issue: n/a
- Link to documentation pull request: n/a

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
