### PR TITLE
Extend sensor platform tests for enphase_envoy

### DIFF
--- a/tests/components/enphase_envoy/test_sensor.py
+++ b/tests/components/enphase_envoy/test_sensor.py
@@ -1,7 +1,6 @@
 """Test Enphase Envoy sensors."""
 
-import itertools
-from typing import Any
+from itertools import chain
 from unittest.mock import AsyncMock, patch
 
 from pyenphase.const import PHASENAMES
@@ -116,18 +115,16 @@ async def test_sensor_production_phase_data(
     sn = mock_envoy.serial_number
     ENTITY_BASE: str = f"{Platform.SENSOR}.envoy_{sn}"
 
-    PRODUCTION_PHASE_TARGET: list[float] = list(
-        itertools.chain(
-            *[
-                (
-                    phase_data.watts_now / 1000.0,
-                    phase_data.watt_hours_today / 1000.0,
-                    phase_data.watt_hours_last_7_days / 1000.0,
-                    phase_data.watt_hours_lifetime / 1000000.0,
-                )
-                for phase_data in mock_envoy.data.system_production_phases.values()
-            ]
-        )
+    PRODUCTION_PHASE_TARGET = chain(
+        *[
+            (
+                phase_data.watts_now / 1000.0,
+                phase_data.watt_hours_today / 1000.0,
+                phase_data.watt_hours_last_7_days / 1000.0,
+                phase_data.watt_hours_lifetime / 1000000.0,
+            )
+            for phase_data in mock_envoy.data.system_production_phases.values()
+        ]
     )
 
     for name, target in list(
@@ -206,18 +203,16 @@ async def test_sensor_consumption_phase_data(
     sn = mock_envoy.serial_number
     ENTITY_BASE: str = f"{Platform.SENSOR}.envoy_{sn}"
 
-    CONSUMPTION_PHASE_TARGET: list[float] = list(
-        itertools.chain(
-            *[
-                (
-                    phase_data.watts_now / 1000.0,
-                    phase_data.watt_hours_today / 1000.0,
-                    phase_data.watt_hours_last_7_days / 1000.0,
-                    phase_data.watt_hours_lifetime / 1000000.0,
-                )
-                for phase_data in mock_envoy.data.system_consumption_phases.values()
-            ]
-        )
+    CONSUMPTION_PHASE_TARGET = chain(
+        *[
+            (
+                phase_data.watts_now / 1000.0,
+                phase_data.watt_hours_today / 1000.0,
+                phase_data.watt_hours_last_7_days / 1000.0,
+                phase_data.watt_hours_lifetime / 1000000.0,
+            )
+            for phase_data in mock_envoy.data.system_consumption_phases.values()
+        ]
     )
 
     for name, target in list(
@@ -303,14 +298,11 @@ async def test_sensor_production_ct_phase_data(
     sn = mock_envoy.serial_number
     ENTITY_BASE: str = f"{Platform.SENSOR}.envoy_{sn}"
 
-    CT_PRODUCTION_NAMES_FLOAT_TARGET: list[int] = list(
-        itertools.chain(
-            *[
-                (len(phase_data.status_flags),)
-                for phase_data in mock_envoy.data.ctmeter_production_phases.values()
-            ]
-        )
-    )
+    CT_PRODUCTION_NAMES_FLOAT_TARGET = [
+        len(phase_data.status_flags)
+        for phase_data in mock_envoy.data.ctmeter_production_phases.values()
+    ]
+
     for name, target in list(
         zip(
             CT_PRODUCTION_NAMES_FLOAT_PHASE,
@@ -321,14 +313,10 @@ async def test_sensor_production_ct_phase_data(
         assert (entity_state := hass.states.get(f"{ENTITY_BASE}_{name}"))
         assert target == float(entity_state.state)
 
-    CT_PRODUCTION_NAMES_STR_TARGET: list[str] = list(
-        itertools.chain(
-            *[
-                (phase_data.metering_status,)
-                for phase_data in mock_envoy.data.ctmeter_production_phases.values()
-            ]
-        )
-    )
+    CT_PRODUCTION_NAMES_STR_TARGET = [
+        phase_data.metering_status
+        for phase_data in mock_envoy.data.ctmeter_production_phases.values()
+    ]
 
     for name, target in list(
         zip(
@@ -432,21 +420,20 @@ async def test_sensor_consumption_ct_phase_data(
     sn = mock_envoy.serial_number
     ENTITY_BASE: str = f"{Platform.SENSOR}.envoy_{sn}"
 
-    CT_CONSUMPTION_NAMES_FLOAT_PHASE_TARGET: list[Any | int] = list(
-        itertools.chain(
-            *[
-                (
-                    phase_data.energy_delivered / 1000000.0,
-                    phase_data.energy_received / 1000000.0,
-                    phase_data.active_power / 1000.0,
-                    phase_data.frequency,
-                    phase_data.voltage,
-                    len(phase_data.status_flags),
-                )
-                for phase_data in mock_envoy.data.ctmeter_consumption_phases.values()
-            ]
-        )
+    CT_CONSUMPTION_NAMES_FLOAT_PHASE_TARGET = chain(
+        *[
+            (
+                phase_data.energy_delivered / 1000000.0,
+                phase_data.energy_received / 1000000.0,
+                phase_data.active_power / 1000.0,
+                phase_data.frequency,
+                phase_data.voltage,
+                len(phase_data.status_flags),
+            )
+            for phase_data in mock_envoy.data.ctmeter_consumption_phases.values()
+        ]
     )
+
     for name, target in list(
         zip(
             CT_CONSUMPTION_NAMES_FLOAT_PHASE,
@@ -457,14 +444,10 @@ async def test_sensor_consumption_ct_phase_data(
         assert (entity_state := hass.states.get(f"{ENTITY_BASE}_{name}"))
         assert target == float(entity_state.state)
 
-    CT_CONSUMPTION_NAMES_STR_PHASE_TARGET: list[Any] = list(
-        itertools.chain(
-            *[
-                (phase_data.metering_status,)
-                for phase_data in mock_envoy.data.ctmeter_consumption_phases.values()
-            ]
-        )
-    )
+    CT_CONSUMPTION_NAMES_STR_PHASE_TARGET = [
+        phase_data.metering_status
+        for phase_data in mock_envoy.data.ctmeter_consumption_phases.values()
+    ]
 
     for name, target in list(
         zip(
@@ -561,20 +544,19 @@ async def test_sensor_storage_ct_phase_data(
     sn = mock_envoy.serial_number
     ENTITY_BASE: str = f"{Platform.SENSOR}.envoy_{sn}"
 
-    CT_STORAGE_NAMES_FLOAT_PHASE_TARGET: list[float | int] = list(
-        itertools.chain(
-            *[
-                (
-                    phase_data.energy_delivered / 1000000.0,
-                    phase_data.energy_received / 1000000.0,
-                    phase_data.active_power / 1000.0,
-                    phase_data.voltage,
-                    len(phase_data.status_flags),
-                )
-                for phase_data in mock_envoy.data.ctmeter_storage_phases.values()
-            ]
-        )
+    CT_STORAGE_NAMES_FLOAT_PHASE_TARGET = chain(
+        *[
+            (
+                phase_data.energy_delivered / 1000000.0,
+                phase_data.energy_received / 1000000.0,
+                phase_data.active_power / 1000.0,
+                phase_data.voltage,
+                len(phase_data.status_flags),
+            )
+            for phase_data in mock_envoy.data.ctmeter_storage_phases.values()
+        ]
     )
+
     for name, target in list(
         zip(
             CT_STORAGE_NAMES_FLOAT_PHASE,
@@ -585,14 +567,10 @@ async def test_sensor_storage_ct_phase_data(
         assert (entity_state := hass.states.get(f"{ENTITY_BASE}_{name}"))
         assert target == float(entity_state.state)
 
-    CT_STORAGE_NAMES_STR_PHASE_TARGET: list[Any] = list(
-        itertools.chain(
-            *[
-                (phase_data.metering_status,)
-                for phase_data in mock_envoy.data.ctmeter_storage_phases.values()
-            ]
-        )
-    )
+    CT_STORAGE_NAMES_STR_PHASE_TARGET = [
+        phase_data.metering_status
+        for phase_data in mock_envoy.data.ctmeter_storage_phases.values()
+    ]
 
     for name, target in list(
         zip(

--- a/tests/components/enphase_envoy/test_sensor.py
+++ b/tests/components/enphase_envoy/test_sensor.py
@@ -1,13 +1,19 @@
 """Test Enphase Envoy sensors."""
 
+import itertools
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
+from pyenphase.const import PHASENAMES
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.enphase_envoy.const import Platform
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
+from homeassistant.util.unit_conversion import TemperatureConverter
 
 from . import setup_integration
 
@@ -37,3 +43,825 @@ async def test_sensor(
     with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SENSOR]):
         await setup_integration(hass, config_entry)
     await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
+
+
+PRODUCTION_NAMES: tuple[str, ...] = (
+    "current_power_production",
+    "energy_production_today",
+    "energy_production_last_seven_days",
+    "lifetime_energy_production",
+)
+
+
+@pytest.mark.parametrize(
+    ("mock_envoy"),
+    [
+        "envoy",
+        "envoy_1p_metered",
+        "envoy_metered_batt_relay",
+        "envoy_nobatt_metered_3p",
+        "envoy_tot_cons_metered",
+    ],
+    indirect=["mock_envoy"],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_sensor_production_data(
+    hass: HomeAssistant,
+    mock_envoy: AsyncMock,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test production entities values."""
+    with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, config_entry)
+
+    sn = mock_envoy.serial_number
+    ENTITY_BASE: str = f"{Platform.SENSOR}.envoy_{sn}"
+
+    data = mock_envoy.data.system_production
+    PRODUCTION_TARGETS: tuple[float, ...] = (
+        data.watts_now / 1000.0,
+        data.watt_hours_today / 1000.0,
+        data.watt_hours_last_7_days / 1000.0,
+        data.watt_hours_lifetime / 1000000.0,
+    )
+
+    for name, target in list(zip(PRODUCTION_NAMES, PRODUCTION_TARGETS, strict=False)):
+        assert (entity_state := hass.states.get(f"{ENTITY_BASE}_{name}"))
+        assert target == float(entity_state.state)
+
+
+PRODUCTION_PHASE_NAMES: list[str] = [
+    f"{name}_{phase.lower()}" for phase in PHASENAMES for name in PRODUCTION_NAMES
+]
+
+
+@pytest.mark.parametrize(
+    ("mock_envoy"),
+    [
+        "envoy_metered_batt_relay",
+        "envoy_nobatt_metered_3p",
+    ],
+    indirect=["mock_envoy"],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_sensor_production_phase_data(
+    hass: HomeAssistant,
+    mock_envoy: AsyncMock,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test production phase entities values."""
+    with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, config_entry)
+
+    sn = mock_envoy.serial_number
+    ENTITY_BASE: str = f"{Platform.SENSOR}.envoy_{sn}"
+
+    PRODUCTION_PHASE_TARGET: list[float] = list(
+        itertools.chain(
+            *[
+                (
+                    phase_data.watts_now / 1000.0,
+                    phase_data.watt_hours_today / 1000.0,
+                    phase_data.watt_hours_last_7_days / 1000.0,
+                    phase_data.watt_hours_lifetime / 1000000.0,
+                )
+                for phase_data in mock_envoy.data.system_production_phases.values()
+            ]
+        )
+    )
+
+    for name, target in list(
+        zip(PRODUCTION_PHASE_NAMES, PRODUCTION_PHASE_TARGET, strict=False)
+    ):
+        assert (entity_state := hass.states.get(f"{ENTITY_BASE}_{name}"))
+        assert target == float(entity_state.state)
+
+
+CONSUMPTION_NAMES: tuple[str, ...] = (
+    "current_power_consumption",
+    "energy_consumption_today",
+    "energy_consumption_last_seven_days",
+    "lifetime_energy_consumption",
+)
+
+
+@pytest.mark.parametrize(
+    ("mock_envoy"),
+    [
+        "envoy_1p_metered",
+        "envoy_metered_batt_relay",
+        "envoy_nobatt_metered_3p",
+    ],
+    indirect=["mock_envoy"],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_sensor_consumption_data(
+    hass: HomeAssistant,
+    mock_envoy: AsyncMock,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test consumption entities values."""
+    with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, config_entry)
+
+    sn = mock_envoy.serial_number
+    ENTITY_BASE: str = f"{Platform.SENSOR}.envoy_{sn}"
+
+    data = mock_envoy.data.system_consumption
+    CONSUMPTION_TARGETS = (
+        data.watts_now / 1000.0,
+        data.watt_hours_today / 1000.0,
+        data.watt_hours_last_7_days / 1000.0,
+        data.watt_hours_lifetime / 1000000.0,
+    )
+
+    for name, target in list(zip(CONSUMPTION_NAMES, CONSUMPTION_TARGETS, strict=False)):
+        assert (entity_state := hass.states.get(f"{ENTITY_BASE}_{name}"))
+        assert target == float(entity_state.state)
+
+
+CONSUMPTION_PHASE_NAMES: list[str] = [
+    f"{name}_{phase.lower()}" for phase in PHASENAMES for name in CONSUMPTION_NAMES
+]
+
+
+@pytest.mark.parametrize(
+    ("mock_envoy"),
+    [
+        "envoy_metered_batt_relay",
+        "envoy_nobatt_metered_3p",
+    ],
+    indirect=["mock_envoy"],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_sensor_consumption_phase_data(
+    hass: HomeAssistant,
+    mock_envoy: AsyncMock,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test consumption phase entities values."""
+    with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, config_entry)
+
+    sn = mock_envoy.serial_number
+    ENTITY_BASE: str = f"{Platform.SENSOR}.envoy_{sn}"
+
+    CONSUMPTION_PHASE_TARGET: list[float] = list(
+        itertools.chain(
+            *[
+                (
+                    phase_data.watts_now / 1000.0,
+                    phase_data.watt_hours_today / 1000.0,
+                    phase_data.watt_hours_last_7_days / 1000.0,
+                    phase_data.watt_hours_lifetime / 1000000.0,
+                )
+                for phase_data in mock_envoy.data.system_consumption_phases.values()
+            ]
+        )
+    )
+
+    for name, target in list(
+        zip(CONSUMPTION_PHASE_NAMES, CONSUMPTION_PHASE_TARGET, strict=False)
+    ):
+        assert (entity_state := hass.states.get(f"{ENTITY_BASE}_{name}"))
+        assert target == float(entity_state.state)
+
+
+CT_PRODUCTION_NAMES_INT = ("meter_status_flags_active_production_ct",)
+CT_PRODUCTION_NAMES_STR = ("metering_status_production_ct",)
+
+
+@pytest.mark.parametrize(
+    ("mock_envoy"),
+    [
+        "envoy_metered_batt_relay",
+        "envoy_nobatt_metered_3p",
+    ],
+    indirect=["mock_envoy"],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_sensor_production_ct_data(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_envoy: AsyncMock,
+) -> None:
+    """Test production CT phase entities values."""
+    with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, config_entry)
+
+    sn = mock_envoy.serial_number
+    ENTITY_BASE: str = f"{Platform.SENSOR}.envoy_{sn}"
+
+    data = mock_envoy.data.ctmeter_production
+
+    CT_PRODUCTION_TARGETS_INT = (len(data.status_flags),)
+    for name, target in list(
+        zip(CT_PRODUCTION_NAMES_INT, CT_PRODUCTION_TARGETS_INT, strict=False)
+    ):
+        assert (entity_state := hass.states.get(f"{ENTITY_BASE}_{name}"))
+        assert target == float(entity_state.state)
+
+    CT_PRODUCTION_TARGETS_STR = (data.metering_status,)
+    for name, target in list(
+        zip(CT_PRODUCTION_NAMES_STR, CT_PRODUCTION_TARGETS_STR, strict=False)
+    ):
+        assert (entity_state := hass.states.get(f"{ENTITY_BASE}_{name}"))
+        assert target == entity_state.state
+
+
+CT_PRODUCTION_NAMES_FLOAT_PHASE = [
+    f"{name}_{phase.lower()}"
+    for phase in PHASENAMES
+    for name in CT_PRODUCTION_NAMES_INT
+]
+
+CT_PRODUCTION_NAMES_STR_PHASE = [
+    f"{name}_{phase.lower()}"
+    for phase in PHASENAMES
+    for name in CT_PRODUCTION_NAMES_STR
+]
+
+
+@pytest.mark.parametrize(
+    ("mock_envoy"),
+    [
+        "envoy_metered_batt_relay",
+        "envoy_nobatt_metered_3p",
+    ],
+    indirect=["mock_envoy"],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_sensor_production_ct_phase_data(
+    hass: HomeAssistant,
+    mock_envoy: AsyncMock,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test production ct phase entities values."""
+    with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, config_entry)
+
+    sn = mock_envoy.serial_number
+    ENTITY_BASE: str = f"{Platform.SENSOR}.envoy_{sn}"
+
+    CT_PRODUCTION_NAMES_FLOAT_TARGET: list[int] = list(
+        itertools.chain(
+            *[
+                (len(phase_data.status_flags),)
+                for phase_data in mock_envoy.data.ctmeter_production_phases.values()
+            ]
+        )
+    )
+    for name, target in list(
+        zip(
+            CT_PRODUCTION_NAMES_FLOAT_PHASE,
+            CT_PRODUCTION_NAMES_FLOAT_TARGET,
+            strict=False,
+        )
+    ):
+        assert (entity_state := hass.states.get(f"{ENTITY_BASE}_{name}"))
+        assert target == float(entity_state.state)
+
+    CT_PRODUCTION_NAMES_STR_TARGET: list[str] = list(
+        itertools.chain(
+            *[
+                (phase_data.metering_status,)
+                for phase_data in mock_envoy.data.ctmeter_production_phases.values()
+            ]
+        )
+    )
+
+    for name, target in list(
+        zip(
+            CT_PRODUCTION_NAMES_STR_PHASE,
+            CT_PRODUCTION_NAMES_STR_TARGET,
+            strict=False,
+        )
+    ):
+        assert (entity_state := hass.states.get(f"{ENTITY_BASE}_{name}"))
+        assert target == entity_state.state
+
+
+CT_CONSUMPTION_NAMES_FLOAT: tuple[str, ...] = (
+    "lifetime_net_energy_consumption",
+    "lifetime_net_energy_production",
+    "current_net_power_consumption",
+    "frequency_net_consumption_ct",
+    "voltage_net_consumption_ct",
+    "meter_status_flags_active_net_consumption_ct",
+)
+
+CT_CONSUMPTION_NAMES_STR: tuple[str, ...] = ("metering_status_net_consumption_ct",)
+
+
+@pytest.mark.parametrize(
+    ("mock_envoy"),
+    [
+        "envoy_metered_batt_relay",
+        "envoy_nobatt_metered_3p",
+    ],
+    indirect=["mock_envoy"],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_sensor_consumption_ct_data(
+    hass: HomeAssistant,
+    mock_envoy: AsyncMock,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test consumption CT phase entities values."""
+    with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, config_entry)
+
+    sn = mock_envoy.serial_number
+    ENTITY_BASE: str = f"{Platform.SENSOR}.envoy_{sn}"
+
+    data = mock_envoy.data.ctmeter_consumption
+
+    CT_CONSUMPTION_TARGETS_FLOAT = (
+        data.energy_delivered / 1000000.0,
+        data.energy_received / 1000000.0,
+        data.active_power / 1000.0,
+        data.frequency,
+        data.voltage,
+        len(data.status_flags),
+    )
+    for name, target in list(
+        zip(CT_CONSUMPTION_NAMES_FLOAT, CT_CONSUMPTION_TARGETS_FLOAT, strict=False)
+    ):
+        assert (entity_state := hass.states.get(f"{ENTITY_BASE}_{name}"))
+        assert target == float(entity_state.state)
+
+    CT_CONSUMPTION_TARGETS_STR = (data.metering_status,)
+    for name, target in list(
+        zip(CT_CONSUMPTION_NAMES_STR, CT_CONSUMPTION_TARGETS_STR, strict=False)
+    ):
+        assert (entity_state := hass.states.get(f"{ENTITY_BASE}_{name}"))
+        assert target == entity_state.state
+
+
+CT_CONSUMPTION_NAMES_FLOAT_PHASE = [
+    f"{name}_{phase.lower()}"
+    for phase in PHASENAMES
+    for name in CT_CONSUMPTION_NAMES_FLOAT
+]
+
+CT_CONSUMPTION_NAMES_STR_PHASE = [
+    f"{name}_{phase.lower()}"
+    for phase in PHASENAMES
+    for name in CT_CONSUMPTION_NAMES_STR
+]
+
+
+@pytest.mark.parametrize(
+    ("mock_envoy"),
+    [
+        "envoy_metered_batt_relay",
+        "envoy_nobatt_metered_3p",
+    ],
+    indirect=["mock_envoy"],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_sensor_consumption_ct_phase_data(
+    hass: HomeAssistant,
+    mock_envoy: AsyncMock,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test consumption ct phase entities values."""
+    with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, config_entry)
+
+    sn = mock_envoy.serial_number
+    ENTITY_BASE: str = f"{Platform.SENSOR}.envoy_{sn}"
+
+    CT_CONSUMPTION_NAMES_FLOAT_PHASE_TARGET: list[Any | int] = list(
+        itertools.chain(
+            *[
+                (
+                    phase_data.energy_delivered / 1000000.0,
+                    phase_data.energy_received / 1000000.0,
+                    phase_data.active_power / 1000.0,
+                    phase_data.frequency,
+                    phase_data.voltage,
+                    len(phase_data.status_flags),
+                )
+                for phase_data in mock_envoy.data.ctmeter_consumption_phases.values()
+            ]
+        )
+    )
+    for name, target in list(
+        zip(
+            CT_CONSUMPTION_NAMES_FLOAT_PHASE,
+            CT_CONSUMPTION_NAMES_FLOAT_PHASE_TARGET,
+            strict=False,
+        )
+    ):
+        assert (entity_state := hass.states.get(f"{ENTITY_BASE}_{name}"))
+        assert target == float(entity_state.state)
+
+    CT_CONSUMPTION_NAMES_STR_PHASE_TARGET: list[Any] = list(
+        itertools.chain(
+            *[
+                (phase_data.metering_status,)
+                for phase_data in mock_envoy.data.ctmeter_consumption_phases.values()
+            ]
+        )
+    )
+
+    for name, target in list(
+        zip(
+            CT_CONSUMPTION_NAMES_STR_PHASE,
+            CT_CONSUMPTION_NAMES_STR_PHASE_TARGET,
+            strict=False,
+        )
+    ):
+        assert (entity_state := hass.states.get(f"{ENTITY_BASE}_{name}"))
+        assert target == entity_state.state
+
+
+CT_STORAGE_NAMES_FLOAT = (
+    "lifetime_battery_energy_discharged",
+    "lifetime_battery_energy_charged",
+    "current_battery_discharge",
+    "voltage_storage_ct",
+    "meter_status_flags_active_storage_ct",
+)
+CT_STORAGE_NAMES_STR = ("metering_status_storage_ct",)
+
+
+@pytest.mark.parametrize(
+    ("mock_envoy"),
+    [
+        "envoy_metered_batt_relay",
+    ],
+    indirect=["mock_envoy"],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_sensor_storage_ct_data(
+    hass: HomeAssistant,
+    mock_envoy: AsyncMock,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test storage phase entities values."""
+    with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, config_entry)
+
+    sn = mock_envoy.serial_number
+    ENTITY_BASE: str = f"{Platform.SENSOR}.envoy_{sn}"
+
+    data = mock_envoy.data.ctmeter_storage
+
+    CT_STORAGE_TARGETS_FLOAT = (
+        data.energy_delivered / 1000000.0,
+        data.energy_received / 1000000.0,
+        data.active_power / 1000.0,
+        data.voltage,
+        len(data.status_flags),
+    )
+    for name, target in list(
+        zip(CT_STORAGE_NAMES_FLOAT, CT_STORAGE_TARGETS_FLOAT, strict=False)
+    ):
+        assert (entity_state := hass.states.get(f"{ENTITY_BASE}_{name}"))
+        assert target == float(entity_state.state)
+
+    CT_STORAGE_TARGETS_STR = (data.metering_status,)
+    for name, target in list(
+        zip(CT_STORAGE_NAMES_STR, CT_STORAGE_TARGETS_STR, strict=False)
+    ):
+        assert (entity_state := hass.states.get(f"{ENTITY_BASE}_{name}"))
+        assert target == entity_state.state
+
+
+CT_STORAGE_NAMES_FLOAT_PHASE = [
+    f"{name}_{phase.lower()}"
+    for phase in PHASENAMES
+    for name in (CT_STORAGE_NAMES_FLOAT)
+]
+
+CT_STORAGE_NAMES_STR_PHASE = [
+    f"{name}_{phase.lower()}" for phase in PHASENAMES for name in (CT_STORAGE_NAMES_STR)
+]
+
+
+@pytest.mark.parametrize(
+    ("mock_envoy"),
+    [
+        "envoy_metered_batt_relay",
+    ],
+    indirect=["mock_envoy"],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_sensor_storage_ct_phase_data(
+    hass: HomeAssistant,
+    mock_envoy: AsyncMock,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test storage ct phase entities values."""
+    with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, config_entry)
+
+    sn = mock_envoy.serial_number
+    ENTITY_BASE: str = f"{Platform.SENSOR}.envoy_{sn}"
+
+    CT_STORAGE_NAMES_FLOAT_PHASE_TARGET: list[float | int] = list(
+        itertools.chain(
+            *[
+                (
+                    phase_data.energy_delivered / 1000000.0,
+                    phase_data.energy_received / 1000000.0,
+                    phase_data.active_power / 1000.0,
+                    phase_data.voltage,
+                    len(phase_data.status_flags),
+                )
+                for phase_data in mock_envoy.data.ctmeter_storage_phases.values()
+            ]
+        )
+    )
+    for name, target in list(
+        zip(
+            CT_STORAGE_NAMES_FLOAT_PHASE,
+            CT_STORAGE_NAMES_FLOAT_PHASE_TARGET,
+            strict=False,
+        )
+    ):
+        assert (entity_state := hass.states.get(f"{ENTITY_BASE}_{name}"))
+        assert target == float(entity_state.state)
+
+    CT_STORAGE_NAMES_STR_PHASE_TARGET: list[Any] = list(
+        itertools.chain(
+            *[
+                (phase_data.metering_status,)
+                for phase_data in mock_envoy.data.ctmeter_storage_phases.values()
+            ]
+        )
+    )
+
+    for name, target in list(
+        zip(
+            CT_STORAGE_NAMES_STR_PHASE,
+            CT_STORAGE_NAMES_STR_PHASE_TARGET,
+            strict=False,
+        )
+    ):
+        assert (entity_state := hass.states.get(f"{ENTITY_BASE}_{name}"))
+        assert target == entity_state.state
+
+
+@pytest.mark.parametrize(
+    ("mock_envoy"),
+    [
+        "envoy_metered_batt_relay",
+        "envoy_nobatt_metered_3p",
+    ],
+    indirect=["mock_envoy"],
+)
+async def test_sensor_all_phase_entities_disabled_by_integration(
+    hass: HomeAssistant,
+    mock_envoy: AsyncMock,
+    config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test all phase entities are disabled by integration."""
+    with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, config_entry)
+
+    sn = mock_envoy.serial_number
+    ENTITY_BASE: str = f"{Platform.SENSOR}.envoy_{sn}"
+
+    assert all(
+        f"{ENTITY_BASE}_{entity}"
+        in (integration_disabled_entities(entity_registry, config_entry))
+        for entity in (
+            PRODUCTION_PHASE_NAMES
+            + CONSUMPTION_PHASE_NAMES
+            + CT_PRODUCTION_NAMES_FLOAT_PHASE
+            + CT_PRODUCTION_NAMES_STR_PHASE
+            + CT_CONSUMPTION_NAMES_FLOAT_PHASE
+            + CT_CONSUMPTION_NAMES_STR_PHASE
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    ("mock_envoy"),
+    [
+        "envoy_metered_batt_relay",
+    ],
+    indirect=["mock_envoy"],
+)
+async def test_sensor_storage_phase_disabled_by_integration(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    mock_envoy: AsyncMock,
+) -> None:
+    """Test all storage CT phase entities are disabled by integration."""
+    with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, config_entry)
+
+    sn = mock_envoy.serial_number
+    ENTITY_BASE: str = f"{Platform.SENSOR}.envoy_{sn}"
+
+    assert all(
+        f"{ENTITY_BASE}_{entity}"
+        in integration_disabled_entities(entity_registry, config_entry)
+        for entity in (CT_STORAGE_NAMES_FLOAT_PHASE + CT_STORAGE_NAMES_STR_PHASE)
+    )
+
+
+@pytest.mark.parametrize(
+    ("mock_envoy"),
+    [
+        "envoy",
+        "envoy_1p_metered",
+        "envoy_metered_batt_relay",
+        "envoy_nobatt_metered_3p",
+        "envoy_tot_cons_metered",
+    ],
+    indirect=["mock_envoy"],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_sensor_inverter_data(
+    hass: HomeAssistant,
+    mock_envoy: AsyncMock,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test enphase_envoy inverter entities values."""
+    with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, config_entry)
+
+    entity_base = f"{Platform.SENSOR}.inverter"
+
+    for sn, inverter in mock_envoy.data.inverters.items():
+        assert (entity_state := hass.states.get(f"{entity_base}_{sn}"))
+        assert (inverter.last_report_watts) == float(entity_state.state)
+        assert (last_reported := hass.states.get(f"{entity_base}_{sn}_last_reported"))
+        assert dt_util.utc_from_timestamp(
+            inverter.last_report_date
+        ) == dt_util.parse_datetime(last_reported.state)
+
+
+@pytest.mark.parametrize(
+    ("mock_envoy"),
+    [
+        "envoy",
+        "envoy_1p_metered",
+        "envoy_metered_batt_relay",
+        "envoy_nobatt_metered_3p",
+        "envoy_tot_cons_metered",
+    ],
+    indirect=["mock_envoy"],
+)
+async def test_sensor_inverter_disabled_by_integration(
+    hass: HomeAssistant,
+    mock_envoy: AsyncMock,
+    config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test enphase_envoy inverter disabled by integration entities."""
+    with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, config_entry)
+
+    INVERTER_BASE = f"{Platform.SENSOR}.inverter"
+
+    assert all(
+        f"{INVERTER_BASE}_{sn}_last_reported"
+        in integration_disabled_entities(entity_registry, config_entry)
+        for sn in mock_envoy.data.inverters
+    )
+
+
+@pytest.mark.parametrize(
+    ("mock_envoy"),
+    [
+        "envoy_metered_batt_relay",
+    ],
+    indirect=["mock_envoy"],
+)
+async def test_sensor_encharge_aggregate_data(
+    hass: HomeAssistant,
+    mock_envoy: AsyncMock,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test enphase_envoy encharge aggregate entities values."""
+    with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, config_entry)
+
+    sn = mock_envoy.serial_number
+    ENTITY_BASE = f"{Platform.SENSOR}.envoy_{sn}"
+
+    data = mock_envoy.data.encharge_aggregate
+
+    for target in (
+        ("battery", data.state_of_charge),
+        ("reserve_battery_level", data.reserve_state_of_charge),
+        ("available_battery_energy", data.available_energy),
+        ("reserve_battery_energy", data.backup_reserve),
+        ("battery_capacity", data.max_available_capacity),
+    ):
+        assert (entity_state := hass.states.get(f"{ENTITY_BASE}_{target[0]}"))
+        assert target[1] == float(entity_state.state)
+
+
+@pytest.mark.parametrize(
+    ("mock_envoy"),
+    [
+        "envoy_metered_batt_relay",
+    ],
+    indirect=["mock_envoy"],
+)
+async def test_sensor_encharge_enpower_data(
+    hass: HomeAssistant,
+    mock_envoy: AsyncMock,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test enphase_envoy encharge enpower entities values."""
+    with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, config_entry)
+
+    sn = mock_envoy.data.enpower.serial_number
+    ENTITY_BASE = f"{Platform.SENSOR}.enpower"
+
+    assert (entity_state := hass.states.get(f"{ENTITY_BASE}_{sn}_temperature"))
+    assert mock_envoy.data.enpower.temperature == round(
+        TemperatureConverter.convert(
+            float(entity_state.state),
+            hass.config.units.temperature_unit,
+            UnitOfTemperature.FAHRENHEIT
+            if mock_envoy.data.enpower.temperature_unit == "F"
+            else UnitOfTemperature.CELSIUS,
+        )
+    )
+    assert (entity_state := hass.states.get(f"{ENTITY_BASE}_{sn}_last_reported"))
+    assert dt_util.utc_from_timestamp(
+        mock_envoy.data.enpower.last_report_date
+    ) == dt_util.parse_datetime(entity_state.state)
+
+
+@pytest.mark.parametrize(
+    ("mock_envoy"),
+    [
+        "envoy_metered_batt_relay",
+    ],
+    indirect=["mock_envoy"],
+)
+async def test_sensor_encharge_power_data(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_envoy: AsyncMock,
+) -> None:
+    """Test enphase_envoy encharge_power entities values."""
+    with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, config_entry)
+
+    ENTITY_BASE = f"{Platform.SENSOR}.encharge"
+
+    ENCHARGE_POWER_NAMES = (
+        "battery",
+        "apparent_power",
+        "power",
+    )
+
+    ENCHARGE_POWER_TARGETS = [
+        (
+            sn,
+            (
+                encharge_power.soc,
+                encharge_power.apparent_power_mva / 1000.0,
+                encharge_power.real_power_mw / 1000.0,
+            ),
+        )
+        for sn, encharge_power in mock_envoy.data.encharge_power.items()
+    ]
+
+    for sn, sn_target in ENCHARGE_POWER_TARGETS:
+        for name, target in list(zip(ENCHARGE_POWER_NAMES, sn_target, strict=False)):
+            assert (entity_state := hass.states.get(f"{ENTITY_BASE}_{sn}_{name}"))
+            assert target == float(entity_state.state)
+
+    for sn, encharge_inventory in mock_envoy.data.encharge_inventory.items():
+        assert (entity_state := hass.states.get(f"{ENTITY_BASE}_{sn}_temperature"))
+        assert encharge_inventory.temperature == round(
+            TemperatureConverter.convert(
+                float(entity_state.state),
+                hass.config.units.temperature_unit,
+                UnitOfTemperature.FAHRENHEIT
+                if encharge_inventory.temperature_unit == "F"
+                else UnitOfTemperature.CELSIUS,
+            )
+        )
+        assert (entity_state := hass.states.get(f"{ENTITY_BASE}_{sn}_last_reported"))
+        assert dt_util.utc_from_timestamp(
+            encharge_inventory.last_report_date
+        ) == dt_util.parse_datetime(entity_state.state)
+
+
+def integration_disabled_entities(
+    entity_registry: er.EntityRegistry, config_entry: MockConfigEntry
+) -> list[str]:
+    """Return list of entity ids marked as disabled by integration."""
+    return [
+        entity_entry.entity_id
+        for entity_entry in er.async_entries_for_config_entry(
+            entity_registry, config_entry.entry_id
+        )
+        if entity_entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
+    ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Currently enphase_envoy integration has tests for the sensor platform but these only test snapshot changes. This PR adds tests for the various Enphase_envoy configurations as available in the fixture files.

Specifically this PR:

- Adds tests to test_sensor.py which
  - test if Envoy production entities states match values in the fixtures
  - test if Envoy consumption entities states match values in the fixtures
  - test if Envoy production Current transformer entities states match values in the fixtures
  - test if Envoy consumption Current transformer entities states match values in the fixtures
  - test if Envoy storage Current transformer entities states match values in the fixtures
  - test if Envoy phase entities are disabled by integration
  - test if Envoy inverter entities states match values in the fixtures
  - test if Envoy some inverter entities are disabled by integration
  - test if Envoy encharge aggregate entities states match values in the fixtures
  - test if Envoy encharge enpower entities states match values in the fixtures
  - test if Envoy enpower power entities states match values in the fixtures
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
