### PR TITLE
TotalConnect state attribute deprecation warning

### DIFF
--- a/homeassistant/components/totalconnect/alarm_control_panel.py
+++ b/homeassistant/components/totalconnect/alarm_control_panel.py
@@ -103,6 +103,7 @@ class TotalConnectAlarm(TotalConnectLocationEntity, AlarmControlPanelEntity):
     @property
     def state(self) -> str | None:
         """Return the state of the device."""
+        # State attributes can be removed in 2025.2
         attr = {
             "location_id": self._location.location_id,
             "partition": self._partition_id,
@@ -144,14 +145,7 @@ class TotalConnectAlarm(TotalConnectLocationEntity, AlarmControlPanelEntity):
             attr["triggered_source"] = "Carbon Monoxide"
 
         self._attr_extra_state_attributes = attr
-        # DEPRECATION WARNING
-        # The following state attributes will be removed in 2025.1:
-        # - triggered_source:  instead use alarm panel Binary Sensors
-        #  'Police', 'Fire' and 'Carbon Monoxide'
-        # - ac_loss: instead use alarm panel Binary Sensor 'Power'
-        # - low_battery: instead use alarm panel Binary Sensor 'Battery'
-        # - cover_tampered: instead use alarm panel Binary Sensor 'Tamper'
-        # - triggered_zone: never provided information and will be removed
+
         return state
 
     async def async_alarm_disarm(self, code: str | None = None) -> None:

--- a/homeassistant/components/totalconnect/alarm_control_panel.py
+++ b/homeassistant/components/totalconnect/alarm_control_panel.py
@@ -144,7 +144,14 @@ class TotalConnectAlarm(TotalConnectLocationEntity, AlarmControlPanelEntity):
             attr["triggered_source"] = "Carbon Monoxide"
 
         self._attr_extra_state_attributes = attr
-
+        # DEPRECATION WARNING
+        # The following state attributes will be removed in 2025.1:
+        # - triggered_source:  instead use alarm panel Binary Sensors
+        #  'Police', 'Fire' and 'Carbon Monoxide'
+        # - ac_loss: instead use alarm panel Binary Sensor 'Power'
+        # - low_battery: instead use alarm panel Binary Sensor 'Battery'
+        # - cover_tampered: instead use alarm panel Binary Sensor 'Tamper'
+        # - triggered_zone: never provided information and will be removed
         return state
 
     async def async_alarm_disarm(self, code: str | None = None) -> None:

--- a/homeassistant/components/totalconnect/alarm_control_panel.py
+++ b/homeassistant/components/totalconnect/alarm_control_panel.py
@@ -103,7 +103,7 @@ class TotalConnectAlarm(TotalConnectLocationEntity, AlarmControlPanelEntity):
     @property
     def state(self) -> str | None:
         """Return the state of the device."""
-        # State attributes can be removed in 2025.2
+        # State attributes can be removed in 2025.3
         attr = {
             "location_id": self._location.location_id,
             "partition": self._partition_id,


### PR DESCRIPTION
## Breaking change
The TotalConnect integration will remove the following state attributes in 2025.1:
- triggered_source:  instead use panel Binary Sensors 'Police', 'Fire' and 'Carbon Monoxide'
- ac_loss: instead use panel Binary Sensor 'Power'
- low_battery: instead use panel Binary Sensor 'Battery'
- cover_tampered: instead use panel Binary Sensor 'Tamper'
- triggered_zone: never provided information and will be removed.  Instead monitor individual zone Binary Sensors.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This is just a warning that the state attributes are being removed, and that users should move to using the binary sensors instead.  A follow up PR is required to actually remove the attributes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # n/a
- This PR is related to issue: n/a
- Link to documentation pull request: n/a

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
