### PR TITLE
Fix flaky Reolink tests

### DIFF
--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -35,6 +35,7 @@ TEST_NVR_NAME = "test_reolink_name"
 TEST_NVR_NAME2 = "test2_reolink_name"
 TEST_USE_HTTPS = True
 TEST_HOST_MODEL = "RLN8-410"
+TEST_ITEM_NUMBER = "P000"
 TEST_CAM_MODEL = "RLC-123"
 
 
@@ -83,6 +84,7 @@ def reolink_connect_class() -> Generator[MagicMock]:
         host_mock.sw_version = "v1.0.0.0.0.0000"
         host_mock.manufacturer = "Reolink"
         host_mock.model = TEST_HOST_MODEL
+        host_mock.item_number = TEST_ITEM_NUMBER
         host_mock.camera_model.return_value = TEST_CAM_MODEL
         host_mock.camera_name.return_value = TEST_NVR_NAME
         host_mock.camera_hardware_version.return_value = "IPC_00001"

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -24,7 +24,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers import device_registry as dr
 from homeassistant.util.dt import utcnow
 
 from .conftest import (
@@ -212,7 +212,7 @@ async def test_options_flow(hass: HomeAssistant, mock_setup_entry: MagicMock) ->
     """Test specifying non default settings using options flow."""
     config_entry = MockConfigEntry(
         domain=const.DOMAIN,
-        unique_id=format_mac(TEST_MAC),
+        unique_id=dr.format_mac(TEST_MAC),
         data={
             CONF_HOST: TEST_HOST,
             CONF_USERNAME: TEST_USERNAME,
@@ -252,7 +252,7 @@ async def test_change_connection_settings(
     """Test changing connection settings by issuing a second user config flow."""
     config_entry = MockConfigEntry(
         domain=const.DOMAIN,
-        unique_id=format_mac(TEST_MAC),
+        unique_id=dr.format_mac(TEST_MAC),
         data={
             CONF_HOST: TEST_HOST,
             CONF_USERNAME: TEST_USERNAME,
@@ -295,7 +295,7 @@ async def test_reauth(hass: HomeAssistant, mock_setup_entry: MagicMock) -> None:
     """Test a reauth flow."""
     config_entry = MockConfigEntry(
         domain=const.DOMAIN,
-        unique_id=format_mac(TEST_MAC),
+        unique_id=dr.format_mac(TEST_MAC),
         data={
             CONF_HOST: TEST_HOST,
             CONF_USERNAME: TEST_USERNAME,
@@ -319,7 +319,7 @@ async def test_reauth(hass: HomeAssistant, mock_setup_entry: MagicMock) -> None:
             "source": config_entries.SOURCE_REAUTH,
             "entry_id": config_entry.entry_id,
             "title_placeholders": {"name": TEST_NVR_NAME},
-            "unique_id": format_mac(TEST_MAC),
+            "unique_id": dr.format_mac(TEST_MAC),
         },
         data=config_entry.data,
     )
@@ -426,6 +426,7 @@ async def test_dhcp_ip_update(
     hass: HomeAssistant,
     reolink_connect_class: MagicMock,
     reolink_connect: MagicMock,
+    device_registry: dr.DeviceRegistry,
     last_update_success: bool,
     attr: str,
     value: Any,
@@ -435,7 +436,7 @@ async def test_dhcp_ip_update(
     """Test dhcp discovery aborts if already configured where the IP is updated if appropriate."""
     config_entry = MockConfigEntry(
         domain=const.DOMAIN,
-        unique_id=format_mac(TEST_MAC),
+        unique_id=dr.format_mac(TEST_MAC),
         data={
             CONF_HOST: TEST_HOST,
             CONF_USERNAME: TEST_USERNAME,
@@ -495,3 +496,5 @@ async def test_dhcp_ip_update(
 
     await hass.async_block_till_done()
     assert config_entry.data[CONF_HOST] == expected
+
+    device_registry._data_to_save()

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -24,7 +24,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.device_registry import format_mac
 from homeassistant.util.dt import utcnow
 
 from .conftest import (
@@ -212,7 +212,7 @@ async def test_options_flow(hass: HomeAssistant, mock_setup_entry: MagicMock) ->
     """Test specifying non default settings using options flow."""
     config_entry = MockConfigEntry(
         domain=const.DOMAIN,
-        unique_id=dr.format_mac(TEST_MAC),
+        unique_id=format_mac(TEST_MAC),
         data={
             CONF_HOST: TEST_HOST,
             CONF_USERNAME: TEST_USERNAME,
@@ -252,7 +252,7 @@ async def test_change_connection_settings(
     """Test changing connection settings by issuing a second user config flow."""
     config_entry = MockConfigEntry(
         domain=const.DOMAIN,
-        unique_id=dr.format_mac(TEST_MAC),
+        unique_id=format_mac(TEST_MAC),
         data={
             CONF_HOST: TEST_HOST,
             CONF_USERNAME: TEST_USERNAME,
@@ -295,7 +295,7 @@ async def test_reauth(hass: HomeAssistant, mock_setup_entry: MagicMock) -> None:
     """Test a reauth flow."""
     config_entry = MockConfigEntry(
         domain=const.DOMAIN,
-        unique_id=dr.format_mac(TEST_MAC),
+        unique_id=format_mac(TEST_MAC),
         data={
             CONF_HOST: TEST_HOST,
             CONF_USERNAME: TEST_USERNAME,
@@ -319,7 +319,7 @@ async def test_reauth(hass: HomeAssistant, mock_setup_entry: MagicMock) -> None:
             "source": config_entries.SOURCE_REAUTH,
             "entry_id": config_entry.entry_id,
             "title_placeholders": {"name": TEST_NVR_NAME},
-            "unique_id": dr.format_mac(TEST_MAC),
+            "unique_id": format_mac(TEST_MAC),
         },
         data=config_entry.data,
     )
@@ -426,7 +426,6 @@ async def test_dhcp_ip_update(
     hass: HomeAssistant,
     reolink_connect_class: MagicMock,
     reolink_connect: MagicMock,
-    device_registry: dr.DeviceRegistry,
     last_update_success: bool,
     attr: str,
     value: Any,
@@ -436,7 +435,7 @@ async def test_dhcp_ip_update(
     """Test dhcp discovery aborts if already configured where the IP is updated if appropriate."""
     config_entry = MockConfigEntry(
         domain=const.DOMAIN,
-        unique_id=dr.format_mac(TEST_MAC),
+        unique_id=format_mac(TEST_MAC),
         data={
             CONF_HOST: TEST_HOST,
             CONF_USERNAME: TEST_USERNAME,
@@ -496,5 +495,3 @@ async def test_dhcp_ip_update(
 
     await hass.async_block_till_done()
     assert config_entry.data[CONF_HOST] == expected
-
-    device_registry._data_to_save()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix flaky Reolink tests.
Thanks @joostlek @emontnemery for making me aware of this and helping to fix it.

This was intoduced only 2 days ago when I added the model_id to the device_info.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
