### PR TITLE
Bump govee-ble to 0.33.0

### DIFF
--- a/homeassistant/components/govee_ble/manifest.json
+++ b/homeassistant/components/govee_ble/manifest.json
@@ -114,5 +114,5 @@
   "dependencies": ["bluetooth_adapters"],
   "documentation": "https://www.home-assistant.io/integrations/govee_ble",
   "iot_class": "local_push",
-  "requirements": ["govee-ble==0.32.0"]
+  "requirements": ["govee-ble==0.33.0"]
 }

--- a/homeassistant/components/govee_ble/manifest.json
+++ b/homeassistant/components/govee_ble/manifest.json
@@ -15,6 +15,26 @@
       "connectable": false
     },
     {
+      "local_name": "GV5121*",
+      "connectable": false
+    },
+    {
+      "local_name": "GV5122*",
+      "connectable": false
+    },
+    {
+      "local_name": "GV5123*",
+      "connectable": false
+    },
+    {
+      "local_name": "GV5125*",
+      "connectable": false
+    },
+    {
+      "local_name": "GV5126*",
+      "connectable": false
+    },
+    {
       "manufacturer_id": 1,
       "service_uuid": "0000ec88-0000-1000-8000-00805f9b34fb",
       "connectable": false
@@ -83,6 +103,10 @@
       "manufacturer_id": 19506,
       "service_uuid": "00001801-0000-1000-8000-00805f9b34fb",
       "connectable": false
+    },
+    {
+      "manufacturer_id": 61320,
+      "connectable": false
     }
   ],
   "codeowners": ["@bdraco", "@PierreAronnax"],
@@ -90,5 +114,5 @@
   "dependencies": ["bluetooth_adapters"],
   "documentation": "https://www.home-assistant.io/integrations/govee_ble",
   "iot_class": "local_push",
-  "requirements": ["govee-ble==0.31.3"]
+  "requirements": ["govee-ble==0.32.0"]
 }

--- a/homeassistant/generated/bluetooth.py
+++ b/homeassistant/generated/bluetooth.py
@@ -140,6 +140,31 @@ BLUETOOTH: Final[list[dict[str, bool | str | int | list[int]]]] = [
     {
         "connectable": False,
         "domain": "govee_ble",
+        "local_name": "GV5121*",
+    },
+    {
+        "connectable": False,
+        "domain": "govee_ble",
+        "local_name": "GV5122*",
+    },
+    {
+        "connectable": False,
+        "domain": "govee_ble",
+        "local_name": "GV5123*",
+    },
+    {
+        "connectable": False,
+        "domain": "govee_ble",
+        "local_name": "GV5125*",
+    },
+    {
+        "connectable": False,
+        "domain": "govee_ble",
+        "local_name": "GV5126*",
+    },
+    {
+        "connectable": False,
+        "domain": "govee_ble",
         "manufacturer_id": 1,
         "service_uuid": "0000ec88-0000-1000-8000-00805f9b34fb",
     },
@@ -220,6 +245,11 @@ BLUETOOTH: Final[list[dict[str, bool | str | int | list[int]]]] = [
         "domain": "govee_ble",
         "manufacturer_id": 19506,
         "service_uuid": "00001801-0000-1000-8000-00805f9b34fb",
+    },
+    {
+        "connectable": False,
+        "domain": "govee_ble",
+        "manufacturer_id": 61320,
     },
     {
         "domain": "homekit_controller",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -989,7 +989,7 @@ goslide-api==0.5.1
 gotailwind==0.2.3
 
 # homeassistant.components.govee_ble
-govee-ble==0.32.0
+govee-ble==0.33.0
 
 # homeassistant.components.govee_light_local
 govee-local-api==1.5.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -989,7 +989,7 @@ goslide-api==0.5.1
 gotailwind==0.2.3
 
 # homeassistant.components.govee_ble
-govee-ble==0.31.3
+govee-ble==0.32.0
 
 # homeassistant.components.govee_light_local
 govee-local-api==1.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -827,7 +827,7 @@ googlemaps==2.5.1
 gotailwind==0.2.3
 
 # homeassistant.components.govee_ble
-govee-ble==0.32.0
+govee-ble==0.33.0
 
 # homeassistant.components.govee_light_local
 govee-local-api==1.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -827,7 +827,7 @@ googlemaps==2.5.1
 gotailwind==0.2.3
 
 # homeassistant.components.govee_ble
-govee-ble==0.31.3
+govee-ble==0.32.0
 
 # homeassistant.components.govee_light_local
 govee-local-api==1.5.1


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
changelog: https://github.com/Bluetooth-Devices/govee-ble/compare/v0.31.3...v0.33.0

Adds support for the H5121/H5122/H5123/H5125/H5126

Only the battery sensor is supported at this point for these models as an `event` and `binary_sensor` platform needs to be added to be able to support the additional types.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33767

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
