### PR TITLE
Remove support for live schema migration of old recorder databases

### DIFF
--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -119,7 +119,10 @@ from .util import (
 if TYPE_CHECKING:
     from . import Recorder
 
-LIVE_MIGRATION_MIN_SCHEMA_VERSION = 0
+# Live schema migration supported starting from schema version 42 or newer
+# Schema version 41 was introduced in HA Core 2023.4
+# Schema version 42 was introduced in HA Core 2023.11
+LIVE_MIGRATION_MIN_SCHEMA_VERSION = 42
 
 MIGRATION_NOTE_OFFLINE = (
     "Note: this may take several hours on large databases and slow machines. "

--- a/tests/components/recorder/test_migrate.py
+++ b/tests/components/recorder/test_migrate.py
@@ -87,10 +87,23 @@ async def test_schema_update_calls(
         call(instance, hass, engine, session_maker, version + 1, 0)
         for version in range(db_schema.SCHEMA_VERSION)
     ]
-    status = migration.SchemaValidationStatus(0, True, set(), 0)
     assert migrate_schema.mock_calls == [
-        call(instance, hass, engine, session_maker, status, 0),
-        call(instance, hass, engine, session_maker, status, db_schema.SCHEMA_VERSION),
+        call(
+            instance,
+            hass,
+            engine,
+            session_maker,
+            migration.SchemaValidationStatus(0, True, set(), 0),
+            42,
+        ),
+        call(
+            instance,
+            hass,
+            engine,
+            session_maker,
+            migration.SchemaValidationStatus(42, True, set(), 0),
+            db_schema.SCHEMA_VERSION,
+        ),
     ]
 
 

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -2555,7 +2555,9 @@ async def test_recorder_info_migration_queue_exhausted(
             recorder.core, "MIN_AVAILABLE_MEMORY_FOR_QUEUE_BACKLOG", sys.maxsize
         ),
     ):
-        async with async_test_recorder(hass, wait_recorder=False):
+        async with async_test_recorder(
+            hass, wait_recorder=False, wait_recorder_setup=False
+        ):
             await hass.async_add_executor_job(
                 instrument_migration.migration_started.wait
             )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove support for live schema migration of old recorder databases

### Summary

Live schema migration is now supported starting from schema version 42 or newer
Schema version 41 was introduced in HA Core 2023.4
Schema version 42 was introduced in HA Core 2023.11

During the non-live migration, we show this splash screen:
![image](https://github.com/user-attachments/assets/c094e6ee-329f-4978-95bb-f60f7bf3222e)

### Background

Without the changes in this PR, we allow the recorder to be accessed while schema and data migration is in progress. This means the recorder code complexity is greatly increased because every recorder functionality needs to be compatible with all recorder schemas from when the recorder was first introduced many years ago.
The added complexity means there's a high risk of bugs, and there is also some performance impact due to the additional checks needed.

With this PR, schema migration from a schema version more than a year old will block Home Assistant startup until completed

### Future improvements

- Introduce non-live data migration, where recorder data migration steps introduced more than a year ago will block Home Assistant startup until completed
- Remove dead code which handles old schemas
- We should consider improving the non-live splash screen in frontend PRs:
  - Make the message translated
  - Improve the language


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
