### PR TITLE
Deprecate simulated integration

### DIFF
--- a/homeassistant/components/simulated/sensor.py
+++ b/homeassistant/components/simulated/sensor.py
@@ -14,6 +14,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -38,6 +39,8 @@ DEFAULT_SEED = 999
 DEFAULT_UNIT = "value"
 DEFAULT_RELATIVE_TO_EPOCH = True
 
+DOMAIN = "simulated"
+
 PLATFORM_SCHEMA = SENSOR_PLATFORM_SCHEMA.extend(
     {
         vol.Optional(CONF_AMP, default=DEFAULT_AMP): vol.Coerce(float),
@@ -55,13 +58,27 @@ PLATFORM_SCHEMA = SENSOR_PLATFORM_SCHEMA.extend(
 )
 
 
-def setup_platform(
+async def async_setup_platform(
     hass: HomeAssistant,
     config: ConfigType,
-    add_entities: AddEntitiesCallback,
+    async_add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the simulated sensor."""
+    # Simulated has been deprecated and will be removed in 2025.1
+
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        DOMAIN,
+        breaks_in_ha_version="2025.1.0",
+        is_fixable=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="simulated_deprecation",
+        translation_placeholders={"integration": DOMAIN},
+        learn_more_url="https://www.home-assistant.io/integrations/simulated",
+    )
+
     name = config.get(CONF_NAME)
     unit = config.get(CONF_UNIT)
     amp = config.get(CONF_AMP)
@@ -75,7 +92,7 @@ def setup_platform(
     sensor = SimulatedSensor(
         name, unit, amp, mean, period, phase, fwhm, seed, relative_to_epoch
     )
-    add_entities([sensor], True)
+    async_add_entities([sensor], True)
 
 
 class SimulatedSensor(SensorEntity):

--- a/homeassistant/components/simulated/strings.json
+++ b/homeassistant/components/simulated/strings.json
@@ -1,0 +1,8 @@
+{
+  "issues": {
+    "simulated_deprecation": {
+      "description": "The {integration} integration is deprecated",
+      "title": "The {integration} integration has been deprecated and will be removed in 2025.1. Please remove the {integration} from your configuration.yaml settings and restart Home Assistant to fix this issue."
+    }
+  }
+}

--- a/tests/components/simulated/test_sensor.py
+++ b/tests/components/simulated/test_sensor.py
@@ -16,13 +16,17 @@ from homeassistant.components.simulated.sensor import (
     DEFAULT_PHASE,
     DEFAULT_RELATIVE_TO_EPOCH,
     DEFAULT_SEED,
+    DOMAIN,
 )
 from homeassistant.const import CONF_FRIENDLY_NAME
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.setup import async_setup_component
 
 
-async def test_simulated_sensor_default_config(hass: HomeAssistant) -> None:
+async def test_simulated_sensor_default_config(
+    hass: HomeAssistant, issue_registry: ir.IssueRegistry
+) -> None:
     """Test default config."""
     config = {"sensor": {"platform": "simulated"}}
     assert await async_setup_component(hass, "sensor", config)
@@ -40,3 +44,7 @@ async def test_simulated_sensor_default_config(hass: HomeAssistant) -> None:
     assert state.attributes.get(CONF_FWHM) == DEFAULT_FWHM
     assert state.attributes.get(CONF_SEED) == DEFAULT_SEED
     assert state.attributes.get(CONF_RELATIVE_TO_EPOCH) == DEFAULT_RELATIVE_TO_EPOCH
+
+    issue = issue_registry.async_get_issue(DOMAIN, DOMAIN)
+    assert issue.issue_id == DOMAIN
+    assert issue.translation_key == "simulated_deprecation"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
`simulated` integration has been deprecated and will be removed in 2025.1

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33872

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
