### PR TITLE
Deduplicate light data with deCONZ websocket fixture

### DIFF
--- a/tests/components/deconz/conftest.py
+++ b/tests/components/deconz/conftest.py
@@ -269,6 +269,19 @@ def fixture_websocket_data(_mock_websocket: _WebsocketMock) -> WebsocketDataType
     return change_websocket_data
 
 
+@pytest.fixture(name="light_ws_data")
+def fixture_light_websocket_data(
+    mock_websocket_data: WebsocketDataType,
+) -> WebsocketDataType:
+    """Fixture to send light data over websocket."""
+
+    async def send_light_data(data: dict[str, Any]) -> None:
+        """Send light data on the websocket."""
+        await mock_websocket_data({"r": "lights"} | data)
+
+    return send_light_data
+
+
 @pytest.fixture(name="sensor_ws_data")
 def fixture_sensor_websocket_data(
     mock_websocket_data: WebsocketDataType,

--- a/tests/components/deconz/test_alarm_control_panel.py
+++ b/tests/components/deconz/test_alarm_control_panel.py
@@ -111,15 +111,11 @@ async def test_alarm_control_panel(
     # Event signals alarm control panel armed away
 
     await sensor_ws_data({"state": {"panel": AncillaryControlPanel.ARMED_AWAY}})
-    await hass.async_block_till_done()
-
     assert hass.states.get("alarm_control_panel.keypad").state == STATE_ALARM_ARMED_AWAY
 
     # Event signals alarm control panel armed night
 
     await sensor_ws_data({"state": {"panel": AncillaryControlPanel.ARMED_NIGHT}})
-    await hass.async_block_till_done()
-
     assert (
         hass.states.get("alarm_control_panel.keypad").state == STATE_ALARM_ARMED_NIGHT
     )
@@ -127,15 +123,11 @@ async def test_alarm_control_panel(
     # Event signals alarm control panel armed home
 
     await sensor_ws_data({"state": {"panel": AncillaryControlPanel.ARMED_STAY}})
-    await hass.async_block_till_done()
-
     assert hass.states.get("alarm_control_panel.keypad").state == STATE_ALARM_ARMED_HOME
 
     # Event signals alarm control panel disarmed
 
     await sensor_ws_data({"state": {"panel": AncillaryControlPanel.DISARMED}})
-    await hass.async_block_till_done()
-
     assert hass.states.get("alarm_control_panel.keypad").state == STATE_ALARM_DISARMED
 
     # Event signals alarm control panel arming
@@ -146,8 +138,6 @@ async def test_alarm_control_panel(
         AncillaryControlPanel.ARMING_STAY,
     ):
         await sensor_ws_data({"state": {"panel": arming_event}})
-        await hass.async_block_till_done()
-
         assert hass.states.get("alarm_control_panel.keypad").state == STATE_ALARM_ARMING
 
     # Event signals alarm control panel pending
@@ -157,8 +147,6 @@ async def test_alarm_control_panel(
         AncillaryControlPanel.EXIT_DELAY,
     ):
         await sensor_ws_data({"state": {"panel": pending_event}})
-        await hass.async_block_till_done()
-
         assert (
             hass.states.get("alarm_control_panel.keypad").state == STATE_ALARM_PENDING
         )
@@ -166,15 +154,11 @@ async def test_alarm_control_panel(
     # Event signals alarm control panel triggered
 
     await sensor_ws_data({"state": {"panel": AncillaryControlPanel.IN_ALARM}})
-    await hass.async_block_till_done()
-
     assert hass.states.get("alarm_control_panel.keypad").state == STATE_ALARM_TRIGGERED
 
     # Event signals alarm control panel unknown state keeps previous state
 
     await sensor_ws_data({"state": {"panel": AncillaryControlPanel.NOT_READY}})
-    await hass.async_block_till_done()
-
     assert hass.states.get("alarm_control_panel.keypad").state == STATE_ALARM_TRIGGERED
 
     # Verify service calls

--- a/tests/components/deconz/test_binary_sensor.py
+++ b/tests/components/deconz/test_binary_sensor.py
@@ -493,7 +493,6 @@ async def test_binary_sensors(
     # Change state
 
     await sensor_ws_data({"state": expected["websocket_event"]})
-    await hass.async_block_till_done()
     assert hass.states.get(expected["entity_id"]).state == expected["next_state"]
 
     # Unload entry
@@ -611,8 +610,6 @@ async def test_add_new_binary_sensor(
         },
     }
     await sensor_ws_data(event_added_sensor)
-    await hass.async_block_till_done()
-
     assert len(hass.states.async_all()) == 1
     assert hass.states.get("binary_sensor.presence_sensor").state == STATE_OFF
 
@@ -640,8 +637,6 @@ async def test_add_new_binary_sensor_ignored_load_entities_on_service_call(
     assert len(hass.states.async_all()) == 0
 
     await sensor_ws_data({"e": "added", "sensor": sensor})
-    await hass.async_block_till_done()
-
     assert len(hass.states.async_all()) == 0
     assert not hass.states.get("binary_sensor.presence_sensor")
 
@@ -687,8 +682,6 @@ async def test_add_new_binary_sensor_ignored_load_entities_on_options_change(
     assert len(hass.states.async_all()) == 0
 
     await sensor_ws_data({"e": "added", "sensor": sensor})
-    await hass.async_block_till_done()
-
     assert len(hass.states.async_all()) == 0
     assert not hass.states.get("binary_sensor.presence_sensor")
 

--- a/tests/components/deconz/test_climate.py
+++ b/tests/components/deconz/test_climate.py
@@ -111,8 +111,6 @@ async def test_simple_climate_device(
     # Event signals thermostat configured off
 
     await sensor_ws_data({"state": {"on": False}})
-    await hass.async_block_till_done()
-
     assert hass.states.get("climate.thermostat").state == STATE_OFF
     assert (
         hass.states.get("climate.thermostat").attributes["hvac_action"]
@@ -122,8 +120,6 @@ async def test_simple_climate_device(
     # Event signals thermostat state on
 
     await sensor_ws_data({"state": {"on": True}})
-    await hass.async_block_till_done()
-
     assert hass.states.get("climate.thermostat").state == HVACMode.HEAT
     assert (
         hass.states.get("climate.thermostat").attributes["hvac_action"]
@@ -212,8 +208,6 @@ async def test_climate_device_without_cooling_support(
     # Event signals thermostat configured off
 
     await sensor_ws_data({"config": {"mode": "off"}})
-    await hass.async_block_till_done()
-
     assert hass.states.get("climate.thermostat").state == STATE_OFF
     assert (
         hass.states.get("climate.thermostat").attributes["hvac_action"]
@@ -223,8 +217,6 @@ async def test_climate_device_without_cooling_support(
     # Event signals thermostat state on
 
     await sensor_ws_data({"config": {"mode": "other"}, "state": {"on": True}})
-    await hass.async_block_till_done()
-
     assert hass.states.get("climate.thermostat").state == HVACMode.HEAT
     assert (
         hass.states.get("climate.thermostat").attributes["hvac_action"]
@@ -234,8 +226,6 @@ async def test_climate_device_without_cooling_support(
     # Event signals thermostat state off
 
     await sensor_ws_data({"state": {"on": False}})
-    await hass.async_block_till_done()
-
     assert hass.states.get("climate.thermostat").state == STATE_OFF
     assert (
         hass.states.get("climate.thermostat").attributes["hvac_action"]
@@ -378,9 +368,6 @@ async def test_climate_device_with_cooling_support(
     # Event signals thermostat mode cool
 
     await sensor_ws_data({"config": {"mode": "cool"}})
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
-
     assert hass.states.get("climate.zen_01").state == HVACMode.COOL
     assert hass.states.get("climate.zen_01").attributes["temperature"] == 11.1
     assert (
@@ -390,8 +377,6 @@ async def test_climate_device_with_cooling_support(
     # Event signals thermostat state on
 
     await sensor_ws_data({"state": {"on": True}})
-    await hass.async_block_till_done()
-
     assert hass.states.get("climate.zen_01").state == HVACMode.COOL
     assert (
         hass.states.get("climate.zen_01").attributes["hvac_action"]
@@ -470,8 +455,6 @@ async def test_climate_device_with_fan_support(
     # Event signals fan mode defaults to off
 
     await sensor_ws_data({"config": {"fanmode": "unsupported"}})
-    await hass.async_block_till_done()
-
     assert hass.states.get("climate.zen_01").attributes["fan_mode"] == FAN_OFF
     assert (
         hass.states.get("climate.zen_01").attributes["hvac_action"] == HVACAction.IDLE
@@ -480,8 +463,6 @@ async def test_climate_device_with_fan_support(
     # Event signals unsupported fan mode
 
     await sensor_ws_data({"config": {"fanmode": "unsupported"}, "state": {"on": True}})
-    await hass.async_block_till_done()
-
     assert hass.states.get("climate.zen_01").attributes["fan_mode"] == FAN_ON
     assert (
         hass.states.get("climate.zen_01").attributes["hvac_action"]
@@ -491,8 +472,6 @@ async def test_climate_device_with_fan_support(
     # Event signals unsupported fan mode
 
     await sensor_ws_data({"config": {"fanmode": "unsupported"}})
-    await hass.async_block_till_done()
-
     assert hass.states.get("climate.zen_01").attributes["fan_mode"] == FAN_ON
     assert (
         hass.states.get("climate.zen_01").attributes["hvac_action"]
@@ -595,8 +574,6 @@ async def test_climate_device_with_preset(
     # Event signals deCONZ preset
 
     await sensor_ws_data({"config": {"preset": "manual"}})
-    await hass.async_block_till_done()
-
     assert (
         hass.states.get("climate.zen_01").attributes["preset_mode"]
         == DECONZ_PRESET_MANUAL
@@ -605,8 +582,6 @@ async def test_climate_device_with_preset(
     # Event signals unknown preset
 
     await sensor_ws_data({"config": {"preset": "unsupported"}})
-    await hass.async_block_till_done()
-
     assert hass.states.get("climate.zen_01").attributes["preset_mode"] is None
 
     # Verify service calls
@@ -739,8 +714,6 @@ async def test_verify_state_update(
     )
 
     await sensor_ws_data({"state": {"on": False}})
-    await hass.async_block_till_done()
-
     assert hass.states.get("climate.thermostat").state == HVACMode.AUTO
     assert (
         hass.states.get("climate.thermostat").attributes["hvac_action"]
@@ -775,7 +748,6 @@ async def test_add_new_climate_device(
     assert len(hass.states.async_all()) == 0
 
     await sensor_ws_data(event_added_sensor)
-    await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 2
     assert hass.states.get("climate.thermostat").state == HVACMode.AUTO
@@ -898,7 +870,6 @@ async def test_boost_mode(
     # Event signals thermostat preset boost and valve 100 (real data)
 
     await sensor_ws_data({"config": {"preset": "boost"}, "state": {"valve": 100}})
-    await hass.async_block_till_done()
 
     climate_thermostat = hass.states.get("climate.thermostat")
     assert climate_thermostat.attributes["preset_mode"] is PRESET_BOOST

--- a/tests/components/deconz/test_cover.py
+++ b/tests/components/deconz/test_cover.py
@@ -69,8 +69,6 @@ async def test_cover(
     # Event signals cover is open
 
     await light_ws_data({"state": {"lift": 0, "open": True}})
-    await hass.async_block_till_done()
-
     cover = hass.states.get("cover.window_covering_device")
     assert cover.state == STATE_OPEN
     assert cover.attributes[ATTR_CURRENT_POSITION] == 100

--- a/tests/components/deconz/test_cover.py
+++ b/tests/components/deconz/test_cover.py
@@ -57,7 +57,7 @@ async def test_cover(
     hass: HomeAssistant,
     config_entry_setup: ConfigEntry,
     mock_put_request: Callable[[str, str], AiohttpClientMocker],
-    mock_websocket_data: WebsocketDataType,
+    light_ws_data: WebsocketDataType,
 ) -> None:
     """Test that all supported cover entities are created."""
     assert len(hass.states.async_all()) == 2
@@ -68,7 +68,7 @@ async def test_cover(
 
     # Event signals cover is open
 
-    await mock_websocket_data({"r": "lights", "state": {"lift": 0, "open": True}})
+    await light_ws_data({"state": {"lift": 0, "open": True}})
     await hass.async_block_till_done()
 
     cover = hass.states.get("cover.window_covering_device")

--- a/tests/components/deconz/test_deconz_event.py
+++ b/tests/components/deconz/test_deconz_event.py
@@ -99,7 +99,6 @@ async def test_deconz_events(
     captured_events = async_capture_events(hass, CONF_DECONZ_EVENT)
 
     await sensor_ws_data({"id": "1", "state": {"buttonevent": 2000}})
-    await hass.async_block_till_done()
 
     device = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, "00:00:00:00:00:00:00:01")}
@@ -114,7 +113,6 @@ async def test_deconz_events(
     }
 
     await sensor_ws_data({"id": "3", "state": {"buttonevent": 2000}})
-    await hass.async_block_till_done()
 
     device = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, "00:00:00:00:00:00:00:03")}
@@ -130,7 +128,6 @@ async def test_deconz_events(
     }
 
     await sensor_ws_data({"id": "4", "state": {"gesture": 0}})
-    await hass.async_block_till_done()
 
     device = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, "00:00:00:00:00:00:00:04")}
@@ -150,7 +147,6 @@ async def test_deconz_events(
         "state": {"buttonevent": 6002, "angle": 110, "xy": [0.5982, 0.3897]},
     }
     await sensor_ws_data(event_changed_sensor)
-    await hass.async_block_till_done()
 
     device = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, "00:00:00:00:00:00:00:05")}
@@ -169,8 +165,6 @@ async def test_deconz_events(
     # Unsupported event
 
     await sensor_ws_data({"id": "1", "name": "other name"})
-    await hass.async_block_till_done()
-
     assert len(captured_events) == 4
 
     await hass.config_entries.async_unload(config_entry_setup.entry_id)
@@ -272,7 +266,6 @@ async def test_deconz_alarm_events(
     # Emergency event
 
     await sensor_ws_data({"state": {"action": AncillaryControlAction.EMERGENCY}})
-    await hass.async_block_till_done()
 
     device = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, "00:00:00:00:00:00:00:01")}
@@ -289,7 +282,6 @@ async def test_deconz_alarm_events(
     # Fire event
 
     await sensor_ws_data({"state": {"action": AncillaryControlAction.FIRE}})
-    await hass.async_block_till_done()
 
     device = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, "00:00:00:00:00:00:00:01")}
@@ -306,7 +298,6 @@ async def test_deconz_alarm_events(
     # Invalid code event
 
     await sensor_ws_data({"state": {"action": AncillaryControlAction.INVALID_CODE}})
-    await hass.async_block_till_done()
 
     device = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, "00:00:00:00:00:00:00:01")}
@@ -323,7 +314,6 @@ async def test_deconz_alarm_events(
     # Panic event
 
     await sensor_ws_data({"state": {"action": AncillaryControlAction.PANIC}})
-    await hass.async_block_till_done()
 
     device = device_registry.async_get_device(
         identifiers={(DECONZ_DOMAIN, "00:00:00:00:00:00:00:01")}
@@ -340,15 +330,11 @@ async def test_deconz_alarm_events(
     # Only care for changes to specific action events
 
     await sensor_ws_data({"state": {"action": AncillaryControlAction.ARMED_AWAY}})
-    await hass.async_block_till_done()
-
     assert len(captured_events) == 4
 
     # Only care for action events
 
     await sensor_ws_data({"state": {"panel": AncillaryControlPanel.ARMED_AWAY}})
-    await hass.async_block_till_done()
-
     assert len(captured_events) == 4
 
     await hass.config_entries.async_unload(config_entry_setup.entry_id)
@@ -425,7 +411,6 @@ async def test_deconz_presence_events(
         PresenceStatePresenceEvent.RIGHT_LEAVE,
     ):
         await sensor_ws_data({"state": {"presenceevent": presence_event}})
-        await hass.async_block_till_done()
 
         assert len(captured_events) == 1
         assert captured_events[0].data == {
@@ -439,8 +424,6 @@ async def test_deconz_presence_events(
     # Unsupported presence event
 
     await sensor_ws_data({"state": {"presenceevent": PresenceStatePresenceEvent.NINE}})
-    await hass.async_block_till_done()
-
     assert len(captured_events) == 0
 
     await hass.config_entries.async_unload(config_entry_setup.entry_id)
@@ -514,7 +497,6 @@ async def test_deconz_relative_rotary_events(
             }
         }
         await sensor_ws_data(event_changed_sensor)
-        await hass.async_block_till_done()
 
         assert len(captured_events) == 1
         assert captured_events[0].data == {
@@ -530,8 +512,6 @@ async def test_deconz_relative_rotary_events(
     # Unsupported relative rotary event
 
     await sensor_ws_data({"name": "123"})
-    await hass.async_block_till_done()
-
     assert len(captured_events) == 0
 
     await hass.config_entries.async_unload(config_entry_setup.entry_id)

--- a/tests/components/deconz/test_device_trigger.py
+++ b/tests/components/deconz/test_device_trigger.py
@@ -344,8 +344,6 @@ async def test_functional_device_trigger(
     assert len(hass.states.async_entity_ids(AUTOMATION_DOMAIN)) == 1
 
     await sensor_ws_data({"state": {"buttonevent": 1002}})
-    await hass.async_block_till_done()
-
     assert len(service_calls) == 1
     assert service_calls[0].data["some"] == "test_trigger_button_press"
 

--- a/tests/components/deconz/test_fan.py
+++ b/tests/components/deconz/test_fan.py
@@ -57,32 +57,22 @@ async def test_fans(
     # Test states
 
     await light_ws_data({"state": {"speed": 1}})
-    await hass.async_block_till_done()
-
     assert hass.states.get("fan.ceiling_fan").state == STATE_ON
     assert hass.states.get("fan.ceiling_fan").attributes[ATTR_PERCENTAGE] == 25
 
     await light_ws_data({"state": {"speed": 2}})
-    await hass.async_block_till_done()
-
     assert hass.states.get("fan.ceiling_fan").state == STATE_ON
     assert hass.states.get("fan.ceiling_fan").attributes[ATTR_PERCENTAGE] == 50
 
     await light_ws_data({"state": {"speed": 3}})
-    await hass.async_block_till_done()
-
     assert hass.states.get("fan.ceiling_fan").state == STATE_ON
     assert hass.states.get("fan.ceiling_fan").attributes[ATTR_PERCENTAGE] == 75
 
     await light_ws_data({"state": {"speed": 4}})
-    await hass.async_block_till_done()
-
     assert hass.states.get("fan.ceiling_fan").state == STATE_ON
     assert hass.states.get("fan.ceiling_fan").attributes[ATTR_PERCENTAGE] == 100
 
     await light_ws_data({"state": {"speed": 0}})
-    await hass.async_block_till_done()
-
     assert hass.states.get("fan.ceiling_fan").state == STATE_OFF
     assert hass.states.get("fan.ceiling_fan").attributes[ATTR_PERCENTAGE] == 0
 
@@ -173,8 +163,6 @@ async def test_fans(
     # Events with an unsupported speed does not get converted
 
     await light_ws_data({"state": {"speed": 5}})
-    await hass.async_block_till_done()
-
     assert hass.states.get("fan.ceiling_fan").state == STATE_ON
     assert not hass.states.get("fan.ceiling_fan").attributes[ATTR_PERCENTAGE]
 

--- a/tests/components/deconz/test_fan.py
+++ b/tests/components/deconz/test_fan.py
@@ -47,7 +47,7 @@ async def test_fans(
     aioclient_mock: AiohttpClientMocker,
     config_entry_setup: ConfigEntry,
     mock_put_request: Callable[[str, str], AiohttpClientMocker],
-    mock_websocket_data: WebsocketDataType,
+    light_ws_data: WebsocketDataType,
 ) -> None:
     """Test that all supported fan entities are created."""
     assert len(hass.states.async_all()) == 2  # Light and fan
@@ -56,31 +56,31 @@ async def test_fans(
 
     # Test states
 
-    await mock_websocket_data({"r": "lights", "state": {"speed": 1}})
+    await light_ws_data({"state": {"speed": 1}})
     await hass.async_block_till_done()
 
     assert hass.states.get("fan.ceiling_fan").state == STATE_ON
     assert hass.states.get("fan.ceiling_fan").attributes[ATTR_PERCENTAGE] == 25
 
-    await mock_websocket_data({"r": "lights", "state": {"speed": 2}})
+    await light_ws_data({"state": {"speed": 2}})
     await hass.async_block_till_done()
 
     assert hass.states.get("fan.ceiling_fan").state == STATE_ON
     assert hass.states.get("fan.ceiling_fan").attributes[ATTR_PERCENTAGE] == 50
 
-    await mock_websocket_data({"r": "lights", "state": {"speed": 3}})
+    await light_ws_data({"state": {"speed": 3}})
     await hass.async_block_till_done()
 
     assert hass.states.get("fan.ceiling_fan").state == STATE_ON
     assert hass.states.get("fan.ceiling_fan").attributes[ATTR_PERCENTAGE] == 75
 
-    await mock_websocket_data({"r": "lights", "state": {"speed": 4}})
+    await light_ws_data({"state": {"speed": 4}})
     await hass.async_block_till_done()
 
     assert hass.states.get("fan.ceiling_fan").state == STATE_ON
     assert hass.states.get("fan.ceiling_fan").attributes[ATTR_PERCENTAGE] == 100
 
-    await mock_websocket_data({"r": "lights", "state": {"speed": 0}})
+    await light_ws_data({"state": {"speed": 0}})
     await hass.async_block_till_done()
 
     assert hass.states.get("fan.ceiling_fan").state == STATE_OFF
@@ -172,7 +172,7 @@ async def test_fans(
 
     # Events with an unsupported speed does not get converted
 
-    await mock_websocket_data({"r": "lights", "state": {"speed": 5}})
+    await light_ws_data({"state": {"speed": 5}})
     await hass.async_block_till_done()
 
     assert hass.states.get("fan.ceiling_fan").state == STATE_ON

--- a/tests/components/deconz/test_light.py
+++ b/tests/components/deconz/test_light.py
@@ -477,8 +477,6 @@ async def test_light_state_change(
     assert hass.states.get("light.hue_go").state == STATE_ON
 
     await light_ws_data({"state": {"on": False}})
-    await hass.async_block_till_done()
-
     assert hass.states.get("light.hue_go").state == STATE_OFF
 
 
@@ -1314,8 +1312,6 @@ async def test_non_color_light_reports_color(
         "uniqueid": "ec:1b:bd:ff:fe:ee:ed:dd-01",
     }
     await light_ws_data(event_changed_light)
-    await hass.async_block_till_done()
-
     group = hass.states.get("light.group")
     assert group.attributes[ATTR_COLOR_MODE] == ColorMode.XY
     assert group.attributes[ATTR_HS_COLOR] == (40.571, 41.176)

--- a/tests/components/deconz/test_light.py
+++ b/tests/components/deconz/test_light.py
@@ -471,12 +471,12 @@ async def test_lights(
 @pytest.mark.usefixtures("config_entry_setup")
 async def test_light_state_change(
     hass: HomeAssistant,
-    mock_websocket_data: WebsocketDataType,
+    light_ws_data: WebsocketDataType,
 ) -> None:
     """Verify light can change state on websocket event."""
     assert hass.states.get("light.hue_go").state == STATE_ON
 
-    await mock_websocket_data({"r": "lights", "state": {"on": False}})
+    await light_ws_data({"state": {"on": False}})
     await hass.async_block_till_done()
 
     assert hass.states.get("light.hue_go").state == STATE_OFF
@@ -1280,7 +1280,7 @@ async def test_disable_light_groups(
 @pytest.mark.usefixtures("config_entry_setup")
 async def test_non_color_light_reports_color(
     hass: HomeAssistant,
-    mock_websocket_data: WebsocketDataType,
+    light_ws_data: WebsocketDataType,
 ) -> None:
     """Verify hs_color does not crash when a group gets updated with a bad color value.
 
@@ -1303,7 +1303,6 @@ async def test_non_color_light_reports_color(
     # for a non-color light causing an exception in hs_color
     event_changed_light = {
         "id": "1",
-        "r": "lights",
         "state": {
             "alert": None,
             "bri": 216,
@@ -1314,7 +1313,7 @@ async def test_non_color_light_reports_color(
         },
         "uniqueid": "ec:1b:bd:ff:fe:ee:ed:dd-01",
     }
-    await mock_websocket_data(event_changed_light)
+    await light_ws_data(event_changed_light)
     await hass.async_block_till_done()
 
     group = hass.states.get("light.group")

--- a/tests/components/deconz/test_lock.py
+++ b/tests/components/deconz/test_lock.py
@@ -45,13 +45,13 @@ async def test_lock_from_light(
     hass: HomeAssistant,
     config_entry_setup: ConfigEntry,
     mock_put_request: Callable[[str, str], AiohttpClientMocker],
-    mock_websocket_data: WebsocketDataType,
+    light_ws_data: WebsocketDataType,
 ) -> None:
     """Test that all supported lock entities based on lights are created."""
     assert len(hass.states.async_all()) == 1
     assert hass.states.get("lock.door_lock").state == STATE_UNLOCKED
 
-    await mock_websocket_data({"r": "lights", "state": {"on": True}})
+    await light_ws_data({"state": {"on": True}})
     await hass.async_block_till_done()
 
     assert hass.states.get("lock.door_lock").state == STATE_LOCKED

--- a/tests/components/deconz/test_lock.py
+++ b/tests/components/deconz/test_lock.py
@@ -52,8 +52,6 @@ async def test_lock_from_light(
     assert hass.states.get("lock.door_lock").state == STATE_UNLOCKED
 
     await light_ws_data({"state": {"on": True}})
-    await hass.async_block_till_done()
-
     assert hass.states.get("lock.door_lock").state == STATE_LOCKED
 
     # Verify service calls
@@ -129,8 +127,6 @@ async def test_lock_from_sensor(
     assert hass.states.get("lock.door_lock").state == STATE_UNLOCKED
 
     await sensor_ws_data({"state": {"lockstate": "locked"}})
-    await hass.async_block_till_done()
-
     assert hass.states.get("lock.door_lock").state == STATE_LOCKED
 
     # Verify service calls

--- a/tests/components/deconz/test_number.py
+++ b/tests/components/deconz/test_number.py
@@ -135,7 +135,6 @@ async def test_number_entities(
     # Change state
 
     await sensor_ws_data(expected["websocket_event"])
-    await hass.async_block_till_done()
     assert hass.states.get(expected["entity_id"]).state == expected["next_state"]
 
     # Verify service calls

--- a/tests/components/deconz/test_scene.py
+++ b/tests/components/deconz/test_scene.py
@@ -131,6 +131,4 @@ async def test_only_new_scenes_are_created(
         "scenes": [{"id": "1", "name": "Scene"}],
     }
     await mock_websocket_data(event_changed_group)
-    await hass.async_block_till_done()
-
     assert len(hass.states.async_all()) == 2

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -953,7 +953,6 @@ async def test_sensors(
     # Change state
 
     await sensor_ws_data(expected["websocket_event"])
-    await hass.async_block_till_done()
     assert hass.states.get(expected["entity_id"]).state == expected["next_state"]
 
     # Unload entry
@@ -1073,8 +1072,6 @@ async def test_add_new_sensor(
     assert len(hass.states.async_all()) == 0
 
     await sensor_ws_data(event_added_sensor)
-    await hass.async_block_till_done()
-
     assert len(hass.states.async_all()) == 2
     assert hass.states.get("sensor.light_level_sensor").state == "999.8"
 
@@ -1172,15 +1169,10 @@ async def test_add_battery_later(
     assert len(hass.states.async_all()) == 0
 
     await sensor_ws_data({"id": "2", "config": {"battery": 50}})
-    await hass.async_block_till_done()
-
     assert len(hass.states.async_all()) == 0
 
     await sensor_ws_data({"id": "1", "config": {"battery": 50}})
-    await hass.async_block_till_done()
-
     assert len(hass.states.async_all()) == 1
-
     assert hass.states.get("sensor.switch_1_battery").state == "50"
 
 

--- a/tests/components/deconz/test_siren.py
+++ b/tests/components/deconz/test_siren.py
@@ -35,14 +35,14 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 async def test_sirens(
     hass: HomeAssistant,
     config_entry_setup: ConfigEntry,
-    mock_websocket_data: WebsocketDataType,
+    light_ws_data: WebsocketDataType,
     mock_put_request: Callable[[str, str], AiohttpClientMocker],
 ) -> None:
     """Test that siren entities are created."""
     assert len(hass.states.async_all()) == 1
     assert hass.states.get("siren.warning_device").state == STATE_ON
 
-    await mock_websocket_data({"r": "lights", "state": {"alert": None}})
+    await light_ws_data({"state": {"alert": None}})
     await hass.async_block_till_done()
 
     assert hass.states.get("siren.warning_device").state == STATE_OFF

--- a/tests/components/deconz/test_siren.py
+++ b/tests/components/deconz/test_siren.py
@@ -43,8 +43,6 @@ async def test_sirens(
     assert hass.states.get("siren.warning_device").state == STATE_ON
 
     await light_ws_data({"state": {"alert": None}})
-    await hass.async_block_till_done()
-
     assert hass.states.get("siren.warning_device").state == STATE_OFF
 
     # Verify service calls

--- a/tests/components/deconz/test_switch.py
+++ b/tests/components/deconz/test_switch.py
@@ -66,7 +66,6 @@ async def test_power_plugs(
     assert hass.states.get("switch.unsupported_switch") is None
 
     await light_ws_data({"state": {"on": False}})
-
     assert hass.states.get("switch.on_off_switch").state == STATE_OFF
 
     # Verify service calls

--- a/tests/components/deconz/test_switch.py
+++ b/tests/components/deconz/test_switch.py
@@ -56,7 +56,7 @@ async def test_power_plugs(
     hass: HomeAssistant,
     config_entry_setup: ConfigEntry,
     mock_put_request: Callable[[str, str], AiohttpClientMocker],
-    mock_websocket_data: WebsocketDataType,
+    light_ws_data: WebsocketDataType,
 ) -> None:
     """Test that all supported switch entities are created."""
     assert len(hass.states.async_all()) == 4
@@ -65,8 +65,7 @@ async def test_power_plugs(
     assert hass.states.get("switch.on_off_relay").state == STATE_ON
     assert hass.states.get("switch.unsupported_switch") is None
 
-    await mock_websocket_data({"r": "lights", "state": {"on": False}})
-    await hass.async_block_till_done()
+    await light_ws_data({"state": {"on": False}})
 
     assert hass.states.get("switch.on_off_switch").state == STATE_OFF
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Also remove all uses of async_block_till_done in conjunction with the websocket fixture as it apparently doesn't do anything.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
