### PR TITLE
Return from ha-av to av 12.2.0

### DIFF
--- a/homeassistant/components/generic/manifest.json
+++ b/homeassistant/components/generic/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/generic",
   "integration_type": "device",
   "iot_class": "local_push",
-  "requirements": ["ha-av==10.1.1", "Pillow==10.3.0"]
+  "requirements": ["av==12.2.0", "Pillow==10.3.0"]
 }

--- a/homeassistant/components/stream/manifest.json
+++ b/homeassistant/components/stream/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "system",
   "iot_class": "local_push",
   "quality_scale": "internal",
-  "requirements": ["PyTurboJPEG==1.7.1", "ha-av==10.1.1", "numpy==1.26.0"]
+  "requirements": ["PyTurboJPEG==1.7.1", "av==12.2.0", "numpy==1.26.0"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -13,6 +13,7 @@ async-interrupt==1.1.2
 async-upnp-client==0.39.0
 atomicwrites-homeassistant==1.4.1
 attrs==23.2.0
+av==12.2.0
 awesomeversion==24.6.0
 bcrypt==4.1.2
 bleak-retry-connector==3.5.0
@@ -26,7 +27,6 @@ ciso8601==2.3.1
 cryptography==42.0.8
 dbus-fast==2.22.1
 fnv-hash-fast==0.5.0
-ha-av==10.1.1
 ha-ffmpeg==3.2.0
 habluetooth==3.1.3
 hass-nabucasa==0.81.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -513,6 +513,10 @@ aurorapy==0.2.7
 # homeassistant.components.autarco
 autarco==2.0.0
 
+# homeassistant.components.generic
+# homeassistant.components.stream
+av==12.2.0
+
 # homeassistant.components.avea
 # avea==1.5.1
 
@@ -1026,10 +1030,6 @@ guppy3==3.1.4.post1
 
 # homeassistant.components.iaqualink
 h2==4.1.0
-
-# homeassistant.components.generic
-# homeassistant.components.stream
-ha-av==10.1.1
 
 # homeassistant.components.ffmpeg
 ha-ffmpeg==3.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -465,6 +465,10 @@ aurorapy==0.2.7
 # homeassistant.components.autarco
 autarco==2.0.0
 
+# homeassistant.components.generic
+# homeassistant.components.stream
+av==12.2.0
+
 # homeassistant.components.axis
 axis==62
 
@@ -855,10 +859,6 @@ guppy3==3.1.4.post1
 
 # homeassistant.components.iaqualink
 h2==4.1.0
-
-# homeassistant.components.generic
-# homeassistant.components.stream
-ha-av==10.1.1
 
 # homeassistant.components.ffmpeg
 ha-ffmpeg==3.2.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Move from `ha-av` back to `av`, since the upstream is moving, while the fork
hasn't seen any new release in the last 11 months.

https://github.com/PyAV-Org/PyAV/blob/v12.2.0/CHANGELOG.rst

The (supposed) [fork](https://github.com/uvjustin/PyAV/commits/main/) introduced [bitstream filters](https://github.com/uvjustin/PyAV/commit/d4aba90c60c28159da97ff46cd837eac773d4cf6), which have been merged upstream
in the 12.1.0 release.

https://github.com/PyAV-Org/PyAV/commit/82e3397e0a42b559118821368c8f31af95829db8

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
