### PR TITLE
Check for incompatible special chars in Reolink password

### DIFF
--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN
-from .exceptions import ReolinkException, UserNotAdmin
+from .exceptions import ReolinkException, UserNotAdmin, PasswordIncompatible
 from .host import ReolinkHost
 
 _LOGGER = logging.getLogger(__name__)
@@ -56,7 +56,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     try:
         await host.async_init()
-    except (UserNotAdmin, CredentialsInvalidError) as err:
+    except (UserNotAdmin, CredentialsInvalidError, PasswordIncompatible) as err:
         await host.stop()
         raise ConfigEntryAuthFailed(err) from err
     except (

--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN
-from .exceptions import ReolinkException, UserNotAdmin, PasswordIncompatible
+from .exceptions import PasswordIncompatible, ReolinkException, UserNotAdmin
 from .host import ReolinkHost
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/reolink/config_flow.py
+++ b/homeassistant/components/reolink/config_flow.py
@@ -30,7 +30,12 @@ from homeassistant.helpers import config_validation as cv, selector
 from homeassistant.helpers.device_registry import format_mac
 
 from .const import CONF_USE_HTTPS, DOMAIN
-from .exceptions import ReolinkException, ReolinkWebhookException, UserNotAdmin, PasswordIncompatible
+from .exceptions import (
+    PasswordIncompatible,
+    ReolinkException,
+    ReolinkWebhookException,
+    UserNotAdmin,
+)
 from .host import ReolinkHost
 from .util import is_connected
 

--- a/homeassistant/components/reolink/config_flow.py
+++ b/homeassistant/components/reolink/config_flow.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 import logging
 from typing import Any
 
+from reolink_aio.api import ALLOWED_SPECIAL_CHARS
 from reolink_aio.exceptions import ApiError, CredentialsInvalidError, ReolinkError
 import voluptuous as vol
 
@@ -29,7 +30,7 @@ from homeassistant.helpers import config_validation as cv, selector
 from homeassistant.helpers.device_registry import format_mac
 
 from .const import CONF_USE_HTTPS, DOMAIN
-from .exceptions import ReolinkException, ReolinkWebhookException, UserNotAdmin
+from .exceptions import ReolinkException, ReolinkWebhookException, UserNotAdmin, PasswordIncompatible
 from .host import ReolinkHost
 from .util import is_connected
 
@@ -206,8 +207,11 @@ class ReolinkFlowHandler(ConfigFlow, domain=DOMAIN):
                 errors[CONF_USERNAME] = "not_admin"
                 placeholders["username"] = host.api.username
                 placeholders["userlevel"] = host.api.user_level
+            except PasswordIncompatible:
+                errors[CONF_PASSWORD] = "password_incompatible"
+                placeholders["special_chars"] = ALLOWED_SPECIAL_CHARS
             except CredentialsInvalidError:
-                errors[CONF_HOST] = "invalid_auth"
+                errors[CONF_PASSWORD] = "invalid_auth"
             except ApiError as err:
                 placeholders["error"] = str(err)
                 errors[CONF_HOST] = "api_error"

--- a/homeassistant/components/reolink/exceptions.py
+++ b/homeassistant/components/reolink/exceptions.py
@@ -17,3 +17,6 @@ class ReolinkWebhookException(ReolinkException):
 
 class UserNotAdmin(ReolinkException):
     """Raised when user is not admin."""
+
+class PasswordIncompatible(ReolinkException):
+    """Raised when the password contains special chars that are incompatible."""

--- a/homeassistant/components/reolink/exceptions.py
+++ b/homeassistant/components/reolink/exceptions.py
@@ -18,5 +18,6 @@ class ReolinkWebhookException(ReolinkException):
 class UserNotAdmin(ReolinkException):
     """Raised when user is not admin."""
 
+
 class PasswordIncompatible(ReolinkException):
     """Raised when the password contains special chars that are incompatible."""

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -31,7 +31,12 @@ from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.network import NoURLAvailableError, get_url
 
 from .const import CONF_USE_HTTPS, DOMAIN
-from .exceptions import ReolinkSetupException, ReolinkWebhookException, UserNotAdmin, PasswordIncompatible
+from .exceptions import (
+    PasswordIncompatible,
+    ReolinkSetupException,
+    ReolinkWebhookException,
+    UserNotAdmin,
+)
 
 DEFAULT_TIMEOUT = 30
 FIRST_ONVIF_TIMEOUT = 10
@@ -127,10 +132,9 @@ class ReolinkHost:
             raise PasswordIncompatible(
                 "Reolink password contains incompatible special character, "
                 "please change the password to only contain characters: "
-                "a-z, A-Z, 0-9 or %s",
-                ALLOWED_SPECIAL_CHARS
+                f"a-z, A-Z, 0-9 or {ALLOWED_SPECIAL_CHARS}"
             )
-        
+
         await self._api.get_host_data()
 
         if self._api.mac_address is None:

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -11,7 +11,7 @@ from typing import Any, Literal
 
 import aiohttp
 from aiohttp.web import Request
-from reolink_aio.api import Host
+from reolink_aio.api import ALLOWED_SPECIAL_CHARS, Host
 from reolink_aio.enums import SubType
 from reolink_aio.exceptions import NotSupportedError, ReolinkError, SubscriptionError
 
@@ -31,7 +31,7 @@ from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.network import NoURLAvailableError, get_url
 
 from .const import CONF_USE_HTTPS, DOMAIN
-from .exceptions import ReolinkSetupException, ReolinkWebhookException, UserNotAdmin
+from .exceptions import ReolinkSetupException, ReolinkWebhookException, UserNotAdmin, PasswordIncompatible
 
 DEFAULT_TIMEOUT = 30
 FIRST_ONVIF_TIMEOUT = 10
@@ -123,6 +123,14 @@ class ReolinkHost:
 
     async def async_init(self) -> None:
         """Connect to Reolink host."""
+        if not self._api.valid_password():
+            raise PasswordIncompatible(
+                "Reolink password contains incompatible special character, "
+                "please change the password to only contain characters: "
+                "a-z, A-Z, 0-9 or %s",
+                ALLOWED_SPECIAL_CHARS
+            )
+        
         await self._api.get_host_data()
 
         if self._api.mac_address is None:

--- a/homeassistant/components/reolink/strings.json
+++ b/homeassistant/components/reolink/strings.json
@@ -29,6 +29,7 @@
       "cannot_connect": "Failed to connect, check the IP address of the camera",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "not_admin": "User needs to be admin, user \"{username}\" has authorisation level \"{userlevel}\"",
+      "password_incompatible": "Password contains incompatible special character, only these characters are allowed: a-z, A-Z, 0-9 or \"{special_chars}\"",
       "unknown": "[%key:common::config_flow::error::unknown%]",
       "webhook_exception": "Home Assistant URL is not available, go to Settings > System > Network > Home Assistant URL and correct the URLs, see {more_info}"
     },

--- a/homeassistant/components/reolink/strings.json
+++ b/homeassistant/components/reolink/strings.json
@@ -29,7 +29,7 @@
       "cannot_connect": "Failed to connect, check the IP address of the camera",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "not_admin": "User needs to be admin, user \"{username}\" has authorisation level \"{userlevel}\"",
-      "password_incompatible": "Password contains incompatible special character, only these characters are allowed: a-z, A-Z, 0-9 or \"{special_chars}\"",
+      "password_incompatible": "Password contains incompatible special character, only these characters are allowed: a-z, A-Z, 0-9 or {special_chars}",
       "unknown": "[%key:common::config_flow::error::unknown%]",
       "webhook_exception": "Home Assistant URL is not available, go to Settings > System > Network > Home Assistant URL and correct the URLs, see {more_info}"
     },

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -12,10 +12,7 @@ from homeassistant import config_entries
 from homeassistant.components import dhcp
 from homeassistant.components.reolink import DEVICE_UPDATE_INTERVAL, const
 from homeassistant.components.reolink.config_flow import DEFAULT_PROTOCOL
-from homeassistant.components.reolink.exceptions import (
-    PasswordIncompatible,
-    ReolinkWebhookException,
-)
+from homeassistant.components.reolink.exceptions import ReolinkWebhookException
 from homeassistant.components.reolink.host import DEFAULT_TIMEOUT
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
@@ -171,7 +168,7 @@ async def test_config_flow_errors(
     assert result["step_id"] == "user"
     assert result["errors"] == {CONF_PASSWORD: "invalid_auth"}
 
-    reolink_connect.get_host_data.side_effect = PasswordIncompatible("Test error")
+    reolink_connect.valid_password.return_value = False
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
@@ -185,6 +182,7 @@ async def test_config_flow_errors(
     assert result["step_id"] == "user"
     assert result["errors"] == {CONF_PASSWORD: "password_incompatible"}
 
+    reolink_connect.valid_password.return_value = True
     reolink_connect.get_host_data.side_effect = ApiError("Test error")
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -12,7 +12,10 @@ from homeassistant import config_entries
 from homeassistant.components import dhcp
 from homeassistant.components.reolink import DEVICE_UPDATE_INTERVAL, const
 from homeassistant.components.reolink.config_flow import DEFAULT_PROTOCOL
-from homeassistant.components.reolink.exceptions import ReolinkWebhookException
+from homeassistant.components.reolink.exceptions import (
+    PasswordIncompatible,
+    ReolinkWebhookException,
+)
 from homeassistant.components.reolink.host import DEFAULT_TIMEOUT
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
@@ -166,7 +169,21 @@ async def test_config_flow_errors(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
-    assert result["errors"] == {CONF_HOST: "invalid_auth"}
+    assert result["errors"] == {CONF_PASSWORD: "invalid_auth"}
+
+    reolink_connect.get_host_data.side_effect = PasswordIncompatible("Test error")
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_USERNAME: TEST_USERNAME,
+            CONF_PASSWORD: TEST_PASSWORD,
+            CONF_HOST: TEST_HOST,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {CONF_PASSWORD: "password_incompatible"}
 
     reolink_connect.get_host_data.side_effect = ApiError("Test error")
     result = await hass.config_entries.flow.async_configure(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Check for incompatible special chars in Reolink password since using those chars will break the RTSP, RTMP or FLV stream urls, causing errors when tyring to view the camera stream or playback videos.

During config flow the following error will be shown:
![afbeelding](https://github.com/user-attachments/assets/2e628282-188a-404b-b529-c556b3a62808)

Existing users with incompatible chars will get a re-auth flow with a simular error message.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
