### PR TITLE
Add support for specifying supported features to ZhaFan

### DIFF
--- a/homeassistant/components/zha/fan.py
+++ b/homeassistant/components/zha/fan.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import functools
 from typing import Any
 
+from zha.application.platforms.fan.const import FanEntityFeature as ZHAFanEntityFeature
+
 from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -15,6 +17,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .entity import ZHAEntity
 from .helpers import (
     SIGNAL_ADD_ENTITIES,
+    EntityData,
     async_add_entities as zha_async_add_entities,
     convert_zha_error_to_ha_error,
     get_zha_data,
@@ -43,8 +46,25 @@ async def async_setup_entry(
 class ZhaFan(FanEntity, ZHAEntity):
     """Representation of a ZHA fan."""
 
-    _attr_supported_features = FanEntityFeature.SET_SPEED
     _attr_translation_key: str = "fan"
+
+    def __init__(self, entity_data: EntityData, **kwargs: Any) -> None:
+        """Initialize the ZHA fan entity."""
+        super().__init__(entity_data, **kwargs)
+
+        features: FanEntityFeature = FanEntityFeature(0)
+        zha_features: ZHAFanEntityFeature = self.entity_data.entity.supported_features
+
+        if ZHAFanEntityFeature.SET_SPEED in zha_features:
+            features |= FanEntityFeature.SET_SPEED
+        if ZHAFanEntityFeature.OSCILLATE in zha_features:
+            features |= FanEntityFeature.OSCILLATE
+        if ZHAFanEntityFeature.DIRECTION in zha_features:
+            features |= FanEntityFeature.DIRECTION
+        if ZHAFanEntityFeature.PRESET_MODE in zha_features:
+            features |= FanEntityFeature.PRESET_MODE
+
+        self._attr_supported_features = features
 
     @property
     def preset_mode(self) -> str | None:

--- a/homeassistant/components/zha/fan.py
+++ b/homeassistant/components/zha/fan.py
@@ -57,10 +57,6 @@ class ZhaFan(FanEntity, ZHAEntity):
 
         if ZHAFanEntityFeature.SET_SPEED in zha_features:
             features |= FanEntityFeature.SET_SPEED
-        if ZHAFanEntityFeature.OSCILLATE in zha_features:
-            features |= FanEntityFeature.OSCILLATE
-        if ZHAFanEntityFeature.DIRECTION in zha_features:
-            features |= FanEntityFeature.DIRECTION
         if ZHAFanEntityFeature.PRESET_MODE in zha_features:
             features |= FanEntityFeature.PRESET_MODE
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

After #120190 it was no longer possible for ZHA Fans to specify which features they support. This is needed to fix #97440 (previous PR #114854) and most likely also regressed this feature for King Of Fans Zigbee Fans (though I don't have one to test).

The code is adapted from the ZHA Climate entity and similar code is also already present in the ZHA light and alarm entities.

- This PR is related to issue: #97440 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
