### PR TITLE
Complete coverage for doorbird init

### DIFF
--- a/tests/components/doorbird/__init__.py
+++ b/tests/components/doorbird/__init__.py
@@ -39,6 +39,7 @@ def get_mock_doorbird_api(
     info: dict[str, Any] | None = None,
     info_side_effect: Exception | None = None,
     schedule: list[DoorBirdScheduleEntry] | None = None,
+    favorites_side_effect: Exception | None = None,
 ) -> DoorBird:
     """Return a mock DoorBirdAPI object with return values."""
     doorbirdapi_mock = MagicMock(spec_set=DoorBird)
@@ -46,7 +47,8 @@ def get_mock_doorbird_api(
         side_effect=info_side_effect, return_value=info
     )
     type(doorbirdapi_mock).favorites = AsyncMock(
-        return_value={"http": {"x": {"value": "http://webhook"}}}
+        side_effect=favorites_side_effect,
+        return_value={"http": {"x": {"value": "http://webhook"}}},
     )
     type(doorbirdapi_mock).change_favorite = AsyncMock(return_value=True)
     type(doorbirdapi_mock).schedule = AsyncMock(return_value=schedule)

--- a/tests/components/doorbird/conftest.py
+++ b/tests/components/doorbird/conftest.py
@@ -81,6 +81,7 @@ async def doorbird_mocker(
         info: dict[str, Any] | None = None,
         info_side_effect: Exception | None = None,
         schedule: list[DoorBirdScheduleEntry] | None = None,
+        favorites_side_effect: Exception | None = None,
     ) -> MockDoorbirdEntry:
         """Create a MockDoorbirdEntry from defaults or specific values."""
         entry = entry or MockConfigEntry(
@@ -93,6 +94,7 @@ async def doorbird_mocker(
             info=info or doorbird_info,
             info_side_effect=info_side_effect,
             schedule=schedule or doorbird_schedule,
+            favorites_side_effect=favorites_side_effect,
         )
         entry.add_to_hass(hass)
         with patch_doorbird_api_entry_points(api):

--- a/tests/components/doorbird/test_init.py
+++ b/tests/components/doorbird/test_init.py
@@ -1,10 +1,12 @@
 """Test DoorBird init."""
 
+import pytest
+
 from homeassistant.components.doorbird.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
-from . import mock_unauthorized_exception
+from . import mock_not_found_exception, mock_unauthorized_exception
 from .conftest import DoorbirdMockerType
 
 
@@ -30,3 +32,52 @@ async def test_auth_fails(
     flows = hass.config_entries.flow.async_progress(DOMAIN)
     assert len(flows) == 1
     assert flows[0]["step_id"] == "reauth_confirm"
+
+
+@pytest.mark.parametrize(
+    "side_effect",
+    [OSError, mock_not_found_exception()],
+)
+async def test_http_info_request_fails(
+    doorbird_mocker: DoorbirdMockerType, side_effect: Exception
+) -> None:
+    """Test basic setup with an http failure."""
+    doorbird_entry = await doorbird_mocker(info_side_effect=side_effect)
+    assert doorbird_entry.entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_http_favorites_request_fails(
+    doorbird_mocker: DoorbirdMockerType,
+) -> None:
+    """Test basic setup with an http failure."""
+    doorbird_entry = await doorbird_mocker(
+        favorites_side_effect=mock_not_found_exception()
+    )
+    assert doorbird_entry.entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_events_changed(
+    hass: HomeAssistant,
+    doorbird_mocker: DoorbirdMockerType,
+) -> None:
+    """Test basic setup."""
+    doorbird_entry = await doorbird_mocker()
+    entry = doorbird_entry.entry
+    assert entry.state is ConfigEntryState.LOADED
+    api = doorbird_entry.api
+    api.favorites.reset_mock()
+    api.change_favorite.reset_mock()
+    api.schedule.reset_mock()
+
+    hass.config_entries.async_update_entry(entry, options={"events": ["xyz"]})
+    await hass.async_block_till_done()
+    assert len(api.favorites.mock_calls) == 2
+    assert len(api.schedule.mock_calls) == 1
+
+    assert len(api.change_favorite.mock_calls) == 1
+    favorite_type, title, url = api.change_favorite.mock_calls[0][1]
+    assert favorite_type == "http"
+    assert title == "Home Assistant (mydoorbird_xyz)"
+    assert url == (
+        f"http://10.10.10.10:8123/api/doorbird/mydoorbird_xyz?token={entry.entry_id}"
+    )


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Complete coverage for doorbird init

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
