### PR TITLE
Add device info to Russound RIO

### DIFF
--- a/homeassistant/components/russound_rio/media_player.py
+++ b/homeassistant/components/russound_rio/media_player.py
@@ -123,11 +123,20 @@ class RussoundZoneDevice(MediaPlayerEntity):
 
     def __init__(self, zone: Zone, sources: dict[int, Source]) -> None:
         """Initialize the zone device."""
-        super().__init__()
         self._controller = zone.controller
         self._zone = zone
         self._sources = sources
         self._attr_unique_id = str(self._zone)
+        self._attr_device_info = DeviceInfo(
+            identifiers={
+                # Use MAC address of Russound device as identifier
+                (DOMAIN, self._controller.mac_address)
+            },
+            manufacturer="Russound",
+            name=self._controller.controller_type,
+            model=self._controller.controller_type,
+            sw_version=self._controller.firmware_version,
+        )
 
     def _callback_handler(self, device_str, *args):
         if (
@@ -217,17 +226,3 @@ class RussoundZoneDevice(MediaPlayerEntity):
                 continue
             await self._zone.send_event("SelectSource", source_id)
             break
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return the device info."""
-        return DeviceInfo(
-            identifiers={
-                # Use MAC address of Russound device as identifier
-                (DOMAIN, self._controller.mac_address)
-            },
-            manufacturer="Russound",
-            name=self._controller.controller_type,
-            model=self._controller.controller_type,
-            sw_version=self._controller.firmware_version,
-        )

--- a/homeassistant/components/russound_rio/media_player.py
+++ b/homeassistant/components/russound_rio/media_player.py
@@ -126,6 +126,8 @@ class RussoundZoneDevice(MediaPlayerEntity):
         self._controller = zone.controller
         self._zone = zone
         self._sources = sources
+        self._attr_name = zone.name
+        self._attr_has_entity_name = True
         self._attr_unique_id = f"{self._controller.mac_address}-{zone.device_str()}"
         self._attr_device_info = DeviceInfo(
             # Use MAC address of Russound device as identifier
@@ -135,6 +137,11 @@ class RussoundZoneDevice(MediaPlayerEntity):
             model=self._controller.controller_type,
             sw_version=self._controller.firmware_version,
         )
+        if self._controller.parent_controller:
+            self._attr_device_info["via_device"] = (
+                DOMAIN,
+                self._controller.parent_controller.mac_address,
+            )
 
     def _callback_handler(self, device_str, *args):
         if (
@@ -149,11 +156,6 @@ class RussoundZoneDevice(MediaPlayerEntity):
 
     def _current_source(self) -> Source:
         return self._zone.fetch_current_source()
-
-    @property
-    def name(self):
-        """Return the name of the zone."""
-        return self._zone.name
 
     @property
     def state(self) -> MediaPlayerState | None:

--- a/homeassistant/components/russound_rio/media_player.py
+++ b/homeassistant/components/russound_rio/media_player.py
@@ -17,7 +17,7 @@ from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResultType
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -126,12 +126,10 @@ class RussoundZoneDevice(MediaPlayerEntity):
         self._controller = zone.controller
         self._zone = zone
         self._sources = sources
-        self._attr_unique_id = str(self._zone)
+        self._attr_unique_id = f"{self._controller.mac_address}-{zone.device_str()}"
         self._attr_device_info = DeviceInfo(
-            identifiers={
-                # Use MAC address of Russound device as identifier
-                (DOMAIN, self._controller.mac_address)
-            },
+            # Use MAC address of Russound device as identifier
+            connections={(CONNECTION_NETWORK_MAC, self._controller.mac_address)},
             manufacturer="Russound",
             name=self._controller.controller_type,
             model=self._controller.controller_type,

--- a/homeassistant/components/russound_rio/media_player.py
+++ b/homeassistant/components/russound_rio/media_player.py
@@ -7,6 +7,7 @@ import logging
 from aiorussound import Source, Zone
 
 from homeassistant.components.media_player import (
+    MediaPlayerDeviceClass,
     MediaPlayerEntity,
     MediaPlayerEntityFeature,
     MediaPlayerState,
@@ -109,6 +110,7 @@ async def async_setup_entry(
 class RussoundZoneDevice(MediaPlayerEntity):
     """Representation of a Russound Zone."""
 
+    _attr_device_class = MediaPlayerDeviceClass.SPEAKER
     _attr_media_content_type = MediaType.MUSIC
     _attr_should_poll = False
     _attr_supported_features = (

--- a/homeassistant/components/russound_rio/media_player.py
+++ b/homeassistant/components/russound_rio/media_player.py
@@ -113,6 +113,7 @@ class RussoundZoneDevice(MediaPlayerEntity):
     _attr_device_class = MediaPlayerDeviceClass.SPEAKER
     _attr_media_content_type = MediaType.MUSIC
     _attr_should_poll = False
+    _attr_has_entity_name = True
     _attr_supported_features = (
         MediaPlayerEntityFeature.VOLUME_MUTE
         | MediaPlayerEntityFeature.VOLUME_SET
@@ -127,7 +128,6 @@ class RussoundZoneDevice(MediaPlayerEntity):
         self._zone = zone
         self._sources = sources
         self._attr_name = zone.name
-        self._attr_has_entity_name = True
         self._attr_unique_id = f"{self._controller.mac_address}-{zone.device_str()}"
         self._attr_device_info = DeviceInfo(
             # Use MAC address of Russound device as identifier

--- a/homeassistant/components/russound_rio/media_player.py
+++ b/homeassistant/components/russound_rio/media_player.py
@@ -131,6 +131,7 @@ class RussoundZoneDevice(MediaPlayerEntity):
         self._attr_unique_id = f"{self._controller.mac_address}-{zone.device_str()}"
         self._attr_device_info = DeviceInfo(
             # Use MAC address of Russound device as identifier
+            identifiers={(DOMAIN, self._controller.mac_address)},
             connections={(CONNECTION_NETWORK_MAC, self._controller.mac_address)},
             manufacturer="Russound",
             name=self._controller.controller_type,

--- a/homeassistant/components/russound_rio/media_player.py
+++ b/homeassistant/components/russound_rio/media_player.py
@@ -224,8 +224,8 @@ class RussoundZoneDevice(MediaPlayerEntity):
                 # Use MAC address of Russound device as identifier
                 (DOMAIN, self._controller.mac_address)
             },
-            name=self.name,
             manufacturer="Russound",
+            name=self._controller.controller_type,
             model=self._controller.controller_type,
             sw_version=self._controller.firmware_version,
         )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The following features were added:
1. `device_info` was added to the media player for the device registry. Devices are identified using the MAC address of the controllers.
2. A unique ID was added to the media player entity that consists of the controller MAC address conjoined with the zone identifier. The internal __str__ method in the Russound zone object (from lib) returns the following `{CTRL_MAC_ADDR}-{ZONE_IDF}`.
3. The media player device class was set to `MediaPlayerDeviceClass.Speaker`.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
