### PR TITLE
Use TypeVar defaults for Generator

### DIFF
--- a/homeassistant/components/conversation/trace.py
+++ b/homeassistant/components/conversation/trace.py
@@ -94,7 +94,7 @@ def async_conversation_trace_append(
 
 
 @contextmanager
-def async_conversation_trace() -> Generator[ConversationTrace, None]:
+def async_conversation_trace() -> Generator[ConversationTrace]:
     """Create a new active ConversationTrace."""
     trace = ConversationTrace()
     token = _current_trace.set(trace)

--- a/homeassistant/components/litterrobot/hub.py
+++ b/homeassistant/components/litterrobot/hub.py
@@ -60,13 +60,13 @@ class LitterRobotHub:
         except LitterRobotException as ex:
             raise ConfigEntryNotReady("Unable to connect to Litter-Robot API") from ex
 
-    def litter_robots(self) -> Generator[LitterRobot, Any, Any]:
+    def litter_robots(self) -> Generator[LitterRobot]:
         """Get Litter-Robots from the account."""
         return (
             robot for robot in self.account.robots if isinstance(robot, LitterRobot)
         )
 
-    def feeder_robots(self) -> Generator[FeederRobot, Any, Any]:
+    def feeder_robots(self) -> Generator[FeederRobot]:
         """Get Feeder-Robots from the account."""
         return (
             robot for robot in self.account.robots if isinstance(robot, FeederRobot)

--- a/tests/components/chacon_dio/conftest.py
+++ b/tests/components/chacon_dio/conftest.py
@@ -24,7 +24,7 @@ MOCK_COVER_DEVICE = {
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.chacon_dio.async_setup_entry", return_value=True

--- a/tests/components/doorbird/conftest.py
+++ b/tests/components/doorbird/conftest.py
@@ -42,7 +42,7 @@ def doorbird_schedule() -> list[DoorBirdScheduleEntry]:
 @pytest.fixture
 def doorbird_api(
     doorbird_info: dict[str, Any], doorbird_schedule: dict[str, Any]
-) -> Generator[Any, Any, DoorBird]:
+) -> Generator[DoorBird]:
     """Mock the DoorBirdAPI."""
     api = get_mock_doorbird_api(info=doorbird_info, schedule=doorbird_schedule)
     with patch_doorbird_api_entry_points(api):
@@ -50,7 +50,7 @@ def doorbird_api(
 
 
 @contextmanager
-def patch_doorbird_api_entry_points(api: MagicMock) -> Generator[Any, Any, DoorBird]:
+def patch_doorbird_api_entry_points(api: MagicMock) -> Generator[DoorBird]:
     """Mock the DoorBirdAPI."""
     with (
         patch(

--- a/tests/components/enphase_envoy/conftest.py
+++ b/tests/components/enphase_envoy/conftest.py
@@ -67,7 +67,7 @@ def config_fixture() -> dict[str, str]:
 @pytest.fixture
 async def mock_envoy(
     request: pytest.FixtureRequest,
-) -> AsyncGenerator[AsyncMock, None]:
+) -> AsyncGenerator[AsyncMock]:
     """Define a mocked Envoy fixture."""
     with (
         patch(

--- a/tests/components/home_connect/test_light.py
+++ b/tests/components/home_connect/test_light.py
@@ -1,7 +1,6 @@
 """Tests for home_connect light entities."""
 
 from collections.abc import Awaitable, Callable, Generator
-from typing import Any
 from unittest.mock import MagicMock, Mock
 
 from homeconnect.api import HomeConnectError
@@ -48,7 +47,7 @@ def platforms() -> list[str]:
 
 
 async def test_light(
-    bypass_throttle: Generator[None, Any, None],
+    bypass_throttle: Generator[None],
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     integration_setup: Callable[[], Awaitable[bool]],
@@ -159,7 +158,7 @@ async def test_light_functionality(
     service_data: dict,
     state: str,
     appliance: Mock,
-    bypass_throttle: Generator[None, Any, None],
+    bypass_throttle: Generator[None],
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     integration_setup: Callable[[], Awaitable[bool]],
@@ -273,7 +272,7 @@ async def test_switch_exception_handling(
     mock_attr: str,
     attr_side_effect: list,
     problematic_appliance: Mock,
-    bypass_throttle: Generator[None, Any, None],
+    bypass_throttle: Generator[None],
     hass: HomeAssistant,
     integration_setup: Callable[[], Awaitable[bool]],
     config_entry: MockConfigEntry,

--- a/tests/components/home_connect/test_switch.py
+++ b/tests/components/home_connect/test_switch.py
@@ -1,7 +1,6 @@
 """Tests for home_connect sensor entities."""
 
 from collections.abc import Awaitable, Callable, Generator
-from typing import Any
 from unittest.mock import MagicMock, Mock
 
 from homeconnect.api import HomeConnectError
@@ -48,7 +47,7 @@ def platforms() -> list[str]:
 
 
 async def test_switches(
-    bypass_throttle: Generator[None, Any, None],
+    bypass_throttle: Generator[None],
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     integration_setup: Callable[[], Awaitable[bool]],
@@ -119,7 +118,7 @@ async def test_switch_functionality(
     status: dict,
     service: str,
     state: str,
-    bypass_throttle: Generator[None, Any, None],
+    bypass_throttle: Generator[None],
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     integration_setup: Callable[[], Awaitable[bool]],
@@ -189,7 +188,7 @@ async def test_switch_exception_handling(
     status: dict,
     service: str,
     mock_attr: str,
-    bypass_throttle: Generator[None, Any, None],
+    bypass_throttle: Generator[None],
     hass: HomeAssistant,
     integration_setup: Callable[[], Awaitable[bool]],
     config_entry: MockConfigEntry,

--- a/tests/components/madvr/conftest.py
+++ b/tests/components/madvr/conftest.py
@@ -14,7 +14,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.madvr.async_setup_entry",
@@ -24,7 +24,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_madvr_client() -> Generator[AsyncMock, None, None]:
+def mock_madvr_client() -> Generator[AsyncMock]:
     """Mock a MadVR client."""
     with (
         patch(

--- a/tests/components/madvr/test_config_flow.py
+++ b/tests/components/madvr/test_config_flow.py
@@ -17,7 +17,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture(autouse=True)
-async def avoid_wait() -> AsyncGenerator[None, None]:
+async def avoid_wait() -> AsyncGenerator[None]:
     """Mock sleep."""
     with patch("homeassistant.components.madvr.config_flow.RETRY_INTERVAL", 0):
         yield

--- a/tests/components/mqtt/test_select.py
+++ b/tests/components/mqtt/test_select.py
@@ -67,9 +67,7 @@ DEFAULT_CONFIG = {
 }
 
 
-def _test_run_select_setup_params(
-    topic: str,
-) -> Generator[tuple[ConfigType, str], None]:
+def _test_run_select_setup_params(topic: str) -> Generator[tuple[ConfigType, str]]:
     yield (
         {
             mqtt.DOMAIN: {
@@ -593,7 +591,7 @@ async def test_entity_debug_info_message(
 
 def _test_options_attributes_options_config(
     request: tuple[list[str]],
-) -> Generator[tuple[ConfigType, list[str]], None]:
+) -> Generator[tuple[ConfigType, list[str]]]:
     for option in request:
         yield (
             {

--- a/tests/components/simplefin/conftest.py
+++ b/tests/components/simplefin/conftest.py
@@ -16,7 +16,7 @@ MOCK_ACCESS_URL = "https://i:am@yomama.house.com"
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.simplefin.async_setup_entry", return_value=True

--- a/tests/components/system_bridge/conftest.py
+++ b/tests/components/system_bridge/conftest.py
@@ -64,7 +64,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture(autouse=True)
-def mock_setup_notify_platform() -> Generator[AsyncMock, None, None]:
+def mock_setup_notify_platform() -> Generator[AsyncMock]:
     """Mock notify platform setup."""
     with patch(
         "homeassistant.helpers.discovery.async_load_platform",
@@ -73,7 +73,7 @@ def mock_setup_notify_platform() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_version() -> Generator[AsyncMock, None, None]:
+def mock_version() -> Generator[AsyncMock]:
     """Return a mocked Version class."""
     with patch(
         "homeassistant.components.system_bridge.Version",
@@ -90,7 +90,7 @@ def mock_websocket_client(
     register_data_listener_model: RegisterDataListener = RegisterDataListener(
         modules=REGISTER_MODULES,
     ),
-) -> Generator[MagicMock, None, None]:
+) -> Generator[MagicMock]:
     """Return a mocked WebSocketClient client."""
 
     with (


### PR DESCRIPTION
## Proposed change
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
