### PR TITLE
Migrate harmony to use entry.runtime_data

### DIFF
--- a/homeassistant/components/harmony/__init__.py
+++ b/homeassistant/components/harmony/__init__.py
@@ -3,26 +3,18 @@
 import logging
 
 from homeassistant.components.remote import ATTR_ACTIVITY, ATTR_DELAY_SECS
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_NAME, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from .const import (
-    CANCEL_LISTENER,
-    CANCEL_STOP,
-    DOMAIN,
-    HARMONY_DATA,
-    HARMONY_OPTIONS_UPDATE,
-    PLATFORMS,
-)
-from .data import HarmonyData
+from .const import DOMAIN, HARMONY_OPTIONS_UPDATE, PLATFORMS  # noqa: F401
+from .data import HarmonyConfigEntry, HarmonyData
 
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: HarmonyConfigEntry) -> bool:
     """Set up Logitech Harmony Hub from a config entry."""
     # As there currently is no way to import options from yaml
     # when setting up a config entry, we fallback to adding
@@ -37,19 +29,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await _migrate_old_unique_ids(hass, entry.entry_id, data)
 
-    cancel_listener = entry.add_update_listener(_update_listener)
+    entry.async_on_unload(entry.add_update_listener(_update_listener))
 
     async def _async_on_stop(event: Event) -> None:
         await data.shutdown()
 
-    cancel_stop = hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, _async_on_stop)
+    entry.async_on_unload(
+        hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, _async_on_stop)
+    )
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
-        HARMONY_DATA: data,
-        CANCEL_LISTENER: cancel_listener,
-        CANCEL_STOP: cancel_stop,
-    }
-
+    entry.runtime_data = data
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
@@ -84,7 +73,7 @@ async def _migrate_old_unique_ids(
 
 @callback
 def _async_import_options_from_data_if_missing(
-    hass: HomeAssistant, entry: ConfigEntry
+    hass: HomeAssistant, entry: HarmonyConfigEntry
 ) -> None:
     options = dict(entry.options)
     modified = 0
@@ -97,24 +86,16 @@ def _async_import_options_from_data_if_missing(
         hass.config_entries.async_update_entry(entry, options=options)
 
 
-async def _update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def _update_listener(hass: HomeAssistant, entry: HarmonyConfigEntry) -> None:
     """Handle options update."""
     async_dispatcher_send(
         hass, f"{HARMONY_OPTIONS_UPDATE}-{entry.unique_id}", entry.options
     )
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: HarmonyConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-
     # Shutdown a harmony remote for removal
-    entry_data = hass.data[DOMAIN][entry.entry_id]
-    entry_data[CANCEL_LISTENER]()
-    entry_data[CANCEL_STOP]()
-    await entry_data[HARMONY_DATA].shutdown()
-
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
-
+    await entry.runtime_data.shutdown()
     return unload_ok

--- a/homeassistant/components/harmony/config_flow.py
+++ b/homeassistant/components/harmony/config_flow.py
@@ -27,7 +27,8 @@ from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 
-from .const import DOMAIN, HARMONY_DATA, PREVIOUS_ACTIVE_ACTIVITY, UNIQUE_ID
+from .const import DOMAIN, PREVIOUS_ACTIVE_ACTIVITY, UNIQUE_ID
+from .data import HarmonyConfigEntry
 from .util import (
     find_best_name_for_remote,
     find_unique_id_for_remote,
@@ -185,7 +186,7 @@ def _options_from_user_input(user_input: dict[str, Any]) -> dict[str, Any]:
 class OptionsFlowHandler(OptionsFlow):
     """Handle a option flow for Harmony."""
 
-    def __init__(self, config_entry: ConfigEntry) -> None:
+    def __init__(self, config_entry: HarmonyConfigEntry) -> None:
         """Initialize options flow."""
         self.config_entry = config_entry
 
@@ -196,8 +197,7 @@ class OptionsFlowHandler(OptionsFlow):
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 
-        remote = self.hass.data[DOMAIN][self.config_entry.entry_id][HARMONY_DATA]
-
+        remote = self.config_entry.runtime_data
         data_schema = vol.Schema(
             {
                 vol.Optional(

--- a/homeassistant/components/harmony/const.py
+++ b/homeassistant/components/harmony/const.py
@@ -13,8 +13,3 @@ ATTR_DEVICES_LIST = "devices_list"
 ATTR_LAST_ACTIVITY = "last_activity"
 ATTR_ACTIVITY_STARTING = "activity_starting"
 PREVIOUS_ACTIVE_ACTIVITY = "Previous Active Activity"
-
-
-HARMONY_DATA = "harmony_data"
-CANCEL_LISTENER = "cancel_listener"
-CANCEL_STOP = "cancel_stop"

--- a/homeassistant/components/harmony/data.py
+++ b/homeassistant/components/harmony/data.py
@@ -9,6 +9,7 @@ from aioharmony.const import ClientCallbackType, SendCommandDevice
 import aioharmony.exceptions as aioexc
 from aioharmony.harmonyapi import HarmonyAPI as HarmonyClient
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -17,6 +18,9 @@ from .const import ACTIVITY_POWER_OFF
 from .subscriber import HarmonySubscriberMixin
 
 _LOGGER = logging.getLogger(__name__)
+
+
+type HarmonyConfigEntry = ConfigEntry[HarmonyData]
 
 
 class HarmonyData(HarmonySubscriberMixin):

--- a/homeassistant/components/harmony/remote.py
+++ b/homeassistant/components/harmony/remote.py
@@ -19,7 +19,6 @@ from homeassistant.components.remote import (
     RemoteEntity,
     RemoteEntityFeature,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HassJob, HomeAssistant, callback
 from homeassistant.helpers import entity_platform
 import homeassistant.helpers.config_validation as cv
@@ -34,13 +33,12 @@ from .const import (
     ATTR_DEVICES_LIST,
     ATTR_LAST_ACTIVITY,
     DOMAIN,
-    HARMONY_DATA,
     HARMONY_OPTIONS_UPDATE,
     PREVIOUS_ACTIVE_ACTIVITY,
     SERVICE_CHANGE_CHANNEL,
     SERVICE_SYNC,
 )
-from .data import HarmonyData
+from .data import HarmonyConfigEntry, HarmonyData
 from .entity import HarmonyEntity
 from .subscriber import HarmonyCallback
 
@@ -57,11 +55,12 @@ HARMONY_CHANGE_CHANNEL_SCHEMA: VolDictType = {
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: HarmonyConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Harmony config entry."""
-
-    data: HarmonyData = hass.data[DOMAIN][entry.entry_id][HARMONY_DATA]
+    data = entry.runtime_data
 
     _LOGGER.debug("HarmonyData : %s", data)
 

--- a/homeassistant/components/harmony/select.py
+++ b/homeassistant/components/harmony/select.py
@@ -5,12 +5,11 @@ from __future__ import annotations
 import logging
 
 from homeassistant.components.select import SelectEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HassJob, HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import ACTIVITY_POWER_OFF, DOMAIN, HARMONY_DATA
-from .data import HarmonyData
+from .const import ACTIVITY_POWER_OFF, DOMAIN
+from .data import HarmonyConfigEntry, HarmonyData
 from .entity import HarmonyEntity
 from .subscriber import HarmonyCallback
 
@@ -20,11 +19,12 @@ TRANSLATABLE_POWER_OFF = "power_off"
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: HarmonyConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up harmony activities select."""
-    data: HarmonyData = hass.data[DOMAIN][entry.entry_id][HARMONY_DATA]
-    async_add_entities([HarmonyActivitySelect(data)])
+    async_add_entities([HarmonyActivitySelect(entry.runtime_data)])
 
 
 class HarmonyActivitySelect(HarmonyEntity, SelectEntity):


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate harmony to use entry.runtime_data

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
