### PR TITLE
Ensure states table rebuild still happens if the event_id index was removed

### DIFF
--- a/tests/components/recorder/test_v32_migration.py
+++ b/tests/components/recorder/test_v32_migration.py
@@ -433,7 +433,6 @@ async def test_migrate_can_resume_ix_states_event_id_removed(
             await hass.async_stop()
             await hass.async_block_till_done()
 
-    assert "ix_states_event_id" not in states_index_names
     assert "ix_states_entity_id_last_updated_ts" in states_index_names
 
     async with (

--- a/tests/components/recorder/test_v32_migration.py
+++ b/tests/components/recorder/test_v32_migration.py
@@ -3,14 +3,14 @@
 from datetime import timedelta
 import importlib
 import sys
-from unittest.mock import patch
+from unittest.mock import DEFAULT, patch
 
 import pytest
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.orm import Session
 
 from homeassistant.components import recorder
-from homeassistant.components.recorder import core, statistics
+from homeassistant.components.recorder import core, migration, statistics
 from homeassistant.components.recorder.queries import select_event_type_ids
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.core import EVENT_STATE_CHANGED, Event, EventOrigin, State
@@ -104,21 +104,14 @@ async def test_migrate_times(
         patch.object(core, "States", old_db_schema.States),
         patch.object(core, "Events", old_db_schema.Events),
         patch(CREATE_ENGINE_TARGET, new=_create_engine_test),
-        patch(
-            "homeassistant.components.recorder.Recorder._migrate_events_context_ids",
-        ),
-        patch(
-            "homeassistant.components.recorder.Recorder._migrate_states_context_ids",
-        ),
-        patch(
-            "homeassistant.components.recorder.Recorder._migrate_event_type_ids",
-        ),
-        patch(
-            "homeassistant.components.recorder.Recorder._migrate_entity_ids",
-        ),
-        patch("homeassistant.components.recorder.Recorder._post_migrate_entity_ids"),
-        patch(
-            "homeassistant.components.recorder.Recorder._cleanup_legacy_states_event_ids"
+        patch.multiple(
+            "homeassistant.components.recorder.Recorder",
+            _migrate_events_context_ids=DEFAULT,
+            _migrate_states_context_ids=DEFAULT,
+            _migrate_event_type_ids=DEFAULT,
+            _migrate_entity_ids=DEFAULT,
+            _post_migrate_entity_ids=DEFAULT,
+            _cleanup_legacy_states_event_ids=DEFAULT,
         ),
     ):
         async with (
@@ -267,21 +260,14 @@ async def test_migrate_can_resume_entity_id_post_migration(
         patch.object(core, "States", old_db_schema.States),
         patch.object(core, "Events", old_db_schema.Events),
         patch(CREATE_ENGINE_TARGET, new=_create_engine_test),
-        patch(
-            "homeassistant.components.recorder.Recorder._migrate_events_context_ids",
-        ),
-        patch(
-            "homeassistant.components.recorder.Recorder._migrate_states_context_ids",
-        ),
-        patch(
-            "homeassistant.components.recorder.Recorder._migrate_event_type_ids",
-        ),
-        patch(
-            "homeassistant.components.recorder.Recorder._migrate_entity_ids",
-        ),
-        patch("homeassistant.components.recorder.Recorder._post_migrate_entity_ids"),
-        patch(
-            "homeassistant.components.recorder.Recorder._cleanup_legacy_states_event_ids"
+        patch.multiple(
+            "homeassistant.components.recorder.Recorder",
+            _migrate_events_context_ids=DEFAULT,
+            _migrate_states_context_ids=DEFAULT,
+            _migrate_event_type_ids=DEFAULT,
+            _migrate_entity_ids=DEFAULT,
+            _post_migrate_entity_ids=DEFAULT,
+            _cleanup_legacy_states_event_ids=DEFAULT,
         ),
     ):
         async with (
@@ -328,5 +314,144 @@ async def test_migrate_can_resume_entity_id_post_migration(
         states_indexes = await instance.async_add_executor_job(_get_states_index_names)
         states_index_names = {index["name"] for index in states_indexes}
         assert "ix_states_entity_id_last_updated_ts" not in states_index_names
+        assert "ix_states_event_id" not in states_index_names
+
+        await hass.async_stop()
+
+
+@pytest.mark.parametrize("persistent_database", [True])
+@pytest.mark.usefixtures("hass_storage")  # Prevent test hass from writing to storage
+async def test_migrate_can_resume_ix_states_event_id_removed(
+    async_test_recorder: RecorderInstanceGenerator,
+    caplog: pytest.LogCaptureFixture,
+    recorder_db_url: str,
+) -> None:
+    """Test we resume the entity id post migration after a restart.
+
+    This case tests the migration still happens if
+    ix_states_event_id is removed from the states table.
+    """
+    importlib.import_module(SCHEMA_MODULE)
+    old_db_schema = sys.modules[SCHEMA_MODULE]
+    now = dt_util.utcnow()
+    one_second_past = now - timedelta(seconds=1)
+    mock_state = State(
+        "sensor.test",
+        "old",
+        {"last_reset": now.isoformat()},
+        last_changed=one_second_past,
+        last_updated=now,
+    )
+    state_changed_event = Event(
+        EVENT_STATE_CHANGED,
+        {
+            "entity_id": "sensor.test",
+            "old_state": None,
+            "new_state": mock_state,
+        },
+        EventOrigin.local,
+        time_fired_timestamp=now.timestamp(),
+    )
+    custom_event = Event(
+        "custom_event",
+        {"entity_id": "sensor.custom"},
+        EventOrigin.local,
+        time_fired_timestamp=now.timestamp(),
+    )
+    number_of_migrations = 5
+
+    def _get_event_id_foreign_keys():
+        assert instance.engine is not None
+        return next(
+            (
+                fk  # type: ignore[misc]
+                for fk in inspect(instance.engine).get_foreign_keys("states")
+                if fk["constrained_columns"] == ["event_id"]
+            ),
+            None,
+        )
+
+    def _get_states_index_names():
+        with session_scope(hass=hass) as session:
+            return inspect(session.connection()).get_indexes("states")
+
+    with (
+        patch.object(recorder, "db_schema", old_db_schema),
+        patch.object(
+            recorder.migration, "SCHEMA_VERSION", old_db_schema.SCHEMA_VERSION
+        ),
+        patch.object(core, "StatesMeta", old_db_schema.StatesMeta),
+        patch.object(core, "EventTypes", old_db_schema.EventTypes),
+        patch.object(core, "EventData", old_db_schema.EventData),
+        patch.object(core, "States", old_db_schema.States),
+        patch.object(core, "Events", old_db_schema.Events),
+        patch(CREATE_ENGINE_TARGET, new=_create_engine_test),
+        patch.multiple(
+            "homeassistant.components.recorder.Recorder",
+            _migrate_events_context_ids=DEFAULT,
+            _migrate_states_context_ids=DEFAULT,
+            _migrate_event_type_ids=DEFAULT,
+            _migrate_entity_ids=DEFAULT,
+            _post_migrate_entity_ids=DEFAULT,
+            _cleanup_legacy_states_event_ids=DEFAULT,
+        ),
+    ):
+        async with (
+            async_test_home_assistant() as hass,
+            async_test_recorder(hass) as instance,
+        ):
+            await hass.async_block_till_done()
+            await async_wait_recording_done(hass)
+            await async_wait_recording_done(hass)
+
+            def _add_data():
+                with session_scope(hass=hass) as session:
+                    session.add(old_db_schema.Events.from_event(custom_event))
+                    session.add(old_db_schema.States.from_event(state_changed_event))
+
+            await instance.async_add_executor_job(_add_data)
+            await hass.async_block_till_done()
+            await instance.async_block_till_done()
+
+            await instance.async_add_executor_job(
+                migration._drop_index,
+                instance.get_session,
+                "states",
+                "ix_states_event_id",
+            )
+
+            states_indexes = await instance.async_add_executor_job(
+                _get_states_index_names
+            )
+            states_index_names = {index["name"] for index in states_indexes}
+            assert instance.use_legacy_events_index is True
+            assert (
+                await instance.async_add_executor_job(_get_event_id_foreign_keys)
+                is not None
+            )
+
+            await hass.async_stop()
+            await hass.async_block_till_done()
+
+    assert "ix_states_event_id" not in states_index_names
+    assert "ix_states_entity_id_last_updated_ts" in states_index_names
+
+    async with (
+        async_test_home_assistant() as hass,
+        async_test_recorder(hass) as instance,
+    ):
+        await hass.async_block_till_done()
+
+        # We need to wait for all the migration tasks to complete
+        # before we can check the database.
+        for _ in range(number_of_migrations):
+            await instance.async_block_till_done()
+            await async_wait_recording_done(hass)
+
+        states_indexes = await instance.async_add_executor_job(_get_states_index_names)
+        states_index_names = {index["name"] for index in states_indexes}
+        assert "ix_states_entity_id_last_updated_ts" not in states_index_names
+        assert "ix_states_event_id" not in states_index_names
+        assert await instance.async_add_executor_job(_get_event_id_foreign_keys) is None
 
         await hass.async_stop()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If `ix_states_event_id` index was removed but the foreign key still exists, the states table would not get rebuilt. This should not happen under normal circumstances but can if:

- The index was removed manually
- Home Assistant was restarted forcefully in the middle of a previous migration from years ago
- The system ran out of disk space during a previous migration

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #121909
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
