### PR TITLE
Use Generator as return type for fixtures

### DIFF
--- a/tests/components/dlna_dmr/conftest.py
+++ b/tests/components/dlna_dmr/conftest.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Generator
 from socket import AddressFamily  # pylint: disable=no-name-in-module
 from unittest.mock import Mock, create_autospec, patch, seal
 
@@ -32,7 +32,7 @@ NEW_DEVICE_LOCATION = "http://198.51.100.7" + "/dmr_description.xml"
 
 
 @pytest.fixture
-def domain_data_mock(hass: HomeAssistant) -> Iterable[Mock]:
+def domain_data_mock(hass: HomeAssistant) -> Mock:
     """Mock the global data used by this component.
 
     This includes network clients and library object factories. Mocking it
@@ -114,7 +114,7 @@ def config_entry_mock_no_mac() -> MockConfigEntry:
 
 
 @pytest.fixture
-def dmr_device_mock(domain_data_mock: Mock) -> Iterable[Mock]:
+def dmr_device_mock(domain_data_mock: Mock) -> Generator[Mock]:
     """Mock the async_upnp_client DMR device, initially connected."""
     with patch(
         "homeassistant.components.dlna_dmr.media_player.DmrDevice", autospec=True
@@ -135,7 +135,7 @@ def dmr_device_mock(domain_data_mock: Mock) -> Iterable[Mock]:
 
 
 @pytest.fixture(autouse=True)
-def ssdp_scanner_mock() -> Iterable[Mock]:
+def ssdp_scanner_mock() -> Generator[Mock]:
     """Mock the SSDP Scanner."""
     with patch("homeassistant.components.ssdp.Scanner", autospec=True) as mock_scanner:
         reg_callback = mock_scanner.return_value.async_register_callback
@@ -144,14 +144,14 @@ def ssdp_scanner_mock() -> Iterable[Mock]:
 
 
 @pytest.fixture(autouse=True)
-def ssdp_server_mock() -> Iterable[Mock]:
+def ssdp_server_mock() -> Generator[None]:
     """Mock the SSDP Server."""
     with patch("homeassistant.components.ssdp.Server", autospec=True):
         yield
 
 
 @pytest.fixture(autouse=True)
-def async_get_local_ip_mock() -> Iterable[Mock]:
+def async_get_local_ip_mock() -> Generator[Mock]:
     """Mock the async_get_local_ip utility function to prevent network access."""
     with patch(
         "homeassistant.components.dlna_dmr.media_player.async_get_local_ip",

--- a/tests/components/dlna_dmr/test_config_flow.py
+++ b/tests/components/dlna_dmr/test_config_flow.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Generator
 import dataclasses
 import logging
 from unittest.mock import Mock, patch
@@ -89,7 +89,7 @@ MOCK_DISCOVERY = ssdp.SsdpServiceInfo(
 
 
 @pytest.fixture(autouse=True)
-def mock_get_mac_address() -> Iterable[Mock]:
+def mock_get_mac_address() -> Generator[Mock]:
     """Mock the get_mac_address function to prevent network access and assist tests."""
     with patch(
         "homeassistant.components.dlna_dmr.config_flow.get_mac_address", autospec=True
@@ -99,7 +99,7 @@ def mock_get_mac_address() -> Iterable[Mock]:
 
 
 @pytest.fixture(autouse=True)
-def mock_setup_entry() -> Iterable[Mock]:
+def mock_setup_entry() -> Generator[Mock]:
     """Mock async_setup_entry."""
     with patch(
         "homeassistant.components.dlna_dmr.async_setup_entry", return_value=True

--- a/tests/components/dlna_dmr/test_data.py
+++ b/tests/components/dlna_dmr/test_data.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Generator
 from unittest.mock import ANY, Mock, patch
 
 from async_upnp_client.aiohttp import AiohttpNotifyServer
@@ -16,7 +16,7 @@ from homeassistant.core import Event, HomeAssistant
 
 
 @pytest.fixture
-def aiohttp_notify_servers_mock() -> Iterable[Mock]:
+def aiohttp_notify_servers_mock() -> Generator[Mock]:
     """Construct mock AiohttpNotifyServer on demand, eliminating network use.
 
     This fixture provides a list of the constructed servers.

--- a/tests/components/dlna_dmr/test_media_player.py
+++ b/tests/components/dlna_dmr/test_media_player.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterable, Mapping
+from collections.abc import AsyncGenerator, Mapping
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any
@@ -95,7 +95,7 @@ async def mock_entity_id(
     config_entry_mock: MockConfigEntry,
     ssdp_scanner_mock: Mock,
     dmr_device_mock: Mock,
-) -> AsyncIterable[str]:
+) -> AsyncGenerator[str]:
     """Fixture to set up a mock DlnaDmrEntity in a connected state.
 
     Yields the entity ID. Cleans up the entity after the test is complete.
@@ -145,7 +145,7 @@ async def mock_disconnected_entity_id(
     config_entry_mock: MockConfigEntry,
     ssdp_scanner_mock: Mock,
     dmr_device_mock: Mock,
-) -> AsyncIterable[str]:
+) -> AsyncGenerator[str]:
     """Fixture to set up a mock DlnaDmrEntity in a disconnected state.
 
     Yields the entity ID. Cleans up the entity after the test is complete.

--- a/tests/components/dlna_dms/conftest.py
+++ b/tests/components/dlna_dms/conftest.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterable, Iterable
+from collections.abc import AsyncGenerator, Generator
 from typing import Final, cast
 from unittest.mock import AsyncMock, MagicMock, Mock, create_autospec, patch, seal
 
@@ -44,7 +44,7 @@ async def setup_media_source(hass: HomeAssistant) -> None:
 
 
 @pytest.fixture
-def upnp_factory_mock() -> Iterable[Mock]:
+def upnp_factory_mock() -> Generator[Mock]:
     """Mock the UpnpFactory class to construct DMS-style UPnP devices."""
     with patch(
         "homeassistant.components.dlna_dms.dms.UpnpFactory",
@@ -82,7 +82,7 @@ def upnp_factory_mock() -> Iterable[Mock]:
 
 
 @pytest.fixture(autouse=True, scope="module")
-def aiohttp_session_requester_mock() -> Iterable[Mock]:
+def aiohttp_session_requester_mock() -> Generator[Mock]:
     """Mock the AiohttpSessionRequester to prevent network use."""
     with patch(
         "homeassistant.components.dlna_dms.dms.AiohttpSessionRequester", autospec=True
@@ -109,7 +109,7 @@ def config_entry_mock() -> MockConfigEntry:
 
 
 @pytest.fixture
-def dms_device_mock(upnp_factory_mock: Mock) -> Iterable[Mock]:
+def dms_device_mock(upnp_factory_mock: Mock) -> Generator[Mock]:
     """Mock the async_upnp_client DMS device, initially connected."""
     with patch(
         "homeassistant.components.dlna_dms.dms.DmsDevice", autospec=True
@@ -130,7 +130,7 @@ def dms_device_mock(upnp_factory_mock: Mock) -> Iterable[Mock]:
 
 
 @pytest.fixture(autouse=True)
-def ssdp_scanner_mock() -> Iterable[Mock]:
+def ssdp_scanner_mock() -> Generator[Mock]:
     """Mock the SSDP Scanner."""
     with patch("homeassistant.components.ssdp.Scanner", autospec=True) as mock_scanner:
         reg_callback = mock_scanner.return_value.async_register_callback
@@ -139,7 +139,7 @@ def ssdp_scanner_mock() -> Iterable[Mock]:
 
 
 @pytest.fixture(autouse=True)
-def ssdp_server_mock() -> Iterable[Mock]:
+def ssdp_server_mock() -> Generator[None]:
     """Mock the SSDP Server."""
     with patch("homeassistant.components.ssdp.Server", autospec=True):
         yield
@@ -151,7 +151,7 @@ async def device_source_mock(
     config_entry_mock: MockConfigEntry,
     ssdp_scanner_mock: Mock,
     dms_device_mock: Mock,
-) -> AsyncIterable[None]:
+) -> AsyncGenerator[None]:
     """Fixture to set up a DmsDeviceSource in a connected state and cleanup at completion."""
     config_entry_mock.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry_mock.entry_id)

--- a/tests/components/dlna_dms/test_config_flow.py
+++ b/tests/components/dlna_dms/test_config_flow.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Generator
 import dataclasses
 import logging
 from typing import Final
@@ -68,7 +68,7 @@ MOCK_DISCOVERY: Final = ssdp.SsdpServiceInfo(
 
 
 @pytest.fixture(autouse=True)
-def mock_setup_entry() -> Iterable[Mock]:
+def mock_setup_entry() -> Generator[Mock]:
     """Avoid setting up the entire integration."""
     with patch(
         "homeassistant.components.dlna_dms.async_setup_entry",


### PR DESCRIPTION
## Proposed change
SSIA


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
