### PR TITLE
Revert "Add mac address as connection for matter device (#121257)"

### DIFF
--- a/tests/components/matter/test_adapter.py
+++ b/tests/components/matter/test_adapter.py
@@ -187,60 +187,6 @@ async def test_device_registry_single_node_composed_device(
     assert len(dev_reg.devices) == 1
 
 
-async def test_device_registry_single_node_with_connection(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    matter_client: MagicMock,
-) -> None:
-    """Test that a device with mac address adds a connection to the HA device entry."""
-    await setup_integration_with_node_fixture(
-        hass,
-        "thermostat",
-        matter_client,
-    )
-
-    assert device_registry.async_get_device(connections={("mac", "DC:54:75:5F:BA:AC")})
-
-
-async def test_device_registry_single_node_without_mac_address_has_no_mac_connection(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    matter_client: MagicMock,
-) -> None:
-    """Test that a device without mac address doesn't have a `mac` connection in the HA device entry."""
-    await setup_integration_with_node_fixture(
-        hass,
-        "temperature-sensor",
-        matter_client,
-    )
-
-    entry = device_registry.async_get_device(
-        identifiers={
-            (DOMAIN, "deviceid_00000000000004D2-0000000000000001-MatterNodeDevice")
-        }
-    )
-
-    for connection_type, _ in entry.connections:
-        assert connection_type != dr.CONNECTION_NETWORK_MAC
-
-
-async def test_device_registry_node_with_EUI64_address(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    matter_client: MagicMock,
-) -> None:
-    """Test that a device with a mac address has a `zigbee` connection in the HA device entry."""
-    await setup_integration_with_node_fixture(
-        hass,
-        "eve-energy-plug",
-        matter_client,
-    )
-
-    assert device_registry.async_get_device(
-        connections={("zigbee", "ca:6b:4a:23:f6:f8:bb:ee")}
-    )
-
-
 async def test_multi_endpoint_name(
     hass: HomeAssistant,
     matter_client: MagicMock,


### PR DESCRIPTION
## Proposed change
This reverts commit 2723ab3b27b56adbd7c560be0b23e2259ab060ab from PR #121257

It caused collisions due to the fact that mac address is not a stable identifier in Matter.
Also there are devices that simply report 00:00:00:00:00:00 as mac address.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
