### PR TITLE
Add object_id to template entities (sensor, binary_sensor, button...)

### DIFF
--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -43,7 +43,6 @@ from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import selector, template
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device import async_device_info_to_link_from_device_id
-from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_call_later, async_track_point_in_utc_time
 from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
@@ -88,6 +87,8 @@ BINARY_SENSOR_SCHEMA = vol.Schema(
         vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
         vol.Required(CONF_STATE): cv.template,
         vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
+        vol.Optional(CONF_DEVICE_ID): selector.DeviceSelector(),
+        vol.Optional(CONF_OBJECT_ID): cv.string,
     }
 ).extend(TEMPLATE_ENTITY_COMMON_SCHEMA.schema)
 
@@ -230,6 +231,7 @@ class BinarySensorTemplate(TemplateEntity, BinarySensorEntity, RestoreEntity):
     """A virtual binary sensor that triggers from another sensor."""
 
     _attr_should_poll = False
+    _entity_id_format = ENTITY_ID_FORMAT
 
     def __init__(
         self,
@@ -239,10 +241,6 @@ class BinarySensorTemplate(TemplateEntity, BinarySensorEntity, RestoreEntity):
     ) -> None:
         """Initialize the Template binary sensor."""
         super().__init__(hass, config=config, unique_id=unique_id)
-        if (object_id := config.get(CONF_OBJECT_ID)) is not None:
-            self.entity_id = async_generate_entity_id(
-                ENTITY_ID_FORMAT, object_id, hass=hass
-            )
 
         self._attr_device_class = config.get(CONF_DEVICE_CLASS)
         self._template = config[CONF_STATE]

--- a/homeassistant/components/template/button.py
+++ b/homeassistant/components/template/button.py
@@ -7,17 +7,17 @@ from typing import Any
 
 import voluptuous as vol
 
+from homeassistant.components.button import (
+    DEVICE_CLASSES_SCHEMA,
+    ENTITY_ID_FORMAT,
+    ButtonEntity,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_DEVICE_CLASS,
     CONF_DEVICE_ID,
     CONF_NAME,
     CONF_UNIQUE_ID,
-)
-from homeassistant.components.button import (
-    DEVICE_CLASSES_SCHEMA,
-    ENTITY_ID_FORMAT,
-    ButtonEntity,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
@@ -27,7 +27,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.script import Script
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from .const import CONF_PRESS, CONF_OBJECT_ID, DOMAIN
+from .const import CONF_OBJECT_ID, CONF_PRESS, DOMAIN
 from .template_entity import (
     TEMPLATE_ENTITY_AVAILABILITY_SCHEMA,
     TEMPLATE_ENTITY_ICON_SCHEMA,

--- a/homeassistant/components/template/button.py
+++ b/homeassistant/components/template/button.py
@@ -7,13 +7,17 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.components.button import DEVICE_CLASSES_SCHEMA, ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_DEVICE_CLASS,
     CONF_DEVICE_ID,
     CONF_NAME,
     CONF_UNIQUE_ID,
+)
+from homeassistant.components.button import (
+    DEVICE_CLASSES_SCHEMA,
+    ENTITY_ID_FORMAT,
+    ButtonEntity,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
@@ -23,7 +27,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.script import Script
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from .const import CONF_PRESS, DOMAIN
+from .const import CONF_PRESS, CONF_OBJECT_ID, DOMAIN
 from .template_entity import (
     TEMPLATE_ENTITY_AVAILABILITY_SCHEMA,
     TEMPLATE_ENTITY_ICON_SCHEMA,
@@ -42,6 +46,7 @@ BUTTON_SCHEMA = (
             vol.Required(CONF_PRESS): cv.SCRIPT_SCHEMA,
             vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
             vol.Optional(CONF_UNIQUE_ID): cv.string,
+            vol.Optional(CONF_OBJECT_ID): cv.string,
         }
     )
     .extend(TEMPLATE_ENTITY_AVAILABILITY_SCHEMA.schema)
@@ -108,6 +113,7 @@ class TemplateButtonEntity(TemplateEntity, ButtonEntity):
     """Representation of a template button."""
 
     _attr_should_poll = False
+    _entity_id_format = ENTITY_ID_FORMAT
 
     def __init__(
         self,

--- a/homeassistant/components/template/const.py
+++ b/homeassistant/components/template/const.py
@@ -30,7 +30,6 @@ PLATFORMS = [
 
 CONF_AVAILABILITY = "availability"
 CONF_ATTRIBUTES = "attributes"
-CONF_ATTRIBUTE_TEMPLATES = "attribute_templates"
 CONF_PICTURE = "picture"
 CONF_PRESS = "press"
 CONF_OBJECT_ID = "object_id"

--- a/homeassistant/components/template/image.py
+++ b/homeassistant/components/template/image.py
@@ -7,6 +7,11 @@ from typing import Any
 
 import voluptuous as vol
 
+from homeassistant.components.image import (
+    DOMAIN as IMAGE_DOMAIN,
+    ENTITY_ID_FORMAT,
+    ImageEntity,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_DEVICE_ID,
@@ -14,11 +19,6 @@ from homeassistant.const import (
     CONF_UNIQUE_ID,
     CONF_URL,
     CONF_VERIFY_SSL,
-)
-from homeassistant.components.image import (
-    DOMAIN as IMAGE_DOMAIN,
-    ENTITY_ID_FORMAT,
-    ImageEntity,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import TemplateError

--- a/homeassistant/components/template/image.py
+++ b/homeassistant/components/template/image.py
@@ -7,7 +7,6 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.components.image import DOMAIN as IMAGE_DOMAIN, ImageEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_DEVICE_ID,
@@ -15,6 +14,11 @@ from homeassistant.const import (
     CONF_UNIQUE_ID,
     CONF_URL,
     CONF_VERIFY_SSL,
+)
+from homeassistant.components.image import (
+    DOMAIN as IMAGE_DOMAIN,
+    ENTITY_ID_FORMAT,
+    ImageEntity,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import TemplateError
@@ -25,7 +29,7 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt as dt_util
 
 from . import TriggerUpdateCoordinator
-from .const import CONF_PICTURE
+from .const import CONF_OBJECT_ID, CONF_PICTURE
 from .template_entity import TemplateEntity, make_template_entity_common_schema
 from .trigger_entity import TriggerEntity
 
@@ -39,6 +43,7 @@ IMAGE_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_URL): cv.template,
         vol.Optional(CONF_VERIFY_SSL, default=True): bool,
+        vol.Optional(CONF_OBJECT_ID): cv.string,
     }
 ).extend(make_template_entity_common_schema(DEFAULT_NAME).schema)
 
@@ -112,6 +117,8 @@ class StateImageEntity(TemplateEntity, ImageEntity):
 
     _attr_should_poll = False
     _attr_image_url: str | None = None
+
+    _entity_id_format = ENTITY_ID_FORMAT
 
     def __init__(
         self,

--- a/homeassistant/components/template/number.py
+++ b/homeassistant/components/template/number.py
@@ -16,6 +16,7 @@ from homeassistant.components.number import (
     DEFAULT_MIN_VALUE,
     DEFAULT_STEP,
     DOMAIN as NUMBER_DOMAIN,
+    ENTITY_ID_FORMAT,
     NumberEntity,
 )
 from homeassistant.const import CONF_NAME, CONF_OPTIMISTIC, CONF_STATE, CONF_UNIQUE_ID
@@ -26,7 +27,7 @@ from homeassistant.helpers.script import Script
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import TriggerUpdateCoordinator
-from .const import DOMAIN
+from .const import CONF_OBJECT_ID, DOMAIN
 from .template_entity import (
     TEMPLATE_ENTITY_AVAILABILITY_SCHEMA,
     TEMPLATE_ENTITY_ICON_SCHEMA,
@@ -52,6 +53,7 @@ NUMBER_SCHEMA = (
             vol.Optional(ATTR_MAX, default=DEFAULT_MAX_VALUE): cv.template,
             vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
             vol.Optional(CONF_UNIQUE_ID): cv.string,
+            vol.Optional(CONF_OBJECT_ID): cv.string,
         }
     )
     .extend(TEMPLATE_ENTITY_AVAILABILITY_SCHEMA.schema)
@@ -103,6 +105,8 @@ class TemplateNumber(TemplateEntity, NumberEntity):
     """Representation of a template number."""
 
     _attr_should_poll = False
+
+    _entity_id_format = ENTITY_ID_FORMAT
 
     def __init__(
         self,

--- a/homeassistant/components/template/select.py
+++ b/homeassistant/components/template/select.py
@@ -11,6 +11,7 @@ from homeassistant.components.select import (
     ATTR_OPTION,
     ATTR_OPTIONS,
     DOMAIN as SELECT_DOMAIN,
+    ENTITY_ID_FORMAT,
     SelectEntity,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -29,7 +30,7 @@ from homeassistant.helpers.script import Script
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import TriggerUpdateCoordinator
-from .const import DOMAIN
+from .const import CONF_OBJECT_ID, DOMAIN
 from .template_entity import (
     TEMPLATE_ENTITY_AVAILABILITY_SCHEMA,
     TEMPLATE_ENTITY_ICON_SCHEMA,
@@ -54,6 +55,7 @@ SELECT_SCHEMA = (
             vol.Required(ATTR_OPTIONS): cv.template,
             vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
             vol.Optional(CONF_UNIQUE_ID): cv.string,
+            vol.Optional(CONF_OBJECT_ID): cv.string,
         }
     )
     .extend(TEMPLATE_ENTITY_AVAILABILITY_SCHEMA.schema)
@@ -128,6 +130,7 @@ class TemplateSelect(TemplateEntity, SelectEntity):
     """Representation of a template select."""
 
     _attr_should_poll = False
+    _entity_id_format = ENTITY_ID_FORMAT
 
     def __init__(
         self,

--- a/homeassistant/components/template/sensor.py
+++ b/homeassistant/components/template/sensor.py
@@ -43,7 +43,6 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import config_validation as cv, selector, template
 from homeassistant.helpers.device import async_device_info_to_link_from_device_id
-from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.trigger_template_entity import TEMPLATE_SENSOR_BASE_SCHEMA
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -88,6 +87,8 @@ SENSOR_SCHEMA = vol.All(
         {
             vol.Required(CONF_STATE): cv.template,
             vol.Optional(ATTR_LAST_RESET): cv.template,
+            vol.Optional(CONF_DEVICE_ID): selector.DeviceSelector(),
+            vol.Optional(CONF_OBJECT_ID): cv.string,
         }
     )
     .extend(TEMPLATE_SENSOR_BASE_SCHEMA.schema)
@@ -255,6 +256,7 @@ class SensorTemplate(TemplateEntity, SensorEntity):
     """Representation of a Template Sensor."""
 
     _attr_should_poll = False
+    _entity_id_format = ENTITY_ID_FORMAT
 
     def __init__(
         self,
@@ -275,10 +277,6 @@ class SensorTemplate(TemplateEntity, SensorEntity):
             hass,
             config.get(CONF_DEVICE_ID),
         )
-        if (object_id := config.get(CONF_OBJECT_ID)) is not None:
-            self.entity_id = async_generate_entity_id(
-                ENTITY_ID_FORMAT, object_id, hass=hass
-            )
 
     @callback
     def _async_setup_templates(self) -> None:

--- a/homeassistant/components/template/template_entity.py
+++ b/homeassistant/components/template/template_entity.py
@@ -345,8 +345,8 @@ class TemplateEntity(Entity):
         if self._object_id:
             if not hasattr(self, "_entity_id_format"):
                 _LOGGER.warning(
-                    "Template entity class %s does not define its _entity_id_format attribute. "
-                    "Assigned object id '%s' will be ignored.",
+                    "Template entity class %s does not define its _entity_id_format attribute, "
+                    "assigned object id '%s' will be ignored",
                     self.__class__.__name__,
                     self._object_id,
                 )

--- a/homeassistant/components/template/weather.py
+++ b/homeassistant/components/template/weather.py
@@ -57,7 +57,8 @@ from .template_entity import TemplateEntity, rewrite_common_legacy_to_modern_con
 from .trigger_entity import TriggerEntity
 
 CHECK_FORECAST_KEYS = (
-    set().union(Forecast.__annotations__.keys())
+    set()
+    .union(Forecast.__annotations__.keys())
     # Manually add the forecast resulting attributes that only exists
     #  as native_* in the Forecast definition
     .union(("apparent_temperature", "wind_gust_speed", "dew_point"))

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -132,7 +132,7 @@ async def test_setup_minimal(
     ],
 )
 async def test_setup(hass: HomeAssistant, start_ha, entity_id) -> None:
-    """Test the setup."""
+    """Test the setup (legacy, current and current with object_id)."""
     state = hass.states.get(entity_id)
     assert state is not None
     assert state.name == "virtual thingy"
@@ -250,9 +250,6 @@ async def test_setup_config_entry(
 async def test_setup_invalid_sensors(hass: HomeAssistant, count, start_ha) -> None:
     """Test setup with no sensors."""
     assert len(hass.states.async_entity_ids("binary_sensor")) == count
-
-
-# async def test_setup_custom_object_ids(hass: HomeAssistant, start_ha) -> None:
 
 
 @pytest.mark.parametrize("count", [1])

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -115,6 +115,20 @@ async def test_setup_minimal(
             template.DOMAIN,
             "binary_sensor.virtual_thingy",
         ),
+        (
+            {
+                "template": {
+                    "binary_sensor": {
+                        "name": "virtual thingy",
+                        "state": "{{ True }}",
+                        "device_class": "motion",
+                        "object_id": "customized_id",
+                    }
+                },
+            },
+            template.DOMAIN,
+            "binary_sensor.customized_id",
+        ),
     ],
 )
 async def test_setup(hass: HomeAssistant, start_ha, entity_id) -> None:
@@ -236,6 +250,9 @@ async def test_setup_config_entry(
 async def test_setup_invalid_sensors(hass: HomeAssistant, count, start_ha) -> None:
     """Test setup with no sensors."""
     assert len(hass.states.async_entity_ids("binary_sensor")) == count
+
+
+# async def test_setup_custom_object_ids(hass: HomeAssistant, start_ha) -> None:
 
 
 @pytest.mark.parametrize("count", [1])

--- a/tests/components/template/test_button.py
+++ b/tests/components/template/test_button.py
@@ -290,3 +290,34 @@ async def test_device_id(
     template_entity = entity_registry.async_get("button.my_template")
     assert template_entity is not None
     assert template_entity.device_id == device_entry.id
+
+
+async def test_custom_entity_id(hass: HomeAssistant) -> None:
+    """Test: Define custom entity_id."""
+    with assert_setup_component(1, "template"):
+        assert await setup.async_setup_component(
+            hass,
+            "template",
+            {
+                "template": {
+                    "button": {
+                        "press": {"service": "script.press"},
+                        "name": "Button {{ 1 + 1 }}",
+                        "object_id": "benjamin",
+                    },
+                }
+            },
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    _verify(
+        hass,
+        STATE_UNKNOWN,
+        {
+            CONF_FRIENDLY_NAME: "Button 2",
+        },
+        "button.benjamin",
+    )

--- a/tests/components/template/test_image.py
+++ b/tests/components/template/test_image.py
@@ -272,6 +272,34 @@ async def test_unique_id(
     assert entry.unique_id == "b-a"
 
 
+async def test_custom_entity_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test custom entity_id configuration."""
+    with assert_setup_component(1, "template"):
+        assert await setup.async_setup_component(
+            hass,
+            "template",
+            {
+                "template": {
+                    "image": {
+                        "url": "http://example.com",
+                        "unique_id": "random-uuid",
+                        "object_id": "best_image_ever",
+                    },
+                }
+            },
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    entry = entity_registry.async_get("image.best_image_ever")
+    assert entry
+    assert entry.unique_id == "random-uuid"
+
+
 @respx.mock
 @pytest.mark.freeze_time("2023-04-01 00:00:00+00:00")
 async def test_custom_entity_picture(

--- a/tests/components/template/test_number.py
+++ b/tests/components/template/test_number.py
@@ -460,3 +460,32 @@ async def test_icon_template_with_trigger(hass: HomeAssistant) -> None:
     state = hass.states.get(_TEST_NUMBER)
     assert float(state.state) == 51
     assert state.attributes[ATTR_ICON] == "mdi:greater"
+
+
+async def test_custom_entity_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test custom entity_id configuration."""
+    with assert_setup_component(1, "template"):
+        assert await setup.async_setup_component(
+            hass,
+            "template",
+            {
+                "template": {
+                    "number": {
+                        "state": 42,
+                        "step": 1,
+                        "set_value": {"service": "script.set_value"},
+                        "object_id": "fortytwo",
+                    },
+                }
+            },
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    state = hass.states.get("number.fortytwo")
+    assert state
+    assert float(state.state) == 42.0

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -160,7 +160,7 @@ async def test_template_legacy(hass: HomeAssistant, start_ha) -> None:
     ],
 )
 async def test_setup(hass: HomeAssistant, start_ha, entity_id) -> None:
-    """Test the setup."""
+    """Test the setup (legacy, current and current with object_id)."""
     state = hass.states.get(entity_id)
     assert state is not None
     assert state.name == "virtual thingy"

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -113,6 +113,60 @@ async def test_template_legacy(hass: HomeAssistant, start_ha) -> None:
     assert hass.states.get(TEST_NAME).state == "It Works."
 
 
+@pytest.mark.parametrize("count", [1])
+@pytest.mark.parametrize(
+    ("config", "domain", "entity_id"),
+    [
+        (
+            {
+                "sensor": {
+                    "platform": "template",
+                    "sensors": {
+                        "test": {
+                            "friendly_name": "virtual thingy",
+                            "value_template": "{{ 'correct' }}",
+                        }
+                    },
+                },
+            },
+            sensor.DOMAIN,
+            "sensor.test",
+        ),
+        (
+            {
+                "template": {
+                    "sensor": {
+                        "name": "virtual thingy",
+                        "state": "{{ 'correct' }}",
+                    }
+                },
+            },
+            template.DOMAIN,
+            "sensor.virtual_thingy",
+        ),
+        (
+            {
+                "template": {
+                    "sensor": {
+                        "name": "virtual thingy",
+                        "state": "{{ 'correct' }}",
+                        "object_id": "customized_id",
+                    }
+                },
+            },
+            template.DOMAIN,
+            "sensor.customized_id",
+        ),
+    ],
+)
+async def test_setup(hass: HomeAssistant, start_ha, entity_id) -> None:
+    """Test the setup."""
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.name == "virtual thingy"
+    assert state.state == "correct"
+
+
 @pytest.mark.parametrize(("count", "domain"), [(1, sensor.DOMAIN)])
 @pytest.mark.parametrize(
     "config",

--- a/tests/components/template/test_weather.py
+++ b/tests/components/template/test_weather.py
@@ -928,3 +928,31 @@ async def test_trigger_entity_restore_state_fail(
     state = hass.states.get("weather.test")
     assert state.state == STATE_UNKNOWN
     assert state.attributes.get("temperature") is None
+
+
+@pytest.mark.parametrize(("count", "domain"), [(1, WEATHER_DOMAIN)])
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            "weather": [
+                {
+                    "platform": "template",
+                    "object_id": "super_weather",
+                    "name": "forecast",
+                    "condition_template": "sunny",
+                    "temperature_template": "{{ 15 }}",
+                    "humidity_template": "{{ 50 }}",
+                },
+            ]
+        },
+    ],
+)
+async def test_custom_entity_id(
+    hass: HomeAssistant,
+    start_ha,
+) -> None:
+    """Test forecast service invalid when is_daytime missing in twice_daily forecast."""
+
+    state = hass.states.get("weather.super_weather")
+    assert state.state == "sunny"

--- a/tests/components/template/test_weather.py
+++ b/tests/components/template/test_weather.py
@@ -952,7 +952,6 @@ async def test_custom_entity_id(
     hass: HomeAssistant,
     start_ha,
 ) -> None:
-    """Test forecast service invalid when is_daytime missing in twice_daily forecast."""
-
+    """Test custom entity_id configuration."""
     state = hass.states.get("weather.super_weather")
     assert state.state == "sunny"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds the option to manually define the `object_id` that is used to compute the `entity_id` of template entites configured in the "new" yaml format. This closes a functional gap that has been introduced with the new config format and allows us yaml-junkies to have both a nice visual name _and_ a clearly defined and referencable entity id right in one place.

Affected template entities are:

- binary_sensor
- button
- image
- number
- select
- sensor
- weather

See https://community.home-assistant.io/t/modern-template-sensor-definition-style-how-to-initially-set-entity-id-and-friendly-name-and-what-about-availability-variables/374432/1 or https://community.home-assistant.io/t/set-template-sensor-entity-id-programmatically/654082/1 for reference.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  TBD

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
