### PR TITLE
Fix rainforest_raven closing device due to timeout

### DIFF
--- a/homeassistant/components/rainforest_raven/coordinator.py
+++ b/homeassistant/components/rainforest_raven/coordinator.py
@@ -167,7 +167,7 @@ class RAVEnDataCoordinator(DataUpdateCoordinator):
                 await device.synchronize()
                 self._device_info = await device.get_device_info()
         except:
-            await device.close()
+            await device.abort()
             raise
 
         self._raven_device = device

--- a/homeassistant/components/rainforest_raven/manifest.json
+++ b/homeassistant/components/rainforest_raven/manifest.json
@@ -6,7 +6,7 @@
   "dependencies": ["usb"],
   "documentation": "https://www.home-assistant.io/integrations/rainforest_raven",
   "iot_class": "local_polling",
-  "requirements": ["aioraven==0.6.0"],
+  "requirements": ["aioraven==0.7.0"],
   "usb": [
     {
       "vid": "0403",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -341,7 +341,7 @@ aiopyarr==23.4.0
 aioqsw==0.3.5
 
 # homeassistant.components.rainforest_raven
-aioraven==0.6.0
+aioraven==0.7.0
 
 # homeassistant.components.recollect_waste
 aiorecollect==2023.09.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -317,7 +317,7 @@ aiopyarr==23.4.0
 aioqsw==0.3.5
 
 # homeassistant.components.rainforest_raven
-aioraven==0.6.0
+aioraven==0.7.0
 
 # homeassistant.components.recollect_waste
 aiorecollect==2023.09.0


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When there's a timeout initializing the device, it's possible that a problem with the serial port is blocking the write operations, meaning that the `flush()` that's part of the call to `close()` might block. The device is already in a bad state, so we should just use `abort()` to abandon the attempt so that we can try again. This will close the device without flushing the write buffer.

I'm still not able to reproduce the reported problems with `rainforest_raven` at startup, but at least one of the backtraces I saw indicated that the call to `await device.close()` wasn't completing and eventually timed out. Though this change doesn't address why the device timed out to begin with, I'm hoping it mitigates the effects and allows Home Assistant to continue startup and try to open the device again later.

The `abort()` method was introduced in `aioraven` 0.7.0, which this PR updates to:
Upstream diff: https://github.com/cottsay/aioraven/compare/0.6.0..0.7.0
Upstream changelog: https://github.com/cottsay/aioraven/blob/0.7.0/CHANGELOG.md#070-2024-07-12

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
  - #113473
  - #121811
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
