### PR TITLE
Add missing coverage for doorbird config_flow

### DIFF
--- a/tests/components/doorbird/__init__.py
+++ b/tests/components/doorbird/__init__.py
@@ -16,9 +16,23 @@ VALID_CONFIG = {
 }
 
 
+def _get_aiohttp_client_error(status: int) -> aiohttp.ClientResponseError:
+    """Return a mock aiohttp client response error."""
+    return aiohttp.ClientResponseError(
+        request_info=Mock(),
+        history=Mock(),
+        status=status,
+    )
+
+
 def mock_unauthorized_exception() -> aiohttp.ClientResponseError:
     """Return a mock unauthorized exception."""
-    return aiohttp.ClientResponseError(request_info=Mock(), history=Mock(), status=401)
+    return _get_aiohttp_client_error(401)
+
+
+def mock_not_found_exception() -> aiohttp.ClientResponseError:
+    """Return a mock not found exception."""
+    return _get_aiohttp_client_error(404)
 
 
 def get_mock_doorbird_api(
@@ -31,9 +45,14 @@ def get_mock_doorbird_api(
     type(doorbirdapi_mock).info = AsyncMock(
         side_effect=info_side_effect, return_value=info
     )
-    type(doorbirdapi_mock).favorites = AsyncMock(return_value={})
+    type(doorbirdapi_mock).favorites = AsyncMock(
+        return_value={"http": {"x": {"value": "http://webhook"}}}
+    )
     type(doorbirdapi_mock).change_favorite = AsyncMock(return_value=True)
     type(doorbirdapi_mock).schedule = AsyncMock(return_value=schedule)
+    type(doorbirdapi_mock).energize_relay = AsyncMock(return_value=True)
+    type(doorbirdapi_mock).turn_light_on = AsyncMock(return_value=True)
+    type(doorbirdapi_mock).delete_favorite = AsyncMock(return_value=True)
     type(doorbirdapi_mock).doorbell_state = AsyncMock(
         side_effect=mock_unauthorized_exception()
     )

--- a/tests/components/doorbird/test_config_flow.py
+++ b/tests/components/doorbird/test_config_flow.py
@@ -19,7 +19,12 @@ from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_USERNA
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from . import VALID_CONFIG, get_mock_doorbird_api, mock_unauthorized_exception
+from . import (
+    VALID_CONFIG,
+    get_mock_doorbird_api,
+    mock_not_found_exception,
+    mock_unauthorized_exception,
+)
 
 from tests.common import MockConfigEntry
 
@@ -279,6 +284,100 @@ async def test_form_user_invalid_auth(hass: HomeAssistant) -> None:
 
     assert result2["type"] is FlowResultType.FORM
     assert result2["errors"] == {"base": "invalid_auth"}
+
+
+async def test_form_user_doorbird_not_found(
+    doorbird_api: DoorBird, hass: HomeAssistant
+) -> None:
+    """Test handling unable to connect to the device."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    mock_error = mock_not_found_exception()
+    doorbirdapi = get_mock_doorbird_api(info_side_effect=mock_error)
+    with patch(
+        "homeassistant.components.doorbird.config_flow.DoorBird",
+        return_value=doorbirdapi,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            VALID_CONFIG,
+        )
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["errors"] == {"base": "cannot_connect"}
+
+    with (
+        patch(
+            "homeassistant.components.doorbird.async_setup", return_value=True
+        ) as mock_setup,
+        patch(
+            "homeassistant.components.doorbird.async_setup_entry",
+            return_value=True,
+        ) as mock_setup_entry,
+    ):
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"], VALID_CONFIG
+        )
+        await hass.async_block_till_done()
+
+    assert result3["type"] is FlowResultType.CREATE_ENTRY
+    assert result3["title"] == "1.2.3.4"
+    assert result3["data"] == {
+        "host": "1.2.3.4",
+        "name": "mydoorbird",
+        "password": "password",
+        "username": "friend",
+    }
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_user_doorbird_unknown_exception(
+    doorbird_api: DoorBird, hass: HomeAssistant
+) -> None:
+    """Test handling unable an unknown exception."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    doorbirdapi = get_mock_doorbird_api(info_side_effect=ValueError)
+    with patch(
+        "homeassistant.components.doorbird.config_flow.DoorBird",
+        return_value=doorbirdapi,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            VALID_CONFIG,
+        )
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["errors"] == {"base": "unknown"}
+
+    with (
+        patch(
+            "homeassistant.components.doorbird.async_setup", return_value=True
+        ) as mock_setup,
+        patch(
+            "homeassistant.components.doorbird.async_setup_entry",
+            return_value=True,
+        ) as mock_setup_entry,
+    ):
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"], VALID_CONFIG
+        )
+        await hass.async_block_till_done()
+
+    assert result3["type"] is FlowResultType.CREATE_ENTRY
+    assert result3["title"] == "1.2.3.4"
+    assert result3["data"] == {
+        "host": "1.2.3.4",
+        "name": "mydoorbird",
+        "password": "password",
+        "username": "friend",
+    }
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_options_flow(hass: HomeAssistant) -> None:


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add missing coverage for doorbird config_flow

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
