### PR TITLE
Revert "Add static routes for frontend modern and legacy service workers"

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -398,10 +398,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     static_paths_configs: list[StaticPathConfig] = []
 
     for path, should_cache in (
-        ("sw-modern.js", False),
-        ("sw-modern.js.map", False),
-        ("sw-legacy.js", False),
-        ("sw-legacy.js.map", False),
+        ("service_worker.js", False),
         ("robots.txt", False),
         ("onboarding.html", not is_dev),
         ("static", not is_dev),

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -174,12 +174,9 @@ async def test_frontend_and_static(mock_http_client: TestClient) -> None:
     assert "public" in resp.headers.get("cache-control")
 
 
-@pytest.mark.parametrize("sw_url", ["/sw-modern.js", "/sw-legacy.js"])
-async def test_dont_cache_service_worker(
-    mock_http_client: TestClient, sw_url: str
-) -> None:
+async def test_dont_cache_service_worker(mock_http_client: TestClient) -> None:
     """Test that we don't cache the service worker."""
-    resp = await mock_http_client.get(sw_url)
+    resp = await mock_http_client.get("/service_worker.js")
     assert resp.status == 200
     assert "cache-control" not in resp.headers
 


### PR DESCRIPTION
Reverts home-assistant/core#120488

Needs a frontend bump for tests to pass.