### PR TITLE
Platinum quality for Tessie

### DIFF
--- a/homeassistant/components/tessie/binary_sensor.py
+++ b/homeassistant/components/tessie/binary_sensor.py
@@ -20,6 +20,8 @@ from .const import TessieState
 from .entity import TessieEnergyEntity, TessieEntity
 from .models import TessieEnergyData, TessieVehicleData
 
+PARALLEL_UPDATES = 0
+
 
 @dataclass(frozen=True, kw_only=True)
 class TessieBinarySensorEntityDescription(BinarySensorEntityDescription):

--- a/homeassistant/components/tessie/button.py
+++ b/homeassistant/components/tessie/button.py
@@ -22,6 +22,8 @@ from . import TessieConfigEntry
 from .entity import TessieEntity
 from .models import TessieVehicleData
 
+PARALLEL_UPDATES = 0
+
 
 @dataclass(frozen=True, kw_only=True)
 class TessieButtonEntityDescription(ButtonEntityDescription):

--- a/homeassistant/components/tessie/climate.py
+++ b/homeassistant/components/tessie/climate.py
@@ -26,6 +26,8 @@ from .const import TessieClimateKeeper
 from .entity import TessieEntity
 from .models import TessieVehicleData
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/homeassistant/components/tessie/config_flow.py
+++ b/homeassistant/components/tessie/config_flow.py
@@ -38,6 +38,7 @@ class TessieConfigFlow(ConfigFlow, domain=DOMAIN):
         """Get configuration from the user."""
         errors: dict[str, str] = {}
         if user_input:
+            self._async_abort_entries_match(dict(user_input))
             try:
                 await get_state_of_all_vehicles(
                     session=async_get_clientsession(self.hass),

--- a/homeassistant/components/tessie/cover.py
+++ b/homeassistant/components/tessie/cover.py
@@ -29,6 +29,8 @@ from .const import TessieCoverStates
 from .entity import TessieEntity
 from .models import TessieVehicleData
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/homeassistant/components/tessie/device_tracker.py
+++ b/homeassistant/components/tessie/device_tracker.py
@@ -12,6 +12,8 @@ from . import TessieConfigEntry
 from .entity import TessieEntity
 from .models import TessieVehicleData
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/homeassistant/components/tessie/lock.py
+++ b/homeassistant/components/tessie/lock.py
@@ -26,6 +26,8 @@ from .const import DOMAIN, TessieChargeCableLockStates
 from .entity import TessieEntity
 from .models import TessieVehicleData
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/homeassistant/components/tessie/manifest.json
+++ b/homeassistant/components/tessie/manifest.json
@@ -6,5 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/tessie",
   "iot_class": "cloud_polling",
   "loggers": ["tessie"],
+  "quality_scale": "platinum",
   "requirements": ["tessie-api==0.1.1", "tesla-fleet-api==0.7.2"]
 }

--- a/homeassistant/components/tessie/media_player.py
+++ b/homeassistant/components/tessie/media_player.py
@@ -20,6 +20,8 @@ STATES = {
     "Stopped": MediaPlayerState.IDLE,
 }
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/homeassistant/components/tessie/number.py
+++ b/homeassistant/components/tessie/number.py
@@ -31,6 +31,8 @@ from .entity import TessieEnergyEntity, TessieEntity
 from .helpers import handle_command
 from .models import TessieEnergyData, TessieVehicleData
 
+PARALLEL_UPDATES = 0
+
 
 @dataclass(frozen=True, kw_only=True)
 class TessieNumberEntityDescription(NumberEntityDescription):

--- a/homeassistant/components/tessie/select.py
+++ b/homeassistant/components/tessie/select.py
@@ -32,6 +32,8 @@ SEAT_COOLERS = {
     "climate_state_seat_fan_front_right": "front_right",
 }
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/homeassistant/components/tessie/sensor.py
+++ b/homeassistant/components/tessie/sensor.py
@@ -367,6 +367,8 @@ ENERGY_INFO_DESCRIPTIONS: tuple[TessieSensorEntityDescription, ...] = (
     ),
 )
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/homeassistant/components/tessie/strings.json
+++ b/homeassistant/components/tessie/strings.json
@@ -1,5 +1,8 @@
 {
   "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
+    },
     "error": {
       "invalid_access_token": "[%key:common::config_flow::error::invalid_access_token%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",

--- a/homeassistant/components/tessie/switch.py
+++ b/homeassistant/components/tessie/switch.py
@@ -71,6 +71,8 @@ CHARGE_DESCRIPTION: TessieSwitchEntityDescription = TessieSwitchEntityDescriptio
     off_func=lambda: stop_charging,
 )
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/homeassistant/components/tessie/update.py
+++ b/homeassistant/components/tessie/update.py
@@ -15,6 +15,8 @@ from .const import TessieUpdateStatus
 from .entity import TessieEntity
 from .models import TessieVehicleData
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/tests/components/tessie/test_config_flow.py
+++ b/tests/components/tessie/test_config_flow.py
@@ -67,6 +67,33 @@ async def test_form(
     assert result2["data"] == TEST_CONFIG
 
 
+async def test_abort(
+    hass: HomeAssistant,
+    mock_config_flow_get_state_of_all_vehicles,
+    mock_async_setup_entry,
+) -> None:
+    """Test a duplicate entry aborts."""
+
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=TEST_CONFIG,
+    )
+    mock_entry.add_to_hass(hass)
+
+    result1 = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result1["flow_id"],
+        TEST_CONFIG,
+    )
+    await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.ABORT
+    assert result2["reason"] == "already_configured"
+
+
 @pytest.mark.parametrize(
     ("side_effect", "error"),
     [


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Platinum qualiy for Tessie.

The biggest departure documented below is the inability to set a unique ID on a config flow or abort duplicate entries. Unfortunately Tessie does not provide any sort of unique identifier for an account.

No score
- [x] Satisfy all requirements for [creating components](https://developers.home-assistant.io/docs/creating_component_code_review) and [creating platforms](https://developers.home-assistant.io/docs/creating_platform_code_review).
- [ ] Configurable via configuration.yaml

Silver 🥈
- [x] Satisfying all No score level requirements.
- [x] Connection/configuration is handled via a component.
- [x] Set an appropriate SCAN_INTERVAL (if a polling integration)
- [ ] Raise [PlatformNotReady](https://developers.home-assistant.io/docs/integration_setup_failures#integrations-using-async_setup_platform) if unable to connect during platform setup (if appropriate)
- [x] Handles expiration of auth credentials. Refresh if possible or print correct error and fail setup. If based on a config entry, should trigger a new config entry flow to re-authorize. ([docs](https://developers.home-assistant.io/docs/config_entries_config_flow_handler#reauthentication))
- [x] Handles internet unavailable. Log a warning once when unavailable, log once when reconnected.
- [x] Handles device/service unavailable. Log a warning once when unavailable, log once when reconnected.
- [x] Operations like service calls and entity methods (e.g. Set HVAC Mode) have proper exception handling. Raise ServiceValidationError on invalid user input and raise HomeAssistantError for other failures such as a problem communicating with a device. [Read more](https://developers.home-assistant.io/docs/core/platform/raising_exceptions) about raising exceptions.
- [x] Set available property to False if appropriate ([docs](https://developers.home-assistant.io/docs/core/entity#generic-properties))
- [x] Entities have unique ID (if available) ([docs](https://developers.home-assistant.io/docs/entity_registry_index#unique-id-requirements))

Gold 🥇

- [x] Satisfying all Silver level requirements.
- Configurable via config entries.
- [x] Don't allow configuring already configured device/service (example: no 2 entries for same hub) **N/A**
- [ ] Discoverable (if available)
- [x] Set unique ID in config flow (if available) **N/A**
- [x] Raise [ConfigEntryNotReady](https://developers.home-assistant.io/docs/integration_setup_failures#integrations-using-async_setup_entry) if unable to connect during entry setup (if appropriate)
- [x] Entities have device info (if available) ([docs](https://developers.home-assistant.io/docs/device_registry_index#defining-devices))
- Tests
- [x] Full test coverage for the config flow
- [x] Above average test coverage for all integration modules
- [x] Tests for fetching data from the integration and controlling it ([docs](https://developers.home-assistant.io/docs/development_testing))
- [x] Has a code owner ([docs](https://developers.home-assistant.io/docs/creating_integration_manifest#code-owners))
- [x] Entities only subscribe to updates inside async_added_to_hass and unsubscribe inside async_will_remove_from_hass ([docs](https://developers.home-assistant.io/docs/core/entity#lifecycle-hooks))
- [x] Entities have correct device classes where appropriate ([docs](https://developers.home-assistant.io/docs/core/entity#generic-properties))
- [x] Supports entities being disabled and leverages Entity.entity_registry_enabled_default to disable less popular entities ([docs](https://developers.home-assistant.io/docs/core/entity#advanced-properties))
- [ ] If the device/service API can remove entities, the integration should make sure to clean up the entity and device registry. **N/A**
- [x] When communicating with a device or service, the integration implements the diagnostics platform which redacts sensitive information.

Platinum 🏆

- [x] Satisfying all Gold level requirements.
- [x] Set appropriate PARALLEL_UPDATES constant ([docs](https://developers.home-assistant.io/docs/integration_fetching_data#request-parallelism))
- [x] Support config entry unloading (called when config entry is removed)
Integration + dependency are async ([docs](https://developers.home-assistant.io/docs/asyncio_working_with_async))
- [x] Uses aiohttp or httpx and allows passing in websession (if making HTTP requests)
[Handles expired credentials](https://developers.home-assistant.io/docs/integration_setup_failures#handling-expired-credentials) (if appropriate)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
