### PR TITLE
Improve vizio tests typing

### DIFF
--- a/tests/components/vizio/conftest.py
+++ b/tests/components/vizio/conftest.py
@@ -1,5 +1,6 @@
 """Configure py.test."""
 
+from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -35,13 +36,13 @@ class MockInput:
         self.name = name
 
 
-def get_mock_inputs(input_list):
+def get_mock_inputs(input_list) -> list[MockInput]:
     """Return list of MockInput."""
     return [MockInput(device_input) for device_input in input_list]
 
 
 @pytest.fixture(name="vizio_get_unique_id", autouse=True)
-def vizio_get_unique_id_fixture():
+def vizio_get_unique_id_fixture() -> Generator[None]:
     """Mock get vizio unique ID."""
     with patch(
         "homeassistant.components.vizio.config_flow.VizioAsync.get_unique_id",
@@ -51,7 +52,7 @@ def vizio_get_unique_id_fixture():
 
 
 @pytest.fixture(name="vizio_data_coordinator_update", autouse=True)
-def vizio_data_coordinator_update_fixture():
+def vizio_data_coordinator_update_fixture() -> Generator[None]:
     """Mock get data coordinator update."""
     with patch(
         "homeassistant.components.vizio.coordinator.gen_apps_list_from_url",
@@ -61,7 +62,7 @@ def vizio_data_coordinator_update_fixture():
 
 
 @pytest.fixture(name="vizio_data_coordinator_update_failure")
-def vizio_data_coordinator_update_failure_fixture():
+def vizio_data_coordinator_update_failure_fixture() -> Generator[None]:
     """Mock get data coordinator update failure."""
     with patch(
         "homeassistant.components.vizio.coordinator.gen_apps_list_from_url",
@@ -71,7 +72,7 @@ def vizio_data_coordinator_update_failure_fixture():
 
 
 @pytest.fixture(name="vizio_no_unique_id")
-def vizio_no_unique_id_fixture():
+def vizio_no_unique_id_fixture() -> Generator[None]:
     """Mock no vizio unique ID returrned."""
     with patch(
         "homeassistant.components.vizio.config_flow.VizioAsync.get_unique_id",
@@ -81,7 +82,7 @@ def vizio_no_unique_id_fixture():
 
 
 @pytest.fixture(name="vizio_connect")
-def vizio_connect_fixture():
+def vizio_connect_fixture() -> Generator[None]:
     """Mock valid vizio device and entry setup."""
     with patch(
         "homeassistant.components.vizio.config_flow.VizioAsync.validate_ha_config",
@@ -91,7 +92,7 @@ def vizio_connect_fixture():
 
 
 @pytest.fixture(name="vizio_complete_pairing")
-def vizio_complete_pairing_fixture():
+def vizio_complete_pairing_fixture() -> Generator[None]:
     """Mock complete vizio pairing workflow."""
     with (
         patch(
@@ -107,7 +108,7 @@ def vizio_complete_pairing_fixture():
 
 
 @pytest.fixture(name="vizio_start_pairing_failure")
-def vizio_start_pairing_failure_fixture():
+def vizio_start_pairing_failure_fixture() -> Generator[None]:
     """Mock vizio start pairing failure."""
     with patch(
         "homeassistant.components.vizio.config_flow.VizioAsync.start_pair",
@@ -117,7 +118,7 @@ def vizio_start_pairing_failure_fixture():
 
 
 @pytest.fixture(name="vizio_invalid_pin_failure")
-def vizio_invalid_pin_failure_fixture():
+def vizio_invalid_pin_failure_fixture() -> Generator[None]:
     """Mock vizio failure due to invalid pin."""
     with (
         patch(
@@ -133,14 +134,14 @@ def vizio_invalid_pin_failure_fixture():
 
 
 @pytest.fixture(name="vizio_bypass_setup")
-def vizio_bypass_setup_fixture():
+def vizio_bypass_setup_fixture() -> Generator[None]:
     """Mock component setup."""
     with patch("homeassistant.components.vizio.async_setup_entry", return_value=True):
         yield
 
 
 @pytest.fixture(name="vizio_bypass_update")
-def vizio_bypass_update_fixture():
+def vizio_bypass_update_fixture() -> Generator[None]:
     """Mock component update."""
     with (
         patch(
@@ -153,7 +154,7 @@ def vizio_bypass_update_fixture():
 
 
 @pytest.fixture(name="vizio_guess_device_type")
-def vizio_guess_device_type_fixture():
+def vizio_guess_device_type_fixture() -> Generator[None]:
     """Mock vizio async_guess_device_type function."""
     with patch(
         "homeassistant.components.vizio.config_flow.async_guess_device_type",
@@ -163,7 +164,7 @@ def vizio_guess_device_type_fixture():
 
 
 @pytest.fixture(name="vizio_cant_connect")
-def vizio_cant_connect_fixture():
+def vizio_cant_connect_fixture() -> Generator[None]:
     """Mock vizio device can't connect with valid auth."""
     with (
         patch(
@@ -179,7 +180,7 @@ def vizio_cant_connect_fixture():
 
 
 @pytest.fixture(name="vizio_update")
-def vizio_update_fixture():
+def vizio_update_fixture() -> Generator[None]:
     """Mock valid updates to vizio device."""
     with (
         patch(
@@ -223,7 +224,7 @@ def vizio_update_fixture():
 
 
 @pytest.fixture(name="vizio_update_with_apps")
-def vizio_update_with_apps_fixture(vizio_update: pytest.fixture):
+def vizio_update_with_apps_fixture(vizio_update: None) -> Generator[None]:
     """Mock valid updates to vizio device that supports apps."""
     with (
         patch(
@@ -243,7 +244,7 @@ def vizio_update_with_apps_fixture(vizio_update: pytest.fixture):
 
 
 @pytest.fixture(name="vizio_update_with_apps_on_input")
-def vizio_update_with_apps_on_input_fixture(vizio_update: pytest.fixture):
+def vizio_update_with_apps_on_input_fixture(vizio_update: None) -> Generator[None]:
     """Mock valid updates to vizio device that supports apps but is on a TV input."""
     with (
         patch(
@@ -263,7 +264,7 @@ def vizio_update_with_apps_on_input_fixture(vizio_update: pytest.fixture):
 
 
 @pytest.fixture(name="vizio_hostname_check")
-def vizio_hostname_check():
+def vizio_hostname_check() -> Generator[None]:
     """Mock vizio hostname resolution."""
     with patch(
         "homeassistant.components.vizio.config_flow.socket.gethostbyname",

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -57,11 +57,8 @@ from .const import (
 from tests.common import MockConfigEntry
 
 
-async def test_user_flow_minimum_fields(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_setup: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_bypass_setup")
+async def test_user_flow_minimum_fields(hass: HomeAssistant) -> None:
     """Test user config flow with minimum fields."""
     # test form shows
     result = await hass.config_entries.flow.async_init(
@@ -81,11 +78,8 @@ async def test_user_flow_minimum_fields(
     assert result["data"][CONF_DEVICE_CLASS] == MediaPlayerDeviceClass.SPEAKER
 
 
-async def test_user_flow_all_fields(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_setup: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_bypass_setup")
+async def test_user_flow_all_fields(hass: HomeAssistant) -> None:
     """Test user config flow with all fields."""
     # test form shows
     result = await hass.config_entries.flow.async_init(
@@ -108,11 +102,8 @@ async def test_user_flow_all_fields(
     assert CONF_APPS not in result["data"]
 
 
-async def test_speaker_options_flow(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_update: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_bypass_update")
+async def test_speaker_options_flow(hass: HomeAssistant) -> None:
     """Test options config flow for speaker."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=MOCK_SPEAKER_CONFIG
@@ -136,11 +127,8 @@ async def test_speaker_options_flow(
     assert CONF_APPS not in result["data"]
 
 
-async def test_tv_options_flow_no_apps(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_update: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_bypass_update")
+async def test_tv_options_flow_no_apps(hass: HomeAssistant) -> None:
     """Test options config flow for TV without providing apps option."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=MOCK_USER_VALID_TV_CONFIG
@@ -167,11 +155,8 @@ async def test_tv_options_flow_no_apps(
     assert CONF_APPS not in result["data"]
 
 
-async def test_tv_options_flow_with_apps(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_update: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_bypass_update")
+async def test_tv_options_flow_with_apps(hass: HomeAssistant) -> None:
     """Test options config flow for TV with providing apps option."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=MOCK_USER_VALID_TV_CONFIG
@@ -199,11 +184,8 @@ async def test_tv_options_flow_with_apps(
     assert result["data"][CONF_APPS] == {CONF_INCLUDE: [CURRENT_APP]}
 
 
-async def test_tv_options_flow_start_with_volume(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_update: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_bypass_update")
+async def test_tv_options_flow_start_with_volume(hass: HomeAssistant) -> None:
     """Test options config flow for TV with providing apps option after providing volume step in initial config."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=MOCK_USER_VALID_TV_CONFIG
@@ -241,11 +223,8 @@ async def test_tv_options_flow_start_with_volume(
     assert result["data"][CONF_APPS] == {CONF_INCLUDE: [CURRENT_APP]}
 
 
-async def test_user_host_already_configured(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_setup: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_bypass_setup")
+async def test_user_host_already_configured(hass: HomeAssistant) -> None:
     """Test host is already configured during user setup."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -265,11 +244,8 @@ async def test_user_host_already_configured(
     assert result["errors"] == {CONF_HOST: "existing_config_entry_found"}
 
 
-async def test_user_serial_number_already_exists(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_setup: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_bypass_setup")
+async def test_user_serial_number_already_exists(hass: HomeAssistant) -> None:
     """Test serial_number is already configured with different host and name during user setup."""
     # Set up new entry
     MockConfigEntry(
@@ -289,9 +265,8 @@ async def test_user_serial_number_already_exists(
     assert result["errors"] == {CONF_HOST: "existing_config_entry_found"}
 
 
-async def test_user_error_on_could_not_connect(
-    hass: HomeAssistant, vizio_no_unique_id: pytest.fixture
-) -> None:
+@pytest.mark.usefixtures("vizio_no_unique_id")
+async def test_user_error_on_could_not_connect(hass: HomeAssistant) -> None:
     """Test with could_not_connect during user setup due to no connectivity."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=MOCK_USER_VALID_TV_CONFIG
@@ -301,8 +276,9 @@ async def test_user_error_on_could_not_connect(
     assert result["errors"] == {CONF_HOST: "cannot_connect"}
 
 
+@pytest.mark.usefixtures("vizio_cant_connect")
 async def test_user_error_on_could_not_connect_invalid_token(
-    hass: HomeAssistant, vizio_cant_connect: pytest.fixture
+    hass: HomeAssistant,
 ) -> None:
     """Test with could_not_connect during user setup due to invalid token."""
     result = await hass.config_entries.flow.async_init(
@@ -313,12 +289,10 @@ async def test_user_error_on_could_not_connect_invalid_token(
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_user_tv_pairing_no_apps(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_setup: pytest.fixture,
-    vizio_complete_pairing: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures(
+    "vizio_connect", "vizio_bypass_setup", "vizio_complete_pairing"
+)
+async def test_user_tv_pairing_no_apps(hass: HomeAssistant) -> None:
     """Test pairing config flow when access token not provided for tv during user entry and no apps configured."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=MOCK_TV_CONFIG_NO_TOKEN
@@ -344,12 +318,10 @@ async def test_user_tv_pairing_no_apps(
     assert CONF_APPS not in result["data"]
 
 
-async def test_user_start_pairing_failure(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_setup: pytest.fixture,
-    vizio_start_pairing_failure: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures(
+    "vizio_connect", "vizio_bypass_setup", "vizio_start_pairing_failure"
+)
+async def test_user_start_pairing_failure(hass: HomeAssistant) -> None:
     """Test failure to start pairing from user config flow."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=MOCK_TV_CONFIG_NO_TOKEN
@@ -360,12 +332,10 @@ async def test_user_start_pairing_failure(
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_user_invalid_pin(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_setup: pytest.fixture,
-    vizio_invalid_pin_failure: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures(
+    "vizio_connect", "vizio_bypass_setup", "vizio_invalid_pin_failure"
+)
+async def test_user_invalid_pin(hass: HomeAssistant) -> None:
     """Test failure to complete pairing from user config flow."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=MOCK_TV_CONFIG_NO_TOKEN
@@ -383,11 +353,8 @@ async def test_user_invalid_pin(
     assert result["errors"] == {CONF_PIN: "complete_pairing_failed"}
 
 
-async def test_user_ignore(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_setup: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_bypass_setup")
+async def test_user_ignore(hass: HomeAssistant) -> None:
     """Test user config flow doesn't throw an error when there's an existing ignored source."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -403,11 +370,8 @@ async def test_user_ignore(
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
-async def test_import_flow_minimum_fields(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_setup: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_bypass_setup")
+async def test_import_flow_minimum_fields(hass: HomeAssistant) -> None:
     """Test import config flow with minimum fields."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -425,11 +389,8 @@ async def test_import_flow_minimum_fields(
     assert result["data"][CONF_VOLUME_STEP] == DEFAULT_VOLUME_STEP
 
 
-async def test_import_flow_all_fields(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_setup: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_bypass_setup")
+async def test_import_flow_all_fields(hass: HomeAssistant) -> None:
     """Test import config flow with all fields."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -446,11 +407,8 @@ async def test_import_flow_all_fields(
     assert result["data"][CONF_VOLUME_STEP] == VOLUME_STEP
 
 
-async def test_import_entity_already_configured(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_setup: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_bypass_setup")
+async def test_import_entity_already_configured(hass: HomeAssistant) -> None:
     """Test entity is already configured during import setup."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -468,11 +426,8 @@ async def test_import_entity_already_configured(
     assert result["reason"] == "already_configured_device"
 
 
-async def test_import_flow_update_options(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_update: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_bypass_update")
+async def test_import_flow_update_options(hass: HomeAssistant) -> None:
     """Test import config flow with updated options."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -499,11 +454,8 @@ async def test_import_flow_update_options(
     assert config_entry.options[CONF_VOLUME_STEP] == VOLUME_STEP + 1
 
 
-async def test_import_flow_update_name_and_apps(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_update: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_bypass_update")
+async def test_import_flow_update_name_and_apps(hass: HomeAssistant) -> None:
     """Test import config flow with updated name and apps."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -533,11 +485,8 @@ async def test_import_flow_update_name_and_apps(
     assert config_entry.options[CONF_APPS] == {CONF_INCLUDE: [CURRENT_APP]}
 
 
-async def test_import_flow_update_remove_apps(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_update: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_bypass_update")
+async def test_import_flow_update_remove_apps(hass: HomeAssistant) -> None:
     """Test import config flow with removed apps."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -566,12 +515,10 @@ async def test_import_flow_update_remove_apps(
     assert CONF_APPS not in config_entry.options
 
 
-async def test_import_needs_pairing(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_setup: pytest.fixture,
-    vizio_complete_pairing: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures(
+    "vizio_connect", "vizio_bypass_setup", "vizio_complete_pairing"
+)
+async def test_import_needs_pairing(hass: HomeAssistant) -> None:
     """Test pairing config flow when access token not provided for tv during import."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_IMPORT}, data=MOCK_TV_CONFIG_NO_TOKEN
@@ -603,12 +550,10 @@ async def test_import_needs_pairing(
     assert result["data"][CONF_DEVICE_CLASS] == MediaPlayerDeviceClass.TV
 
 
-async def test_import_with_apps_needs_pairing(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_setup: pytest.fixture,
-    vizio_complete_pairing: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures(
+    "vizio_connect", "vizio_bypass_setup", "vizio_complete_pairing"
+)
+async def test_import_with_apps_needs_pairing(hass: HomeAssistant) -> None:
     """Test pairing config flow when access token not provided for tv but apps are included during import."""
     import_config = MOCK_TV_CONFIG_NO_TOKEN.copy()
     import_config[CONF_APPS] = {CONF_INCLUDE: [CURRENT_APP]}
@@ -646,11 +591,8 @@ async def test_import_with_apps_needs_pairing(
     assert result["data"][CONF_APPS][CONF_INCLUDE] == [CURRENT_APP]
 
 
-async def test_import_flow_additional_configs(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_update: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_bypass_update")
+async def test_import_flow_additional_configs(hass: HomeAssistant) -> None:
     """Test import config flow with additional configs defined in CONF_APPS."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -666,10 +608,9 @@ async def test_import_flow_additional_configs(
     assert CONF_APPS not in config_entry.options
 
 
+@pytest.mark.usefixtures("vizio_connect", "vizio_bypass_setup")
 async def test_import_error(
     hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_setup: pytest.fixture,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that error is logged when import config has an error."""
@@ -700,11 +641,8 @@ async def test_import_error(
     assert len(vizio_log_list) == 1
 
 
-async def test_import_ignore(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_setup: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_bypass_setup")
+async def test_import_ignore(hass: HomeAssistant) -> None:
     """Test import config flow doesn't throw an error when there's an existing ignored source."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -723,12 +661,10 @@ async def test_import_ignore(
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
-async def test_zeroconf_flow(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_setup: pytest.fixture,
-    vizio_guess_device_type: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures(
+    "vizio_connect", "vizio_bypass_setup", "vizio_guess_device_type"
+)
+async def test_zeroconf_flow(hass: HomeAssistant) -> None:
     """Test zeroconf config flow."""
     discovery_info = dataclasses.replace(MOCK_ZEROCONF_SERVICE_INFO)
     result = await hass.config_entries.flow.async_init(
@@ -760,12 +696,10 @@ async def test_zeroconf_flow(
     assert result["data"][CONF_DEVICE_CLASS] == MediaPlayerDeviceClass.SPEAKER
 
 
-async def test_zeroconf_flow_already_configured(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_setup: pytest.fixture,
-    vizio_guess_device_type: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures(
+    "vizio_connect", "vizio_bypass_setup", "vizio_guess_device_type"
+)
+async def test_zeroconf_flow_already_configured(hass: HomeAssistant) -> None:
     """Test entity is already configured during zeroconf setup."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -786,12 +720,10 @@ async def test_zeroconf_flow_already_configured(
     assert result["reason"] == "already_configured"
 
 
-async def test_zeroconf_flow_with_port_in_host(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_setup: pytest.fixture,
-    vizio_guess_device_type: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures(
+    "vizio_connect", "vizio_bypass_setup", "vizio_guess_device_type"
+)
+async def test_zeroconf_flow_with_port_in_host(hass: HomeAssistant) -> None:
     """Test entity is already configured during zeroconf setup when port is in host."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -814,12 +746,10 @@ async def test_zeroconf_flow_with_port_in_host(
     assert result["reason"] == "already_configured"
 
 
-async def test_zeroconf_dupe_fail(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_setup: pytest.fixture,
-    vizio_guess_device_type: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures(
+    "vizio_connect", "vizio_bypass_setup", "vizio_guess_device_type"
+)
+async def test_zeroconf_dupe_fail(hass: HomeAssistant) -> None:
     """Test zeroconf config flow when device gets discovered multiple times."""
     discovery_info = dataclasses.replace(MOCK_ZEROCONF_SERVICE_INFO)
     result = await hass.config_entries.flow.async_init(
@@ -840,12 +770,10 @@ async def test_zeroconf_dupe_fail(
     assert result["reason"] == "already_in_progress"
 
 
-async def test_zeroconf_ignore(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_setup: pytest.fixture,
-    vizio_guess_device_type: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures(
+    "vizio_connect", "vizio_bypass_setup", "vizio_guess_device_type"
+)
+async def test_zeroconf_ignore(hass: HomeAssistant) -> None:
     """Test zeroconf discovery doesn't throw an error when there's an existing ignored source."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -863,11 +791,8 @@ async def test_zeroconf_ignore(
     assert result["type"] is FlowResultType.FORM
 
 
-async def test_zeroconf_no_unique_id(
-    hass: HomeAssistant,
-    vizio_guess_device_type: pytest.fixture,
-    vizio_no_unique_id: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_guess_device_type", "vizio_no_unique_id")
+async def test_zeroconf_no_unique_id(hass: HomeAssistant) -> None:
     """Test zeroconf discovery aborts when unique_id is None."""
 
     discovery_info = dataclasses.replace(MOCK_ZEROCONF_SERVICE_INFO)
@@ -879,12 +804,10 @@ async def test_zeroconf_no_unique_id(
     assert result["reason"] == "cannot_connect"
 
 
-async def test_zeroconf_abort_when_ignored(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_setup: pytest.fixture,
-    vizio_guess_device_type: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures(
+    "vizio_connect", "vizio_bypass_setup", "vizio_guess_device_type"
+)
+async def test_zeroconf_abort_when_ignored(hass: HomeAssistant) -> None:
     """Test zeroconf discovery aborts when the same host has been ignored."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -904,13 +827,13 @@ async def test_zeroconf_abort_when_ignored(
     assert result["reason"] == "already_configured"
 
 
-async def test_zeroconf_flow_already_configured_hostname(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_setup: pytest.fixture,
-    vizio_hostname_check: pytest.fixture,
-    vizio_guess_device_type: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures(
+    "vizio_connect",
+    "vizio_bypass_setup",
+    "vizio_hostname_check",
+    "vizio_guess_device_type",
+)
+async def test_zeroconf_flow_already_configured_hostname(hass: HomeAssistant) -> None:
     """Test entity is already configured during zeroconf setup when existing entry uses hostname."""
     config = MOCK_SPEAKER_CONFIG.copy()
     config[CONF_HOST] = "hostname"
@@ -933,12 +856,8 @@ async def test_zeroconf_flow_already_configured_hostname(
     assert result["reason"] == "already_configured"
 
 
-async def test_import_flow_already_configured_hostname(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_setup: pytest.fixture,
-    vizio_hostname_check: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_bypass_setup", "vizio_hostname_check")
+async def test_import_flow_already_configured_hostname(hass: HomeAssistant) -> None:
     """Test entity is already configured during import setup when existing entry uses hostname."""
     config = MOCK_SPEAKER_CONFIG.copy()
     config[CONF_HOST] = "hostname"

--- a/tests/components/vizio/test_init.py
+++ b/tests/components/vizio/test_init.py
@@ -15,11 +15,8 @@ from .const import MOCK_SPEAKER_CONFIG, MOCK_USER_VALID_TV_CONFIG, UNIQUE_ID
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-async def test_setup_component(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_update: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_update")
+async def test_setup_component(hass: HomeAssistant) -> None:
     """Test component setup."""
     assert await async_setup_component(
         hass, DOMAIN, {DOMAIN: MOCK_USER_VALID_TV_CONFIG}
@@ -28,11 +25,8 @@ async def test_setup_component(
     assert len(hass.states.async_entity_ids(Platform.MEDIA_PLAYER)) == 1
 
 
-async def test_tv_load_and_unload(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_update: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_update")
+async def test_tv_load_and_unload(hass: HomeAssistant) -> None:
     """Test loading and unloading TV entry."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data=MOCK_USER_VALID_TV_CONFIG, unique_id=UNIQUE_ID
@@ -52,11 +46,8 @@ async def test_tv_load_and_unload(
     assert DOMAIN not in hass.data
 
 
-async def test_speaker_load_and_unload(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_update: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_update")
+async def test_speaker_load_and_unload(hass: HomeAssistant) -> None:
     """Test loading and unloading speaker entry."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data=MOCK_SPEAKER_CONFIG, unique_id=UNIQUE_ID
@@ -76,11 +67,11 @@ async def test_speaker_load_and_unload(
     assert DOMAIN not in hass.data
 
 
+@pytest.mark.usefixtures(
+    "vizio_connect", "vizio_bypass_update", "vizio_data_coordinator_update_failure"
+)
 async def test_coordinator_update_failure(
     hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_bypass_update: pytest.fixture,
-    vizio_data_coordinator_update_failure: pytest.fixture,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test coordinator update failure after 10 days."""

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import timedelta
 from typing import Any
@@ -129,7 +130,7 @@ def _get_attr_and_assert_base_attr(
 @asynccontextmanager
 async def _cm_for_test_setup_without_apps(
     all_settings: dict[str, Any], vizio_power_state: bool | None
-) -> None:
+) -> AsyncIterator[None]:
     """Context manager to setup test for Vizio devices without including app specific patches."""
     with (
         patch(
@@ -211,7 +212,7 @@ async def _test_setup_speaker(
 @asynccontextmanager
 async def _cm_for_test_setup_tv_with_apps(
     hass: HomeAssistant, device_config: dict[str, Any], app_config: dict[str, Any]
-) -> None:
+) -> AsyncIterator[None]:
     """Context manager to setup test for Vizio TV with support for apps."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data=vol.Schema(VIZIO_SCHEMA)(device_config), unique_id=UNIQUE_ID
@@ -280,63 +281,46 @@ async def _test_service(
             assert service_call.call_args == call(*args, **kwargs)
 
 
-async def test_speaker_on(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_update: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_update")
+async def test_speaker_on(hass: HomeAssistant) -> None:
     """Test Vizio Speaker entity setup when on."""
     await _test_setup_speaker(hass, True)
 
 
-async def test_speaker_off(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_update: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_update")
+async def test_speaker_off(hass: HomeAssistant) -> None:
     """Test Vizio Speaker entity setup when off."""
     await _test_setup_speaker(hass, False)
 
 
+@pytest.mark.usefixtures("vizio_connect", "vizio_update")
 async def test_speaker_unavailable(
     hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_update: pytest.fixture,
 ) -> None:
     """Test Vizio Speaker entity setup when unavailable."""
     await _test_setup_speaker(hass, None)
 
 
-async def test_init_tv_on(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_update: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_update")
+async def test_init_tv_on(hass: HomeAssistant) -> None:
     """Test Vizio TV entity setup when on."""
     await _test_setup_tv(hass, True)
 
 
-async def test_init_tv_off(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_update: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_update")
+async def test_init_tv_off(hass: HomeAssistant) -> None:
     """Test Vizio TV entity setup when off."""
     await _test_setup_tv(hass, False)
 
 
-async def test_init_tv_unavailable(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_update: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_update")
+async def test_init_tv_unavailable(hass: HomeAssistant) -> None:
     """Test Vizio TV entity setup when unavailable."""
     await _test_setup_tv(hass, None)
 
 
-async def test_setup_unavailable_speaker(
-    hass: HomeAssistant, vizio_cant_connect: pytest.fixture
-) -> None:
+@pytest.mark.usefixtures("vizio_cant_connect")
+async def test_setup_unavailable_speaker(hass: HomeAssistant) -> None:
     """Test speaker entity sets up as unavailable."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data=MOCK_SPEAKER_CONFIG, unique_id=UNIQUE_ID
@@ -346,9 +330,8 @@ async def test_setup_unavailable_speaker(
     assert hass.states.get("media_player.vizio").state == STATE_UNAVAILABLE
 
 
-async def test_setup_unavailable_tv(
-    hass: HomeAssistant, vizio_cant_connect: pytest.fixture
-) -> None:
+@pytest.mark.usefixtures("vizio_cant_connect")
+async def test_setup_unavailable_tv(hass: HomeAssistant) -> None:
     """Test TV entity sets up as unavailable."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data=MOCK_USER_VALID_TV_CONFIG, unique_id=UNIQUE_ID
@@ -358,11 +341,8 @@ async def test_setup_unavailable_tv(
     assert hass.states.get("media_player.vizio").state == STATE_UNAVAILABLE
 
 
-async def test_services(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_update: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_update")
+async def test_services(hass: HomeAssistant) -> None:
     """Test all Vizio media player entity services."""
     await _test_setup_tv(hass, True)
 
@@ -449,11 +429,8 @@ async def test_services(
     await _test_service(hass, MP_DOMAIN, "pause", SERVICE_MEDIA_PAUSE, None)
 
 
-async def test_options_update(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_update: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_update")
+async def test_options_update(hass: HomeAssistant) -> None:
     """Test when config entry update event fires."""
     await _test_setup_speaker(hass, True)
     config_entry = hass.config_entries.async_entries(DOMAIN)[0]
@@ -476,7 +453,7 @@ async def _test_update_availability_switch(
     hass: HomeAssistant,
     initial_power_state: bool | None,
     final_power_state: bool | None,
-    caplog: pytest.fixture,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     now = dt_util.utcnow()
     future_interval = timedelta(minutes=1)
@@ -516,30 +493,27 @@ async def _test_update_availability_switch(
     assert len(vizio_log_list) == 1
 
 
+@pytest.mark.usefixtures("vizio_connect", "vizio_update")
 async def test_update_unavailable_to_available(
     hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_update: pytest.fixture,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test device becomes available after being unavailable."""
     await _test_update_availability_switch(hass, None, True, caplog)
 
 
+@pytest.mark.usefixtures("vizio_connect", "vizio_update")
 async def test_update_available_to_unavailable(
     hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_update: pytest.fixture,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test device becomes unavailable after being available."""
     await _test_update_availability_switch(hass, True, None, caplog)
 
 
+@pytest.mark.usefixtures("vizio_connect", "vizio_update_with_apps")
 async def test_setup_with_apps(
     hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_update_with_apps: pytest.fixture,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test device setup with apps."""
@@ -564,10 +538,9 @@ async def test_setup_with_apps(
     )
 
 
+@pytest.mark.usefixtures("vizio_connect", "vizio_update_with_apps")
 async def test_setup_with_apps_include(
     hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_update_with_apps: pytest.fixture,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test device setup with apps and apps["include"] in config."""
@@ -582,10 +555,9 @@ async def test_setup_with_apps_include(
         assert "app_id" not in attr
 
 
+@pytest.mark.usefixtures("vizio_connect", "vizio_update_with_apps")
 async def test_setup_with_apps_exclude(
     hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_update_with_apps: pytest.fixture,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test device setup with apps and apps["exclude"] in config."""
@@ -600,10 +572,9 @@ async def test_setup_with_apps_exclude(
         assert "app_id" not in attr
 
 
+@pytest.mark.usefixtures("vizio_connect", "vizio_update_with_apps")
 async def test_setup_with_apps_additional_apps_config(
     hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_update_with_apps: pytest.fixture,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test device setup with apps and apps["additional_configs"] in config."""
@@ -679,10 +650,9 @@ def test_invalid_apps_config(hass: HomeAssistant) -> None:
         vol.Schema(vol.All(VIZIO_SCHEMA, validate_apps))(MOCK_SPEAKER_APPS_FAILURE)
 
 
+@pytest.mark.usefixtures("vizio_connect", "vizio_update_with_apps")
 async def test_setup_with_unknown_app_config(
     hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_update_with_apps: pytest.fixture,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test device setup with apps where app config returned is unknown."""
@@ -696,10 +666,9 @@ async def test_setup_with_unknown_app_config(
         assert attr["app_id"] == UNKNOWN_APP_CONFIG
 
 
+@pytest.mark.usefixtures("vizio_connect", "vizio_update_with_apps")
 async def test_setup_with_no_running_app(
     hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_update_with_apps: pytest.fixture,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test device setup with apps where no app is running."""
@@ -713,11 +682,8 @@ async def test_setup_with_no_running_app(
         assert "app_name" not in attr
 
 
-async def test_setup_tv_without_mute(
-    hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_update: pytest.fixture,
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_update")
+async def test_setup_tv_without_mute(hass: HomeAssistant) -> None:
     """Test Vizio TV entity setup when mute property isn't returned by Vizio API."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -737,10 +703,9 @@ async def test_setup_tv_without_mute(
         assert "is_volume_muted" not in attr
 
 
+@pytest.mark.usefixtures("vizio_connect", "vizio_update_with_apps")
 async def test_apps_update(
     hass: HomeAssistant,
-    vizio_connect: pytest.fixture,
-    vizio_update_with_apps: pytest.fixture,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test device setup with apps where no app is running."""
@@ -772,9 +737,8 @@ async def test_apps_update(
                 assert len(apps) == len(APP_LIST)
 
 
-async def test_vizio_update_with_apps_on_input(
-    hass: HomeAssistant, vizio_connect, vizio_update_with_apps_on_input
-) -> None:
+@pytest.mark.usefixtures("vizio_connect", "vizio_update_with_apps_on_input")
+async def test_vizio_update_with_apps_on_input(hass: HomeAssistant) -> None:
     """Test a vizio TV with apps that is on a TV input."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,


### PR DESCRIPTION
## Proposed change
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
