### PR TITLE
Handle empty energy sites in Tesla integrations

### DIFF
--- a/homeassistant/components/tesla_fleet/__init__.py
+++ b/homeassistant/components/tesla_fleet/__init__.py
@@ -26,7 +26,7 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import DeviceInfo
 
-from .const import DOMAIN, MODELS
+from .const import DOMAIN, LOGGER, MODELS
 from .coordinator import (
     TeslaFleetEnergySiteInfoCoordinator,
     TeslaFleetEnergySiteLiveCoordinator,
@@ -113,6 +113,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -
             )
         elif "energy_site_id" in product and tesla.energy:
             site_id = product["energy_site_id"]
+            if not (
+                product["components"]["battery"]
+                or product["components"]["solar"]
+                or "wall_connectors" in product["components"]
+            ):
+                LOGGER.debug(
+                    "Skipping Energy Site %s as it has no components",
+                    site_id,
+                )
+                continue
+
             api = EnergySpecific(tesla.energy, site_id)
 
             live_coordinator = TeslaFleetEnergySiteLiveCoordinator(hass, api)

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -108,6 +108,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
             )
         elif "energy_site_id" in product and Scope.ENERGY_DEVICE_DATA in scopes:
             site_id = product["energy_site_id"]
+            if not (
+                product["components"]["battery"]
+                or product["components"]["solar"]
+                or "wall_connectors" in product["components"]
+            ):
+                LOGGER.debug(
+                    "Skipping Energy Site %s as it has no components",
+                    site_id,
+                )
+                continue
+
             api = EnergySpecific(teslemetry.energy, site_id)
             live_coordinator = TeslemetryEnergySiteLiveCoordinator(hass, api)
             info_coordinator = TeslemetryEnergySiteInfoCoordinator(hass, api, product)

--- a/homeassistant/components/tessie/__init__.py
+++ b/homeassistant/components/tessie/__init__.py
@@ -111,6 +111,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: TessieConfigEntry) -> bo
         for product in products:
             if "energy_site_id" in product:
                 site_id = product["energy_site_id"]
+                if not (
+                    product["components"]["battery"]
+                    or product["components"]["solar"]
+                    or "wall_connectors" in product["components"]
+                ):
+                    _LOGGER.debug(
+                        "Skipping Energy Site %s as it has no components",
+                        site_id,
+                    )
+                    continue
+
                 api = EnergySpecific(tessie.energy, site_id)
                 energysites.append(
                     TessieEnergyData(

--- a/tests/components/tesla_fleet/fixtures/products.json
+++ b/tests/components/tesla_fleet/fixtures/products.json
@@ -115,7 +115,17 @@
       "features": {
         "rate_plan_manager_no_pricing_constraint": true
       }
+    },
+    {
+      "energy_site_id": 98765,
+      "components": {
+        "battery": false,
+        "solar": false,
+        "grid": false,
+        "load_meter": false,
+        "market_type": "residential"
+      }
     }
   ],
-  "count": 2
+  "count": 3
 }

--- a/tests/components/teslemetry/fixtures/products.json
+++ b/tests/components/teslemetry/fixtures/products.json
@@ -115,7 +115,17 @@
       "features": {
         "rate_plan_manager_no_pricing_constraint": true
       }
+    },
+    {
+      "energy_site_id": 98765,
+      "components": {
+        "battery": false,
+        "solar": false,
+        "grid": false,
+        "load_meter": false,
+        "market_type": "residential"
+      }
     }
   ],
-  "count": 2
+  "count": 3
 }

--- a/tests/components/tessie/fixtures/products.json
+++ b/tests/components/tessie/fixtures/products.json
@@ -115,7 +115,17 @@
       "features": {
         "rate_plan_manager_no_pricing_constraint": true
       }
+    },
+    {
+      "energy_site_id": 98765,
+      "components": {
+        "battery": false,
+        "solar": false,
+        "grid": false,
+        "load_meter": false,
+        "market_type": "residential"
+      }
     }
   ],
-  "count": 2
+  "count": 3
 }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A rare condition exists in Tesla Fleet API based integrations that can cause the integration to fail when a user has an energy site with no components. This occurs for customers with Tesla Electricity in Texas.

This PR ensures there is at least 1 useful component in the energy site, otherwise its ignored.

This can wait for 2024.8, as most of this functionality hasnt been released (except in Teslemetry)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
