### PR TITLE
Add AirTouch5 cover

### DIFF
--- a/homeassistant/components/airtouch5/__init__.py
+++ b/homeassistant/components/airtouch5/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import DOMAIN
 
-PLATFORMS: list[Platform] = [Platform.CLIMATE]
+PLATFORMS: list[Platform] = [Platform.CLIMATE, Platform.COVER]
 
 type Airtouch5ConfigEntry = ConfigEntry[Airtouch5SimpleClient]
 

--- a/homeassistant/components/airtouch5/climate.py
+++ b/homeassistant/components/airtouch5/climate.py
@@ -121,6 +121,7 @@ class Airtouch5ClimateEntity(ClimateEntity, Airtouch5Entity):
     """Base class for Airtouch5 Climate Entities."""
 
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_translation_key = DOMAIN
     _attr_target_temperature_step = 1
     _attr_name = None
     _enable_turn_on_off_backwards_compatibility = False

--- a/homeassistant/components/airtouch5/cover.py
+++ b/homeassistant/components/airtouch5/cover.py
@@ -1,4 +1,5 @@
 """Representation of the Damper for AirTouch 5 Devices."""
+
 import logging
 from typing import Any
 
@@ -17,11 +18,11 @@ from homeassistant.components.cover import (
     CoverEntity,
     CoverEntityFeature,
 )
-from . import Airtouch5ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import Airtouch5ConfigEntry
 from .const import DOMAIN
 from .entity import Airtouch5Entity
 
@@ -36,15 +37,13 @@ async def async_setup_entry(
     """Set up the Airtouch 5 Cover entities."""
     client = config_entry.runtime_data
 
-    entities: list[CoverEntity] = []
-
     # Each zone has a cover for its open percentage
-    for zone in client.zones:
-        entities.append(
-            Airtouch5ZoneOpenPercentage(
-                client, zone, client.latest_zone_status[zone.zone_number].has_sensor
-            )
+    entities = [
+        Airtouch5ZoneOpenPercentage(
+            client, zone, client.latest_zone_status[zone.zone_number].has_sensor
         )
+        for zone in client.zones
+    ]
 
     async_add_entities(entities)
 
@@ -73,10 +72,10 @@ class Airtouch5ZoneOpenPercentage(CoverEntity, Airtouch5Entity):
         # Zones with temperature sensors shouldn't be manually controlled.
         # We allow it but warn the user in the integration documentation.
         self._attr_supported_features = (
-                CoverEntityFeature.SET_POSITION
-                | CoverEntityFeature.OPEN
-                | CoverEntityFeature.CLOSE
-            )
+            CoverEntityFeature.SET_POSITION
+            | CoverEntityFeature.OPEN
+            | CoverEntityFeature.CLOSE
+        )
 
     @callback
     def _async_update_attrs(self, data: dict[int, ZoneStatusZone]) -> None:
@@ -125,13 +124,13 @@ class Airtouch5ZoneOpenPercentage(CoverEntity, Airtouch5Entity):
             power = ZoneSettingPower.SET_TO_OFF
         else:
             power = ZoneSettingPower.SET_TO_ON
-        
+
         zcz = ZoneControlZone(
             self._name.zone_number,
             ZoneSettingValue.SET_OPEN_PERCENTAGE,
             power,
             position_percent / 100.0,
         )
-        
+
         packet = self._client.data_packet_factory.zone_control([zcz])
         await self._client.send_packet(packet)

--- a/homeassistant/components/airtouch5/cover.py
+++ b/homeassistant/components/airtouch5/cover.py
@@ -1,0 +1,139 @@
+"""Representation of the Damper for AirTouch 5 Devices."""
+import logging
+from typing import Any
+
+from airtouch5py.airtouch5_simple_client import Airtouch5SimpleClient
+from airtouch5py.packets.zone_control import (
+    ZoneControlZone,
+    ZoneSettingPower,
+    ZoneSettingValue,
+)
+from airtouch5py.packets.zone_name import ZoneName
+from airtouch5py.packets.zone_status import ZoneStatusZone
+
+from homeassistant.components.cover import (
+    ATTR_POSITION,
+    CoverDeviceClass,
+    CoverEntity,
+    CoverEntityFeature,
+)
+from . import Airtouch5ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .entity import Airtouch5Entity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: Airtouch5ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Airtouch 5 Cover entities."""
+    client = config_entry.runtime_data
+
+    entities: list[CoverEntity] = []
+
+    # Each zone has a cover for its open percentage
+    for zone in client.zones:
+        entities.append(
+            Airtouch5ZoneOpenPercentage(
+                client, zone, client.latest_zone_status[zone.zone_number].has_sensor
+            )
+        )
+
+    async_add_entities(entities)
+
+
+class Airtouch5ZoneOpenPercentage(CoverEntity, Airtouch5Entity):
+    """How open the damper is in each zone."""
+
+    _attr_device_class = CoverDeviceClass.DAMPER
+
+    def __init__(
+        self, client: Airtouch5SimpleClient, name: ZoneName, has_sensor: bool
+    ) -> None:
+        """Initialise the Cover Entity."""
+        super().__init__(client)
+        self._name = name
+
+        self._attr_unique_id = f"zone_{name.zone_number}_open_percentage"
+        self._attr_name = "Damper"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"zone_{name.zone_number}")},
+            name=name.zone_name,
+            manufacturer="Polyaire",
+            model="AirTouch 5",
+        )
+
+        # Zones with temperature sensors shouldn't be manually controlled
+        if has_sensor:
+            self._attr_supported_features = CoverEntityFeature(0)
+        else:
+            self._attr_supported_features = (
+                CoverEntityFeature.SET_POSITION
+                | CoverEntityFeature.OPEN
+                | CoverEntityFeature.CLOSE
+            )
+
+    @callback
+    def _async_update_attrs(self, data: dict[int, ZoneStatusZone]) -> None:
+        if self._name.zone_number not in data:
+            return
+        status = data[self._name.zone_number]
+
+        self._attr_current_cover_position = int(status.open_percentage * 100)
+        if status.open_percentage == 0:
+            self._attr_is_closed = True
+        else:
+            self._attr_is_closed = False
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Add data updated listener after this object has been initialized."""
+        await super().async_added_to_hass()
+        self._client.zone_status_callbacks.append(self._async_update_attrs)
+        self._async_update_attrs(self._client.latest_zone_status)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove data updated listener after this object has been initialized."""
+        await super().async_will_remove_from_hass()
+        self._client.zone_status_callbacks.remove(self._async_update_attrs)
+
+    async def async_open_cover(self, **kwargs: Any) -> None:
+        """Open the damper."""
+        await self._set_cover_position(100)
+
+    async def async_close_cover(self, **kwargs: Any) -> None:
+        """Close damper."""
+        await self._set_cover_position(0)
+
+    async def async_set_cover_position(self, **kwargs: Any) -> None:
+        """Update the damper to a specific position."""
+
+        if (position := kwargs.get(ATTR_POSITION)) is None:
+            _LOGGER.debug("Argument `position` is missing in set_cover_position")
+            return
+        await self._set_cover_position(position)
+
+    async def _set_cover_position(self, position_percent: float) -> None:
+        power: ZoneSettingPower
+
+        if position_percent == 0:
+            power = ZoneSettingPower.SET_TO_OFF
+        else:
+            power = ZoneSettingPower.SET_TO_ON
+        
+        zcz = ZoneControlZone(
+            self._name.zone_number,
+            ZoneSettingValue.SET_OPEN_PERCENTAGE,
+            power,
+            position_percent / 100.0,
+        )
+        
+        packet = self._client.data_packet_factory.zone_control([zcz])
+        await self._client.send_packet(packet)

--- a/homeassistant/components/airtouch5/cover.py
+++ b/homeassistant/components/airtouch5/cover.py
@@ -68,11 +68,9 @@ class Airtouch5ZoneOpenPercentage(CoverEntity, Airtouch5Entity):
             model="AirTouch 5",
         )
 
-        # Zones with temperature sensors shouldn't be manually controlled
-        if has_sensor:
-            self._attr_supported_features = CoverEntityFeature(0)
-        else:
-            self._attr_supported_features = (
+        # Zones with temperature sensors shouldn't be manually controlled.
+        # We allow it but warn the user in the integration documentation.
+        self._attr_supported_features = (
                 CoverEntityFeature.SET_POSITION
                 | CoverEntityFeature.OPEN
                 | CoverEntityFeature.CLOSE

--- a/homeassistant/components/airtouch5/cover.py
+++ b/homeassistant/components/airtouch5/cover.py
@@ -59,8 +59,6 @@ class Airtouch5ZoneOpenPercentage(CoverEntity, Airtouch5Entity):
     ) -> None:
         """Initialise the Cover Entity."""
         super().__init__(client)
-        self._name = name
-
         self._attr_unique_id = f"zone_{name.zone_number}_open_percentage"
         self._attr_name = "Damper"
         self._attr_device_info = DeviceInfo(

--- a/homeassistant/components/airtouch5/cover.py
+++ b/homeassistant/components/airtouch5/cover.py
@@ -59,6 +59,8 @@ class Airtouch5ZoneOpenPercentage(CoverEntity, Airtouch5Entity):
     ) -> None:
         """Initialise the Cover Entity."""
         super().__init__(client)
+        self._name = name
+
         self._attr_unique_id = f"zone_{name.zone_number}_open_percentage"
         self._attr_name = "Damper"
         self._attr_device_info = DeviceInfo(

--- a/homeassistant/components/airtouch5/entity.py
+++ b/homeassistant/components/airtouch5/entity.py
@@ -6,15 +6,12 @@ from airtouch5py.airtouch5_simple_client import Airtouch5SimpleClient
 from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
 
-from .const import DOMAIN
-
 
 class Airtouch5Entity(Entity):
     """Base class for Airtouch5 entities."""
 
     _attr_should_poll = False
     _attr_has_entity_name = True
-    _attr_translation_key = DOMAIN
 
     def __init__(self, client: Airtouch5SimpleClient) -> None:
         """Initialise the Entity."""

--- a/homeassistant/components/airtouch5/strings.json
+++ b/homeassistant/components/airtouch5/strings.json
@@ -27,6 +27,11 @@
           }
         }
       }
+    },
+    "cover": {
+      "damper": {
+        "name": "[%key:component::cover::entity_component::damper::name%]"
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Each zone of the AirTouch5 has a damper that can be controlled as a cover. This PR adds the cover entity to the integration.

The original AirTouch5 integration PR #98136 initially had 3 platforms but reduce that down to 1 to meet the PR standards. Recently some users, myself included, asked for the cover entity to be added. See: https://github.com/danzel/airtouch5py/issues/2

I dug up the original cover.py file and updated it to make it work. Original work done by @danzel.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/danzel/airtouch5py/issues/2
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33940

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
