### PR TITLE
Deprecate `topic_template` and `payload_template` for mqtt publish action

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -296,10 +296,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         qos: int = call.data[ATTR_QOS]
         retain: bool = call.data[ATTR_RETAIN]
         if msg_topic_template is not None:
+            # The use of a topic_template in an mqtt publish action call
+            # has been deprecated with HA Core 2024.8.0
+            # and will be removed with HA Core 2025.2.0
             rendered_topic: Any = MqttCommandTemplate(
                 template.Template(msg_topic_template),
                 hass=hass,
             ).async_render()
+            ir.async_create_issue(
+                hass,
+                DOMAIN,
+                f"topic_template_deprecation_{rendered_topic}",
+                breaks_in_ha_version="2025.2.0",
+                is_fixable=False,
+                severity=ir.IssueSeverity.WARNING,
+                translation_key="topic_template_deprecation",
+                translation_placeholders={
+                    "topic_template": msg_topic_template,
+                    "topic": rendered_topic,
+                },
+            )
             try:
                 msg_topic = valid_publish_topic(rendered_topic)
             except vol.Invalid as err:
@@ -315,6 +331,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 ) from err
 
         if payload_template is not None:
+            # The use of a payload_template in an mqtt publish action call
+            # has been deprecated with HA Core 2024.8.0
+            # and will be removed with HA Core 2025.2.0
+            if TYPE_CHECKING:
+                assert msg_topic is not None
+            ir.async_create_issue(
+                hass,
+                DOMAIN,
+                f"payload_template_deprecation_{msg_topic}",
+                breaks_in_ha_version="2025.2.0",
+                is_fixable=False,
+                severity=ir.IssueSeverity.WARNING,
+                translation_key="payload_template_deprecation",
+                translation_placeholders={
+                    "topic": msg_topic,
+                    "payload_template": payload_template,
+                },
+            )
             payload = MqttCommandTemplate(
                 template.Template(payload_template), hass=hass
             ).async_render()

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -155,7 +155,10 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-# Service call validation schema
+# The use of a topic_template and payload_template in an mqtt publish action call
+# have been deprecated with HA Core 2024.8.0 and will be removed with HA Core 2025.2.0
+
+# Publish action call validation schema
 MQTT_PUBLISH_SCHEMA = vol.All(
     vol.Schema(
         {

--- a/homeassistant/components/mqtt/services.yaml
+++ b/homeassistant/components/mqtt/services.yaml
@@ -8,12 +8,7 @@ publish:
       selector:
         text:
     payload:
-      example: This is great
-      selector:
-        text:
-    payload_template:
-      advanced: true
-      example: "{{ states('sensor.temperature') }}"
+      example: "The temperature is {{ states('sensor.temperature') }}"
       selector:
         template:
     qos:

--- a/homeassistant/components/mqtt/services.yaml
+++ b/homeassistant/components/mqtt/services.yaml
@@ -8,6 +8,7 @@ publish:
       selector:
         text:
     payload:
+      required: true
       example: "The temperature is {{ states('sensor.temperature') }}"
       selector:
         template:

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -14,7 +14,7 @@
     },
     "payload_template_deprecation": {
       "title": "Deprecated option used in mqtt publish action call",
-      "description": "Deprecated `payload_template` option used in MQTT publish action call to topic `{topic}` from payload template `{payload_template}`. Use the `payload` option instead. In automations templates are supported nativly. Update the automation or script to use the `topic` option instead and restart Home Assistant to fix this issue."
+      "description": "Deprecated `payload_template` option used in MQTT publish action call to topic `{topic}` from payload template `{payload_template}`. Use the `payload` option instead. In automations templates are supported nativly. Update the automation or script to use the `payload` option instead and restart Home Assistant to fix this issue."
     },
     "topic_template_deprecation": {
       "title": "Deprecated option used in mqtt publish action call",

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -14,11 +14,11 @@
     },
     "payload_template_deprecation": {
       "title": "Deprecated option used in mqtt publish action call",
-      "description": "Deprecated `payload_template` option used in MQTT publish action call to topic `{topic}` from payload template `{payload_template}`. Use the `payload` option instead. In automations templates are supported nativly. Update the automation or script to use the `payload` option instead and restart Home Assistant to fix this issue."
+      "description": "Deprecated `payload_template` option used in MQTT publish action call to topic `{topic}` from payload template `{payload_template}`. Use the `payload` option instead. In automations templates are supported natively. Update the automation or script to use the `payload` option instead and restart Home Assistant to fix this issue."
     },
     "topic_template_deprecation": {
       "title": "Deprecated option used in mqtt publish action call",
-      "description": "Deprecated `topic_template` option used in MQTT publish action call to topic `{topic}` from topic template `{topic_template}`. Use the `topic` option instead. In automations templates are supported nativly. Update the automation or script to use the `topic` option instead and restart Home Assistant to fix this issue."
+      "description": "Deprecated `topic_template` option used in MQTT publish action call to topic `{topic}` from topic template `{topic_template}`. Use the `topic` option instead. In automations templates are supported natively. Update the automation or script to use the `topic` option instead and restart Home Assistant to fix this issue."
     }
   },
   "config": {

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -11,6 +11,14 @@
     "invalid_platform_config": {
       "title": "Invalid config found for mqtt {domain} item",
       "description": "Home Assistant detected an invalid config for a manually configured item.\n\nPlatform domain: **{domain}**\nConfiguration file: **{config_file}**\nNear line: **{line}**\nConfiguration found:\n```yaml\n{config}\n```\nError: **{error}**.\n\nMake sure the configuration is valid and [reload](/developer-tools/yaml) the manually configured MQTT items or restart Home Assistant to fix this issue."
+    },
+    "payload_template_deprecation": {
+      "title": "Deprecated option used in mqtt publish action call",
+      "description": "Deprecated `payload_template` option used in MQTT publish action call to topic `{topic}` from payload template `{payload_template}`. Use the `payload` option instead. In automations templates are supported nativly. Update the automation or script to use the `topic` option instead and restart Home Assistant to fix this issue."
+    },
+    "topic_template_deprecation": {
+      "title": "Deprecated option used in mqtt publish action call",
+      "description": "Deprecated `topic_template` option used in MQTT publish action call to topic `{topic}` from topic template `{topic_template}`. Use the `topic` option instead. In automations templates are supported nativly. Update the automation or script to use the `topic` option instead and restart Home Assistant to fix this issue."
     }
   },
   "config": {

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -260,10 +260,12 @@ async def test_service_call_without_topic_does_not_publish(
     assert not mqtt_mock.async_publish.called
 
 
-async def test_service_call_with_topic_and_topic_template_does_not_publish(
+# The use of a topic_template in an mqtt publish action call
+# has been deprecated with HA Core 2024.8.0 and will be removed with HA Core 2025.2.0
+async def test_mqtt_publish_action_call_with_topic_and_topic_template_does_not_publish(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
-    """Test the service call with topic/topic template.
+    """Test the mqtt publish action call with topic/topic template.
 
     If both 'topic' and 'topic_template' are provided then fail.
     """
@@ -284,10 +286,12 @@ async def test_service_call_with_topic_and_topic_template_does_not_publish(
     assert not mqtt_mock.async_publish.called
 
 
-async def test_service_call_with_invalid_topic_template_does_not_publish(
+# The use of a topic_template in an mqtt publish action call
+# has been deprecated with HA Core 2024.8.0 and will be removed with HA Core 2025.2.0
+async def test_mqtt_action_call_with_invalid_topic_template_does_not_publish(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
-    """Test the service call with a problematic topic template."""
+    """Test the mqtt publish action call with a problematic topic template."""
     mqtt_mock = await mqtt_mock_entry()
     with pytest.raises(MqttCommandTemplateException) as exc:
         await hass.services.async_call(
@@ -307,10 +311,12 @@ async def test_service_call_with_invalid_topic_template_does_not_publish(
     assert not mqtt_mock.async_publish.called
 
 
-async def test_service_call_with_template_topic_renders_template(
+# The use of a topic_template in an mqtt publish action call
+# has been deprecated with HA Core 2024.8.0 and will be removed with HA Core 2025.2.0
+async def test_mqtt_publish_action_call_with_template_topic_renders_template(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
-    """Test the service call with rendered topic template.
+    """Test the mqtt publish action call with rendered topic template.
 
     If 'topic_template' is provided and 'topic' is not, then render it.
     """
@@ -331,7 +337,7 @@ async def test_service_call_with_template_topic_renders_template(
 async def test_service_call_with_template_topic_renders_invalid_topic(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
-    """Test the service call with rendered, invalid topic template.
+    """Test the action call with rendered, invalid topic template.
 
     If a wildcard topic is rendered, then fail.
     """
@@ -354,10 +360,12 @@ async def test_service_call_with_template_topic_renders_invalid_topic(
     assert not mqtt_mock.async_publish.called
 
 
-async def test_service_call_with_invalid_rendered_template_topic_doesnt_render_template(
+# The use of a payload_template in an mqtt publish action call
+# has been deprecated with HA Core 2024.8.0 and will be removed with HA Core 2025.2.0
+async def test_action_call_with_invalid_rendered_payload_template_doesnt_render_template(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
-    """Test the service call with unrendered template.
+    """Test the action call with unrendered payload template.
 
     If both 'payload' and 'payload_template' are provided then fail.
     """
@@ -378,10 +386,12 @@ async def test_service_call_with_invalid_rendered_template_topic_doesnt_render_t
     assert not mqtt_mock.async_publish.called
 
 
-async def test_service_call_with_template_payload_renders_template(
+# The use of a payload_template in an mqtt publish action call
+# has been deprecated with HA Core 2024.8.0 and will be removed with HA Core 2025.2.0
+async def test_mqtt_publish_action_call_with_template_payload_renders_template(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
-    """Test the service call with rendered template.
+    """Test the mqtt publish action call with rendered template.
 
     If 'payload_template' is provided and 'payload' is not, then render it.
     """
@@ -410,10 +420,12 @@ async def test_service_call_with_template_payload_renders_template(
     mqtt_mock.reset_mock()
 
 
-async def test_service_call_with_bad_template(
+# The use of a payload_template in an mqtt publish action call
+# has been deprecated with HA Core 2024.8.0 and will be removed with HA Core 2025.2.0
+async def test_publish_action_call_with_bad_payload_template(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
-    """Test the service call with a bad template does not publish."""
+    """Test the mqtt publish action call with a bad template does not publish."""
     mqtt_mock = await mqtt_mock_entry()
     with pytest.raises(MqttCommandTemplateException) as exc:
         await hass.services.async_call(
@@ -432,10 +444,12 @@ async def test_service_call_with_bad_template(
     )
 
 
-async def test_service_call_with_payload_doesnt_render_template(
+# The use of a payload_template in an mqtt publish action call
+# has been deprecated with HA Core 2024.8.0 and will be removed with HA Core 2025.2.0
+async def test_action_call_with_payload_doesnt_render_template(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
-    """Test the service call with unrendered template.
+    """Test the mqtt publish action call with an unrendered template.
 
     If both 'payload' and 'payload_template' are provided then fail.
     """
@@ -1626,10 +1640,12 @@ async def test_debug_info_qos_retain(
     } in messages
 
 
+# The use of a payload_template in an mqtt publish action call
+# has been deprecated with HA Core 2024.8.0 and will be removed with HA Core 2025.2.0
 async def test_publish_json_from_template(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
-    """Test the publishing of call to services."""
+    """Test the publishing of call to mqtt publish action."""
     mqtt_mock = await mqtt_mock_entry()
 
     test_str = "{'valid': 'python', 'invalid': 'json'}"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Deprecate `topic_template` and `payload_template` for mqtt publish action.

Both options are redundant as in scripts and automation's users can make use of templates nativly.

An issue is logged if a deprecated option is used for each topic for which it is used. User must update there automations to use `topic` and `payload` options instead.

Note that support for the use of a`topic_template` in the UI was never added. The `topic` option was set as `required` option. With deprecating the `payload_template` option from the UI, the payload option will be marked required in the UI service schema and the `payload_template` will not be visible anymore. The exiting automation's and scripts will not break because of this, because they depend on the MQTT publish action schema, in which the deprecated options are still valid.

A 6 months of grace period is planned till the support will be removed.

### Example repair issue with `topic_template` used
![afbeelding](https://github.com/user-attachments/assets/94971168-5eb9-4b85-851d-726d52d1b39c)

### Example repair issue with `payload_template` used
![afbeelding](https://github.com/user-attachments/assets/2af156ad-242a-4a30-8cf2-0a80d9324106)

### UI form dev tools
![afbeelding](https://github.com/user-attachments/assets/1e5ef95b-5121-414d-b49a-e91e4ad33c73)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/home-assistant.io/issues/33653
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33854

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
