### PR TITLE
Add zip to template engine

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -2844,6 +2844,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.globals["iif"] = iif
         self.globals["bool"] = forgiving_boolean
         self.globals["version"] = version
+        self.globals["zip"] = zip
         self.tests["is_number"] = is_number
         self.tests["list"] = _is_list
         self.tests["set"] = _is_set

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -6247,7 +6247,7 @@ async def test_template_thread_safety_checks(hass: HomeAssistant) -> None:
     ],
 )
 def test_zip(hass: HomeAssistant, cola, colb, expected) -> None:
-    """Test contains."""
+    """Test zip."""
     assert (
         template.Template("{{ zip(cola, colb) | list }}", hass).async_render(
             {"cola": cola, "colb": colb}
@@ -6270,7 +6270,7 @@ def test_zip(hass: HomeAssistant, cola, colb, expected) -> None:
     ],
 )
 def test_unzip(hass: HomeAssistant, col, expected) -> None:
-    """Test contayins."""
+    """Test unzipping using zip."""
     assert (
         template.Template("{{ zip(*col) | list }}", hass).async_render({"col": col})
         == expected

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -6236,3 +6236,48 @@ async def test_template_thread_safety_checks(hass: HomeAssistant) -> None:
         await hass.async_add_executor_job(template_obj.async_render_to_info)
 
     assert template_obj.async_render_to_info().result() == 23
+
+
+@pytest.mark.parametrize(
+    ("cola", "colb", "expected"),
+    [
+        ([1, 2], [3, 4], [(1, 3), (2, 4)]),
+        ([1, 2], [3, 4, 5], [(1, 3), (2, 4)]),
+        ([1, 2, 3, 4], [3, 4], [(1, 3), (2, 4)]),
+    ],
+)
+def test_zip(hass: HomeAssistant, cola, colb, expected) -> None:
+    """Test contains."""
+    assert (
+        template.Template("{{ zip(cola, colb) | list }}", hass).async_render(
+            {"cola": cola, "colb": colb}
+        )
+        == expected
+    )
+    assert (
+        template.Template(
+            "[{% for a, b in zip(cola, colb) %}({{a}}, {{b}}), {% endfor %}]", hass
+        ).async_render({"cola": cola, "colb": colb})
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("col", "expected"),
+    [
+        ([(1, 3), (2, 4)], [(1, 2), (3, 4)]),
+        (["ax", "by", "cz"], [("a", "b", "c"), ("x", "y", "z")]),
+    ],
+)
+def test_unzip(hass: HomeAssistant, col, expected) -> None:
+    """Test contayins."""
+    assert (
+        template.Template("{{ zip(*col) | list }}", hass).async_render({"col": col})
+        == expected
+    )
+    assert (
+        template.Template(
+            "{% set a, b = zip(*col) %}[{{a}}, {{b}}]", hass
+        ).async_render({"col": col})
+        == expected
+    )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add the zip function to templates.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33934

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
