### PR TITLE
Add created_at/modified_at for area registry

### DIFF
--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Iterable
 import dataclasses
+from datetime import datetime
 from functools import cached_property
 from typing import Any, Literal, TypedDict
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.util import slugify
+from homeassistant.util.dt import utc_from_timestamp, utcnow
 from homeassistant.util.event_type import EventType
 from homeassistant.util.hass_dict import HassKey
 
@@ -31,7 +33,7 @@ EVENT_AREA_REGISTRY_UPDATED: EventType[EventAreaRegistryUpdatedData] = EventType
 )
 STORAGE_KEY = "core.area_registry"
 STORAGE_VERSION_MAJOR = 1
-STORAGE_VERSION_MINOR = 6
+STORAGE_VERSION_MINOR = 7
 
 
 class _AreaStoreData(TypedDict):
@@ -44,6 +46,8 @@ class _AreaStoreData(TypedDict):
     labels: list[str]
     name: str
     picture: str | None
+    created_at: datetime
+    modified_at: datetime
 
 
 class AreasRegistryStoreData(TypedDict):
@@ -83,6 +87,8 @@ class AreaEntry(NormalizedNameBaseRegistryEntry):
                     "labels": list(self.labels),
                     "name": self.name,
                     "picture": self.picture,
+                    "created_at": self.created_at,
+                    "modified_at": self.modified_at,
                 }
             )
         )
@@ -124,6 +130,11 @@ class AreaRegistryStore(Store[AreasRegistryStoreData]):
                 # Version 1.6 adds labels
                 for area in old_data["areas"]:
                     area["labels"] = []
+
+            if old_minor_version < 7:
+                # Version 1.7 adds created_at and modiefied_at
+                for area in old_data["areas"]:
+                    area["created_at"] = area["modified_at"] = utc_from_timestamp(0)
 
         if old_major_version > 1:
             raise NotImplementedError
@@ -315,7 +326,7 @@ class AreaRegistry(BaseRegistry[AreasRegistryStoreData]):
         """Update name of area."""
         old = self.areas[area_id]
 
-        new_values = {
+        new_values: dict[str, Any] = {
             attr_name: value
             for attr_name, value in (
                 ("aliases", aliases),
@@ -334,8 +345,10 @@ class AreaRegistry(BaseRegistry[AreasRegistryStoreData]):
         if not new_values:
             return old
 
+        new_values["modified_at"] = utcnow()
+
         self.hass.verify_event_loop_thread("area_registry.async_update")
-        new = self.areas[area_id] = dataclasses.replace(old, **new_values)  # type: ignore[arg-type]
+        new = self.areas[area_id] = dataclasses.replace(old, **new_values)
 
         self.async_schedule_save()
         return new
@@ -361,6 +374,8 @@ class AreaRegistry(BaseRegistry[AreasRegistryStoreData]):
                     name=area["name"],
                     normalized_name=normalized_name,
                     picture=area["picture"],
+                    created_at=area["created_at"],
+                    modified_at=area["modified_at"],
                 )
 
         self.areas = areas
@@ -379,6 +394,8 @@ class AreaRegistry(BaseRegistry[AreasRegistryStoreData]):
                     "labels": list(entry.labels),
                     "name": entry.name,
                     "picture": entry.picture,
+                    "created_at": entry.created_at,
+                    "modified_at": entry.modified_at,
                 }
                 for entry in self.areas.values()
             ]

--- a/homeassistant/helpers/normalized_name_base_registry.py
+++ b/homeassistant/helpers/normalized_name_base_registry.py
@@ -1,7 +1,10 @@
 """Provide a base class for registries that use a normalized name index."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from datetime import datetime
 from functools import lru_cache
+
+from homeassistant.util import dt as dt_util
 
 from .registry import BaseRegistryItems
 
@@ -12,6 +15,8 @@ class NormalizedNameBaseRegistryEntry:
 
     name: str
     normalized_name: str
+    created_at: datetime = field(default_factory=dt_util.utcnow)
+    modified_at: datetime = field(default_factory=dt_util.utcnow)
 
 
 @lru_cache(maxsize=1024)

--- a/tests/components/config/test_area_registry.py
+++ b/tests/components/config/test_area_registry.py
@@ -1,11 +1,13 @@
 """Test area_registry API."""
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 from pytest_unordered import unordered
 
 from homeassistant.components.config import area_registry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import area_registry as ar
+from homeassistant.util.dt import utcnow
 
 from tests.common import ANY
 from tests.typing import MockHAClientWebSocket, WebSocketGenerator
@@ -21,10 +23,17 @@ async def client_fixture(
 
 
 async def test_list_areas(
-    client: MockHAClientWebSocket, area_registry: ar.AreaRegistry
+    client: MockHAClientWebSocket,
+    area_registry: ar.AreaRegistry,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test list entries."""
+    created_area1 = "2024-07-16T13:30:00.900075+00:00"
+    freezer.move_to(created_area1)
     area1 = area_registry.async_create("mock 1")
+
+    created_area2 = "2024-07-16T13:45:00.900075+00:00"
+    freezer.move_to(created_area2)
     area2 = area_registry.async_create(
         "mock 2",
         aliases={"alias_1", "alias_2"},
@@ -46,6 +55,8 @@ async def test_list_areas(
             "labels": [],
             "name": "mock 1",
             "picture": None,
+            "created_at": created_area1,
+            "modified_at": created_area1,
         },
         {
             "aliases": unordered(["alias_1", "alias_2"]),
@@ -55,12 +66,16 @@ async def test_list_areas(
             "labels": unordered(["label_1", "label_2"]),
             "name": "mock 2",
             "picture": "/image/example.png",
+            "created_at": created_area2,
+            "modified_at": created_area2,
         },
     ]
 
 
 async def test_create_area(
-    client: MockHAClientWebSocket, area_registry: ar.AreaRegistry
+    client: MockHAClientWebSocket,
+    area_registry: ar.AreaRegistry,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test create entry."""
     # Create area with only mandatory parameters
@@ -78,6 +93,8 @@ async def test_create_area(
         "labels": [],
         "name": "mock",
         "picture": None,
+        "created_at": utcnow().isoformat(),
+        "modified_at": utcnow().isoformat(),
     }
     assert len(area_registry.areas) == 1
 
@@ -104,6 +121,8 @@ async def test_create_area(
         "labels": unordered(["label_1", "label_2"]),
         "name": "mock 2",
         "picture": "/image/example.png",
+        "created_at": utcnow().isoformat(),
+        "modified_at": utcnow().isoformat(),
     }
     assert len(area_registry.areas) == 2
 
@@ -161,10 +180,16 @@ async def test_delete_non_existing_area(
 
 
 async def test_update_area(
-    client: MockHAClientWebSocket, area_registry: ar.AreaRegistry
+    client: MockHAClientWebSocket,
+    area_registry: ar.AreaRegistry,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test update entry."""
+    created_at = "2024-07-16T13:30:00.900075+00:00"
+    freezer.move_to(created_at)
     area = area_registry.async_create("mock 1")
+    modified_at = "2024-07-16T13:45:00.900075+00:00"
+    freezer.move_to(modified_at)
 
     await client.send_json_auto_id(
         {
@@ -189,8 +214,13 @@ async def test_update_area(
         "labels": unordered(["label_1", "label_2"]),
         "name": "mock 2",
         "picture": "/image/example.png",
+        "created_at": created_at,
+        "modified_at": modified_at,
     }
     assert len(area_registry.areas) == 1
+
+    modified_at = "2024-07-16T13:50:00.900075+00:00"
+    freezer.move_to(modified_at)
 
     await client.send_json_auto_id(
         {
@@ -214,6 +244,8 @@ async def test_update_area(
         "labels": [],
         "name": "mock 2",
         "picture": None,
+        "created_at": created_at,
+        "modified_at": modified_at,
     }
     assert len(area_registry.areas) == 1
 

--- a/tests/helpers/test_area_registry.py
+++ b/tests/helpers/test_area_registry.py
@@ -1,5 +1,6 @@
 """Tests for the Area Registry."""
 
+from datetime import timedelta
 from functools import partial
 from typing import Any
 
@@ -33,7 +34,6 @@ async def test_create_area(
 ) -> None:
     """Make sure that we can create an area."""
     update_events = async_capture_events(hass, ar.EVENT_AREA_REGISTRY_UPDATED)
-    # freezer.move_to("2021-01-09 12:00:00+00:00")
 
     # Create area with only mandatory parameters
     area = area_registry.async_create("mock")
@@ -52,6 +52,8 @@ async def test_create_area(
     )
     assert len(area_registry.areas) == 1
 
+    freezer.tick(timedelta(minutes=5))
+
     await hass.async_block_till_done()
 
     assert len(update_events) == 1
@@ -61,16 +63,14 @@ async def test_create_area(
     }
 
     # Create area with all parameters
-    area = area_registry.async_create(
+    area2 = area_registry.async_create(
         "mock 2",
         aliases={"alias_1", "alias_2"},
         labels={"label1", "label2"},
         picture="/image/example.png",
-        created_at=utcnow(),
-        modified_at=utcnow(),
     )
 
-    assert area == ar.AreaEntry(
+    assert area2 == ar.AreaEntry(
         aliases={"alias_1", "alias_2"},
         floor_id=None,
         icon=None,
@@ -83,13 +83,15 @@ async def test_create_area(
         modified_at=utcnow(),
     )
     assert len(area_registry.areas) == 2
+    assert area.created_at != area2.created_at
+    assert area.modified_at != area2.modified_at
 
     await hass.async_block_till_done()
 
     assert len(update_events) == 2
     assert update_events[-1].data == {
         "action": "create",
-        "area_id": area.id,
+        "area_id": area2.id,
     }
 
 

--- a/tests/helpers/test_area_registry.py
+++ b/tests/helpers/test_area_registry.py
@@ -3,6 +3,7 @@
 from functools import partial
 from typing import Any
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.core import HomeAssistant
@@ -11,6 +12,7 @@ from homeassistant.helpers import (
     floor_registry as fr,
     label_registry as lr,
 )
+from homeassistant.util.dt import utcnow
 
 from tests.common import ANY, async_capture_events, flush_store
 
@@ -24,9 +26,14 @@ async def test_list_areas(area_registry: ar.AreaRegistry) -> None:
     assert len(areas) == len(area_registry.areas)
 
 
-async def test_create_area(hass: HomeAssistant, area_registry: ar.AreaRegistry) -> None:
+async def test_create_area(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    area_registry: ar.AreaRegistry,
+) -> None:
     """Make sure that we can create an area."""
     update_events = async_capture_events(hass, ar.EVENT_AREA_REGISTRY_UPDATED)
+    # freezer.move_to("2021-01-09 12:00:00+00:00")
 
     # Create area with only mandatory parameters
     area = area_registry.async_create("mock")
@@ -40,6 +47,8 @@ async def test_create_area(hass: HomeAssistant, area_registry: ar.AreaRegistry) 
         name="mock",
         normalized_name=ANY,
         picture=None,
+        created_at=utcnow(),
+        modified_at=utcnow(),
     )
     assert len(area_registry.areas) == 1
 
@@ -57,6 +66,8 @@ async def test_create_area(hass: HomeAssistant, area_registry: ar.AreaRegistry) 
         aliases={"alias_1", "alias_2"},
         labels={"label1", "label2"},
         picture="/image/example.png",
+        created_at=utcnow(),
+        modified_at=utcnow(),
     )
 
     assert area == ar.AreaEntry(
@@ -68,6 +79,8 @@ async def test_create_area(hass: HomeAssistant, area_registry: ar.AreaRegistry) 
         name="mock 2",
         normalized_name=ANY,
         picture="/image/example.png",
+        created_at=utcnow(),
+        modified_at=utcnow(),
     )
     assert len(area_registry.areas) == 2
 
@@ -176,6 +189,7 @@ async def test_update_area(
         name="mock1",
         normalized_name=ANY,
         picture="/image/example.png",
+        created_at=area.created_at,
     )
     assert len(area_registry.areas) == 1
 
@@ -285,6 +299,8 @@ async def test_loading_area_from_storage(
                     "labels": ["mock-label1", "mock-label2"],
                     "name": "mock",
                     "picture": "blah",
+                    "created_at": utcnow().isoformat(),
+                    "modified_at": utcnow().isoformat(),
                 }
             ]
         },
@@ -329,6 +345,8 @@ async def test_migration_from_1_1(
                     "labels": [],
                     "name": "mock",
                     "picture": None,
+                    "created_at": "1970-01-01T00:00:00+00:00",
+                    "modified_at": "1970-01-01T00:00:00+00:00",
                 }
             ]
         },

--- a/tests/helpers/test_area_registry.py
+++ b/tests/helpers/test_area_registry.py
@@ -1,6 +1,6 @@
 """Tests for the Area Registry."""
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 from functools import partial
 from typing import Any
 
@@ -165,11 +165,18 @@ async def test_update_area(
     area_registry: ar.AreaRegistry,
     floor_registry: fr.FloorRegistry,
     label_registry: lr.LabelRegistry,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Make sure that we can read areas."""
+    created_at = datetime.fromisoformat("2024-01-01T01:00:00+00:00")
+    freezer.move_to(created_at)
     update_events = async_capture_events(hass, ar.EVENT_AREA_REGISTRY_UPDATED)
     floor_registry.async_create("first")
     area = area_registry.async_create("mock")
+    assert area.modified_at == created_at
+
+    modified_at = datetime.fromisoformat("2024-02-01T01:00:00+00:00")
+    freezer.move_to(modified_at)
 
     updated_area = area_registry.async_update(
         area.id,
@@ -191,7 +198,8 @@ async def test_update_area(
         name="mock1",
         normalized_name=ANY,
         picture="/image/example.png",
-        created_at=area.created_at,
+        created_at=created_at,
+        modified_at=modified_at,
     )
     assert len(area_registry.areas) == 1
 

--- a/tests/patch_time.py
+++ b/tests/patch_time.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 import datetime
 import time
 
-from homeassistant import runner, util
-from homeassistant.helpers import event as event_helper
-from homeassistant.util import dt as dt_util
+from homeassistant import util
 
 
 def _utcnow() -> datetime.datetime:
@@ -20,10 +18,15 @@ def _monotonic() -> float:
     return time.monotonic()
 
 
-# Replace partial functions which are not found by freezegun
-dt_util.utcnow = _utcnow  # type: ignore[assignment]
-event_helper.time_tracker_utcnow = _utcnow  # type: ignore[assignment]
-util.utcnow = _utcnow  # type: ignore[assignment]
+# Before importing anything else, replace partial utcnow
+# with a regular function which can be found by freezegun
+util.utcnow = util.dt.utcnow = _utcnow  # type: ignore[assignment]
 
-# Replace bound methods which are not found by freezegun
+
+# Replace partial functions which are not found by freezegun
+from homeassistant import runner  # noqa: E402
+from homeassistant.helpers import event as event_helper  # noqa: E402
+
+# Replace partial functions which are not found by freezegun
+event_helper.time_tracker_utcnow = _utcnow  # type: ignore[assignment]
 runner.monotonic = _monotonic  # type: ignore[assignment]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `created_at` and `modified_at` date-times for the area registry to see when an area entry was created and last modified.
For existing areas we use `1970-01-01T00:00` as datetime during migration

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
