### PR TITLE
Update aioairzone to v0.8.0

### DIFF
--- a/homeassistant/components/airzone/manifest.json
+++ b/homeassistant/components/airzone/manifest.json
@@ -11,5 +11,5 @@
   "documentation": "https://www.home-assistant.io/integrations/airzone",
   "iot_class": "local_polling",
   "loggers": ["aioairzone"],
-  "requirements": ["aioairzone==0.7.7"]
+  "requirements": ["aioairzone==0.8.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -179,7 +179,7 @@ aioairq==0.3.2
 aioairzone-cloud==0.5.4
 
 # homeassistant.components.airzone
-aioairzone==0.7.7
+aioairzone==0.8.0
 
 # homeassistant.components.ambient_network
 # homeassistant.components.ambient_station

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -164,7 +164,7 @@ aioairq==0.3.2
 aioairzone-cloud==0.5.4
 
 # homeassistant.components.airzone
-aioairzone==0.7.7
+aioairzone==0.8.0
 
 # homeassistant.components.ambient_network
 # homeassistant.components.ambient_station

--- a/tests/components/airzone/snapshots/test_diagnostics.ambr
+++ b/tests/components/airzone/snapshots/test_diagnostics.ambr
@@ -267,10 +267,6 @@
         'temp-set': 45,
         'temp-unit': 0,
       }),
-      'new-systems': list([
-      ]),
-      'new-zones': list([
-      ]),
       'num-systems': 3,
       'num-zones': 7,
       'systems': dict({


### PR DESCRIPTION
## Proposed change
Update aioairzone to [v0.8.0](https://github.com/Noltari/aioairzone/compare/0.7.7...0.8.0).

Releases:
- https://github.com/Noltari/aioairzone/releases/tag/0.8.0

Git compare: https://github.com/Noltari/aioairzone/compare/0.7.7...0.8.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
