### PR TITLE
Add support for Shelly `enum` virtual component

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -62,6 +62,7 @@ PLATFORMS: Final = [
     Platform.EVENT,
     Platform.LIGHT,
     Platform.NUMBER,
+    Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.TEXT,

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -244,7 +244,8 @@ SHELLY_PLUS_RGBW_CHANNELS = 4
 VIRTUAL_COMPONENTS_MAP = {
     "binary_sensor": {"types": ["boolean"], "modes": ["label"]},
     "number": {"types": ["number"], "modes": ["field", "slider"]},
-    "sensor": {"types": ["number", "text"], "modes": ["label"]},
+    "select": {"types": ["enum"], "modes": ["dropdown"]},
+    "sensor": {"types": ["enum", "number", "text"], "modes": ["label"]},
     "switch": {"types": ["boolean"], "modes": ["toggle"]},
     "text": {"types": ["text"], "modes": ["field"]},
 }

--- a/homeassistant/components/shelly/entity.py
+++ b/homeassistant/components/shelly/entity.py
@@ -292,6 +292,7 @@ class RpcEntityDescription(EntityDescription):
     use_polling_coordinator: bool = False
     supported: Callable = lambda _: False
     unit: Callable[[dict], str | None] | None = None
+    options_fn: Callable[[dict], list[str]] | None = None
 
 
 @dataclass(frozen=True)

--- a/homeassistant/components/shelly/entity.py
+++ b/homeassistant/components/shelly/entity.py
@@ -515,6 +515,19 @@ class ShellyRpcAttributeEntity(ShellyRpcEntity, Entity):
                 coordinator.device.config[key]
             )
 
+        self.option_map: dict[str, str] = {}
+        self.reversed_option_map: dict[str, str] = {}
+        if "enum" in key:
+            titles = self.coordinator.device.config[key]["meta"]["ui"]["titles"]
+            options = self.coordinator.device.config[key]["options"]
+            self.option_map = {
+                opt: (titles[opt] if titles.get(opt) is not None else opt)
+                for opt in options
+            }
+            self.reversed_option_map = {
+                tit: opt for opt, tit in self.option_map.items()
+            }
+
     @property
     def sub_status(self) -> Any:
         """Device status by entity key."""

--- a/homeassistant/components/shelly/select.py
+++ b/homeassistant/components/shelly/select.py
@@ -1,0 +1,103 @@
+"""Select for Shelly."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Final
+
+from aioshelly.const import RPC_GENERATIONS
+
+from homeassistant.components.select import (
+    DOMAIN as SELECT_PLATFORM,
+    SelectEntity,
+    SelectEntityDescription,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .coordinator import ShellyConfigEntry, ShellyRpcCoordinator
+from .entity import (
+    RpcEntityDescription,
+    ShellyRpcAttributeEntity,
+    async_setup_entry_rpc,
+)
+from .utils import (
+    async_remove_orphaned_virtual_entities,
+    get_device_entry_gen,
+    get_virtual_component_ids,
+)
+
+
+@dataclass(frozen=True, kw_only=True)
+class RpcSelectDescription(RpcEntityDescription, SelectEntityDescription):
+    """Class to describe a RPC select entity."""
+
+
+RPC_SELECT_ENTITIES: Final = {
+    "enum": RpcSelectDescription(
+        key="enum",
+        sub_key="value",
+        has_entity_name=True,
+        options_fn=lambda config: config["options"],
+    ),
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ShellyConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up selectors for device."""
+    if get_device_entry_gen(config_entry) in RPC_GENERATIONS:
+        coordinator = config_entry.runtime_data.rpc
+        assert coordinator
+
+        async_setup_entry_rpc(
+            hass, config_entry, async_add_entities, RPC_SELECT_ENTITIES, RpcSelect
+        )
+
+        # the user can remove virtual components from the device configuration, so
+        # we need to remove orphaned entities
+        virtual_text_ids = get_virtual_component_ids(
+            coordinator.device.config, SELECT_PLATFORM
+        )
+        async_remove_orphaned_virtual_entities(
+            hass,
+            config_entry.entry_id,
+            coordinator.mac,
+            SELECT_PLATFORM,
+            "enum",
+            virtual_text_ids,
+        )
+
+
+class RpcSelect(ShellyRpcAttributeEntity, SelectEntity):
+    """Represent a RPC select entity."""
+
+    entity_description: RpcSelectDescription
+
+    def __init__(
+        self,
+        coordinator: ShellyRpcCoordinator,
+        key: str,
+        attribute: str,
+        description: RpcSelectDescription,
+    ) -> None:
+        """Initialize select."""
+        super().__init__(coordinator, key, attribute, description)
+
+        if callable(description.options_fn):
+            self._attr_options = description.options_fn(coordinator.device.config[key])
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the selected entity option to represent the entity state."""
+        if TYPE_CHECKING:
+            assert isinstance(self.attribute_value, str | None)
+
+        return self.attribute_value
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the value."""
+        await self.call_rpc("Enum.Set", {"id": self._id, "value": option})

--- a/homeassistant/components/shelly/select.py
+++ b/homeassistant/components/shelly/select.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Final, cast
+from typing import Final
 
 from aioshelly.const import RPC_GENERATIONS
 
@@ -86,19 +86,15 @@ class RpcSelect(ShellyRpcAttributeEntity, SelectEntity):
         """Initialize select."""
         super().__init__(coordinator, key, attribute, description)
 
-        titles = self.coordinator.device.config[key]["meta"]["ui"]["titles"]
-        opts = self.coordinator.device.config[key]["options"]
-        self.option_map = {
-            opt: (titles[opt] if titles.get(opt) is not None else opt) for opt in opts
-        }
-        self.reversed_option_map = {tit: opt for opt, tit in self.option_map.items()}
-
         self._attr_options = list(self.option_map.values())
 
     @property
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
-        return cast(str | None, self.option_map.get(self.attribute_value))
+        if not isinstance(self.attribute_value, str):
+            return None
+
+        return self.option_map[self.attribute_value]
 
     async def async_select_option(self, option: str) -> None:
         """Change the value."""

--- a/homeassistant/components/shelly/select.py
+++ b/homeassistant/components/shelly/select.py
@@ -87,21 +87,21 @@ class RpcSelect(ShellyRpcAttributeEntity, SelectEntity):
         super().__init__(coordinator, key, attribute, description)
 
         titles = self.coordinator.device.config[key]["meta"]["ui"]["titles"]
-        options = self.coordinator.device.config[key]["options"]
-        self._option_map = {
-            key: (titles[key] if titles[key] is not None else key) for key in options
+        opts = self.coordinator.device.config[key]["options"]
+        self.option_map = {
+            opt: (titles[opt] if titles.get(opt) is not None else opt) for opt in opts
         }
-        self._rev_option_map = {title: key for key, title in self._option_map.items()}
+        self.reversed_option_map = {tit: opt for opt, tit in self.option_map.items()}
 
-        self._attr_options = list(self._option_map.values())
+        self._attr_options = list(self.option_map.values())
 
     @property
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
-        return cast(str, self._option_map[self.attribute_value])
+        return cast(str | None, self.option_map.get(self.attribute_value))
 
     async def async_select_option(self, option: str) -> None:
         """Change the value."""
         await self.call_rpc(
-            "Enum.Set", {"id": self._id, "value": self._rev_option_map[option]}
+            "Enum.Set", {"id": self._id, "value": self.reversed_option_map[option]}
         )

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -1148,16 +1148,22 @@ class RpcSensor(ShellyRpcAttributeEntity, SensorEntity):
         attribute: str,
         description: RpcSensorDescription,
     ) -> None:
-        """Initialize sensor."""
+        """Initialize select."""
         super().__init__(coordinator, key, attribute, description)
 
-        if callable(description.options_fn):
-            self._attr_options = description.options_fn(coordinator.device.config[key])
+        if self.option_map:
+            self._attr_options = list(self.option_map.values())
 
     @property
     def native_value(self) -> StateType:
         """Return value of sensor."""
-        return self.attribute_value
+        if not self.option_map:
+            return self.attribute_value
+
+        if not isinstance(self.attribute_value, str):
+            return None
+
+        return self.option_map[self.attribute_value]
 
 
 class BlockSleepingSensor(ShellySleepingBlockAttributeEntity, RestoreSensor):

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -1032,6 +1032,13 @@ RPC_SENSORS: Final = {
         if config["meta"]["ui"]["unit"]
         else None,
     ),
+    "enum": RpcSensorDescription(
+        key="enum",
+        sub_key="value",
+        has_entity_name=True,
+        options_fn=lambda config: config["options"],
+        device_class=SensorDeviceClass.ENUM,
+    ),
 }
 
 
@@ -1060,7 +1067,7 @@ async def async_setup_entry(
 
             # the user can remove virtual components from the device configuration, so
             # we need to remove orphaned entities
-            for component in ("text", "number"):
+            for component in ("enum", "number", "text"):
                 virtual_component_ids = get_virtual_component_ids(
                     coordinator.device.config, SENSOR_PLATFORM
                 )
@@ -1133,6 +1140,19 @@ class RpcSensor(ShellyRpcAttributeEntity, SensorEntity):
     """Represent a RPC sensor."""
 
     entity_description: RpcSensorDescription
+
+    def __init__(
+        self,
+        coordinator: ShellyRpcCoordinator,
+        key: str,
+        attribute: str,
+        description: RpcSensorDescription,
+    ) -> None:
+        """Initialize sensor."""
+        super().__init__(coordinator, key, attribute, description)
+
+        if callable(description.options_fn):
+            self._attr_options = description.options_fn(coordinator.device.config[key])
 
     @property
     def native_value(self) -> StateType:

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -323,7 +323,7 @@ def get_rpc_channel_name(device: RpcDevice, key: str) -> str:
             return f"{device_name} {key.replace(':', '_')}"
         if key.startswith("em1"):
             return f"{device_name} EM{key.split(':')[-1]}"
-        if key.startswith(("boolean:", "number:", "text:")):
+        if key.startswith(("boolean:", "enum", "number:", "text:")):
             return key.replace(":", " ").title()
         return device_name
 

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -323,7 +323,7 @@ def get_rpc_channel_name(device: RpcDevice, key: str) -> str:
             return f"{device_name} {key.replace(':', '_')}"
         if key.startswith("em1"):
             return f"{device_name} EM{key.split(':')[-1]}"
-        if key.startswith(("boolean:", "enum", "number:", "text:")):
+        if key.startswith(("boolean:", "enum:", "number:", "text:")):
             return key.replace(":", " ").title()
         return device_name
 

--- a/tests/components/shelly/test_select.py
+++ b/tests/components/shelly/test_select.py
@@ -11,7 +11,7 @@ from homeassistant.components.select import (
     DOMAIN as SELECT_PLATFORM,
     SERVICE_SELECT_OPTION,
 )
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceRegistry
 from homeassistant.helpers.entity_registry import EntityRegistry
@@ -20,10 +20,10 @@ from . import init_integration, register_device, register_entity
 
 
 @pytest.mark.parametrize(
-    ("name", "entity_id"),
+    ("name", "entity_id", "value", "expected_state"),
     [
-        ("Virtual enum", "select.test_name_virtual_enum"),
-        (None, "select.test_name_enum_203"),
+        ("Virtual enum", "select.test_name_virtual_enum", "lorem ipsum", "lorem ipsum"),
+        (None, "select.test_name_enum_203", None, STATE_UNKNOWN),
     ],
 )
 async def test_rpc_device_virtual_enum(
@@ -33,6 +33,8 @@ async def test_rpc_device_virtual_enum(
     monkeypatch: pytest.MonkeyPatch,
     name: str | None,
     entity_id: str,
+    value: str | None,
+    expected_state: str,
 ) -> None:
     """Test a virtual enum for RPC device."""
     config = deepcopy(mock_rpc_device.config)
@@ -44,14 +46,14 @@ async def test_rpc_device_virtual_enum(
     monkeypatch.setattr(mock_rpc_device, "config", config)
 
     status = deepcopy(mock_rpc_device.status)
-    status["enum:203"] = {"value": "lorem ipsum"}
+    status["enum:203"] = {"value": value}
     monkeypatch.setattr(mock_rpc_device, "status", status)
 
     await init_integration(hass, 3)
 
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == "lorem ipsum"
+    assert state.state == expected_state
     assert state.attributes.get(ATTR_OPTIONS) == [
         "lorem ipsum",
         "dolor sit amet",

--- a/tests/components/shelly/test_select.py
+++ b/tests/components/shelly/test_select.py
@@ -1,0 +1,140 @@
+"""Tests for Shelly select platform."""
+
+from copy import deepcopy
+from unittest.mock import Mock
+
+import pytest
+
+from homeassistant.components.select import (
+    ATTR_OPTION,
+    ATTR_OPTIONS,
+    DOMAIN as SELECT_PLATFORM,
+    SERVICE_SELECT_OPTION,
+)
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceRegistry
+from homeassistant.helpers.entity_registry import EntityRegistry
+
+from . import init_integration, register_device, register_entity
+
+
+@pytest.mark.parametrize(
+    ("name", "entity_id"),
+    [
+        ("Virtual enum", "select.test_name_virtual_enum"),
+        (None, "select.test_name_enum_203"),
+    ],
+)
+async def test_rpc_device_virtual_enum(
+    hass: HomeAssistant,
+    entity_registry: EntityRegistry,
+    mock_rpc_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+    name: str | None,
+    entity_id: str,
+) -> None:
+    """Test a virtual enum for RPC device."""
+    config = deepcopy(mock_rpc_device.config)
+    config["enum:203"] = {
+        "name": name,
+        "options": ["lorem ipsum", "dolor sit amet", "sed do eiusmod"],
+        "meta": {"ui": {"view": "dropdown"}},
+    }
+    monkeypatch.setattr(mock_rpc_device, "config", config)
+
+    status = deepcopy(mock_rpc_device.status)
+    status["enum:203"] = {"value": "lorem ipsum"}
+    monkeypatch.setattr(mock_rpc_device, "status", status)
+
+    await init_integration(hass, 3)
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "lorem ipsum"
+    assert state.attributes.get(ATTR_OPTIONS) == [
+        "lorem ipsum",
+        "dolor sit amet",
+        "sed do eiusmod",
+    ]
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-enum:203-enum"
+
+    monkeypatch.setitem(mock_rpc_device.status["enum:203"], "value", "dolor sit amet")
+    mock_rpc_device.mock_update()
+    assert hass.states.get(entity_id).state == "dolor sit amet"
+
+    monkeypatch.setitem(mock_rpc_device.status["enum:203"], "value", "sed do eiusmod")
+    await hass.services.async_call(
+        SELECT_PLATFORM,
+        SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: entity_id, ATTR_OPTION: "sed do eiusmod"},
+        blocking=True,
+    )
+    mock_rpc_device.mock_update()
+    assert hass.states.get(entity_id).state == "sed do eiusmod"
+
+
+async def test_rpc_remove_virtual_enum_when_mode_label(
+    hass: HomeAssistant,
+    entity_registry: EntityRegistry,
+    device_registry: DeviceRegistry,
+    mock_rpc_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test if the virtual enum will be removed if the mode has been changed to a label."""
+    config = deepcopy(mock_rpc_device.config)
+    config["enum:200"] = {
+        "name": None,
+        "options": ["one", "two"],
+        "meta": {"ui": {"view": "label"}},
+    }
+    monkeypatch.setattr(mock_rpc_device, "config", config)
+
+    status = deepcopy(mock_rpc_device.status)
+    status["enum:200"] = {"value": "one"}
+    monkeypatch.setattr(mock_rpc_device, "status", status)
+
+    config_entry = await init_integration(hass, 3, skip_setup=True)
+    device_entry = register_device(device_registry, config_entry)
+    entity_id = register_entity(
+        hass,
+        SELECT_PLATFORM,
+        "test_name_enum_200",
+        "enum:200-enum",
+        config_entry,
+        device_id=device_entry.id,
+    )
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entry = entity_registry.async_get(entity_id)
+    assert not entry
+
+
+async def test_rpc_remove_virtual_enum_when_orphaned(
+    hass: HomeAssistant,
+    entity_registry: EntityRegistry,
+    device_registry: DeviceRegistry,
+    mock_rpc_device: Mock,
+) -> None:
+    """Check whether the virtual enum will be removed if it has been removed from the device configuration."""
+    config_entry = await init_integration(hass, 3, skip_setup=True)
+    device_entry = register_device(device_registry, config_entry)
+    entity_id = register_entity(
+        hass,
+        SELECT_PLATFORM,
+        "test_name_enum_200",
+        "enum:200-enum",
+        config_entry,
+        device_id=device_entry.id,
+    )
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entry = entity_registry.async_get(entity_id)
+    assert not entry

--- a/tests/components/shelly/test_sensor.py
+++ b/tests/components/shelly/test_sensor.py
@@ -1072,7 +1072,12 @@ async def test_rpc_remove_number_virtual_sensor_when_orphaned(
 @pytest.mark.parametrize(
     ("name", "entity_id", "value", "expected_state"),
     [
-        ("Virtual enum sensor", "sensor.test_name_virtual_enum_sensor", "one", "one"),
+        (
+            "Virtual enum sensor",
+            "sensor.test_name_virtual_enum_sensor",
+            "one",
+            "Title 1",
+        ),
         (None, "sensor.test_name_enum_203", None, STATE_UNKNOWN),
     ],
 )
@@ -1091,7 +1096,7 @@ async def test_rpc_device_virtual_enum_sensor(
     config["enum:203"] = {
         "name": name,
         "options": ["one", "two", "three"],
-        "meta": {"ui": {"view": "label"}},
+        "meta": {"ui": {"view": "label", "titles": {"one": "Title 1", "two": None}}},
     }
     monkeypatch.setattr(mock_rpc_device, "config", config)
 
@@ -1105,7 +1110,7 @@ async def test_rpc_device_virtual_enum_sensor(
     assert state
     assert state.state == expected_state
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENUM
-    assert state.attributes.get(ATTR_OPTIONS) == ["one", "two", "three"]
+    assert state.attributes.get(ATTR_OPTIONS) == ["Title 1", "two", "three"]
 
     entry = entity_registry.async_get(entity_id)
     assert entry
@@ -1128,7 +1133,12 @@ async def test_rpc_remove_enum_virtual_sensor_when_mode_dropdown(
     config["enum:200"] = {
         "name": None,
         "options": ["option 1", "option 2", "option 3"],
-        "meta": {"ui": {"view": "dropdown"}},
+        "meta": {
+            "ui": {
+                "view": "dropdown",
+                "titles": {"option 1": "Title 1", "option 2": None},
+            }
+        },
     }
     monkeypatch.setattr(mock_rpc_device, "config", config)
 

--- a/tests/components/shelly/test_sensor.py
+++ b/tests/components/shelly/test_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.components.homeassistant import (
     SERVICE_UPDATE_ENTITY,
 )
 from homeassistant.components.sensor import (
+    ATTR_OPTIONS,
     ATTR_STATE_CLASS,
     DOMAIN as SENSOR_DOMAIN,
     SensorDeviceClass,
@@ -1057,6 +1058,116 @@ async def test_rpc_remove_number_virtual_sensor_when_orphaned(
         SENSOR_DOMAIN,
         "test_name_number_200",
         "number:200-number",
+        config_entry,
+        device_id=device_entry.id,
+    )
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entry = entity_registry.async_get(entity_id)
+    assert not entry
+
+
+@pytest.mark.parametrize(
+    ("name", "entity_id", "value", "expected_state"),
+    [
+        ("Virtual enum sensor", "sensor.test_name_virtual_enum_sensor", "one", "one"),
+        (None, "sensor.test_name_enum_203", None, STATE_UNKNOWN),
+    ],
+)
+async def test_rpc_device_virtual_enum_sensor(
+    hass: HomeAssistant,
+    entity_registry: EntityRegistry,
+    mock_rpc_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+    name: str | None,
+    entity_id: str,
+    value: str | None,
+    expected_state: str,
+) -> None:
+    """Test a virtual enum sensor for RPC device."""
+    config = deepcopy(mock_rpc_device.config)
+    config["enum:203"] = {
+        "name": name,
+        "options": ["one", "two", "three"],
+        "meta": {"ui": {"view": "label"}},
+    }
+    monkeypatch.setattr(mock_rpc_device, "config", config)
+
+    status = deepcopy(mock_rpc_device.status)
+    status["enum:203"] = {"value": value}
+    monkeypatch.setattr(mock_rpc_device, "status", status)
+
+    await init_integration(hass, 3)
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == expected_state
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENUM
+    assert state.attributes.get(ATTR_OPTIONS) == ["one", "two", "three"]
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-enum:203-enum"
+
+    monkeypatch.setitem(mock_rpc_device.status["enum:203"], "value", "two")
+    mock_rpc_device.mock_update()
+    assert hass.states.get(entity_id).state == "two"
+
+
+async def test_rpc_remove_enum_virtual_sensor_when_mode_dropdown(
+    hass: HomeAssistant,
+    entity_registry: EntityRegistry,
+    device_registry: DeviceRegistry,
+    mock_rpc_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test if the virtual enum sensor will be removed if the mode has been changed to a dropdown."""
+    config = deepcopy(mock_rpc_device.config)
+    config["enum:200"] = {
+        "name": None,
+        "options": ["option 1", "option 2", "option 3"],
+        "meta": {"ui": {"view": "dropdown"}},
+    }
+    monkeypatch.setattr(mock_rpc_device, "config", config)
+
+    status = deepcopy(mock_rpc_device.status)
+    status["enum:200"] = {"value": "option 2"}
+    monkeypatch.setattr(mock_rpc_device, "status", status)
+
+    config_entry = await init_integration(hass, 3, skip_setup=True)
+    device_entry = register_device(device_registry, config_entry)
+    entity_id = register_entity(
+        hass,
+        SENSOR_DOMAIN,
+        "test_name_enum_200",
+        "enum:200-enum",
+        config_entry,
+        device_id=device_entry.id,
+    )
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entry = entity_registry.async_get(entity_id)
+    assert not entry
+
+
+async def test_rpc_remove_enum_virtual_sensor_when_orphaned(
+    hass: HomeAssistant,
+    entity_registry: EntityRegistry,
+    device_registry: DeviceRegistry,
+    mock_rpc_device: Mock,
+) -> None:
+    """Check whether the virtual enum sensor will be removed if it has been removed from the device configuration."""
+    config_entry = await init_integration(hass, 3, skip_setup=True)
+    device_entry = register_device(device_registry, config_entry)
+    entity_id = register_entity(
+        hass,
+        SENSOR_DOMAIN,
+        "test_name_enum_200",
+        "enum:200-enum",
         config_entry,
         device_id=device_entry.id,
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Continuation of https://github.com/home-assistant/core/pull/119932

This PR adds support for `enum` component. Such a component is mapped to:

- `select` platform if the component uses `dropdown` mode
- `sensor` platform if the component uses `label` mode

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33765

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
