### PR TITLE
Dynamically add Airzone entities

### DIFF
--- a/homeassistant/components/airzone/binary_sensor.py
+++ b/homeassistant/components/airzone/binary_sensor.py
@@ -82,33 +82,50 @@ async def async_setup_entry(
     """Add Airzone binary sensors from a config_entry."""
     coordinator = entry.runtime_data
 
-    binary_sensors: list[AirzoneBinarySensor] = [
-        AirzoneSystemBinarySensor(
-            coordinator,
-            description,
-            entry,
-            system_id,
-            system_data,
-        )
-        for system_id, system_data in coordinator.data[AZD_SYSTEMS].items()
-        for description in SYSTEM_BINARY_SENSOR_TYPES
-        if description.key in system_data
-    ]
+    added_systems: set[str] = set()
+    added_zones: set[str] = set()
 
-    binary_sensors.extend(
-        AirzoneZoneBinarySensor(
-            coordinator,
-            description,
-            entry,
-            system_zone_id,
-            zone_data,
-        )
-        for system_zone_id, zone_data in coordinator.data[AZD_ZONES].items()
-        for description in ZONE_BINARY_SENSOR_TYPES
-        if description.key in zone_data
-    )
+    def _async_entity_listener() -> None:
+        """Handle additions of binary sensors."""
 
-    async_add_entities(binary_sensors)
+        systems_data = coordinator.data.get(AZD_SYSTEMS, {})
+        received_systems = set(systems_data)
+        new_systems = received_systems - added_systems
+        if new_systems:
+            async_add_entities(
+                AirzoneSystemBinarySensor(
+                    coordinator,
+                    description,
+                    entry,
+                    system_zone_id,
+                    systems_data.get(system_zone_id),
+                )
+                for system_zone_id in new_systems
+                for description in SYSTEM_BINARY_SENSOR_TYPES
+                if description.key in systems_data.get(system_zone_id)
+            )
+            added_systems.update(new_systems)
+
+        zones_data = coordinator.data.get(AZD_ZONES, {})
+        received_zones = set(zones_data)
+        new_zones = received_zones - added_zones
+        if new_zones:
+            async_add_entities(
+                AirzoneZoneBinarySensor(
+                    coordinator,
+                    description,
+                    entry,
+                    system_zone_id,
+                    zones_data.get(system_zone_id),
+                )
+                for system_zone_id in new_zones
+                for description in ZONE_BINARY_SENSOR_TYPES
+                if description.key in zones_data.get(system_zone_id)
+            )
+            added_zones.update(new_zones)
+
+    coordinator.async_add_listener(_async_entity_listener)
+    _async_entity_listener()
 
 
 class AirzoneBinarySensor(AirzoneEntity, BinarySensorEntity):

--- a/homeassistant/components/airzone/binary_sensor.py
+++ b/homeassistant/components/airzone/binary_sensor.py
@@ -88,11 +88,13 @@ async def async_setup_entry(
     def _async_entity_listener() -> None:
         """Handle additions of binary sensors."""
 
+        entities: list[AirzoneBinarySensor] = []
+
         systems_data = coordinator.data.get(AZD_SYSTEMS, {})
         received_systems = set(systems_data)
         new_systems = received_systems - added_systems
         if new_systems:
-            async_add_entities(
+            entities.extend(
                 AirzoneSystemBinarySensor(
                     coordinator,
                     description,
@@ -110,7 +112,7 @@ async def async_setup_entry(
         received_zones = set(zones_data)
         new_zones = received_zones - added_zones
         if new_zones:
-            async_add_entities(
+            entities.extend(
                 AirzoneZoneBinarySensor(
                     coordinator,
                     description,
@@ -123,6 +125,8 @@ async def async_setup_entry(
                 if description.key in zones_data.get(system_zone_id)
             )
             added_zones.update(new_zones)
+
+        async_add_entities(entities)
 
     coordinator.async_add_listener(_async_entity_listener)
     _async_entity_listener()

--- a/homeassistant/components/airzone/binary_sensor.py
+++ b/homeassistant/components/airzone/binary_sensor.py
@@ -128,7 +128,7 @@ async def async_setup_entry(
 
         async_add_entities(entities)
 
-    coordinator.async_add_listener(_async_entity_listener)
+    entry.async_on_unload(coordinator.async_add_listener(_async_entity_listener))
     _async_entity_listener()
 
 

--- a/homeassistant/components/airzone/climate.py
+++ b/homeassistant/components/airzone/climate.py
@@ -102,17 +102,31 @@ async def async_setup_entry(
     entry: AirzoneConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Add Airzone sensors from a config_entry."""
+    """Add Airzone climate from a config_entry."""
     coordinator = entry.runtime_data
-    async_add_entities(
-        AirzoneClimate(
-            coordinator,
-            entry,
-            system_zone_id,
-            zone_data,
-        )
-        for system_zone_id, zone_data in coordinator.data[AZD_ZONES].items()
-    )
+
+    added_zones: set[str] = set()
+
+    def _async_entity_listener() -> None:
+        """Handle additions of climate."""
+
+        zones_data = coordinator.data.get(AZD_ZONES, {})
+        received_zones = set(zones_data)
+        new_zones = received_zones - added_zones
+        if new_zones:
+            async_add_entities(
+                AirzoneClimate(
+                    coordinator,
+                    entry,
+                    system_zone_id,
+                    zones_data.get(system_zone_id),
+                )
+                for system_zone_id in new_zones
+            )
+            added_zones.update(new_zones)
+
+    coordinator.async_add_listener(_async_entity_listener)
+    _async_entity_listener()
 
 
 class AirzoneClimate(AirzoneZoneEntity, ClimateEntity):

--- a/homeassistant/components/airzone/climate.py
+++ b/homeassistant/components/airzone/climate.py
@@ -125,7 +125,7 @@ async def async_setup_entry(
             )
             added_zones.update(new_zones)
 
-    coordinator.async_add_listener(_async_entity_listener)
+    entry.async_on_unload(coordinator.async_add_listener(_async_entity_listener))
     _async_entity_listener()
 
 

--- a/homeassistant/components/airzone/coordinator.py
+++ b/homeassistant/components/airzone/coordinator.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 import logging
 from typing import Any
 
+from aioairzone.const import AZD_NEW_SYSTEMS, AZD_NEW_ZONES
 from aioairzone.exceptions import AirzoneError
 from aioairzone.localapi import AirzoneLocalApi
 
@@ -34,6 +35,15 @@ class AirzoneUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             update_interval=SCAN_INTERVAL,
         )
 
+    async def _async_check_new_devices(self, data: dict[str, Any]) -> None:
+        """Reload entry if there are new devices."""
+        if (
+            len(data.get(AZD_NEW_SYSTEMS, [])) > 0
+            or len(data.get(AZD_NEW_ZONES, [])) > 0
+        ):
+            assert self.config_entry
+            self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)
+
     async def _async_update_data(self) -> dict[str, Any]:
         """Update data via library."""
         async with timeout(AIOAIRZONE_DEVICE_TIMEOUT_SEC):
@@ -41,4 +51,6 @@ class AirzoneUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 await self.airzone.update()
             except AirzoneError as error:
                 raise UpdateFailed(error) from error
-            return self.airzone.data()
+            data = self.airzone.data()
+        await self._async_check_new_devices(data)
+        return data

--- a/homeassistant/components/airzone/coordinator.py
+++ b/homeassistant/components/airzone/coordinator.py
@@ -7,7 +7,6 @@ from datetime import timedelta
 import logging
 from typing import Any
 
-from aioairzone.const import AZD_NEW_SYSTEMS, AZD_NEW_ZONES
 from aioairzone.exceptions import AirzoneError
 from aioairzone.localapi import AirzoneLocalApi
 
@@ -35,15 +34,6 @@ class AirzoneUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             update_interval=SCAN_INTERVAL,
         )
 
-    async def _async_check_new_devices(self, data: dict[str, Any]) -> None:
-        """Reload entry if there are new devices."""
-        if (
-            len(data.get(AZD_NEW_SYSTEMS, [])) > 0
-            or len(data.get(AZD_NEW_ZONES, [])) > 0
-        ):
-            assert self.config_entry
-            self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)
-
     async def _async_update_data(self) -> dict[str, Any]:
         """Update data via library."""
         async with timeout(AIOAIRZONE_DEVICE_TIMEOUT_SEC):
@@ -51,6 +41,4 @@ class AirzoneUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 await self.airzone.update()
             except AirzoneError as error:
                 raise UpdateFailed(error) from error
-            data = self.airzone.data()
-        await self._async_check_new_devices(data)
-        return data
+            return self.airzone.data()

--- a/homeassistant/components/airzone/select.py
+++ b/homeassistant/components/airzone/select.py
@@ -109,7 +109,7 @@ async def async_setup_entry(
             )
             added_zones.update(new_zones)
 
-    coordinator.async_add_listener(_async_entity_listener)
+    entry.async_on_unload(coordinator.async_add_listener(_async_entity_listener))
     _async_entity_listener()
 
 

--- a/homeassistant/components/airzone/select.py
+++ b/homeassistant/components/airzone/select.py
@@ -83,21 +83,34 @@ async def async_setup_entry(
     entry: AirzoneConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Add Airzone sensors from a config_entry."""
+    """Add Airzone select from a config_entry."""
     coordinator = entry.runtime_data
 
-    async_add_entities(
-        AirzoneZoneSelect(
-            coordinator,
-            description,
-            entry,
-            system_zone_id,
-            zone_data,
-        )
-        for description in ZONE_SELECT_TYPES
-        for system_zone_id, zone_data in coordinator.data[AZD_ZONES].items()
-        if description.key in zone_data
-    )
+    added_zones: set[str] = set()
+
+    def _async_entity_listener() -> None:
+        """Handle additions of select."""
+
+        zones_data = coordinator.data.get(AZD_ZONES, {})
+        received_zones = set(zones_data)
+        new_zones = received_zones - added_zones
+        if new_zones:
+            async_add_entities(
+                AirzoneZoneSelect(
+                    coordinator,
+                    description,
+                    entry,
+                    system_zone_id,
+                    zones_data.get(system_zone_id),
+                )
+                for system_zone_id in new_zones
+                for description in ZONE_SELECT_TYPES
+                if description.key in zones_data.get(system_zone_id)
+            )
+            added_zones.update(new_zones)
+
+    coordinator.async_add_listener(_async_entity_listener)
+    _async_entity_listener()
 
 
 class AirzoneBaseSelect(AirzoneEntity, SelectEntity):

--- a/homeassistant/components/airzone/sensor.py
+++ b/homeassistant/components/airzone/sensor.py
@@ -141,7 +141,7 @@ async def async_setup_entry(
 
         async_add_entities(entities)
 
-    coordinator.async_add_listener(_async_entity_listener)
+    entry.async_on_unload(coordinator.async_add_listener(_async_entity_listener))
     _async_entity_listener()
 
 

--- a/homeassistant/components/airzone/sensor.py
+++ b/homeassistant/components/airzone/sensor.py
@@ -85,41 +85,12 @@ async def async_setup_entry(
     """Add Airzone sensors from a config_entry."""
     coordinator = entry.runtime_data
 
-    added_hotwater: bool = False
-    added_webserver: bool = False
     added_zones: set[str] = set()
 
     def _async_entity_listener() -> None:
         """Handle additions of sensors."""
 
-        nonlocal added_hotwater
-        nonlocal added_webserver
-
         entities: list[AirzoneSensor] = []
-
-        if not added_hotwater and AZD_HOT_WATER in coordinator.data:
-            entities.extend(
-                AirzoneHotWaterSensor(
-                    coordinator,
-                    description,
-                    entry,
-                )
-                for description in HOT_WATER_SENSOR_TYPES
-                if description.key in coordinator.data[AZD_HOT_WATER]
-            )
-            added_hotwater = True
-
-        if not added_webserver and AZD_WEBSERVER in coordinator.data:
-            entities.extend(
-                AirzoneWebServerSensor(
-                    coordinator,
-                    description,
-                    entry,
-                )
-                for description in WEBSERVER_SENSOR_TYPES
-                if description.key in coordinator.data[AZD_WEBSERVER]
-            )
-            added_webserver = True
 
         zones_data = coordinator.data.get(AZD_ZONES, {})
         received_zones = set(zones_data)
@@ -140,6 +111,32 @@ async def async_setup_entry(
             added_zones.update(new_zones)
 
         async_add_entities(entities)
+
+    entities: list[AirzoneSensor] = []
+
+    if AZD_HOT_WATER in coordinator.data:
+        entities.extend(
+            AirzoneHotWaterSensor(
+                coordinator,
+                description,
+                entry,
+            )
+            for description in HOT_WATER_SENSOR_TYPES
+            if description.key in coordinator.data[AZD_HOT_WATER]
+        )
+
+    if AZD_WEBSERVER in coordinator.data:
+        entities.extend(
+            AirzoneWebServerSensor(
+                coordinator,
+                description,
+                entry,
+            )
+            for description in WEBSERVER_SENSOR_TYPES
+            if description.key in coordinator.data[AZD_WEBSERVER]
+        )
+
+    async_add_entities(entities)
 
     entry.async_on_unload(coordinator.async_add_listener(_async_entity_listener))
     _async_entity_listener()

--- a/homeassistant/components/airzone/sensor.py
+++ b/homeassistant/components/airzone/sensor.py
@@ -90,11 +90,13 @@ async def async_setup_entry(
     added_zones: set[str] = set()
 
     def _async_entity_listener() -> None:
-        """Handle additions/deletions of shopping lists."""
-        sensors: list[AirzoneSensor] = []
+        """Handle additions of sensors."""
+
+        nonlocal added_hotwater
+        nonlocal added_webserver
 
         if not added_hotwater and AZD_HOT_WATER in coordinator.data:
-            sensors.extend(
+            async_add_entities(
                 AirzoneHotWaterSensor(
                     coordinator,
                     description,
@@ -103,9 +105,10 @@ async def async_setup_entry(
                 for description in HOT_WATER_SENSOR_TYPES
                 if description.key in coordinator.data[AZD_HOT_WATER]
             )
+            added_hotwater = True
 
         if not added_webserver and AZD_WEBSERVER in coordinator.data:
-            sensors.extend(
+            async_add_entities(
                 AirzoneWebServerSensor(
                     coordinator,
                     description,
@@ -114,12 +117,13 @@ async def async_setup_entry(
                 for description in WEBSERVER_SENSOR_TYPES
                 if description.key in coordinator.data[AZD_WEBSERVER]
             )
+            added_webserver = True
 
         zones_data = coordinator.data.get(AZD_ZONES, {})
         received_zones = set(zones_data)
         new_zones = received_zones - added_zones
         if new_zones:
-            sensors.extend(
+            async_add_entities(
                 AirzoneZoneSensor(
                     coordinator,
                     description,
@@ -132,8 +136,6 @@ async def async_setup_entry(
                 if description.key in zones_data.get(system_zone_id)
             )
             added_zones.update(new_zones)
-
-        async_add_entities(sensors)
 
     coordinator.async_add_listener(_async_entity_listener)
     _async_entity_listener()

--- a/homeassistant/components/airzone/sensor.py
+++ b/homeassistant/components/airzone/sensor.py
@@ -95,8 +95,10 @@ async def async_setup_entry(
         nonlocal added_hotwater
         nonlocal added_webserver
 
+        entities: list[AirzoneSensor] = []
+
         if not added_hotwater and AZD_HOT_WATER in coordinator.data:
-            async_add_entities(
+            entities.extend(
                 AirzoneHotWaterSensor(
                     coordinator,
                     description,
@@ -108,7 +110,7 @@ async def async_setup_entry(
             added_hotwater = True
 
         if not added_webserver and AZD_WEBSERVER in coordinator.data:
-            async_add_entities(
+            entities.extend(
                 AirzoneWebServerSensor(
                     coordinator,
                     description,
@@ -123,7 +125,7 @@ async def async_setup_entry(
         received_zones = set(zones_data)
         new_zones = received_zones - added_zones
         if new_zones:
-            async_add_entities(
+            entities.extend(
                 AirzoneZoneSensor(
                     coordinator,
                     description,
@@ -136,6 +138,8 @@ async def async_setup_entry(
                 if description.key in zones_data.get(system_zone_id)
             )
             added_zones.update(new_zones)
+
+        async_add_entities(entities)
 
     coordinator.async_add_listener(_async_entity_listener)
     _async_entity_listener()

--- a/homeassistant/components/airzone/water_heater.py
+++ b/homeassistant/components/airzone/water_heater.py
@@ -75,7 +75,7 @@ async def async_setup_entry(
             async_add_entities([AirzoneWaterHeater(coordinator, entry)])
             added_hotwater = True
 
-    coordinator.async_add_listener(_async_entity_listener)
+    entry.async_on_unload(coordinator.async_add_listener(_async_entity_listener))
     _async_entity_listener()
 
 

--- a/homeassistant/components/airzone/water_heater.py
+++ b/homeassistant/components/airzone/water_heater.py
@@ -63,20 +63,8 @@ async def async_setup_entry(
 ) -> None:
     """Add Airzone Water Heater from a config_entry."""
     coordinator = entry.runtime_data
-
-    added_hotwater: bool = False
-
-    def _async_entity_listener() -> None:
-        """Handle additions of Water Heater."""
-
-        nonlocal added_hotwater
-
-        if not added_hotwater and AZD_HOT_WATER in coordinator.data:
-            async_add_entities([AirzoneWaterHeater(coordinator, entry)])
-            added_hotwater = True
-
-    entry.async_on_unload(coordinator.async_add_listener(_async_entity_listener))
-    _async_entity_listener()
+    if AZD_HOT_WATER in coordinator.data:
+        async_add_entities([AirzoneWaterHeater(coordinator, entry)])
 
 
 class AirzoneWaterHeater(AirzoneHotWaterEntity, WaterHeaterEntity):

--- a/homeassistant/components/airzone/water_heater.py
+++ b/homeassistant/components/airzone/water_heater.py
@@ -61,10 +61,22 @@ async def async_setup_entry(
     entry: AirzoneConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Add Airzone sensors from a config_entry."""
+    """Add Airzone Water Heater from a config_entry."""
     coordinator = entry.runtime_data
-    if AZD_HOT_WATER in coordinator.data:
-        async_add_entities([AirzoneWaterHeater(coordinator, entry)])
+
+    added_hotwater: bool = False
+
+    def _async_entity_listener() -> None:
+        """Handle additions of Water Heater."""
+
+        nonlocal added_hotwater
+
+        if not added_hotwater and AZD_HOT_WATER in coordinator.data:
+            async_add_entities([AirzoneWaterHeater(coordinator, entry)])
+            added_hotwater = True
+
+    coordinator.async_add_listener(_async_entity_listener)
+    _async_entity_listener()
 
 
 class AirzoneWaterHeater(AirzoneHotWaterEntity, WaterHeaterEntity):

--- a/tests/components/airzone/test_coordinator.py
+++ b/tests/components/airzone/test_coordinator.py
@@ -15,7 +15,7 @@ from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.util.dt import utcnow
 
-from .util import CONFIG, HVAC_MOCK, HVAC_VERSION_MOCK
+from .util import CONFIG, HVAC_MOCK, HVAC_MOCK_NEW_ZONES, HVAC_VERSION_MOCK
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -64,3 +64,58 @@ async def test_coordinator_client_connector_error(hass: HomeAssistant) -> None:
 
         state = hass.states.get("sensor.despacho_temperature")
         assert state.state == STATE_UNAVAILABLE
+
+
+async def test_coordinator_new_devices(hass: HomeAssistant) -> None:
+    """Test new devices on coordinator update."""
+
+    config_entry = MockConfigEntry(
+        data=CONFIG,
+        domain=DOMAIN,
+        unique_id="airzone_unique_id",
+    )
+    config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.airzone.AirzoneLocalApi.get_dhw",
+            side_effect=HotWaterNotAvailable,
+        ),
+        patch(
+            "homeassistant.components.airzone.AirzoneLocalApi.get_hvac",
+            return_value=HVAC_MOCK_NEW_ZONES,
+        ) as mock_hvac,
+        patch(
+            "homeassistant.components.airzone.AirzoneLocalApi.get_hvac_systems",
+            side_effect=SystemOutOfRange,
+        ),
+        patch(
+            "homeassistant.components.airzone.AirzoneLocalApi.get_version",
+            return_value=HVAC_VERSION_MOCK,
+        ),
+        patch(
+            "homeassistant.components.airzone.AirzoneLocalApi.get_webserver",
+            side_effect=InvalidMethod,
+        ),
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+        mock_hvac.assert_called_once()
+        mock_hvac.reset_mock()
+
+        state = hass.states.get("sensor.salon_temperature")
+        assert state.state == "19.6"
+
+        state = hass.states.get("sensor.dorm_ppal_temperature")
+        assert state is None
+
+        mock_hvac.return_value = HVAC_MOCK
+        async_fire_time_changed(hass, utcnow() + SCAN_INTERVAL)
+        await hass.async_block_till_done()
+        mock_hvac.assert_called()
+
+        state = hass.states.get("sensor.salon_temperature")
+        assert state.state == "19.6"
+
+        state = hass.states.get("sensor.dorm_ppal_temperature")
+        assert state.state == "21.1"

--- a/tests/components/airzone/test_coordinator.py
+++ b/tests/components/airzone/test_coordinator.py
@@ -15,7 +15,7 @@ from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.util.dt import utcnow
 
-from .util import CONFIG, HVAC_MOCK, HVAC_MOCK_NEW_ZONES, HVAC_VERSION_MOCK
+from .util import CONFIG, HVAC_MOCK, HVAC_VERSION_MOCK
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -64,58 +64,3 @@ async def test_coordinator_client_connector_error(hass: HomeAssistant) -> None:
 
         state = hass.states.get("sensor.despacho_temperature")
         assert state.state == STATE_UNAVAILABLE
-
-
-async def test_coordinator_new_devices(hass: HomeAssistant) -> None:
-    """Test new devices on coordinator update."""
-
-    config_entry = MockConfigEntry(
-        data=CONFIG,
-        domain=DOMAIN,
-        unique_id="airzone_unique_id",
-    )
-    config_entry.add_to_hass(hass)
-
-    with (
-        patch(
-            "homeassistant.components.airzone.AirzoneLocalApi.get_dhw",
-            side_effect=HotWaterNotAvailable,
-        ),
-        patch(
-            "homeassistant.components.airzone.AirzoneLocalApi.get_hvac",
-            return_value=HVAC_MOCK_NEW_ZONES,
-        ) as mock_hvac,
-        patch(
-            "homeassistant.components.airzone.AirzoneLocalApi.get_hvac_systems",
-            side_effect=SystemOutOfRange,
-        ),
-        patch(
-            "homeassistant.components.airzone.AirzoneLocalApi.get_version",
-            return_value=HVAC_VERSION_MOCK,
-        ),
-        patch(
-            "homeassistant.components.airzone.AirzoneLocalApi.get_webserver",
-            side_effect=InvalidMethod,
-        ),
-    ):
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-        mock_hvac.assert_called_once()
-        mock_hvac.reset_mock()
-
-        state = hass.states.get("sensor.salon_temperature")
-        assert state.state == "19.6"
-
-        state = hass.states.get("sensor.dorm_ppal_temperature")
-        assert state is None
-
-        mock_hvac.return_value = HVAC_MOCK
-        async_fire_time_changed(hass, utcnow() + SCAN_INTERVAL)
-        await hass.async_block_till_done()
-        mock_hvac.assert_called()
-
-        state = hass.states.get("sensor.salon_temperature")
-        assert state.state == "19.6"
-
-        state = hass.states.get("sensor.dorm_ppal_temperature")
-        assert state.state == "21.1"

--- a/tests/components/airzone/util.py
+++ b/tests/components/airzone/util.py
@@ -1,5 +1,6 @@
 """Tests for the Airzone integration."""
 
+from copy import deepcopy
 from unittest.mock import patch
 
 from aioairzone.const import (
@@ -271,6 +272,16 @@ HVAC_MOCK = {
                 },
             ]
         },
+    ]
+}
+
+HVAC_MOCK_NEW_ZONES = {
+    API_SYSTEMS: [
+        {
+            API_DATA: [
+                deepcopy(HVAC_MOCK[API_SYSTEMS][0][API_DATA][0]),
+            ]
+        }
     ]
 }
 

--- a/tests/components/airzone/util.py
+++ b/tests/components/airzone/util.py
@@ -1,6 +1,5 @@
 """Tests for the Airzone integration."""
 
-from copy import deepcopy
 from unittest.mock import patch
 
 from aioairzone.const import (
@@ -272,16 +271,6 @@ HVAC_MOCK = {
                 },
             ]
         },
-    ]
-}
-
-HVAC_MOCK_NEW_ZONES = {
-    API_SYSTEMS: [
-        {
-            API_DATA: [
-                deepcopy(HVAC_MOCK[API_SYSTEMS][0][API_DATA][0]),
-            ]
-        }
     ]
 }
 


### PR DESCRIPTION
## Proposed change
Reload Airzone config entry on new devices in order to expose new devices and entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
