### PR TITLE
Add static routes for frontend modern and legacy service workers (#120488)

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -398,7 +398,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     static_paths_configs: list[StaticPathConfig] = []
 
     for path, should_cache in (
-        ("service_worker.js", False),
+        ("sw-modern.js", False),
+        ("sw-modern.js.map", False),
+        ("sw-legacy.js", False),
+        ("sw-legacy.js.map", False),
         ("robots.txt", False),
         ("onboarding.html", not is_dev),
         ("static", not is_dev),

--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -20,5 +20,5 @@
   "documentation": "https://www.home-assistant.io/integrations/frontend",
   "integration_type": "system",
   "quality_scale": "internal",
-  "requirements": ["home-assistant-frontend==20240710.0"]
+  "requirements": ["home-assistant-frontend==20240719.0"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -32,7 +32,7 @@ habluetooth==3.1.3
 hass-nabucasa==0.81.1
 hassil==1.7.4
 home-assistant-bluetooth==1.12.2
-home-assistant-frontend==20240710.0
+home-assistant-frontend==20240719.0
 home-assistant-intents==2024.7.10
 httpx==0.27.0
 ifaddr==0.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1087,7 +1087,7 @@ hole==0.8.0
 holidays==0.53
 
 # homeassistant.components.frontend
-home-assistant-frontend==20240710.0
+home-assistant-frontend==20240719.0
 
 # homeassistant.components.conversation
 home-assistant-intents==2024.7.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -904,7 +904,7 @@ hole==0.8.0
 holidays==0.53
 
 # homeassistant.components.frontend
-home-assistant-frontend==20240710.0
+home-assistant-frontend==20240719.0
 
 # homeassistant.components.conversation
 home-assistant-intents==2024.7.10

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -174,9 +174,12 @@ async def test_frontend_and_static(mock_http_client: TestClient) -> None:
     assert "public" in resp.headers.get("cache-control")
 
 
-async def test_dont_cache_service_worker(mock_http_client: TestClient) -> None:
+@pytest.mark.parametrize("sw_url", ["/sw-modern.js", "/sw-legacy.js"])
+async def test_dont_cache_service_worker(
+    mock_http_client: TestClient, sw_url: str
+) -> None:
     """Test that we don't cache the service worker."""
-    resp = await mock_http_client.get("/service_worker.js")
+    resp = await mock_http_client.get(sw_url)
     assert resp.status == 200
     assert "cache-control" not in resp.headers
 


### PR DESCRIPTION
Unrevert Add static routes for frontend modern and legacy service workers (#120488)

Now with a bump of the frontend included

Release notes: https://github.com/home-assistant/frontend/releases/tag/20240719.0

Needs: https://github.com/home-assistant/frontend/actions/runs/10006859897