### PR TITLE
Add SensorPush Cloud integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1285,6 +1285,8 @@ build.json @home-assistant/supervisor
 /tests/components/sensorpro/ @bdraco
 /homeassistant/components/sensorpush/ @bdraco
 /tests/components/sensorpush/ @bdraco
+/homeassistant/components/sensorpush_cloud/ @sstallion
+/tests/components/sensorpush_cloud/ @sstallion
 /homeassistant/components/sentry/ @dcramer @frenck
 /tests/components/sentry/ @dcramer @frenck
 /homeassistant/components/senz/ @milanmeu

--- a/homeassistant/brands/sensorpush.json
+++ b/homeassistant/brands/sensorpush.json
@@ -1,0 +1,5 @@
+{
+  "domain": "sensorpush",
+  "name": "SensorPush",
+  "integrations": ["sensorpush", "sensorpush_cloud"]
+}

--- a/homeassistant/components/sensorpush_cloud/__init__.py
+++ b/homeassistant/components/sensorpush_cloud/__init__.py
@@ -1,0 +1,28 @@
+"""The SensorPush Cloud integration."""
+
+from __future__ import annotations
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from .coordinator import SensorPushCloudConfigEntry, SensorPushCloudCoordinator
+
+PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: SensorPushCloudConfigEntry
+) -> bool:
+    """Set up SensorPush Cloud from a config entry."""
+    coordinator = SensorPushCloudCoordinator(hass, entry)
+    await coordinator.async_config_entry_first_refresh()
+    entry.runtime_data = coordinator
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(
+    hass: HomeAssistant, entry: SensorPushCloudConfigEntry
+) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/sensorpush_cloud/api.py
+++ b/homeassistant/components/sensorpush_cloud/api.py
@@ -1,0 +1,124 @@
+"""Library for interfacing with the SensorPush Cloud API."""
+
+from __future__ import annotations
+
+from asyncio import Lock
+from collections.abc import Awaitable, Callable, Coroutine, Mapping
+from datetime import datetime
+from functools import wraps
+from typing import Any, Concatenate
+
+from sensorpush_api import (
+    AccessTokenRequest,
+    ApiApi,
+    ApiClient,
+    AuthorizeRequest,
+    Configuration,
+    Samples,
+    SamplesRequest,
+    Sensor,
+    SensorsRequest,
+)
+
+from homeassistant.util import dt as dt_util
+
+from .const import ACCESS_TOKEN_EXPIRATION, LOGGER, REQUEST_RETRIES, REQUEST_TIMEOUT
+
+
+def api_call[**_P, _R](
+    func: Callable[Concatenate[SensorPushCloudApi, _P], Awaitable[_R]],
+) -> Callable[Concatenate[SensorPushCloudApi, _P], Coroutine[Any, Any, _R]]:
+    """Decorate API calls to handle SensorPush Cloud exceptions."""
+
+    @wraps(func)
+    async def _api_call(
+        self: SensorPushCloudApi, *args: _P.args, **kwargs: _P.kwargs
+    ) -> _R:
+        retries: int = 0
+        LOGGER.debug(f"API call to {func} with args={args}, kwargs={kwargs}")
+        while True:
+            try:
+                result = await func(self, *args, **kwargs)
+            except Exception as e:
+                # Force reauthorization if an exception occurs to avoid
+                # authorization failures after temporary outages.
+                self.deadline = dt_util.now()
+
+                # The SensorPush Cloud API suffers from frequent exceptions;
+                # requests are retried before raising an error.
+                if retries < REQUEST_RETRIES:
+                    retries = retries + 1
+                    continue
+
+                LOGGER.debug(f"API call to {func} failed after {retries} retries")
+                raise SensorPushCloudError from e
+            else:
+                LOGGER.debug(f"API call to {func} succeeded after {retries} retries")
+                return result
+
+    return _api_call
+
+
+class SensorPushCloudError(Exception):
+    """An exception occurred when calling the SensorPush Cloud API."""
+
+
+class SensorPushCloudApi:
+    """SensorPush Cloud API class."""
+
+    email: str
+    password: str
+    configuration: Configuration
+    api: ApiApi
+    deadline: datetime
+    lock: Lock
+
+    def __init__(self, email: str, password: str) -> None:
+        """Initialize the SensorPush Cloud API object."""
+        self.email = email
+        self.password = password
+        self.configuration = Configuration()
+        self.api = ApiApi(ApiClient(self.configuration))
+        self.deadline = dt_util.now()
+        self.lock = Lock()
+
+    async def async_renew_access(self) -> None:
+        """Renew an access token if it has expired."""
+        async with self.lock:  # serialize authorize calls
+            if dt_util.now() >= self.deadline:
+                await self.async_authorize()
+
+    @api_call
+    async def async_authorize(self) -> None:
+        """Sign in and request an authorization code."""
+        # SensorPush provides a simplified OAuth endpoint using access tokens
+        # without refresh tokens. It is not possible to use 3rd party client
+        # IDs without first contacting SensorPush support.
+        auth_response = await self.api.oauth_authorize_post(
+            AuthorizeRequest(email=self.email, password=self.password),
+            _request_timeout=REQUEST_TIMEOUT.total_seconds(),
+        )
+        access_response = await self.api.access_token(
+            AccessTokenRequest(authorization=auth_response.authorization),
+            _request_timeout=REQUEST_TIMEOUT.total_seconds(),
+        )
+        self.configuration.api_key["oauth"] = access_response.accesstoken
+        self.deadline = dt_util.now() + ACCESS_TOKEN_EXPIRATION
+
+    @api_call
+    async def async_sensors(self, *args: Any, **kwargs: Any) -> Mapping[str, Sensor]:
+        """List all sensors."""
+        await self.async_renew_access()
+        return await self.api.sensors(
+            SensorsRequest(*args, **kwargs),
+            _request_timeout=REQUEST_TIMEOUT.total_seconds(),
+        )
+
+    @api_call
+    async def async_samples(self, *args: Any, **kwargs: Any) -> Samples:
+        """Query sensor samples."""
+        await self.async_renew_access()
+        return await self.api.samples(
+            SamplesRequest(*args, **kwargs),
+            _request_timeout=REQUEST_TIMEOUT.total_seconds(),
+        )

--- a/homeassistant/components/sensorpush_cloud/config_flow.py
+++ b/homeassistant/components/sensorpush_cloud/config_flow.py
@@ -1,0 +1,50 @@
+"""Config flow for the SensorPush Cloud integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+
+from .api import SensorPushCloudApi, SensorPushCloudError
+from .const import DOMAIN, LOGGER
+
+
+class SensorPushCloudConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for SensorPush Cloud."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            email, password = user_input[CONF_EMAIL], user_input[CONF_PASSWORD]
+            await self.async_set_unique_id(email, raise_on_progress=False)
+            self._abort_if_unique_id_configured()
+            try:
+                api = SensorPushCloudApi(email, password)
+                await api.async_authorize()
+            except SensorPushCloudError as e:
+                errors["base"] = str(e)
+            except Exception:  # noqa: BLE001
+                LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                return self.async_create_entry(title=email, data=user_input)
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_EMAIL): str,
+                    vol.Required(CONF_PASSWORD): str,
+                }
+            ),
+            errors=errors,
+        )

--- a/homeassistant/components/sensorpush_cloud/const.py
+++ b/homeassistant/components/sensorpush_cloud/const.py
@@ -1,0 +1,27 @@
+"""Constants for the SensorPush Cloud integration."""
+
+from datetime import timedelta
+import logging
+from typing import Final
+
+LOGGER = logging.getLogger(__package__)
+
+DOMAIN: Final = "sensorpush_cloud"
+MANUFACTURER: Final = "SensorPush"
+
+ATTR_ALTITUDE: Final = "altitude"
+ATTR_ATMOSPHERIC_PRESSURE: Final = "atmospheric_pressure"
+ATTR_BATTERY_VOLTAGE: Final = "battery_voltage"
+ATTR_DEWPOINT: Final = "dewpoint"
+ATTR_HUMIDITY: Final = "humidity"
+ATTR_LAST_UPDATE: Final = "last_update"
+ATTR_SIGNAL_STRENGTH: Final = "signal_strength"
+ATTR_VAPOR_PRESSURE: Final = "vapor_pressure"
+
+ACCESS_TOKEN_EXPIRATION: Final = timedelta(minutes=60)
+
+UPDATE_INTERVAL: Final = timedelta(seconds=60)
+MAX_TIME_BETWEEN_UPDATES: Final = UPDATE_INTERVAL * 3
+
+REQUEST_RETRIES: Final = 3
+REQUEST_TIMEOUT: Final = timedelta(seconds=10)

--- a/homeassistant/components/sensorpush_cloud/coordinator.py
+++ b/homeassistant/components/sensorpush_cloud/coordinator.py
@@ -1,0 +1,90 @@
+"""Coordinator for the SensorPush Cloud integration."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterable
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    ATTR_DEVICE_ID,
+    ATTR_MODEL,
+    ATTR_NAME,
+    ATTR_TEMPERATURE,
+    CONF_EMAIL,
+    CONF_PASSWORD,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .api import SensorPushCloudApi, SensorPushCloudError
+from .const import (
+    ATTR_ALTITUDE,
+    ATTR_ATMOSPHERIC_PRESSURE,
+    ATTR_BATTERY_VOLTAGE,
+    ATTR_DEWPOINT,
+    ATTR_HUMIDITY,
+    ATTR_LAST_UPDATE,
+    ATTR_SIGNAL_STRENGTH,
+    ATTR_VAPOR_PRESSURE,
+    LOGGER,
+    UPDATE_INTERVAL,
+)
+
+type SensorPushCloudConfigEntry = ConfigEntry[SensorPushCloudCoordinator]
+
+
+class SensorPushCloudCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """SensorPush Cloud coordinator."""
+
+    api: SensorPushCloudApi
+    devices: dict[str, Any]
+
+    def __init__(self, hass: HomeAssistant, entry: SensorPushCloudConfigEntry) -> None:
+        """Initialize the coordinator."""
+        email, password = entry.data[CONF_EMAIL], entry.data[CONF_PASSWORD]
+        self.api = SensorPushCloudApi(email, password)
+        self.devices = {}
+        super().__init__(
+            hass, LOGGER, name=entry.title, update_interval=UPDATE_INTERVAL
+        )
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Fetch data from API endpoints."""
+        data: dict[str, Any] = {}
+        try:
+            # Sensor data is spread across two endpoints, which are requested
+            # in parallel and denormalized before handing off to entities.
+            sensors, samples = await asyncio.gather(
+                self.api.async_sensors(),
+                self.api.async_samples(limit=1),
+            )
+            for device_id, sensor in sensors.items():
+                sample = samples.sensors[device_id][0]
+
+                if device_id not in self.devices:
+                    self.devices[device_id] = {
+                        ATTR_DEVICE_ID: sensor.device_id,
+                        ATTR_MODEL: sensor.type,
+                        ATTR_NAME: sensor.name,
+                    }
+
+                data[device_id] = {
+                    ATTR_ALTITUDE: sample.altitude,
+                    ATTR_ATMOSPHERIC_PRESSURE: sample.barometric_pressure,
+                    ATTR_BATTERY_VOLTAGE: sensor.battery_voltage,
+                    ATTR_DEWPOINT: sample.dewpoint,
+                    ATTR_HUMIDITY: sample.humidity,
+                    ATTR_LAST_UPDATE: sample.observed,
+                    ATTR_SIGNAL_STRENGTH: sensor.rssi,
+                    ATTR_TEMPERATURE: sample.temperature,
+                    ATTR_VAPOR_PRESSURE: sample.vpd,
+                }
+        except SensorPushCloudError:
+            LOGGER.exception("Unexpected exception")
+        return data
+
+    async def async_get_device_ids(self) -> Iterable[str]:
+        """Return the list of active device IDs."""
+        return (await self.api.async_sensors()).keys()

--- a/homeassistant/components/sensorpush_cloud/manifest.json
+++ b/homeassistant/components/sensorpush_cloud/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "sensorpush_cloud",
+  "name": "SensorPush Cloud",
+  "codeowners": ["@sstallion"],
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/sensorpush_cloud",
+  "iot_class": "cloud_polling",
+  "loggers": ["sensorpush_api"],
+  "requirements": ["sensorpush-api==2.0.0"]
+}

--- a/homeassistant/components/sensorpush_cloud/sensor.py
+++ b/homeassistant/components/sensorpush_cloud/sensor.py
@@ -1,0 +1,166 @@
+"""Support for SensorPush Cloud sensors."""
+
+from __future__ import annotations
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.const import (
+    ATTR_DEVICE_ID,
+    ATTR_MODEL,
+    ATTR_NAME,
+    ATTR_TEMPERATURE,
+    PERCENTAGE,
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    UnitOfElectricPotential,
+    UnitOfLength,
+    UnitOfPressure,
+    UnitOfTemperature,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import StateType
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
+
+from .const import (
+    ATTR_ALTITUDE,
+    ATTR_ATMOSPHERIC_PRESSURE,
+    ATTR_BATTERY_VOLTAGE,
+    ATTR_DEWPOINT,
+    ATTR_HUMIDITY,
+    ATTR_LAST_UPDATE,
+    ATTR_SIGNAL_STRENGTH,
+    ATTR_VAPOR_PRESSURE,
+    DOMAIN,
+    LOGGER,
+    MANUFACTURER,
+    MAX_TIME_BETWEEN_UPDATES,
+)
+from .coordinator import SensorPushCloudConfigEntry, SensorPushCloudCoordinator
+
+SENSORS: tuple[SensorEntityDescription, ...] = (
+    SensorEntityDescription(
+        key=ATTR_ALTITUDE,
+        device_class=SensorDeviceClass.DISTANCE,
+        entity_registry_enabled_default=False,
+        translation_key="altitude",
+        native_unit_of_measurement=UnitOfLength.FEET,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SensorEntityDescription(
+        key=ATTR_ATMOSPHERIC_PRESSURE,
+        device_class=SensorDeviceClass.ATMOSPHERIC_PRESSURE,
+        entity_registry_enabled_default=False,
+        native_unit_of_measurement=UnitOfPressure.INHG,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SensorEntityDescription(
+        key=ATTR_BATTERY_VOLTAGE,
+        device_class=SensorDeviceClass.VOLTAGE,
+        entity_registry_enabled_default=False,
+        translation_key="battery_voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SensorEntityDescription(
+        key=ATTR_DEWPOINT,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        entity_registry_enabled_default=False,
+        translation_key="dewpoint",
+        native_unit_of_measurement=UnitOfTemperature.FAHRENHEIT,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SensorEntityDescription(
+        key=ATTR_HUMIDITY,
+        device_class=SensorDeviceClass.HUMIDITY,
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SensorEntityDescription(
+        key=ATTR_SIGNAL_STRENGTH,
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        entity_registry_enabled_default=False,
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SensorEntityDescription(
+        key=ATTR_TEMPERATURE,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.FAHRENHEIT,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SensorEntityDescription(
+        key=ATTR_VAPOR_PRESSURE,
+        device_class=SensorDeviceClass.PRESSURE,
+        entity_registry_enabled_default=False,
+        translation_key="vapor_pressure",
+        native_unit_of_measurement=UnitOfPressure.KPA,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: SensorPushCloudConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up SensorPush Cloud sensors."""
+    coordinator: SensorPushCloudCoordinator = entry.runtime_data
+    device_ids = await coordinator.async_get_device_ids()
+    async_add_entities(
+        SensorPushCloudSensor(coordinator, entity_description, device_id)
+        for entity_description in SENSORS
+        for device_id in device_ids
+    )
+
+
+class SensorPushCloudSensor(
+    CoordinatorEntity[SensorPushCloudCoordinator], SensorEntity
+):
+    """SensorPush Cloud sensor."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: SensorPushCloudCoordinator,
+        entity_description: SensorEntityDescription,
+        device_id: str,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self.entity_description = entity_description
+        self.device_id = device_id
+
+        if device_id not in self.coordinator.devices:
+            LOGGER.warning(f"Ignoring inactive device: {device_id}")
+            self._attr_available = False
+            return
+
+        device = self.coordinator.devices[device_id]
+        self._attr_unique_id = f"{device[ATTR_DEVICE_ID]}_{entity_description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device[ATTR_DEVICE_ID])},
+            manufacturer=MANUFACTURER,
+            model=device[ATTR_MODEL],
+            name=device[ATTR_NAME],
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return true if entity is available."""
+        if self.device_id not in self.coordinator.data:
+            return False  # inactive device
+        last_update = self.coordinator.data[self.device_id][ATTR_LAST_UPDATE]
+        return dt_util.utcnow() < last_update + MAX_TIME_BETWEEN_UPDATES
+
+    @property
+    def native_value(self) -> StateType:
+        """Return the value reported by the sensor."""
+        return self.coordinator.data[self.device_id][self.entity_description.key]

--- a/homeassistant/components/sensorpush_cloud/strings.json
+++ b/homeassistant/components/sensorpush_cloud/strings.json
@@ -1,0 +1,35 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "description": "Note: To activate API access, log in to the [Gateway Cloud Dashboard](https://dashboard.sensorpush.com/) and agree to the terms of service. Devices are not available until activated with the SensorPush app on iOS or Android.",
+        "data": {
+          "email": "[%key:common::config_flow::data::email%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      }
+    },
+    "error": {
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
+    }
+  },
+  "entity": {
+    "sensor": {
+      "altitude": {
+        "name": "Altitude"
+      },
+      "battery_voltage": {
+        "name": "Battery voltage"
+      },
+      "dewpoint": {
+        "name": "Dew point"
+      },
+      "vapor_pressure": {
+        "name": "Vapor pressure"
+      }
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -510,6 +510,7 @@ FLOWS = {
         "sensirion_ble",
         "sensorpro",
         "sensorpush",
+        "sensorpush_cloud",
         "sentry",
         "senz",
         "seventeentrack",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -5381,9 +5381,20 @@
     },
     "sensorpush": {
       "name": "SensorPush",
-      "integration_type": "hub",
-      "config_flow": true,
-      "iot_class": "local_push"
+      "integrations": {
+        "sensorpush": {
+          "integration_type": "hub",
+          "config_flow": true,
+          "iot_class": "local_push",
+          "name": "SensorPush"
+        },
+        "sensorpush_cloud": {
+          "integration_type": "hub",
+          "config_flow": true,
+          "iot_class": "cloud_polling",
+          "name": "SensorPush Cloud"
+        }
+      }
     },
     "sentry": {
       "name": "Sentry",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2595,6 +2595,9 @@ sensirion-ble==0.1.1
 # homeassistant.components.sensorpro
 sensorpro-ble==0.5.3
 
+# homeassistant.components.sensorpush_cloud
+sensorpush-api==2.0.0
+
 # homeassistant.components.sensorpush
 sensorpush-ble==1.6.2
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2053,6 +2053,9 @@ sensirion-ble==0.1.1
 # homeassistant.components.sensorpro
 sensorpro-ble==0.5.3
 
+# homeassistant.components.sensorpush_cloud
+sensorpush-api==2.0.0
+
 # homeassistant.components.sensorpush
 sensorpush-ble==1.6.2
 

--- a/tests/components/sensorpush_cloud/__init__.py
+++ b/tests/components/sensorpush_cloud/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the SensorPush Cloud integration."""

--- a/tests/components/sensorpush_cloud/conftest.py
+++ b/tests/components/sensorpush_cloud/conftest.py
@@ -1,0 +1,82 @@
+"""Common fixtures for the SensorPush Cloud tests."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Generator
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.sensorpush_cloud.api import SensorPushCloudApi
+from homeassistant.components.sensorpush_cloud.const import DOMAIN
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+
+from tests.common import MockConfigEntry
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Register markers for tests that use samples and sensors."""
+    config.addinivalue_line(
+        "markers", "samples: mark test to run with specified samples"
+    )
+    config.addinivalue_line(
+        "markers", "sensors: mark test to run with specified sensors"
+    )
+
+
+@pytest.fixture
+def mock_api(request: pytest.FixtureRequest) -> Generator[AsyncMock]:
+    """Override SensorPushCloudApi."""
+    mock_api = AsyncMock(SensorPushCloudApi)
+    marker = request.node.get_closest_marker("sensors")
+    if marker is not None:
+        mock_api.async_sensors.return_value = marker.args[0]
+    marker = request.node.get_closest_marker("samples")
+    if marker is not None:
+        mock_api.async_samples.return_value = marker.args[0]
+    with (
+        patch(
+            "homeassistant.components.sensorpush_cloud.config_flow.SensorPushCloudApi",
+            return_value=mock_api,
+        ),
+        patch(
+            "homeassistant.components.sensorpush_cloud.coordinator.SensorPushCloudApi",
+            return_value=mock_api,
+        ),
+    ):
+        yield mock_api
+
+
+@pytest.fixture
+def make_config_entry(
+    request: pytest.FixtureRequest,
+) -> Callable[[dict[str, Any] | None], MockConfigEntry]:
+    """ConfigEntry mock factory."""
+
+    def _make_config_entry(data: dict[str, Any] | None = None):
+        default_data = {
+            CONF_EMAIL: "test@example.com",
+            CONF_PASSWORD: "test-password",
+        }
+        data = default_data if data is None else default_data | data
+        return MockConfigEntry(domain=DOMAIN, data=data, entry_id=data[CONF_EMAIL])
+
+    return _make_config_entry
+
+
+@pytest.fixture
+def mock_config_entry(
+    make_config_entry: Callable[[dict[str, Any] | None], MockConfigEntry],
+) -> MockConfigEntry:
+    """ConfigEntry mock."""
+    return make_config_entry()
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.sensorpush_cloud.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry

--- a/tests/components/sensorpush_cloud/const.py
+++ b/tests/components/sensorpush_cloud/const.py
@@ -1,0 +1,57 @@
+"""Constants for the SensorPush Cloud tests."""
+
+from __future__ import annotations
+
+from typing import Final
+
+from sensorpush_api import Sample, Samples, Sensor
+
+from homeassistant.util import dt as dt_util
+
+NUM_MOCK_DEVICES: Final = 3
+
+MOCK_ENTITY_IDS: Final = (
+    entity_id
+    for i in range(NUM_MOCK_DEVICES)
+    for entity_id in (
+        f"sensor.test_sensor_name_{i}_altitude",
+        f"sensor.test_sensor_name_{i}_atmospheric_pressure",
+        f"sensor.test_sensor_name_{i}_battery_voltage",
+        f"sensor.test_sensor_name_{i}_dew_point",
+        f"sensor.test_sensor_name_{i}_humidity",
+        f"sensor.test_sensor_name_{i}_signal_strength",
+        f"sensor.test_sensor_name_{i}_temperature",
+        f"sensor.test_sensor_name_{i}_vapor_pressure",
+    )
+)
+
+MOCK_SAMPLES: Final = Samples(
+    sensors={
+        f"test-sensor-id-{i}": [
+            Sample(
+                altitude=0.0,
+                barometric_pressure=0.0,
+                dewpoint=0.0,
+                humidity=0.0,
+                observed=dt_util.utcnow(),
+                temperature=0.0,
+                vpd=0.0,
+            )
+        ]
+        for i in range(NUM_MOCK_DEVICES)
+    }
+)
+
+MOCK_SENSORS: Final = {
+    f"test-sensor-id-{i}": Sensor(
+        active=True,
+        address=f"AA:BB:CC:DD:EE:{i:02x}",
+        battery_voltage=0.0,
+        device_id=f"test-sensor-device-id-{i}",
+        id=f"test-sensor-id-{i}",
+        name=f"test-sensor-name-{i}",
+        rssi=0.0,
+        type=f"test-sensor-type-{i}",
+    )
+    for i in range(NUM_MOCK_DEVICES)
+}

--- a/tests/components/sensorpush_cloud/test_config_flow.py
+++ b/tests/components/sensorpush_cloud/test_config_flow.py
@@ -1,0 +1,89 @@
+"""Test the SensorPush Cloud config flow."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components.sensorpush_cloud.api import SensorPushCloudError
+from homeassistant.components.sensorpush_cloud.const import DOMAIN
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from .const import MOCK_SENSORS
+
+
+@pytest.mark.sensors(MOCK_SENSORS)
+async def test_form(
+    hass: HomeAssistant, mock_api: AsyncMock, mock_setup_entry: AsyncMock
+) -> None:
+    """Test we get the form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_EMAIL: "test@example.com",
+            CONF_PASSWORD: "test-password",
+        },
+    )
+    await hass.async_block_till_done()
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "test@example.com"
+    assert result["data"] == {
+        CONF_EMAIL: "test@example.com",
+        CONF_PASSWORD: "test-password",
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_api_error(hass: HomeAssistant, mock_api: AsyncMock) -> None:
+    """Test we display API errors to the user."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    mock_api.async_authorize.side_effect = SensorPushCloudError("test-message")
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_EMAIL: "test@example.com",
+            CONF_PASSWORD: "test-password",
+        },
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "test-message"}
+
+
+async def test_form_unknown_error(hass: HomeAssistant, mock_api: AsyncMock) -> None:
+    """Test we display unknown errors to the user."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    mock_api.async_authorize.side_effect = Exception("test-message")
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_EMAIL: "test@example.com",
+            CONF_PASSWORD: "test-password",
+        },
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "unknown"}

--- a/tests/components/sensorpush_cloud/test_coordinator.py
+++ b/tests/components/sensorpush_cloud/test_coordinator.py
@@ -1,0 +1,49 @@
+"""Test the SensorPush Cloud coordinator."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from homeassistant.components.sensorpush_cloud.api import SensorPushCloudError
+from homeassistant.core import HomeAssistant
+
+from .const import MOCK_SAMPLES, MOCK_SENSORS
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.samples(MOCK_SAMPLES)
+@pytest.mark.sensors(MOCK_SENSORS)
+async def test_update_data(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_api: AsyncMock,
+) -> None:
+    """Test we can update data."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+    assert len(coordinator.devices) == len(MOCK_SENSORS)
+    assert len(coordinator.data) == len(MOCK_SENSORS)
+
+
+@pytest.mark.samples(MOCK_SAMPLES)
+@pytest.mark.sensors(MOCK_SENSORS)
+async def test_update_data_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_api: AsyncMock,
+) -> None:
+    """Test we can handle errors when updating data."""
+    mock_api.async_sensors.side_effect = SensorPushCloudError("test-message")
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+    assert len(coordinator.devices) == 0
+    assert len(coordinator.data) == 0

--- a/tests/components/sensorpush_cloud/test_sensor.py
+++ b/tests/components/sensorpush_cloud/test_sensor.py
@@ -1,0 +1,60 @@
+"""Test SensorPush Cloud sensors."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from unittest.mock import AsyncMock
+
+import pytest
+
+from homeassistant.components.sensorpush_cloud.const import MAX_TIME_BETWEEN_UPDATES
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+
+from .const import MOCK_ENTITY_IDS, MOCK_SAMPLES, MOCK_SENSORS
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.samples(MOCK_SAMPLES)
+@pytest.mark.sensors(MOCK_SENSORS)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_create_sensors(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_api: AsyncMock,
+) -> None:
+    """Test we can create sensors."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    for entity_id in MOCK_ENTITY_IDS:
+        entity = hass.states.get(entity_id)
+        assert entity
+        assert entity.state != STATE_UNAVAILABLE
+
+
+@pytest.mark.sensors(MOCK_SENSORS)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_unavailable(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_api: AsyncMock,
+) -> None:
+    """Test we can set sensors to unavailable."""
+    samples = deepcopy(MOCK_SAMPLES)
+    for sensor in samples.sensors.values():
+        for sample in sensor:
+            sample.observed = dt_util.utcnow() - MAX_TIME_BETWEEN_UPDATES
+    mock_api.async_samples.return_value = samples
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    for entity_id in MOCK_ENTITY_IDS:
+        entity = hass.states.get(entity_id)
+        assert entity
+        assert entity.state == STATE_UNAVAILABLE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds cloud integration for SensorPush devices. It communicates with the publicly available [Cloud API](https://www.sensorpush.com/gateway-cloud-api) using the [sensorpush-api](https://pypi.org/project/sensorpush-api/) Python package. Care was taken to ensure that presented devices appeared the same as those created by the existing SensorPush integration. A [G1 WiFi Gateway](https://www.sensorpush.com/products/p/g1-gateway) is required to make use of the Cloud API.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (you're welcome!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33735

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

1. https://github.com/home-assistant/core/pull/121863#pullrequestreview-2176476754
2. https://github.com/home-assistant/core/pull/121805#pullrequestreview-2176477135

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
