### PR TITLE
Add select platform test to enphase_envoy

### DIFF
--- a/tests/components/enphase_envoy/snapshots/test_select.ambr
+++ b/tests/components/enphase_envoy/snapshots/test_select.ambr
@@ -1,0 +1,754 @@
+# serializer version: 1
+# name: test_select[envoy_metered_batt_relay][select.enpower_654321_storage_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'backup',
+        'self_consumption',
+        'savings',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.enpower_654321_storage_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Storage mode',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'storage_mode',
+    'unique_id': '654321_storage_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_select[envoy_metered_batt_relay][select.enpower_654321_storage_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Enpower 654321 Storage mode',
+      'options': list([
+        'backup',
+        'self_consumption',
+        'savings',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.enpower_654321_storage_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'self_consumption',
+  })
+# ---
+# name: test_select[envoy_metered_batt_relay][select.nc1_fixture_generator_action-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'powered',
+        'not_powered',
+        'schedule',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.nc1_fixture_generator_action',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Generator action',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'relay_generator_action',
+    'unique_id': '654321_relay_NC1_generator_action',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_select[envoy_metered_batt_relay][select.nc1_fixture_generator_action-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'NC1 Fixture Generator action',
+      'options': list([
+        'powered',
+        'not_powered',
+        'schedule',
+        'none',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.nc1_fixture_generator_action',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'not_powered',
+  })
+# ---
+# name: test_select[envoy_metered_batt_relay][select.nc1_fixture_grid_action-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'powered',
+        'not_powered',
+        'schedule',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.nc1_fixture_grid_action',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Grid action',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'relay_grid_action',
+    'unique_id': '654321_relay_NC1_grid_action',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_select[envoy_metered_batt_relay][select.nc1_fixture_grid_action-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'NC1 Fixture Grid action',
+      'options': list([
+        'powered',
+        'not_powered',
+        'schedule',
+        'none',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.nc1_fixture_grid_action',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'not_powered',
+  })
+# ---
+# name: test_select[envoy_metered_batt_relay][select.nc1_fixture_microgrid_action-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'powered',
+        'not_powered',
+        'schedule',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.nc1_fixture_microgrid_action',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Microgrid action',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'relay_microgrid_action',
+    'unique_id': '654321_relay_NC1_microgrid_action',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_select[envoy_metered_batt_relay][select.nc1_fixture_microgrid_action-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'NC1 Fixture Microgrid action',
+      'options': list([
+        'powered',
+        'not_powered',
+        'schedule',
+        'none',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.nc1_fixture_microgrid_action',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'not_powered',
+  })
+# ---
+# name: test_select[envoy_metered_batt_relay][select.nc1_fixture_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'standard',
+        'battery',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.nc1_fixture_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Mode',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'relay_mode',
+    'unique_id': '654321_relay_NC1_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_select[envoy_metered_batt_relay][select.nc1_fixture_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'NC1 Fixture Mode',
+      'options': list([
+        'standard',
+        'battery',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.nc1_fixture_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'standard',
+  })
+# ---
+# name: test_select[envoy_metered_batt_relay][select.nc2_fixture_generator_action-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'powered',
+        'not_powered',
+        'schedule',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.nc2_fixture_generator_action',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Generator action',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'relay_generator_action',
+    'unique_id': '654321_relay_NC2_generator_action',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_select[envoy_metered_batt_relay][select.nc2_fixture_generator_action-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'NC2 Fixture Generator action',
+      'options': list([
+        'powered',
+        'not_powered',
+        'schedule',
+        'none',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.nc2_fixture_generator_action',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'not_powered',
+  })
+# ---
+# name: test_select[envoy_metered_batt_relay][select.nc2_fixture_grid_action-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'powered',
+        'not_powered',
+        'schedule',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.nc2_fixture_grid_action',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Grid action',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'relay_grid_action',
+    'unique_id': '654321_relay_NC2_grid_action',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_select[envoy_metered_batt_relay][select.nc2_fixture_grid_action-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'NC2 Fixture Grid action',
+      'options': list([
+        'powered',
+        'not_powered',
+        'schedule',
+        'none',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.nc2_fixture_grid_action',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'powered',
+  })
+# ---
+# name: test_select[envoy_metered_batt_relay][select.nc2_fixture_microgrid_action-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'powered',
+        'not_powered',
+        'schedule',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.nc2_fixture_microgrid_action',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Microgrid action',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'relay_microgrid_action',
+    'unique_id': '654321_relay_NC2_microgrid_action',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_select[envoy_metered_batt_relay][select.nc2_fixture_microgrid_action-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'NC2 Fixture Microgrid action',
+      'options': list([
+        'powered',
+        'not_powered',
+        'schedule',
+        'none',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.nc2_fixture_microgrid_action',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'not_powered',
+  })
+# ---
+# name: test_select[envoy_metered_batt_relay][select.nc2_fixture_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'standard',
+        'battery',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.nc2_fixture_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Mode',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'relay_mode',
+    'unique_id': '654321_relay_NC2_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_select[envoy_metered_batt_relay][select.nc2_fixture_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'NC2 Fixture Mode',
+      'options': list([
+        'standard',
+        'battery',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.nc2_fixture_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'standard',
+  })
+# ---
+# name: test_select[envoy_metered_batt_relay][select.nc3_fixture_generator_action-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'powered',
+        'not_powered',
+        'schedule',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.nc3_fixture_generator_action',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Generator action',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'relay_generator_action',
+    'unique_id': '654321_relay_NC3_generator_action',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_select[envoy_metered_batt_relay][select.nc3_fixture_generator_action-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'NC3 Fixture Generator action',
+      'options': list([
+        'powered',
+        'not_powered',
+        'schedule',
+        'none',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.nc3_fixture_generator_action',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'powered',
+  })
+# ---
+# name: test_select[envoy_metered_batt_relay][select.nc3_fixture_grid_action-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'powered',
+        'not_powered',
+        'schedule',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.nc3_fixture_grid_action',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Grid action',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'relay_grid_action',
+    'unique_id': '654321_relay_NC3_grid_action',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_select[envoy_metered_batt_relay][select.nc3_fixture_grid_action-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'NC3 Fixture Grid action',
+      'options': list([
+        'powered',
+        'not_powered',
+        'schedule',
+        'none',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.nc3_fixture_grid_action',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'not_powered',
+  })
+# ---
+# name: test_select[envoy_metered_batt_relay][select.nc3_fixture_microgrid_action-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'powered',
+        'not_powered',
+        'schedule',
+        'none',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.nc3_fixture_microgrid_action',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Microgrid action',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'relay_microgrid_action',
+    'unique_id': '654321_relay_NC3_microgrid_action',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_select[envoy_metered_batt_relay][select.nc3_fixture_microgrid_action-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'NC3 Fixture Microgrid action',
+      'options': list([
+        'powered',
+        'not_powered',
+        'schedule',
+        'none',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.nc3_fixture_microgrid_action',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'powered',
+  })
+# ---
+# name: test_select[envoy_metered_batt_relay][select.nc3_fixture_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'standard',
+        'battery',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.nc3_fixture_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Mode',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'relay_mode',
+    'unique_id': '654321_relay_NC3_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_select[envoy_metered_batt_relay][select.nc3_fixture_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'NC3 Fixture Mode',
+      'options': list([
+        'standard',
+        'battery',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.nc3_fixture_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'standard',
+  })
+# ---

--- a/tests/components/enphase_envoy/test_select.py
+++ b/tests/components/enphase_envoy/test_select.py
@@ -1,0 +1,221 @@
+"""Test Enphase Envoy select."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.enphase_envoy.const import Platform
+from homeassistant.components.enphase_envoy.select import (
+    ACTION_OPTIONS,
+    MODE_OPTIONS,
+    RELAY_ACTION_MAP,
+    RELAY_MODE_MAP,
+    REVERSE_RELAY_ACTION_MAP,
+    REVERSE_RELAY_MODE_MAP,
+    REVERSE_STORAGE_MODE_MAP,
+    STORAGE_MODE_MAP,
+    STORAGE_MODE_OPTIONS,
+)
+from homeassistant.components.select import ATTR_OPTION, DOMAIN as SELECT_DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_SELECT_OPTION
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.mark.parametrize(
+    ("mock_envoy"), ["envoy_metered_batt_relay"], indirect=["mock_envoy"]
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_select(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_envoy: AsyncMock,
+    config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test select platform entities against snapshot."""
+    with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SELECT]):
+        await setup_integration(hass, config_entry)
+    await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("mock_envoy"),
+    [
+        "envoy",
+        "envoy_1p_metered",
+        "envoy_nobatt_metered_3p",
+        "envoy_tot_cons_metered",
+    ],
+    indirect=["mock_envoy"],
+)
+async def test_no_select(
+    hass: HomeAssistant,
+    mock_envoy: AsyncMock,
+    config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test select platform entities against snapshot."""
+    with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SELECT]):
+        await setup_integration(hass, config_entry)
+    assert not er.async_entries_for_config_entry(entity_registry, config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("mock_envoy"), ["envoy_metered_batt_relay"], indirect=["mock_envoy"]
+)
+async def test_select_relay_actions(
+    hass: HomeAssistant,
+    mock_envoy: AsyncMock,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test select platform entities dry contact relay actions."""
+    with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SELECT]):
+        await setup_integration(hass, config_entry)
+
+    entity_base = f"{Platform.SELECT}."
+
+    for contact_id, dry_contact in mock_envoy.data.dry_contact_settings.items():
+        name = dry_contact.load_name.lower().replace(" ", "_")
+        for target in (
+            ("generator_action", dry_contact.generator_action, "generator_action"),
+            ("microgrid_action", dry_contact.micro_grid_action, "micro_grid_action"),
+            ("grid_action", dry_contact.grid_action, "grid_action"),
+        ):
+            test_entity = f"{entity_base}{name}_{target[0]}"
+            assert (entity_state := hass.states.get(test_entity))
+            assert RELAY_ACTION_MAP[target[1]] == (current_state := entity_state.state)
+            # set all relay modes except current mode
+            for action in [action for action in ACTION_OPTIONS if not current_state]:
+                await hass.services.async_call(
+                    SELECT_DOMAIN,
+                    SERVICE_SELECT_OPTION,
+                    {
+                        ATTR_ENTITY_ID: test_entity,
+                        ATTR_OPTION: action,
+                    },
+                    blocking=True,
+                )
+                mock_envoy.update_dry_contact.assert_called_once_with(
+                    {"id": contact_id, target[2]: REVERSE_RELAY_ACTION_MAP[action]}
+                )
+                mock_envoy.update_dry_contact.reset_mock()
+            # and finally back to original
+            await hass.services.async_call(
+                SELECT_DOMAIN,
+                SERVICE_SELECT_OPTION,
+                {
+                    ATTR_ENTITY_ID: test_entity,
+                    ATTR_OPTION: current_state,
+                },
+                blocking=True,
+            )
+            mock_envoy.update_dry_contact.assert_called_once_with(
+                {"id": contact_id, target[2]: REVERSE_RELAY_ACTION_MAP[current_state]}
+            )
+            mock_envoy.update_dry_contact.reset_mock()
+
+
+@pytest.mark.parametrize(
+    ("mock_envoy"), ["envoy_metered_batt_relay"], indirect=["mock_envoy"]
+)
+async def test_select_relay_modes(
+    hass: HomeAssistant,
+    mock_envoy: AsyncMock,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test select platform dry contact relay mode changes."""
+    with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SELECT]):
+        await setup_integration(hass, config_entry)
+
+    entity_base = f"{Platform.SELECT}."
+
+    for contact_id, dry_contact in mock_envoy.data.dry_contact_settings.items():
+        name = dry_contact.load_name.lower().replace(" ", "_")
+        test_entity = f"{entity_base}{name}_mode"
+        assert (entity_state := hass.states.get(test_entity))
+        assert RELAY_MODE_MAP[dry_contact.mode] == (current_state := entity_state.state)
+        for mode in [mode for mode in MODE_OPTIONS if not current_state]:
+            await hass.services.async_call(
+                SELECT_DOMAIN,
+                SERVICE_SELECT_OPTION,
+                {
+                    ATTR_ENTITY_ID: test_entity,
+                    ATTR_OPTION: mode,
+                },
+                blocking=True,
+            )
+            mock_envoy.update_dry_contact.assert_called_once_with(
+                {"id": contact_id, "mode": REVERSE_RELAY_MODE_MAP[mode]}
+            )
+            mock_envoy.update_dry_contact.reset_mock()
+
+        # and finally current mode again
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: test_entity,
+                ATTR_OPTION: current_state,
+            },
+            blocking=True,
+        )
+        mock_envoy.update_dry_contact.assert_called_once_with(
+            {"id": contact_id, "mode": REVERSE_RELAY_MODE_MAP[current_state]}
+        )
+        mock_envoy.update_dry_contact.reset_mock()
+
+
+@pytest.mark.parametrize(
+    ("mock_envoy"), ["envoy_metered_batt_relay"], indirect=["mock_envoy"]
+)
+async def test_select_storage_modes(
+    hass: HomeAssistant,
+    mock_envoy: AsyncMock,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test select platform entities storage mode changes."""
+    with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SELECT]):
+        await setup_integration(hass, config_entry)
+
+    sn = mock_envoy.data.enpower.serial_number
+    test_entity = f"{Platform.SELECT}.enpower_{sn}_storage_mode"
+
+    assert (entity_state := hass.states.get(test_entity))
+    assert STORAGE_MODE_MAP[mock_envoy.data.tariff.storage_settings.mode] == (
+        current_state := entity_state.state
+    )
+
+    for mode in [mode for mode in STORAGE_MODE_OPTIONS if not current_state]:
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: test_entity,
+                ATTR_OPTION: mode,
+            },
+            blocking=True,
+        )
+        mock_envoy.set_storage_mode.assert_called_once_with(
+            REVERSE_STORAGE_MODE_MAP[mode]
+        )
+        mock_envoy.set_storage_mode.reset_mock()
+
+    # and finally with original mode
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: test_entity,
+            ATTR_OPTION: current_state,
+        },
+        blocking=True,
+    )
+    mock_envoy.set_storage_mode.assert_called_once_with(
+        REVERSE_STORAGE_MODE_MAP[current_state]
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Currently enphase_envoy integration utilizes the select platform but lacks tests for the platform. This PR adds tests for the Enphase_envoy select platform.

Specifically this PR:

- Adds test_select.py which
  - performs snapshot tests on select entities.
  - tests if entities are not created if not available in enphase_envoy device
  - tests select operations SERVICE_SELECT_OPTION for enhase_envoy dry contact relay actions
  - tests select operations SERVICE_SELECT_OPTION for enhase_envoy dry contact relay modes
  - tests select operations SERVICE_SELECT_OPTION for enhase_envoy storage modes

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
