### PR TITLE
Fix gemini api format conversion

### DIFF
--- a/homeassistant/components/google_generative_ai_conversation/conversation.py
+++ b/homeassistant/components/google_generative_ai_conversation/conversation.py
@@ -89,9 +89,9 @@ def _format_schema(schema: dict[str, Any]) -> dict[str, Any]:
             key = "type_"
             val = val.upper()
         elif key == "format":
-            if schema.get("type") == "string" and val != "enum":
-                continue
-            if schema.get("type") not in ("number", "integer", "string"):
+            if (schema.get("type") == "string" and val != "enum") or (
+                schema.get("type") not in ("number", "integer", "string")
+            ):
                 continue
             key = "format_"
         elif key == "items":

--- a/homeassistant/components/google_generative_ai_conversation/conversation.py
+++ b/homeassistant/components/google_generative_ai_conversation/conversation.py
@@ -73,6 +73,14 @@ SUPPORTED_SCHEMA_KEYS = {
 
 def _format_schema(schema: dict[str, Any]) -> dict[str, Any]:
     """Format the schema to protobuf."""
+    if (subschemas := schema.get("anyOf")) or (subschemas := schema.get("allOf")):
+        for subschema in subschemas:  # Gemini API does not support anyOf and allOf keys
+            if "type" in subschema:  # Fallback to first subschema with 'type' field
+                return _format_schema(subschema)
+        return _format_schema(
+            subschemas[0]
+        )  # Or, if not found, to any of the subschemas
+
     result = {}
     for key, val in schema.items():
         if key not in SUPPORTED_SCHEMA_KEYS:
@@ -83,12 +91,20 @@ def _format_schema(schema: dict[str, Any]) -> dict[str, Any]:
         elif key == "format":
             if schema.get("type") == "string" and val != "enum":
                 continue
+            if schema.get("type") not in ("number", "integer", "string"):
+                continue
             key = "format_"
         elif key == "items":
             val = _format_schema(val)
         elif key == "properties":
             val = {k: _format_schema(v) for k, v in val.items()}
         result[key] = val
+
+    if result.get("type_") == "OBJECT" and not result.get("properties"):
+        # An object with undefined properties is not supported by Gemini API.
+        # Fallback to JSON string. This will probably fail for most tools that want it,
+        # but we don't have a better fallback strategy so far.
+        result["properties"] = {"json": {"type_": "STRING"}}
     return result
 
 

--- a/tests/components/google_generative_ai_conversation/snapshots/test_conversation.ambr
+++ b/tests/components/google_generative_ai_conversation/snapshots/test_conversation.ambr
@@ -443,18 +443,6 @@
     parameters {
       type_: OBJECT
       properties {
-        key: "param3"
-        value {
-          type_: OBJECT
-          properties {
-            key: "json"
-            value {
-              type_: STRING
-            }
-          }
-        }
-      }
-      properties {
         key: "param2"
         value {
           type_: NUMBER

--- a/tests/components/google_generative_ai_conversation/snapshots/test_conversation.ambr
+++ b/tests/components/google_generative_ai_conversation/snapshots/test_conversation.ambr
@@ -443,6 +443,24 @@
     parameters {
       type_: OBJECT
       properties {
+        key: "param3"
+        value {
+          type_: OBJECT
+          properties {
+            key: "json"
+            value {
+              type_: STRING
+            }
+          }
+        }
+      }
+      properties {
+        key: "param2"
+        value {
+          type_: NUMBER
+        }
+      }
+      properties {
         key: "param1"
         value {
           type_: ARRAY

--- a/tests/components/google_generative_ai_conversation/snapshots/test_conversation.ambr
+++ b/tests/components/google_generative_ai_conversation/snapshots/test_conversation.ambr
@@ -443,6 +443,18 @@
     parameters {
       type_: OBJECT
       properties {
+        key: "param3"
+        value {
+          type_: OBJECT
+          properties {
+            key: "json"
+            value {
+              type_: STRING
+            }
+          }
+        }
+      }
+      properties {
         key: "param2"
         value {
           type_: NUMBER

--- a/tests/components/google_generative_ai_conversation/test_conversation.py
+++ b/tests/components/google_generative_ai_conversation/test_conversation.py
@@ -187,6 +187,7 @@ async def test_function_call(
                 vol.All(str, vol.Lower)
             ],
             vol.Optional("param2"): vol.Any(float, int),
+            vol.Optional("param3"): dict,
         }
     )
 

--- a/tests/components/google_generative_ai_conversation/test_conversation.py
+++ b/tests/components/google_generative_ai_conversation/test_conversation.py
@@ -187,7 +187,6 @@ async def test_function_call(
                 vol.All(str, vol.Lower)
             ],
             vol.Optional("param2"): vol.Any(float, int),
-            vol.Optional("param3"): object,
         }
     )
 

--- a/tests/components/google_generative_ai_conversation/test_conversation.py
+++ b/tests/components/google_generative_ai_conversation/test_conversation.py
@@ -185,7 +185,9 @@ async def test_function_call(
         {
             vol.Optional("param1", description="Test parameters"): [
                 vol.All(str, vol.Lower)
-            ]
+            ],
+            vol.Optional("param2"): vol.Any(float, int),
+            vol.Optional("param3"): object,
         }
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I have identified a few other cases that may lead to #120673:

1. Format is only supported for NUMBER, INTEGER and STRING type:
```
* GenerateContentRequest.tools[0].function_declarations[3].parameters.properties[rgb].format: format is only supported for NUMBER, INTEGER and STRING type
```
Added a condition to remove the key.

2. Gemini API does not support `anyOf` and `allOf` keys.
```
* GenerateContentRequest.tools[0].function_declarations[3].parameters.properties[target].properties[entity_id].type: must be specified
```
Just select one of the subschemas (preferably with a 'type' field) and use them instead with a hope that it's the most useful one.

3. Gemini API does not support objects with undefined fields
```
* GenerateContentRequest.tools[0].function_declarations[3].parameters.properties[object].properties: should be non-empty for OBJECT type
```
Replace the object with a string variable named "json". It will probably not what the tool developer expects in most cases, but at least it would allow other parameters and other tools to work.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #120673
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
