### PR TITLE
Add coverage for doorbird button platform

### DIFF
--- a/tests/components/doorbird/__init__.py
+++ b/tests/components/doorbird/__init__.py
@@ -31,9 +31,14 @@ def get_mock_doorbird_api(
     type(doorbirdapi_mock).info = AsyncMock(
         side_effect=info_side_effect, return_value=info
     )
-    type(doorbirdapi_mock).favorites = AsyncMock(return_value={})
+    type(doorbirdapi_mock).favorites = AsyncMock(
+        return_value={"http": {"x": {"value": "http://webhook"}}}
+    )
     type(doorbirdapi_mock).change_favorite = AsyncMock(return_value=True)
     type(doorbirdapi_mock).schedule = AsyncMock(return_value=schedule)
+    type(doorbirdapi_mock).energize_relay = AsyncMock(return_value=True)
+    type(doorbirdapi_mock).turn_light_on = AsyncMock(return_value=True)
+    type(doorbirdapi_mock).delete_favorite = AsyncMock(return_value=True)
     type(doorbirdapi_mock).doorbell_state = AsyncMock(
         side_effect=mock_unauthorized_exception()
     )

--- a/tests/components/doorbird/test_button.py
+++ b/tests/components/doorbird/test_button.py
@@ -24,8 +24,7 @@ async def test_relay_button(
     )
     button_1 = hass.states.get(relay_1_entity_id)
     assert button_1.state != STATE_UNKNOWN
-    api = doorbird_entry.api
-    assert api.energize_relay.call_count == 1
+    assert doorbird_entry.api.energize_relay.call_count == 1
 
 
 async def test_ir_button(
@@ -42,8 +41,7 @@ async def test_ir_button(
     )
     ir_button = hass.states.get(ir_entity_id)
     assert ir_button.state != STATE_UNKNOWN
-    api = doorbird_entry.api
-    assert api.turn_light_on.call_count == 1
+    assert doorbird_entry.api.turn_light_on.call_count == 1
 
 
 async def test_reset_favorites_button(
@@ -60,5 +58,4 @@ async def test_reset_favorites_button(
     )
     reset_button = hass.states.get(reset_entity_id)
     assert reset_button.state != STATE_UNKNOWN
-    api = doorbird_entry.api
-    assert api.delete_favorite.call_count == 1
+    assert doorbird_entry.api.delete_favorite.call_count == 1

--- a/tests/components/doorbird/test_button.py
+++ b/tests/components/doorbird/test_button.py
@@ -17,13 +17,11 @@ async def test_relay_button(
     """Test pressing a relay button."""
     doorbird_entry = await doorbird_mocker()
     relay_1_entity_id = "button.mydoorbird_relay_1"
-    button_1 = hass.states.get(relay_1_entity_id)
-    assert button_1.state == STATE_UNKNOWN
+    assert hass.states.get(relay_1_entity_id).state == STATE_UNKNOWN
     await hass.services.async_call(
         DOMAIN, SERVICE_PRESS, {"entity_id": relay_1_entity_id}, blocking=True
     )
-    button_1 = hass.states.get(relay_1_entity_id)
-    assert button_1.state != STATE_UNKNOWN
+    assert hass.states.get(relay_1_entity_id).state != STATE_UNKNOWN
     assert doorbird_entry.api.energize_relay.call_count == 1
 
 
@@ -34,13 +32,11 @@ async def test_ir_button(
     """Test pressing the IR button."""
     doorbird_entry = await doorbird_mocker()
     ir_entity_id = "button.mydoorbird_ir"
-    ir_button = hass.states.get(ir_entity_id)
-    assert ir_button.state == STATE_UNKNOWN
+    assert hass.states.get(ir_entity_id).state == STATE_UNKNOWN
     await hass.services.async_call(
         DOMAIN, SERVICE_PRESS, {"entity_id": ir_entity_id}, blocking=True
     )
-    ir_button = hass.states.get(ir_entity_id)
-    assert ir_button.state != STATE_UNKNOWN
+    assert hass.states.get(ir_entity_id).state != STATE_UNKNOWN
     assert doorbird_entry.api.turn_light_on.call_count == 1
 
 
@@ -51,11 +47,9 @@ async def test_reset_favorites_button(
     """Test pressing the reset favorites button."""
     doorbird_entry = await doorbird_mocker()
     reset_entity_id = "button.mydoorbird_reset_favorites"
-    reset_button = hass.states.get(reset_entity_id)
-    assert reset_button.state == STATE_UNKNOWN
+    assert hass.states.get(reset_entity_id).state == STATE_UNKNOWN
     await hass.services.async_call(
         DOMAIN, SERVICE_PRESS, {"entity_id": reset_entity_id}, blocking=True
     )
-    reset_button = hass.states.get(reset_entity_id)
-    assert reset_button.state != STATE_UNKNOWN
+    assert hass.states.get(reset_entity_id).state != STATE_UNKNOWN
     assert doorbird_entry.api.delete_favorite.call_count == 1

--- a/tests/components/doorbird/test_button.py
+++ b/tests/components/doorbird/test_button.py
@@ -4,7 +4,7 @@ from collections.abc import Callable, Coroutine
 from typing import Any
 
 from homeassistant.components.button import DOMAIN, SERVICE_PRESS
-from homeassistant.const import STATE_UNKNOWN
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 
 from .conftest import MockDoorbirdEntry
@@ -19,7 +19,7 @@ async def test_relay_button(
     relay_1_entity_id = "button.mydoorbird_relay_1"
     assert hass.states.get(relay_1_entity_id).state == STATE_UNKNOWN
     await hass.services.async_call(
-        DOMAIN, SERVICE_PRESS, {"entity_id": relay_1_entity_id}, blocking=True
+        DOMAIN, SERVICE_PRESS, {ATTR_ENTITY_ID: relay_1_entity_id}, blocking=True
     )
     assert hass.states.get(relay_1_entity_id).state != STATE_UNKNOWN
     assert doorbird_entry.api.energize_relay.call_count == 1
@@ -34,7 +34,7 @@ async def test_ir_button(
     ir_entity_id = "button.mydoorbird_ir"
     assert hass.states.get(ir_entity_id).state == STATE_UNKNOWN
     await hass.services.async_call(
-        DOMAIN, SERVICE_PRESS, {"entity_id": ir_entity_id}, blocking=True
+        DOMAIN, SERVICE_PRESS, {ATTR_ENTITY_ID: ir_entity_id}, blocking=True
     )
     assert hass.states.get(ir_entity_id).state != STATE_UNKNOWN
     assert doorbird_entry.api.turn_light_on.call_count == 1
@@ -49,7 +49,7 @@ async def test_reset_favorites_button(
     reset_entity_id = "button.mydoorbird_reset_favorites"
     assert hass.states.get(reset_entity_id).state == STATE_UNKNOWN
     await hass.services.async_call(
-        DOMAIN, SERVICE_PRESS, {"entity_id": reset_entity_id}, blocking=True
+        DOMAIN, SERVICE_PRESS, {ATTR_ENTITY_ID: reset_entity_id}, blocking=True
     )
     assert hass.states.get(reset_entity_id).state != STATE_UNKNOWN
     assert doorbird_entry.api.delete_favorite.call_count == 1

--- a/tests/components/doorbird/test_button.py
+++ b/tests/components/doorbird/test_button.py
@@ -1,0 +1,64 @@
+"""Test DoorBird buttons."""
+
+from collections.abc import Callable, Coroutine
+from typing import Any
+
+from homeassistant.components.button import DOMAIN, SERVICE_PRESS
+from homeassistant.const import STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
+
+from .conftest import MockDoorbirdEntry
+
+
+async def test_relay_button(
+    hass: HomeAssistant,
+    doorbird_mocker: Callable[[], Coroutine[Any, Any, MockDoorbirdEntry]],
+) -> None:
+    """Test pressing a relay button."""
+    doorbird_entry = await doorbird_mocker()
+    relay_1_entity_id = "button.mydoorbird_relay_1"
+    button_1 = hass.states.get(relay_1_entity_id)
+    assert button_1.state == STATE_UNKNOWN
+    await hass.services.async_call(
+        DOMAIN, SERVICE_PRESS, {"entity_id": relay_1_entity_id}, blocking=True
+    )
+    button_1 = hass.states.get(relay_1_entity_id)
+    assert button_1.state != STATE_UNKNOWN
+    api = doorbird_entry.api
+    assert api.energize_relay.call_count == 1
+
+
+async def test_ir_button(
+    hass: HomeAssistant,
+    doorbird_mocker: Callable[[], Coroutine[Any, Any, MockDoorbirdEntry]],
+) -> None:
+    """Test pressing the IR button."""
+    doorbird_entry = await doorbird_mocker()
+    ir_entity_id = "button.mydoorbird_ir"
+    ir_button = hass.states.get(ir_entity_id)
+    assert ir_button.state == STATE_UNKNOWN
+    await hass.services.async_call(
+        DOMAIN, SERVICE_PRESS, {"entity_id": ir_entity_id}, blocking=True
+    )
+    ir_button = hass.states.get(ir_entity_id)
+    assert ir_button.state != STATE_UNKNOWN
+    api = doorbird_entry.api
+    assert api.turn_light_on.call_count == 1
+
+
+async def test_reset_favorites_button(
+    hass: HomeAssistant,
+    doorbird_mocker: Callable[[], Coroutine[Any, Any, MockDoorbirdEntry]],
+) -> None:
+    """Test pressing the reset favorites button."""
+    doorbird_entry = await doorbird_mocker()
+    reset_entity_id = "button.mydoorbird_reset_favorites"
+    reset_button = hass.states.get(reset_entity_id)
+    assert reset_button.state == STATE_UNKNOWN
+    await hass.services.async_call(
+        DOMAIN, SERVICE_PRESS, {"entity_id": reset_entity_id}, blocking=True
+    )
+    reset_button = hass.states.get(reset_entity_id)
+    assert reset_button.state != STATE_UNKNOWN
+    api = doorbird_entry.api
+    assert api.delete_favorite.call_count == 1


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add coverage for doorbird button platform

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
