### PR TITLE
Improve fixture usage for sensor based deCONZ tests

### DIFF
--- a/tests/components/deconz/conftest.py
+++ b/tests/components/deconz/conftest.py
@@ -185,16 +185,16 @@ def fixture_light_data() -> dict[str, Any]:
 
 
 @pytest.fixture(name="sensor_payload")
-def fixture_sensor_data(sensor_1_payload: dict[str, Any]) -> dict[str, Any]:
+def fixture_sensor_data(sensor_0_payload: dict[str, Any]) -> dict[str, Any]:
     """Sensor data."""
-    if sensor_1_payload:
-        return {"1": sensor_1_payload}
+    if sensor_0_payload:
+        return {"0": sensor_0_payload}
     return {}
 
 
-@pytest.fixture(name="sensor_1_payload")
-def fixture_sensor_1_data() -> dict[str, Any]:
-    """Sensor 1 data."""
+@pytest.fixture(name="sensor_0_payload")
+def fixture_sensor_0_data() -> dict[str, Any]:
+    """Sensor 0 data."""
     return {}
 
 

--- a/tests/components/deconz/conftest.py
+++ b/tests/components/deconz/conftest.py
@@ -122,6 +122,8 @@ def fixture_get_request(
     if "state" in light_payload:
         light_payload = {"0": light_payload}
     data.setdefault("lights", light_payload)
+    if "state" in sensor_payload or "config" in sensor_payload:
+        sensor_payload = {"0": sensor_payload}
     data.setdefault("sensors", sensor_payload)
 
     def __mock_requests(host: str = "") -> None:
@@ -185,16 +187,13 @@ def fixture_light_data() -> dict[str, Any]:
 
 
 @pytest.fixture(name="sensor_payload")
-def fixture_sensor_data(sensor_0_payload: dict[str, Any]) -> dict[str, Any]:
-    """Sensor data."""
-    if sensor_0_payload:
-        return {"0": sensor_0_payload}
-    return {}
+def fixture_sensor_data() -> dict[str, Any]:
+    """Sensor data.
 
-
-@pytest.fixture(name="sensor_0_payload")
-def fixture_sensor_0_data() -> dict[str, Any]:
-    """Sensor 0 data."""
+    Should be
+     - one sensor data payload {"config": ..., "state": ...} ("0")
+     - multiple sensors {"1": ..., "2": ...}
+    """
     return {}
 
 

--- a/tests/components/deconz/test_alarm_control_panel.py
+++ b/tests/components/deconz/test_alarm_control_panel.py
@@ -67,7 +67,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
     ],
 )
 @pytest.mark.parametrize(
-    "sensor_0_payload",
+    "sensor_payload",
     [
         {
             "config": {

--- a/tests/components/deconz/test_alarm_control_panel.py
+++ b/tests/components/deconz/test_alarm_control_panel.py
@@ -67,35 +67,33 @@ from tests.test_util.aiohttp import AiohttpClientMocker
     ],
 )
 @pytest.mark.parametrize(
-    "sensor_payload",
+    "sensor_0_payload",
     [
         {
-            "0": {
-                "config": {
-                    "battery": 95,
-                    "enrolled": 1,
-                    "on": True,
-                    "pending": [],
-                    "reachable": True,
-                },
-                "ep": 1,
-                "etag": "5aaa1c6bae8501f59929539c6e8f44d6",
-                "lastseen": "2021-07-25T18:07Z",
-                "manufacturername": "lk",
-                "modelid": "ZB-KeypadGeneric-D0002",
-                "name": "Keypad",
-                "state": {
-                    "action": "armed_stay",
-                    "lastupdated": "2021-07-25T18:02:51.172",
-                    "lowbattery": False,
-                    "panel": "none",
-                    "seconds_remaining": 55,
-                    "tampered": False,
-                },
-                "swversion": "3.13",
-                "type": "ZHAAncillaryControl",
-                "uniqueid": "00:00:00:00:00:00:00:00-00",
-            }
+            "config": {
+                "battery": 95,
+                "enrolled": 1,
+                "on": True,
+                "pending": [],
+                "reachable": True,
+            },
+            "ep": 1,
+            "etag": "5aaa1c6bae8501f59929539c6e8f44d6",
+            "lastseen": "2021-07-25T18:07Z",
+            "manufacturername": "lk",
+            "modelid": "ZB-KeypadGeneric-D0002",
+            "name": "Keypad",
+            "state": {
+                "action": "armed_stay",
+                "lastupdated": "2021-07-25T18:02:51.172",
+                "lowbattery": False,
+                "panel": "none",
+                "seconds_remaining": 55,
+                "tampered": False,
+            },
+            "swversion": "3.13",
+            "type": "ZHAAncillaryControl",
+            "uniqueid": "00:00:00:00:00:00:00:00-00",
         }
     ],
 )

--- a/tests/components/deconz/test_binary_sensor.py
+++ b/tests/components/deconz/test_binary_sensor.py
@@ -603,7 +603,6 @@ async def test_add_new_binary_sensor(
     event_added_sensor = {
         "e": "added",
         "r": "sensors",
-        "id": "1",
         "sensor": {
             "id": "Presence sensor id",
             "name": "Presence sensor",
@@ -642,7 +641,6 @@ async def test_add_new_binary_sensor_ignored_load_entities_on_service_call(
     event_added_sensor = {
         "e": "added",
         "r": "sensors",
-        "id": "1",
         "sensor": sensor,
     }
 
@@ -663,7 +661,7 @@ async def test_add_new_binary_sensor_ignored_load_entities_on_service_call(
         == 0
     )
 
-    deconz_payload["sensors"] = {"1": sensor}
+    deconz_payload["sensors"]["0"] = sensor
     mock_requests()
 
     await hass.services.async_call(DECONZ_DOMAIN, SERVICE_DEVICE_REFRESH)
@@ -695,7 +693,6 @@ async def test_add_new_binary_sensor_ignored_load_entities_on_options_change(
     event_added_sensor = {
         "e": "added",
         "r": "sensors",
-        "id": "1",
         "sensor": sensor,
     }
 
@@ -716,7 +713,7 @@ async def test_add_new_binary_sensor_ignored_load_entities_on_options_change(
         == 0
     )
 
-    deconz_payload["sensors"] = {"1": sensor}
+    deconz_payload["sensors"]["0"] = sensor
     mock_requests()
 
     hass.config_entries.async_update_entry(

--- a/tests/components/deconz/test_binary_sensor.py
+++ b/tests/components/deconz/test_binary_sensor.py
@@ -454,7 +454,7 @@ TEST_DATA = [
 
 
 @pytest.mark.parametrize("config_entry_options", [{CONF_ALLOW_CLIP_SENSOR: True}])
-@pytest.mark.parametrize(("sensor_0_payload", "expected"), TEST_DATA)
+@pytest.mark.parametrize(("sensor_payload", "expected"), TEST_DATA)
 async def test_binary_sensors(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
@@ -510,7 +510,7 @@ async def test_binary_sensors(
 
 
 @pytest.mark.parametrize(
-    "sensor_0_payload",
+    "sensor_payload",
     [
         {
             "name": "CLIP presence sensor",

--- a/tests/components/deconz/test_binary_sensor.py
+++ b/tests/components/deconz/test_binary_sensor.py
@@ -454,7 +454,7 @@ TEST_DATA = [
 
 
 @pytest.mark.parametrize("config_entry_options", [{CONF_ALLOW_CLIP_SENSOR: True}])
-@pytest.mark.parametrize(("sensor_1_payload", "expected"), TEST_DATA)
+@pytest.mark.parametrize(("sensor_0_payload", "expected"), TEST_DATA)
 async def test_binary_sensors(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
@@ -492,11 +492,7 @@ async def test_binary_sensors(
 
     # Change state
 
-    event_changed_sensor = {
-        "r": "sensors",
-        "id": "1",
-        "state": expected["websocket_event"],
-    }
+    event_changed_sensor = {"r": "sensors", "state": expected["websocket_event"]}
     await mock_websocket_data(event_changed_sensor)
     await hass.async_block_till_done()
     assert hass.states.get(expected["entity_id"]).state == expected["next_state"]
@@ -514,7 +510,7 @@ async def test_binary_sensors(
 
 
 @pytest.mark.parametrize(
-    "sensor_1_payload",
+    "sensor_0_payload",
     [
         {
             "name": "CLIP presence sensor",

--- a/tests/components/deconz/test_climate.py
+++ b/tests/components/deconz/test_climate.py
@@ -51,7 +51,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 @pytest.mark.parametrize(
-    "sensor_0_payload",
+    "sensor_payload",
     [
         {
             "config": {
@@ -174,7 +174,7 @@ async def test_simple_climate_device(
 
 
 @pytest.mark.parametrize(
-    "sensor_0_payload",
+    "sensor_payload",
     [
         {
             "name": "Thermostat",
@@ -344,7 +344,7 @@ async def test_climate_device_without_cooling_support(
 
 
 @pytest.mark.parametrize(
-    "sensor_0_payload",
+    "sensor_payload",
     [
         {
             "config": {
@@ -443,7 +443,7 @@ async def test_climate_device_with_cooling_support(
 
 
 @pytest.mark.parametrize(
-    "sensor_0_payload",
+    "sensor_payload",
     [
         {
             "config": {
@@ -577,7 +577,7 @@ async def test_climate_device_with_fan_support(
 
 
 @pytest.mark.parametrize(
-    "sensor_0_payload",
+    "sensor_payload",
     [
         {
             "config": {
@@ -759,7 +759,7 @@ async def test_clip_climate_device(
 
 
 @pytest.mark.parametrize(
-    "sensor_0_payload",
+    "sensor_payload",
     [
         {
             "name": "Thermostat",
@@ -839,7 +839,7 @@ async def test_add_new_climate_device(
 
 
 @pytest.mark.parametrize(
-    "sensor_0_payload",
+    "sensor_payload",
     [
         {
             "name": "CLIP thermostat sensor",
@@ -858,7 +858,7 @@ async def test_not_allow_clip_thermostat(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "sensor_0_payload",
+    "sensor_payload",
     [
         {
             "config": {
@@ -895,7 +895,7 @@ async def test_no_mode_no_state(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "sensor_0_payload",
+    "sensor_payload",
     [
         {
             "config": {

--- a/tests/components/deconz/test_climate.py
+++ b/tests/components/deconz/test_climate.py
@@ -51,39 +51,37 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 @pytest.mark.parametrize(
-    "sensor_payload",
+    "sensor_0_payload",
     [
         {
-            "0": {
-                "config": {
-                    "battery": 59,
-                    "displayflipped": None,
-                    "heatsetpoint": 2100,
-                    "locked": True,
-                    "mountingmode": None,
-                    "offset": 0,
-                    "on": True,
-                    "reachable": True,
-                },
-                "ep": 1,
-                "etag": "6130553ac247174809bae47144ee23f8",
-                "lastseen": "2020-11-29T19:31Z",
-                "manufacturername": "Danfoss",
-                "modelid": "eTRV0100",
-                "name": "thermostat",
-                "state": {
-                    "errorcode": None,
-                    "lastupdated": "2020-11-29T19:28:40.665",
-                    "mountingmodeactive": False,
-                    "on": True,
-                    "temperature": 2102,
-                    "valve": 24,
-                    "windowopen": "Closed",
-                },
-                "swversion": "01.02.0008 01.02",
-                "type": "ZHAThermostat",
-                "uniqueid": "14:b4:57:ff:fe:d5:4e:77-01-0201",
-            }
+            "config": {
+                "battery": 59,
+                "displayflipped": None,
+                "heatsetpoint": 2100,
+                "locked": True,
+                "mountingmode": None,
+                "offset": 0,
+                "on": True,
+                "reachable": True,
+            },
+            "ep": 1,
+            "etag": "6130553ac247174809bae47144ee23f8",
+            "lastseen": "2020-11-29T19:31Z",
+            "manufacturername": "Danfoss",
+            "modelid": "eTRV0100",
+            "name": "thermostat",
+            "state": {
+                "errorcode": None,
+                "lastupdated": "2020-11-29T19:28:40.665",
+                "mountingmodeactive": False,
+                "on": True,
+                "temperature": 2102,
+                "valve": 24,
+                "windowopen": "Closed",
+            },
+            "swversion": "01.02.0008 01.02",
+            "type": "ZHAThermostat",
+            "uniqueid": "14:b4:57:ff:fe:d5:4e:77-01-0201",
         }
     ],
 )
@@ -176,22 +174,20 @@ async def test_simple_climate_device(
 
 
 @pytest.mark.parametrize(
-    "sensor_payload",
+    "sensor_0_payload",
     [
         {
-            "1": {
-                "name": "Thermostat",
-                "type": "ZHAThermostat",
-                "state": {"on": True, "temperature": 2260, "valve": 30},
-                "config": {
-                    "battery": 100,
-                    "heatsetpoint": 2200,
-                    "mode": "auto",
-                    "offset": 10,
-                    "reachable": True,
-                },
-                "uniqueid": "00:00:00:00:00:00:00:00-00",
-            }
+            "name": "Thermostat",
+            "type": "ZHAThermostat",
+            "state": {"on": True, "temperature": 2260, "valve": 30},
+            "config": {
+                "battery": 100,
+                "heatsetpoint": 2200,
+                "mode": "auto",
+                "offset": 10,
+                "reachable": True,
+            },
+            "uniqueid": "00:00:00:00:00:00:00:00-00",
         }
     ],
 )
@@ -225,7 +221,6 @@ async def test_climate_device_without_cooling_support(
 
     event_changed_sensor = {
         "r": "sensors",
-        "id": "1",
         "config": {"mode": "off"},
     }
     await mock_websocket_data(event_changed_sensor)
@@ -241,7 +236,6 @@ async def test_climate_device_without_cooling_support(
 
     event_changed_sensor = {
         "r": "sensors",
-        "id": "1",
         "config": {"mode": "other"},
         "state": {"on": True},
     }
@@ -258,7 +252,6 @@ async def test_climate_device_without_cooling_support(
 
     event_changed_sensor = {
         "r": "sensors",
-        "id": "1",
         "state": {"on": False},
     }
     await mock_websocket_data(event_changed_sensor)
@@ -272,7 +265,7 @@ async def test_climate_device_without_cooling_support(
 
     # Verify service calls
 
-    aioclient_mock = mock_put_request("/sensors/1/config")
+    aioclient_mock = mock_put_request("/sensors/0/config")
 
     # Service set HVAC mode to auto
 
@@ -351,34 +344,32 @@ async def test_climate_device_without_cooling_support(
 
 
 @pytest.mark.parametrize(
-    "sensor_payload",
+    "sensor_0_payload",
     [
         {
-            "0": {
-                "config": {
-                    "battery": 25,
-                    "coolsetpoint": 1111,
-                    "fanmode": None,
-                    "heatsetpoint": 2222,
-                    "mode": "heat",
-                    "offset": 0,
-                    "on": True,
-                    "reachable": True,
-                },
-                "ep": 1,
-                "etag": "074549903686a77a12ef0f06c499b1ef",
-                "lastseen": "2020-11-27T13:45Z",
-                "manufacturername": "Zen Within",
-                "modelid": "Zen-01",
-                "name": "Zen-01",
-                "state": {
-                    "lastupdated": "2020-11-27T13:42:40.863",
-                    "on": False,
-                    "temperature": 2320,
-                },
-                "type": "ZHAThermostat",
-                "uniqueid": "00:24:46:00:00:11:6f:56-01-0201",
-            }
+            "config": {
+                "battery": 25,
+                "coolsetpoint": 1111,
+                "fanmode": None,
+                "heatsetpoint": 2222,
+                "mode": "heat",
+                "offset": 0,
+                "on": True,
+                "reachable": True,
+            },
+            "ep": 1,
+            "etag": "074549903686a77a12ef0f06c499b1ef",
+            "lastseen": "2020-11-27T13:45Z",
+            "manufacturername": "Zen Within",
+            "modelid": "Zen-01",
+            "name": "Zen-01",
+            "state": {
+                "lastupdated": "2020-11-27T13:42:40.863",
+                "on": False,
+                "temperature": 2320,
+            },
+            "type": "ZHAThermostat",
+            "uniqueid": "00:24:46:00:00:11:6f:56-01-0201",
         }
     ],
 )
@@ -452,34 +443,32 @@ async def test_climate_device_with_cooling_support(
 
 
 @pytest.mark.parametrize(
-    "sensor_payload",
+    "sensor_0_payload",
     [
         {
-            "0": {
-                "config": {
-                    "battery": 25,
-                    "coolsetpoint": None,
-                    "fanmode": "auto",
-                    "heatsetpoint": 2222,
-                    "mode": "heat",
-                    "offset": 0,
-                    "on": True,
-                    "reachable": True,
-                },
-                "ep": 1,
-                "etag": "074549903686a77a12ef0f06c499b1ef",
-                "lastseen": "2020-11-27T13:45Z",
-                "manufacturername": "Zen Within",
-                "modelid": "Zen-01",
-                "name": "Zen-01",
-                "state": {
-                    "lastupdated": "2020-11-27T13:42:40.863",
-                    "on": False,
-                    "temperature": 2320,
-                },
-                "type": "ZHAThermostat",
-                "uniqueid": "00:24:46:00:00:11:6f:56-01-0201",
-            }
+            "config": {
+                "battery": 25,
+                "coolsetpoint": None,
+                "fanmode": "auto",
+                "heatsetpoint": 2222,
+                "mode": "heat",
+                "offset": 0,
+                "on": True,
+                "reachable": True,
+            },
+            "ep": 1,
+            "etag": "074549903686a77a12ef0f06c499b1ef",
+            "lastseen": "2020-11-27T13:45Z",
+            "manufacturername": "Zen Within",
+            "modelid": "Zen-01",
+            "name": "Zen-01",
+            "state": {
+                "lastupdated": "2020-11-27T13:42:40.863",
+                "on": False,
+                "temperature": 2320,
+            },
+            "type": "ZHAThermostat",
+            "uniqueid": "00:24:46:00:00:11:6f:56-01-0201",
         }
     ],
 )
@@ -588,35 +577,33 @@ async def test_climate_device_with_fan_support(
 
 
 @pytest.mark.parametrize(
-    "sensor_payload",
+    "sensor_0_payload",
     [
         {
-            "0": {
-                "config": {
-                    "battery": 25,
-                    "coolsetpoint": None,
-                    "fanmode": None,
-                    "heatsetpoint": 2222,
-                    "mode": "heat",
-                    "preset": "auto",
-                    "offset": 0,
-                    "on": True,
-                    "reachable": True,
-                },
-                "ep": 1,
-                "etag": "074549903686a77a12ef0f06c499b1ef",
-                "lastseen": "2020-11-27T13:45Z",
-                "manufacturername": "Zen Within",
-                "modelid": "Zen-01",
-                "name": "Zen-01",
-                "state": {
-                    "lastupdated": "2020-11-27T13:42:40.863",
-                    "on": False,
-                    "temperature": 2320,
-                },
-                "type": "ZHAThermostat",
-                "uniqueid": "00:24:46:00:00:11:6f:56-01-0201",
-            }
+            "config": {
+                "battery": 25,
+                "coolsetpoint": None,
+                "fanmode": None,
+                "heatsetpoint": 2222,
+                "mode": "heat",
+                "preset": "auto",
+                "offset": 0,
+                "on": True,
+                "reachable": True,
+            },
+            "ep": 1,
+            "etag": "074549903686a77a12ef0f06c499b1ef",
+            "lastseen": "2020-11-27T13:45Z",
+            "manufacturername": "Zen Within",
+            "modelid": "Zen-01",
+            "name": "Zen-01",
+            "state": {
+                "lastupdated": "2020-11-27T13:42:40.863",
+                "on": False,
+                "temperature": 2320,
+            },
+            "type": "ZHAThermostat",
+            "uniqueid": "00:24:46:00:00:11:6f:56-01-0201",
         }
     ],
 )
@@ -772,22 +759,20 @@ async def test_clip_climate_device(
 
 
 @pytest.mark.parametrize(
-    "sensor_payload",
+    "sensor_0_payload",
     [
         {
-            "1": {
-                "name": "Thermostat",
-                "type": "ZHAThermostat",
-                "state": {"on": True, "temperature": 2260, "valve": 30},
-                "config": {
-                    "battery": 100,
-                    "heatsetpoint": 2200,
-                    "mode": "auto",
-                    "offset": 10,
-                    "reachable": True,
-                },
-                "uniqueid": "00:00:00:00:00:00:00:00-00",
-            }
+            "name": "Thermostat",
+            "type": "ZHAThermostat",
+            "state": {"on": True, "temperature": 2260, "valve": 30},
+            "config": {
+                "battery": 100,
+                "heatsetpoint": 2200,
+                "mode": "auto",
+                "offset": 10,
+                "reachable": True,
+            },
+            "uniqueid": "00:00:00:00:00:00:00:00-00",
         }
     ],
 )
@@ -803,11 +788,7 @@ async def test_verify_state_update(
         == HVACAction.HEATING
     )
 
-    event_changed_sensor = {
-        "r": "sensors",
-        "id": "1",
-        "state": {"on": False},
-    }
+    event_changed_sensor = {"r": "sensors", "state": {"on": False}}
     await mock_websocket_data(event_changed_sensor)
     await hass.async_block_till_done()
 
@@ -827,7 +808,6 @@ async def test_add_new_climate_device(
     event_added_sensor = {
         "e": "added",
         "r": "sensors",
-        "id": "1",
         "sensor": {
             "id": "Thermostat id",
             "name": "Thermostat",
@@ -859,17 +839,15 @@ async def test_add_new_climate_device(
 
 
 @pytest.mark.parametrize(
-    "sensor_payload",
+    "sensor_0_payload",
     [
         {
-            "1": {
-                "name": "CLIP thermostat sensor",
-                "type": "CLIPThermostat",
-                "state": {},
-                "config": {},
-                "uniqueid": "00:00:00:00:00:00:00:00-00",
-            },
-        }
+            "name": "CLIP thermostat sensor",
+            "type": "CLIPThermostat",
+            "state": {},
+            "config": {},
+            "uniqueid": "00:00:00:00:00:00:00:00-00",
+        },
     ],
 )
 @pytest.mark.parametrize("config_entry_options", [{CONF_ALLOW_CLIP_SENSOR: False}])
@@ -880,29 +858,27 @@ async def test_not_allow_clip_thermostat(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "sensor_payload",
+    "sensor_0_payload",
     [
         {
-            "0": {
-                "config": {
-                    "battery": 25,
-                    "heatsetpoint": 2222,
-                    "mode": None,
-                    "preset": "auto",
-                    "offset": 0,
-                    "on": True,
-                    "reachable": True,
-                },
-                "ep": 1,
-                "etag": "074549903686a77a12ef0f06c499b1ef",
-                "lastseen": "2020-11-27T13:45Z",
-                "manufacturername": "Zen Within",
-                "modelid": "Zen-01",
-                "name": "Zen-01",
-                "state": {"lastupdated": "none", "on": None, "temperature": 2290},
-                "type": "ZHAThermostat",
-                "uniqueid": "00:24:46:00:00:11:6f:56-01-0201",
-            }
+            "config": {
+                "battery": 25,
+                "heatsetpoint": 2222,
+                "mode": None,
+                "preset": "auto",
+                "offset": 0,
+                "on": True,
+                "reachable": True,
+            },
+            "ep": 1,
+            "etag": "074549903686a77a12ef0f06c499b1ef",
+            "lastseen": "2020-11-27T13:45Z",
+            "manufacturername": "Zen Within",
+            "modelid": "Zen-01",
+            "name": "Zen-01",
+            "state": {"lastupdated": "none", "on": None, "temperature": 2290},
+            "type": "ZHAThermostat",
+            "uniqueid": "00:24:46:00:00:11:6f:56-01-0201",
         }
     ],
 )
@@ -919,41 +895,39 @@ async def test_no_mode_no_state(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "sensor_payload",
+    "sensor_0_payload",
     [
         {
-            "0": {
-                "config": {
-                    "battery": 58,
-                    "heatsetpoint": 2200,
-                    "locked": False,
-                    "mode": "heat",
-                    "offset": -200,
-                    "on": True,
-                    "preset": "manual",
-                    "reachable": True,
-                    "schedule": {},
-                    "schedule_on": False,
-                    "setvalve": False,
-                    "windowopen_set": False,
-                },
-                "ep": 1,
-                "etag": "404c15db68c318ebe7832ce5aa3d1e30",
-                "lastannounced": "2022-08-31T03:00:59Z",
-                "lastseen": "2022-09-19T11:58Z",
-                "manufacturername": "_TZE200_b6wax7g0",
-                "modelid": "TS0601",
-                "name": "Thermostat",
-                "state": {
-                    "lastupdated": "2022-09-19T11:58:24.204",
-                    "lowbattery": False,
-                    "on": False,
-                    "temperature": 2200,
-                    "valve": 0,
-                },
-                "type": "ZHAThermostat",
-                "uniqueid": "84:fd:27:ff:fe:8a:eb:89-01-0201",
-            }
+            "config": {
+                "battery": 58,
+                "heatsetpoint": 2200,
+                "locked": False,
+                "mode": "heat",
+                "offset": -200,
+                "on": True,
+                "preset": "manual",
+                "reachable": True,
+                "schedule": {},
+                "schedule_on": False,
+                "setvalve": False,
+                "windowopen_set": False,
+            },
+            "ep": 1,
+            "etag": "404c15db68c318ebe7832ce5aa3d1e30",
+            "lastannounced": "2022-08-31T03:00:59Z",
+            "lastseen": "2022-09-19T11:58Z",
+            "manufacturername": "_TZE200_b6wax7g0",
+            "modelid": "TS0601",
+            "name": "Thermostat",
+            "state": {
+                "lastupdated": "2022-09-19T11:58:24.204",
+                "lowbattery": False,
+                "on": False,
+                "temperature": 2200,
+                "valve": 0,
+            },
+            "type": "ZHAThermostat",
+            "uniqueid": "84:fd:27:ff:fe:8a:eb:89-01-0201",
         }
     ],
 )

--- a/tests/components/deconz/test_deconz_event.py
+++ b/tests/components/deconz/test_deconz_event.py
@@ -240,35 +240,33 @@ async def test_deconz_events(
     ],
 )
 @pytest.mark.parametrize(
-    "sensor_payload",
+    "sensor_0_payload",
     [
         {
-            "1": {
-                "config": {
-                    "battery": 95,
-                    "enrolled": 1,
-                    "on": True,
-                    "pending": [],
-                    "reachable": True,
-                },
-                "ep": 1,
-                "etag": "5aaa1c6bae8501f59929539c6e8f44d6",
-                "lastseen": "2021-07-25T18:07Z",
-                "manufacturername": "lk",
-                "modelid": "ZB-KeypadGeneric-D0002",
-                "name": "Keypad",
-                "state": {
-                    "action": "invalid_code",
-                    "lastupdated": "2021-07-25T18:02:51.172",
-                    "lowbattery": False,
-                    "panel": "exit_delay",
-                    "seconds_remaining": 55,
-                    "tampered": False,
-                },
-                "swversion": "3.13",
-                "type": "ZHAAncillaryControl",
-                "uniqueid": "00:00:00:00:00:00:00:01-00",
-            }
+            "config": {
+                "battery": 95,
+                "enrolled": 1,
+                "on": True,
+                "pending": [],
+                "reachable": True,
+            },
+            "ep": 1,
+            "etag": "5aaa1c6bae8501f59929539c6e8f44d6",
+            "lastseen": "2021-07-25T18:07Z",
+            "manufacturername": "lk",
+            "modelid": "ZB-KeypadGeneric-D0002",
+            "name": "Keypad",
+            "state": {
+                "action": "invalid_code",
+                "lastupdated": "2021-07-25T18:02:51.172",
+                "lowbattery": False,
+                "panel": "exit_delay",
+                "seconds_remaining": 55,
+                "tampered": False,
+            },
+            "swversion": "3.13",
+            "type": "ZHAAncillaryControl",
+            "uniqueid": "00:00:00:00:00:00:00:01-00",
         }
     ],
 )
@@ -296,7 +294,6 @@ async def test_deconz_alarm_events(
 
     event_changed_sensor = {
         "r": "sensors",
-        "id": "1",
         "state": {"action": AncillaryControlAction.EMERGENCY},
     }
     await mock_websocket_data(event_changed_sensor)
@@ -318,7 +315,6 @@ async def test_deconz_alarm_events(
 
     event_changed_sensor = {
         "r": "sensors",
-        "id": "1",
         "state": {"action": AncillaryControlAction.FIRE},
     }
     await mock_websocket_data(event_changed_sensor)
@@ -340,7 +336,6 @@ async def test_deconz_alarm_events(
 
     event_changed_sensor = {
         "r": "sensors",
-        "id": "1",
         "state": {"action": AncillaryControlAction.INVALID_CODE},
     }
     await mock_websocket_data(event_changed_sensor)
@@ -362,7 +357,6 @@ async def test_deconz_alarm_events(
 
     event_changed_sensor = {
         "r": "sensors",
-        "id": "1",
         "state": {"action": AncillaryControlAction.PANIC},
     }
     await mock_websocket_data(event_changed_sensor)
@@ -384,7 +378,6 @@ async def test_deconz_alarm_events(
 
     event_changed_sensor = {
         "r": "sensors",
-        "id": "1",
         "state": {"action": AncillaryControlAction.ARMED_AWAY},
     }
     await mock_websocket_data(event_changed_sensor)
@@ -396,7 +389,6 @@ async def test_deconz_alarm_events(
 
     event_changed_sensor = {
         "r": "sensors",
-        "id": "1",
         "state": {"panel": AncillaryControlPanel.ARMED_AWAY},
     }
     await mock_websocket_data(event_changed_sensor)
@@ -417,32 +409,30 @@ async def test_deconz_alarm_events(
 
 
 @pytest.mark.parametrize(
-    "sensor_payload",
+    "sensor_0_payload",
     [
         {
-            "1": {
-                "config": {
-                    "devicemode": "undirected",
-                    "on": True,
-                    "reachable": True,
-                    "sensitivity": 3,
-                    "triggerdistance": "medium",
-                },
-                "etag": "13ff209f9401b317987d42506dd4cd79",
-                "lastannounced": None,
-                "lastseen": "2022-06-28T23:13Z",
-                "manufacturername": "aqara",
-                "modelid": "lumi.motion.ac01",
-                "name": "Aqara FP1",
-                "state": {
-                    "lastupdated": "2022-06-28T23:13:38.577",
-                    "presence": True,
-                    "presenceevent": "leave",
-                },
-                "swversion": "20210121",
-                "type": "ZHAPresence",
-                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0406",
-            }
+            "config": {
+                "devicemode": "undirected",
+                "on": True,
+                "reachable": True,
+                "sensitivity": 3,
+                "triggerdistance": "medium",
+            },
+            "etag": "13ff209f9401b317987d42506dd4cd79",
+            "lastannounced": None,
+            "lastseen": "2022-06-28T23:13Z",
+            "manufacturername": "aqara",
+            "modelid": "lumi.motion.ac01",
+            "name": "Aqara FP1",
+            "state": {
+                "lastupdated": "2022-06-28T23:13:38.577",
+                "presence": True,
+                "presenceevent": "leave",
+            },
+            "swversion": "20210121",
+            "type": "ZHAPresence",
+            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0406",
         }
     ],
 )
@@ -481,7 +471,6 @@ async def test_deconz_presence_events(
     ):
         event_changed_sensor = {
             "r": "sensors",
-            "id": "1",
             "state": {"presenceevent": presence_event},
         }
         await mock_websocket_data(event_changed_sensor)
@@ -500,7 +489,6 @@ async def test_deconz_presence_events(
 
     event_changed_sensor = {
         "r": "sensors",
-        "id": "1",
         "state": {"presenceevent": PresenceStatePresenceEvent.NINE},
     }
     await mock_websocket_data(event_changed_sensor)
@@ -521,31 +509,29 @@ async def test_deconz_presence_events(
 
 
 @pytest.mark.parametrize(
-    "sensor_payload",
+    "sensor_0_payload",
     [
         {
-            "1": {
-                "config": {
-                    "battery": 100,
-                    "on": True,
-                    "reachable": True,
-                },
-                "etag": "463728970bdb7d04048fc4373654f45a",
-                "lastannounced": "2022-07-03T13:57:59Z",
-                "lastseen": "2022-07-03T14:02Z",
-                "manufacturername": "Signify Netherlands B.V.",
-                "modelid": "RDM002",
-                "name": "RDM002 44",
-                "state": {
-                    "expectedeventduration": 400,
-                    "expectedrotation": 75,
-                    "lastupdated": "2022-07-03T11:37:49.586",
-                    "rotaryevent": 2,
-                },
-                "swversion": "2.59.19",
-                "type": "ZHARelativeRotary",
-                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-14-fc00",
-            }
+            "config": {
+                "battery": 100,
+                "on": True,
+                "reachable": True,
+            },
+            "etag": "463728970bdb7d04048fc4373654f45a",
+            "lastannounced": "2022-07-03T13:57:59Z",
+            "lastseen": "2022-07-03T14:02Z",
+            "manufacturername": "Signify Netherlands B.V.",
+            "modelid": "RDM002",
+            "name": "RDM002 44",
+            "state": {
+                "expectedeventduration": 400,
+                "expectedrotation": 75,
+                "lastupdated": "2022-07-03T11:37:49.586",
+                "rotaryevent": 2,
+            },
+            "swversion": "2.59.19",
+            "type": "ZHARelativeRotary",
+            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-14-fc00",
         }
     ],
 )
@@ -575,7 +561,6 @@ async def test_deconz_relative_rotary_events(
     for rotary_event, duration, rotation in ((1, 100, 50), (2, 200, -50)):
         event_changed_sensor = {
             "r": "sensors",
-            "id": "1",
             "state": {
                 "rotaryevent": rotary_event,
                 "expectedeventduration": duration,
@@ -600,7 +585,6 @@ async def test_deconz_relative_rotary_events(
 
     event_changed_sensor = {
         "r": "sensors",
-        "id": "1",
         "name": "123",
     }
     await mock_websocket_data(event_changed_sensor)

--- a/tests/components/deconz/test_deconz_event.py
+++ b/tests/components/deconz/test_deconz_event.py
@@ -240,7 +240,7 @@ async def test_deconz_events(
     ],
 )
 @pytest.mark.parametrize(
-    "sensor_0_payload",
+    "sensor_payload",
     [
         {
             "config": {
@@ -409,7 +409,7 @@ async def test_deconz_alarm_events(
 
 
 @pytest.mark.parametrize(
-    "sensor_0_payload",
+    "sensor_payload",
     [
         {
             "config": {
@@ -509,7 +509,7 @@ async def test_deconz_presence_events(
 
 
 @pytest.mark.parametrize(
-    "sensor_0_payload",
+    "sensor_payload",
     [
         {
             "config": {

--- a/tests/components/deconz/test_device_trigger.py
+++ b/tests/components/deconz/test_device_trigger.py
@@ -44,28 +44,26 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.mark.parametrize(
-    "sensor_payload",
+    "sensor_0_payload",
     [
         {
-            "1": {
-                "config": {
-                    "alert": "none",
-                    "battery": 60,
-                    "group": "10",
-                    "on": True,
-                    "reachable": True,
-                },
-                "ep": 1,
-                "etag": "1b355c0b6d2af28febd7ca9165881952",
-                "manufacturername": "IKEA of Sweden",
-                "mode": 1,
-                "modelid": "TRADFRI on/off switch",
-                "name": "TRÅDFRI on/off switch ",
-                "state": {"buttonevent": 2002, "lastupdated": "2019-09-07T07:39:39"},
-                "swversion": "1.4.018",
-                "type": "ZHASwitch",
-                "uniqueid": "d0:cf:5e:ff:fe:71:a4:3a-01-1000",
-            }
+            "config": {
+                "alert": "none",
+                "battery": 60,
+                "group": "10",
+                "on": True,
+                "reachable": True,
+            },
+            "ep": 1,
+            "etag": "1b355c0b6d2af28febd7ca9165881952",
+            "manufacturername": "IKEA of Sweden",
+            "mode": 1,
+            "modelid": "TRADFRI on/off switch",
+            "name": "TRÅDFRI on/off switch ",
+            "state": {"buttonevent": 2002, "lastupdated": "2019-09-07T07:39:39"},
+            "swversion": "1.4.018",
+            "type": "ZHASwitch",
+            "uniqueid": "d0:cf:5e:ff:fe:71:a4:3a-01-1000",
         }
     ],
 )
@@ -150,35 +148,33 @@ async def test_get_triggers(
 
 
 @pytest.mark.parametrize(
-    "sensor_payload",
+    "sensor_0_payload",
     [
         {
-            "1": {
-                "config": {
-                    "battery": 95,
-                    "enrolled": 1,
-                    "on": True,
-                    "pending": [],
-                    "reachable": True,
-                },
-                "ep": 1,
-                "etag": "5aaa1c6bae8501f59929539c6e8f44d6",
-                "lastseen": "2021-07-25T18:07Z",
-                "manufacturername": "lk",
-                "modelid": "ZB-KeypadGeneric-D0002",
-                "name": "Keypad",
-                "state": {
-                    "action": "armed_stay",
-                    "lastupdated": "2021-07-25T18:02:51.172",
-                    "lowbattery": False,
-                    "panel": "exit_delay",
-                    "seconds_remaining": 55,
-                    "tampered": False,
-                },
-                "swversion": "3.13",
-                "type": "ZHAAncillaryControl",
-                "uniqueid": "00:00:00:00:00:00:00:00-00",
-            }
+            "config": {
+                "battery": 95,
+                "enrolled": 1,
+                "on": True,
+                "pending": [],
+                "reachable": True,
+            },
+            "ep": 1,
+            "etag": "5aaa1c6bae8501f59929539c6e8f44d6",
+            "lastseen": "2021-07-25T18:07Z",
+            "manufacturername": "lk",
+            "modelid": "ZB-KeypadGeneric-D0002",
+            "name": "Keypad",
+            "state": {
+                "action": "armed_stay",
+                "lastupdated": "2021-07-25T18:02:51.172",
+                "lowbattery": False,
+                "panel": "exit_delay",
+                "seconds_remaining": 55,
+                "tampered": False,
+            },
+            "swversion": "3.13",
+            "type": "ZHAAncillaryControl",
+            "uniqueid": "00:00:00:00:00:00:00:00-00",
         }
     ],
 )
@@ -247,27 +243,25 @@ async def test_get_triggers_for_alarm_event(
 
 
 @pytest.mark.parametrize(
-    "sensor_payload",
+    "sensor_0_payload",
     [
         {
-            "1": {
-                "config": {
-                    "alert": "none",
-                    "group": "10",
-                    "on": True,
-                    "reachable": True,
-                },
-                "ep": 1,
-                "etag": "1b355c0b6d2af28febd7ca9165881952",
-                "manufacturername": "IKEA of Sweden",
-                "mode": 1,
-                "modelid": "Unsupported model",
-                "name": "TRÅDFRI on/off switch ",
-                "state": {"buttonevent": 2002, "lastupdated": "2019-09-07T07:39:39"},
-                "swversion": "1.4.018",
-                "type": "ZHASwitch",
-                "uniqueid": "d0:cf:5e:ff:fe:71:a4:3a-01-1000",
-            }
+            "config": {
+                "alert": "none",
+                "group": "10",
+                "on": True,
+                "reachable": True,
+            },
+            "ep": 1,
+            "etag": "1b355c0b6d2af28febd7ca9165881952",
+            "manufacturername": "IKEA of Sweden",
+            "mode": 1,
+            "modelid": "Unsupported model",
+            "name": "TRÅDFRI on/off switch ",
+            "state": {"buttonevent": 2002, "lastupdated": "2019-09-07T07:39:39"},
+            "swversion": "1.4.018",
+            "type": "ZHASwitch",
+            "uniqueid": "d0:cf:5e:ff:fe:71:a4:3a-01-1000",
         }
     ],
 )
@@ -290,28 +284,26 @@ async def test_get_triggers_manage_unsupported_remotes(
 
 
 @pytest.mark.parametrize(
-    "sensor_payload",
+    "sensor_0_payload",
     [
         {
-            "1": {
-                "config": {
-                    "alert": "none",
-                    "battery": 60,
-                    "group": "10",
-                    "on": True,
-                    "reachable": True,
-                },
-                "ep": 1,
-                "etag": "1b355c0b6d2af28febd7ca9165881952",
-                "manufacturername": "IKEA of Sweden",
-                "mode": 1,
-                "modelid": "TRADFRI on/off switch",
-                "name": "TRÅDFRI on/off switch ",
-                "state": {"buttonevent": 2002, "lastupdated": "2019-09-07T07:39:39"},
-                "swversion": "1.4.018",
-                "type": "ZHASwitch",
-                "uniqueid": "d0:cf:5e:ff:fe:71:a4:3a-01-1000",
-            }
+            "config": {
+                "alert": "none",
+                "battery": 60,
+                "group": "10",
+                "on": True,
+                "reachable": True,
+            },
+            "ep": 1,
+            "etag": "1b355c0b6d2af28febd7ca9165881952",
+            "manufacturername": "IKEA of Sweden",
+            "mode": 1,
+            "modelid": "TRADFRI on/off switch",
+            "name": "TRÅDFRI on/off switch ",
+            "state": {"buttonevent": 2002, "lastupdated": "2019-09-07T07:39:39"},
+            "swversion": "1.4.018",
+            "type": "ZHASwitch",
+            "uniqueid": "d0:cf:5e:ff:fe:71:a4:3a-01-1000",
         }
     ],
 )
@@ -353,7 +345,6 @@ async def test_functional_device_trigger(
 
     event_changed_sensor = {
         "r": "sensors",
-        "id": "1",
         "state": {"buttonevent": 1002},
     }
     await mock_websocket_data(event_changed_sensor)

--- a/tests/components/deconz/test_device_trigger.py
+++ b/tests/components/deconz/test_device_trigger.py
@@ -44,7 +44,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.mark.parametrize(
-    "sensor_0_payload",
+    "sensor_payload",
     [
         {
             "config": {
@@ -148,7 +148,7 @@ async def test_get_triggers(
 
 
 @pytest.mark.parametrize(
-    "sensor_0_payload",
+    "sensor_payload",
     [
         {
             "config": {
@@ -243,7 +243,7 @@ async def test_get_triggers_for_alarm_event(
 
 
 @pytest.mark.parametrize(
-    "sensor_0_payload",
+    "sensor_payload",
     [
         {
             "config": {
@@ -284,7 +284,7 @@ async def test_get_triggers_manage_unsupported_remotes(
 
 
 @pytest.mark.parametrize(
-    "sensor_0_payload",
+    "sensor_payload",
     [
         {
             "config": {

--- a/tests/components/deconz/test_gateway.py
+++ b/tests/components/deconz/test_gateway.py
@@ -118,7 +118,7 @@ async def test_gateway_device_configuration_url_when_addon(
 
 
 @pytest.mark.parametrize(
-    "sensor_0_payload",
+    "sensor_payload",
     [
         {
             "name": "presence",

--- a/tests/components/deconz/test_gateway.py
+++ b/tests/components/deconz/test_gateway.py
@@ -118,16 +118,14 @@ async def test_gateway_device_configuration_url_when_addon(
 
 
 @pytest.mark.parametrize(
-    "sensor_payload",
+    "sensor_0_payload",
     [
         {
-            "1": {
-                "name": "presence",
-                "type": "ZHAPresence",
-                "state": {"presence": False},
-                "config": {"on": True, "reachable": True},
-                "uniqueid": "00:00:00:00:00:00:00:00-00",
-            }
+            "name": "presence",
+            "type": "ZHAPresence",
+            "state": {"presence": False},
+            "config": {"on": True, "reachable": True},
+            "uniqueid": "00:00:00:00:00:00:00:00-00",
         }
     ],
 )

--- a/tests/components/deconz/test_lock.py
+++ b/tests/components/deconz/test_lock.py
@@ -93,7 +93,7 @@ async def test_lock_from_light(
 
 
 @pytest.mark.parametrize(
-    "sensor_0_payload",
+    "sensor_payload",
     [
         {
             "config": {

--- a/tests/components/deconz/test_lock.py
+++ b/tests/components/deconz/test_lock.py
@@ -93,30 +93,28 @@ async def test_lock_from_light(
 
 
 @pytest.mark.parametrize(
-    "sensor_payload",
+    "sensor_0_payload",
     [
         {
-            "1": {
-                "config": {
-                    "battery": 100,
-                    "lock": False,
-                    "on": True,
-                    "reachable": True,
-                },
-                "ep": 11,
-                "etag": "a43862f76b7fa48b0fbb9107df123b0e",
-                "lastseen": "2021-03-06T22:25Z",
-                "manufacturername": "Onesti Products AS",
-                "modelid": "easyCodeTouch_v1",
-                "name": "Door lock",
-                "state": {
-                    "lastupdated": "2021-03-06T21:25:45.624",
-                    "lockstate": "unlocked",
-                },
-                "swversion": "20201211",
-                "type": "ZHADoorLock",
-                "uniqueid": "00:00:00:00:00:00:00:00-00",
-            }
+            "config": {
+                "battery": 100,
+                "lock": False,
+                "on": True,
+                "reachable": True,
+            },
+            "ep": 11,
+            "etag": "a43862f76b7fa48b0fbb9107df123b0e",
+            "lastseen": "2021-03-06T22:25Z",
+            "manufacturername": "Onesti Products AS",
+            "modelid": "easyCodeTouch_v1",
+            "name": "Door lock",
+            "state": {
+                "lastupdated": "2021-03-06T21:25:45.624",
+                "lockstate": "unlocked",
+            },
+            "swversion": "20201211",
+            "type": "ZHADoorLock",
+            "uniqueid": "00:00:00:00:00:00:00:00-00",
         }
     ],
 )
@@ -132,7 +130,6 @@ async def test_lock_from_sensor(
 
     event_changed_sensor = {
         "r": "sensors",
-        "id": "1",
         "state": {"lockstate": "locked"},
     }
     await mock_websocket_data(event_changed_sensor)
@@ -142,7 +139,7 @@ async def test_lock_from_sensor(
 
     # Verify service calls
 
-    aioclient_mock = mock_put_request("/sensors/1/config")
+    aioclient_mock = mock_put_request("/sensors/0/config")
 
     # Service lock door
 

--- a/tests/components/deconz/test_logbook.py
+++ b/tests/components/deconz/test_logbook.py
@@ -27,33 +27,31 @@ from tests.components.logbook.common import MockRow, mock_humanify
 
 
 @pytest.mark.parametrize(
-    "sensor_payload",
+    "sensor_0_payload",
     [
         {
-            "1": {
-                "config": {
-                    "armed": "disarmed",
-                    "enrolled": 0,
-                    "on": True,
-                    "panel": "disarmed",
-                    "pending": [],
-                    "reachable": True,
-                },
-                "ep": 1,
-                "etag": "3c4008d74035dfaa1f0bb30d24468b12",
-                "lastseen": "2021-04-02T13:07Z",
-                "manufacturername": "Universal Electronics Inc",
-                "modelid": "URC4450BC0-X-R",
-                "name": "Keypad",
-                "state": {
-                    "action": "armed_away,1111,55",
-                    "lastupdated": "2021-04-02T13:08:18.937",
-                    "lowbattery": False,
-                    "tampered": True,
-                },
-                "type": "ZHAAncillaryControl",
-                "uniqueid": "00:0d:6f:00:13:4f:61:39-01-0501",
-            }
+            "config": {
+                "armed": "disarmed",
+                "enrolled": 0,
+                "on": True,
+                "panel": "disarmed",
+                "pending": [],
+                "reachable": True,
+            },
+            "ep": 1,
+            "etag": "3c4008d74035dfaa1f0bb30d24468b12",
+            "lastseen": "2021-04-02T13:07Z",
+            "manufacturername": "Universal Electronics Inc",
+            "modelid": "URC4450BC0-X-R",
+            "name": "Keypad",
+            "state": {
+                "action": "armed_away,1111,55",
+                "lastupdated": "2021-04-02T13:08:18.937",
+                "lowbattery": False,
+                "tampered": True,
+            },
+            "type": "ZHAAncillaryControl",
+            "uniqueid": "00:0d:6f:00:13:4f:61:39-01-0501",
         }
     ],
 )
@@ -64,8 +62,8 @@ async def test_humanifying_deconz_alarm_event(
     sensor_payload: dict[str, Any],
 ) -> None:
     """Test humanifying deCONZ alarm event."""
-    keypad_event_id = slugify(sensor_payload["1"]["name"])
-    keypad_serial = serial_from_unique_id(sensor_payload["1"]["uniqueid"])
+    keypad_event_id = slugify(sensor_payload["0"]["name"])
+    keypad_serial = serial_from_unique_id(sensor_payload["0"]["uniqueid"])
     keypad_entry = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, keypad_serial)}
     )

--- a/tests/components/deconz/test_logbook.py
+++ b/tests/components/deconz/test_logbook.py
@@ -27,7 +27,7 @@ from tests.components.logbook.common import MockRow, mock_humanify
 
 
 @pytest.mark.parametrize(
-    "sensor_0_payload",
+    "sensor_payload",
     [
         {
             "config": {
@@ -62,8 +62,8 @@ async def test_humanifying_deconz_alarm_event(
     sensor_payload: dict[str, Any],
 ) -> None:
     """Test humanifying deCONZ alarm event."""
-    keypad_event_id = slugify(sensor_payload["0"]["name"])
-    keypad_serial = serial_from_unique_id(sensor_payload["0"]["uniqueid"])
+    keypad_event_id = slugify(sensor_payload["name"])
+    keypad_serial = serial_from_unique_id(sensor_payload["uniqueid"])
     keypad_entry = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, keypad_serial)}
     )

--- a/tests/components/deconz/test_number.py
+++ b/tests/components/deconz/test_number.py
@@ -96,7 +96,7 @@ TEST_DATA = [
 ]
 
 
-@pytest.mark.parametrize(("sensor_0_payload", "expected"), TEST_DATA)
+@pytest.mark.parametrize(("sensor_payload", "expected"), TEST_DATA)
 async def test_number_entities(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,

--- a/tests/components/deconz/test_number.py
+++ b/tests/components/deconz/test_number.py
@@ -23,18 +23,16 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 TEST_DATA = [
     (  # Presence sensor - delay configuration
         {
-            "0": {
-                "name": "Presence sensor",
-                "type": "ZHAPresence",
-                "state": {"dark": False, "presence": False},
-                "config": {
-                    "delay": 0,
-                    "on": True,
-                    "reachable": True,
-                    "temperature": 10,
-                },
-                "uniqueid": "00:00:00:00:00:00:00:00-00",
-            }
+            "name": "Presence sensor",
+            "type": "ZHAPresence",
+            "state": {"dark": False, "presence": False},
+            "config": {
+                "delay": 0,
+                "on": True,
+                "reachable": True,
+                "temperature": 10,
+            },
+            "uniqueid": "00:00:00:00:00:00:00:00-00",
         },
         {
             "entity_count": 3,
@@ -61,18 +59,16 @@ TEST_DATA = [
     ),
     (  # Presence sensor - duration configuration
         {
-            "0": {
-                "name": "Presence sensor",
-                "type": "ZHAPresence",
-                "state": {"dark": False, "presence": False},
-                "config": {
-                    "duration": 0,
-                    "on": True,
-                    "reachable": True,
-                    "temperature": 10,
-                },
-                "uniqueid": "00:00:00:00:00:00:00:00-00",
-            }
+            "name": "Presence sensor",
+            "type": "ZHAPresence",
+            "state": {"dark": False, "presence": False},
+            "config": {
+                "duration": 0,
+                "on": True,
+                "reachable": True,
+                "temperature": 10,
+            },
+            "uniqueid": "00:00:00:00:00:00:00:00-00",
         },
         {
             "entity_count": 3,
@@ -100,7 +96,7 @@ TEST_DATA = [
 ]
 
 
-@pytest.mark.parametrize(("sensor_payload", "expected"), TEST_DATA)
+@pytest.mark.parametrize(("sensor_0_payload", "expected"), TEST_DATA)
 async def test_number_entities(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,

--- a/tests/components/deconz/test_select.py
+++ b/tests/components/deconz/test_select.py
@@ -24,29 +24,27 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 TEST_DATA = [
     (  # Presence Device Mode
         {
-            "1": {
-                "config": {
-                    "devicemode": "undirected",
-                    "on": True,
-                    "reachable": True,
-                    "sensitivity": 3,
-                    "triggerdistance": "medium",
-                },
-                "etag": "13ff209f9401b317987d42506dd4cd79",
-                "lastannounced": None,
-                "lastseen": "2022-06-28T23:13Z",
-                "manufacturername": "aqara",
-                "modelid": "lumi.motion.ac01",
-                "name": "Aqara FP1",
-                "state": {
-                    "lastupdated": "2022-06-28T23:13:38.577",
-                    "presence": True,
-                    "presenceevent": "leave",
-                },
-                "swversion": "20210121",
-                "type": "ZHAPresence",
-                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0406",
-            }
+            "config": {
+                "devicemode": "undirected",
+                "on": True,
+                "reachable": True,
+                "sensitivity": 3,
+                "triggerdistance": "medium",
+            },
+            "etag": "13ff209f9401b317987d42506dd4cd79",
+            "lastannounced": None,
+            "lastseen": "2022-06-28T23:13Z",
+            "manufacturername": "aqara",
+            "modelid": "lumi.motion.ac01",
+            "name": "Aqara FP1",
+            "state": {
+                "lastupdated": "2022-06-28T23:13:38.577",
+                "presence": True,
+                "presenceevent": "leave",
+            },
+            "swversion": "20210121",
+            "type": "ZHAPresence",
+            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0406",
         },
         {
             "entity_count": 5,
@@ -59,35 +57,33 @@ TEST_DATA = [
                 "options": ["leftright", "undirected"],
             },
             "option": PresenceConfigDeviceMode.LEFT_AND_RIGHT.value,
-            "request": "/sensors/1/config",
+            "request": "/sensors/0/config",
             "request_data": {"devicemode": "leftright"},
         },
     ),
     (  # Presence Sensitivity
         {
-            "1": {
-                "config": {
-                    "devicemode": "undirected",
-                    "on": True,
-                    "reachable": True,
-                    "sensitivity": 3,
-                    "triggerdistance": "medium",
-                },
-                "etag": "13ff209f9401b317987d42506dd4cd79",
-                "lastannounced": None,
-                "lastseen": "2022-06-28T23:13Z",
-                "manufacturername": "aqara",
-                "modelid": "lumi.motion.ac01",
-                "name": "Aqara FP1",
-                "state": {
-                    "lastupdated": "2022-06-28T23:13:38.577",
-                    "presence": True,
-                    "presenceevent": "leave",
-                },
-                "swversion": "20210121",
-                "type": "ZHAPresence",
-                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0406",
-            }
+            "config": {
+                "devicemode": "undirected",
+                "on": True,
+                "reachable": True,
+                "sensitivity": 3,
+                "triggerdistance": "medium",
+            },
+            "etag": "13ff209f9401b317987d42506dd4cd79",
+            "lastannounced": None,
+            "lastseen": "2022-06-28T23:13Z",
+            "manufacturername": "aqara",
+            "modelid": "lumi.motion.ac01",
+            "name": "Aqara FP1",
+            "state": {
+                "lastupdated": "2022-06-28T23:13:38.577",
+                "presence": True,
+                "presenceevent": "leave",
+            },
+            "swversion": "20210121",
+            "type": "ZHAPresence",
+            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0406",
         },
         {
             "entity_count": 5,
@@ -100,35 +96,33 @@ TEST_DATA = [
                 "options": ["High", "Medium", "Low"],
             },
             "option": "Medium",
-            "request": "/sensors/1/config",
+            "request": "/sensors/0/config",
             "request_data": {"sensitivity": 2},
         },
     ),
     (  # Presence Trigger Distance
         {
-            "1": {
-                "config": {
-                    "devicemode": "undirected",
-                    "on": True,
-                    "reachable": True,
-                    "sensitivity": 3,
-                    "triggerdistance": "medium",
-                },
-                "etag": "13ff209f9401b317987d42506dd4cd79",
-                "lastannounced": None,
-                "lastseen": "2022-06-28T23:13Z",
-                "manufacturername": "aqara",
-                "modelid": "lumi.motion.ac01",
-                "name": "Aqara FP1",
-                "state": {
-                    "lastupdated": "2022-06-28T23:13:38.577",
-                    "presence": True,
-                    "presenceevent": "leave",
-                },
-                "swversion": "20210121",
-                "type": "ZHAPresence",
-                "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0406",
-            }
+            "config": {
+                "devicemode": "undirected",
+                "on": True,
+                "reachable": True,
+                "sensitivity": 3,
+                "triggerdistance": "medium",
+            },
+            "etag": "13ff209f9401b317987d42506dd4cd79",
+            "lastannounced": None,
+            "lastseen": "2022-06-28T23:13Z",
+            "manufacturername": "aqara",
+            "modelid": "lumi.motion.ac01",
+            "name": "Aqara FP1",
+            "state": {
+                "lastupdated": "2022-06-28T23:13:38.577",
+                "presence": True,
+                "presenceevent": "leave",
+            },
+            "swversion": "20210121",
+            "type": "ZHAPresence",
+            "uniqueid": "xx:xx:xx:xx:xx:xx:xx:xx-01-0406",
         },
         {
             "entity_count": 5,
@@ -141,14 +135,14 @@ TEST_DATA = [
                 "options": ["far", "medium", "near"],
             },
             "option": PresenceConfigTriggerDistance.FAR.value,
-            "request": "/sensors/1/config",
+            "request": "/sensors/0/config",
             "request_data": {"triggerdistance": "far"},
         },
     ),
 ]
 
 
-@pytest.mark.parametrize(("sensor_payload", "expected"), TEST_DATA)
+@pytest.mark.parametrize(("sensor_0_payload", "expected"), TEST_DATA)
 async def test_select(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,

--- a/tests/components/deconz/test_select.py
+++ b/tests/components/deconz/test_select.py
@@ -142,7 +142,7 @@ TEST_DATA = [
 ]
 
 
-@pytest.mark.parametrize(("sensor_0_payload", "expected"), TEST_DATA)
+@pytest.mark.parametrize(("sensor_payload", "expected"), TEST_DATA)
 async def test_select(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -971,17 +971,15 @@ async def test_sensors(
 
 
 @pytest.mark.parametrize(
-    "sensor_payload",
+    "sensor_0_payload",
     [
         {
-            "1": {
-                "name": "CLIP temperature sensor",
-                "type": "CLIPTemperature",
-                "state": {"temperature": 2600},
-                "config": {},
-                "uniqueid": "00:00:00:00:00:00:00:02-00",
-            },
-        }
+            "name": "CLIP temperature sensor",
+            "type": "CLIPTemperature",
+            "state": {"temperature": 2600},
+            "config": {},
+            "uniqueid": "00:00:00:00:00:00:00:02-00",
+        },
     ],
 )
 @pytest.mark.parametrize("config_entry_options", [{CONF_ALLOW_CLIP_SENSOR: False}])
@@ -1065,7 +1063,6 @@ async def test_add_new_sensor(
     event_added_sensor = {
         "e": "added",
         "r": "sensors",
-        "id": "1",
         "sensor": {
             "id": "Light sensor id",
             "name": "Light level sensor",
@@ -1102,14 +1099,12 @@ async def test_dont_add_sensor_if_state_is_none(
     sensor_property: str,
 ) -> None:
     """Test sensor with scaled data is not created if state is None."""
-    sensor_payload |= {
-        "1": {
-            "name": "Sensor 1",
-            "type": sensor_type,
-            "state": {sensor_property: None},
-            "config": {},
-            "uniqueid": "00:00:00:00:00:00:00:00-00",
-        }
+    sensor_payload["0"] = {
+        "name": "Sensor 1",
+        "type": sensor_type,
+        "state": {sensor_property: None},
+        "config": {},
+        "uniqueid": "00:00:00:00:00:00:00:00-00",
     }
     await config_entry_factory()
 
@@ -1117,28 +1112,26 @@ async def test_dont_add_sensor_if_state_is_none(
 
 
 @pytest.mark.parametrize(
-    "sensor_payload",
+    "sensor_0_payload",
     [
         {
-            "1": {
-                "config": {
-                    "on": True,
-                    "reachable": True,
-                },
-                "ep": 2,
-                "etag": "c2d2e42396f7c78e11e46c66e2ec0200",
-                "lastseen": "2020-11-20T22:48Z",
-                "manufacturername": "BOSCH",
-                "modelid": "AIR",
-                "name": "BOSCH Air quality sensor",
-                "state": {
-                    "airquality": "poor",
-                    "lastupdated": "2020-11-20T22:48:00.209",
-                },
-                "swversion": "20200402",
-                "type": "ZHAAirQuality",
-                "uniqueid": "00:00:00:00:00:00:00:00-02-fdef",
-            }
+            "config": {
+                "on": True,
+                "reachable": True,
+            },
+            "ep": 2,
+            "etag": "c2d2e42396f7c78e11e46c66e2ec0200",
+            "lastseen": "2020-11-20T22:48Z",
+            "manufacturername": "BOSCH",
+            "modelid": "AIR",
+            "name": "BOSCH Air quality sensor",
+            "state": {
+                "airquality": "poor",
+                "lastupdated": "2020-11-20T22:48:00.209",
+            },
+            "swversion": "20200402",
+            "type": "ZHAAirQuality",
+            "uniqueid": "00:00:00:00:00:00:00:00-02-fdef",
         }
     ],
 )
@@ -1349,8 +1342,8 @@ async def test_special_danfoss_battery_creation(
 
 
 @pytest.mark.parametrize(
-    "sensor_payload",
-    [{"0": {"type": "not supported", "name": "name", "state": {}, "config": {}}}],
+    "sensor_0_payload",
+    [{"type": "not supported", "name": "name", "state": {}, "config": {}}],
 )
 @pytest.mark.usefixtures("config_entry_setup")
 async def test_unsupported_sensor(hass: HomeAssistant) -> None:

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -899,7 +899,7 @@ TEST_DATA = [
 ]
 
 
-@pytest.mark.parametrize(("sensor_1_payload", "expected"), TEST_DATA)
+@pytest.mark.parametrize(("sensor_0_payload", "expected"), TEST_DATA)
 @pytest.mark.parametrize("config_entry_options", [{CONF_ALLOW_CLIP_SENSOR: True}])
 async def test_sensors(
     hass: HomeAssistant,
@@ -952,7 +952,7 @@ async def test_sensors(
 
     # Change state
 
-    event_changed_sensor = {"r": "sensors", "id": "1"}
+    event_changed_sensor = {"r": "sensors"}
     event_changed_sensor |= expected["websocket_event"]
     await mock_websocket_data(event_changed_sensor)
     await hass.async_block_till_done()

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -899,7 +899,7 @@ TEST_DATA = [
 ]
 
 
-@pytest.mark.parametrize(("sensor_0_payload", "expected"), TEST_DATA)
+@pytest.mark.parametrize(("sensor_payload", "expected"), TEST_DATA)
 @pytest.mark.parametrize("config_entry_options", [{CONF_ALLOW_CLIP_SENSOR: True}])
 async def test_sensors(
     hass: HomeAssistant,
@@ -971,7 +971,7 @@ async def test_sensors(
 
 
 @pytest.mark.parametrize(
-    "sensor_0_payload",
+    "sensor_payload",
     [
         {
             "name": "CLIP temperature sensor",
@@ -1112,7 +1112,7 @@ async def test_dont_add_sensor_if_state_is_none(
 
 
 @pytest.mark.parametrize(
-    "sensor_0_payload",
+    "sensor_payload",
     [
         {
             "config": {
@@ -1342,7 +1342,7 @@ async def test_special_danfoss_battery_creation(
 
 
 @pytest.mark.parametrize(
-    "sensor_0_payload",
+    "sensor_payload",
     [{"type": "not supported", "name": "name", "state": {}, "config": {}}],
 )
 @pytest.mark.usefixtures("config_entry_setup")

--- a/tests/components/deconz/test_services.py
+++ b/tests/components/deconz/test_services.py
@@ -236,7 +236,7 @@ async def test_service_refresh_devices(
 
 
 @pytest.mark.parametrize(
-    "sensor_0_payload",
+    "sensor_payload",
     [
         {
             "name": "Switch 1",
@@ -314,7 +314,7 @@ async def test_service_refresh_devices_trigger_no_state_update(
     ],
 )
 @pytest.mark.parametrize(
-    "sensor_0_payload",
+    "sensor_payload",
     [
         {
             "name": "Switch 1",

--- a/tests/components/deconz/test_services.py
+++ b/tests/components/deconz/test_services.py
@@ -236,16 +236,14 @@ async def test_service_refresh_devices(
 
 
 @pytest.mark.parametrize(
-    "sensor_payload",
+    "sensor_0_payload",
     [
         {
-            "1": {
-                "name": "Switch 1",
-                "type": "ZHASwitch",
-                "state": {"buttonevent": 1000},
-                "config": {"battery": 100},
-                "uniqueid": "00:00:00:00:00:00:00:01-00",
-            }
+            "name": "Switch 1",
+            "type": "ZHASwitch",
+            "state": {"buttonevent": 1000},
+            "config": {"battery": 100},
+            "uniqueid": "00:00:00:00:00:00:00:01-00",
         }
     ],
 )
@@ -284,7 +282,7 @@ async def test_service_refresh_devices_trigger_no_state_update(
             }
         },
         "sensors": {
-            "1": {
+            "0": {
                 "name": "Switch 1",
                 "type": "ZHASwitch",
                 "state": {"buttonevent": 1000},
@@ -316,16 +314,14 @@ async def test_service_refresh_devices_trigger_no_state_update(
     ],
 )
 @pytest.mark.parametrize(
-    "sensor_payload",
+    "sensor_0_payload",
     [
         {
-            "1": {
-                "name": "Switch 1",
-                "type": "ZHASwitch",
-                "state": {"buttonevent": 1000, "gesture": 1},
-                "config": {"battery": 100},
-                "uniqueid": "00:00:00:00:00:00:00:03-00",
-            },
+            "name": "Switch 1",
+            "type": "ZHASwitch",
+            "state": {"buttonevent": 1000, "gesture": 1},
+            "config": {"battery": 100},
+            "uniqueid": "00:00:00:00:00:00:00:03-00",
         }
     ],
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR simplifies sensor fixture for tests where there is only one sensor, removing a few unnecessary details by harmonising those to have id "0".
No change to tests in reality and no change in coverage, all changes related to using id "0" and removing all unnecessary duplications in test data.

Same work as was done in https://github.com/home-assistant/core/pull/122209 for lights

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
