### PR TITLE
Fix auth policy for entities with area but without device

### DIFF
--- a/homeassistant/auth/permissions/entities.py
+++ b/homeassistant/auth/permissions/entities.py
@@ -57,8 +57,17 @@ def _lookup_area(
     """Look up entity permissions by area."""
     entity_entry = perm_lookup.entity_registry.async_get(entity_id)
 
-    if entity_entry is None or entity_entry.device_id is None:
+    if entity_entry is None:
         return None
+
+    if entity_entry.area_id is not None:
+        return area_dict.get(entity_entry.area_id)
+
+    if entity_entry.device_id is None:
+        return None
+
+    # if entity_entry is None or entity_entry.device_id is None:
+    #     return None
 
     device_entry = perm_lookup.device_registry.async_get(entity_entry.device_id)
 

--- a/homeassistant/auth/permissions/entities.py
+++ b/homeassistant/auth/permissions/entities.py
@@ -66,9 +66,6 @@ def _lookup_area(
     if entity_entry.device_id is None:
         return None
 
-    # if entity_entry is None or entity_entry.device_id is None:
-    #     return None
-
     device_entry = perm_lookup.device_registry.async_get(entity_entry.device_id)
 
     if device_entry is None or device_entry.area_id is None:

--- a/tests/auth/permissions/test_entities.py
+++ b/tests/auth/permissions/test_entities.py
@@ -219,7 +219,7 @@ def test_entities_areas_area_true(hass: HomeAssistant) -> None:
     assert compiled("switch.kitchen", "read") is False
 
 
-def test_entities_areas_area_true_without_device(hass: HomeAssistant) -> None:
+def test_entities_areas_area_true_without_device_area(hass: HomeAssistant) -> None:
     """Test entity ID policy for areas with specific area."""
     entity_registry = mock_registry(
         hass,
@@ -229,6 +229,63 @@ def test_entities_areas_area_true_without_device(hass: HomeAssistant) -> None:
                 unique_id="1234",
                 platform="test_platform",
                 device_id="mock-dev-id",
+                area_id="mock-area-id",
+            )
+        },
+    )
+    device_registry = mock_device_registry(hass)
+
+    policy = {"area_ids": {"mock-area-id": {"read": True, "control": True}}}
+    ENTITY_POLICY_SCHEMA(policy)
+    compiled = compile_entities(
+        policy, PermissionLookup(entity_registry, device_registry)
+    )
+    assert compiled("light.kitchen", "read") is True
+    assert compiled("light.kitchen", "control") is True
+    assert compiled("light.kitchen", "edit") is False
+    assert compiled("switch.kitchen", "read") is False
+
+
+def test_entities_areas_area_true_with_different_device_area(
+    hass: HomeAssistant,
+) -> None:
+    """Test entity ID policy for areas with specific area."""
+    entity_registry = mock_registry(
+        hass,
+        {
+            "light.kitchen": RegistryEntry(
+                entity_id="light.kitchen",
+                unique_id="1234",
+                platform="test_platform",
+                device_id="mock-dev-id",
+                area_id="mock-area-id",
+            )
+        },
+    )
+    device_registry = mock_device_registry(
+        hass, {"mock-dev-id": DeviceEntry(id="mock-dev-id", area_id="mock-area-id-2")}
+    )
+
+    policy = {"area_ids": {"mock-area-id": {"read": True, "control": True}}}
+    ENTITY_POLICY_SCHEMA(policy)
+    compiled = compile_entities(
+        policy, PermissionLookup(entity_registry, device_registry)
+    )
+    assert compiled("light.kitchen", "read") is True
+    assert compiled("light.kitchen", "control") is True
+    assert compiled("light.kitchen", "edit") is False
+    assert compiled("switch.kitchen", "read") is False
+
+
+def test_entities_areas_area_true_without_device(hass: HomeAssistant) -> None:
+    """Test entity ID policy for areas with specific area."""
+    entity_registry = mock_registry(
+        hass,
+        {
+            "light.kitchen": RegistryEntry(
+                entity_id="light.kitchen",
+                unique_id="1234",
+                platform="test_platform",
                 area_id="mock-area-id",
             )
         },

--- a/tests/auth/permissions/test_entities.py
+++ b/tests/auth/permissions/test_entities.py
@@ -276,6 +276,17 @@ def test_entities_areas_area_true_with_different_device_area(
     assert compiled("light.kitchen", "edit") is False
     assert compiled("switch.kitchen", "read") is False
 
+    # Checking that the area of the device doesn't grant permissions if the entity has its own area
+    policy = {"area_ids": {"mock-area-id-2": {"read": True, "control": True}}}
+    ENTITY_POLICY_SCHEMA(policy)
+    compiled = compile_entities(
+        policy, PermissionLookup(entity_registry, device_registry)
+    )
+    assert compiled("light.kitchen", "read") is False
+    assert compiled("light.kitchen", "control") is False
+    assert compiled("light.kitchen", "edit") is False
+    assert compiled("switch.kitchen", "read") is False
+
 
 def test_entities_areas_area_true_without_device(hass: HomeAssistant) -> None:
     """Test entity ID policy for areas with specific area."""

--- a/tests/auth/permissions/test_entities.py
+++ b/tests/auth/permissions/test_entities.py
@@ -217,3 +217,30 @@ def test_entities_areas_area_true(hass: HomeAssistant) -> None:
     assert compiled("light.kitchen", "control") is True
     assert compiled("light.kitchen", "edit") is False
     assert compiled("switch.kitchen", "read") is False
+
+
+def test_entities_areas_area_true_without_device(hass: HomeAssistant) -> None:
+    """Test entity ID policy for areas with specific area."""
+    entity_registry = mock_registry(
+        hass,
+        {
+            "light.kitchen": RegistryEntry(
+                entity_id="light.kitchen",
+                unique_id="1234",
+                platform="test_platform",
+                device_id="mock-dev-id",
+                area_id="mock-area-id",
+            )
+        },
+    )
+    device_registry = mock_device_registry(hass)
+
+    policy = {"area_ids": {"mock-area-id": {"read": True, "control": True}}}
+    ENTITY_POLICY_SCHEMA(policy)
+    compiled = compile_entities(
+        policy, PermissionLookup(entity_registry, device_registry)
+    )
+    assert compiled("light.kitchen", "read") is True
+    assert compiled("light.kitchen", "control") is True
+    assert compiled("light.kitchen", "edit") is False
+    assert compiled("switch.kitchen", "read") is False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It fixes the auth policy for those entities that have an area set at the entity_id level, regardless of whether they have a device or not.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
