### PR TITLE
Remigrate device_registry created_at/modified_at

### DIFF
--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -57,7 +57,7 @@ EVENT_DEVICE_REGISTRY_UPDATED: EventType[EventDeviceRegistryUpdatedData] = Event
 )
 STORAGE_KEY = "core.device_registry"
 STORAGE_VERSION_MAJOR = 1
-STORAGE_VERSION_MINOR = 7
+STORAGE_VERSION_MINOR = 8
 
 CLEANUP_DELAY = 10
 
@@ -503,14 +503,16 @@ class DeviceRegistryStore(storage.Store[dict[str, list[dict[str, Any]]]]):
                 # Introduced in 2024.7
                 for device in old_data["devices"]:
                     device["primary_config_entry"] = None
-            if old_minor_version < 7:
+            if old_minor_version < 8:
                 # Introduced in 2024.8
                 created_at = utc_from_timestamp(0).isoformat()
                 for device in old_data["devices"]:
-                    device["model_id"] = None
-                    device["created_at"] = device["modified_at"] = created_at
+                    device.setdefault("model_id", None)
+                    device.setdefault("created_at", created_at)
+                    device.setdefault("modified_at", created_at)
                 for device in old_data["deleted_devices"]:
-                    device["created_at"] = device["modified_at"] = created_at
+                    device.setdefault("created_at", created_at)
+                    device.setdefault("modified_at", created_at)
 
         if old_major_version > 1:
             raise NotImplementedError

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -503,15 +503,14 @@ class DeviceRegistryStore(storage.Store[dict[str, list[dict[str, Any]]]]):
                 # Introduced in 2024.7
                 for device in old_data["devices"]:
                     device["primary_config_entry"] = None
-            if old_minor_version < 8:
+            if old_minor_version < 7:
                 # Introduced in 2024.8
-                # Note that 7 is skipped because the migration was initially
-                # missed and we want to ensure the keys exist if a version
-                # without the migration was installed since it will prevent
-                # successful startup if the keys are missing.
-                created_at = utc_from_timestamp(0).isoformat()
                 for device in old_data["devices"]:
                     device["model_id"] = None
+            if old_minor_version < 8:
+                # Introduced in 2024.8
+                created_at = utc_from_timestamp(0).isoformat()
+                for device in old_data["devices"]:
                     device["created_at"] = device["modified_at"] = created_at
                 for device in old_data["deleted_devices"]:
                     device["created_at"] = device["modified_at"] = created_at

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -505,14 +505,16 @@ class DeviceRegistryStore(storage.Store[dict[str, list[dict[str, Any]]]]):
                     device["primary_config_entry"] = None
             if old_minor_version < 8:
                 # Introduced in 2024.8
+                # Note that 7 is skipped because the migration was initially
+                # missed and we want to ensure the keys exist if a version
+                # without the migration was installed since it will prevent
+                # successful startup if the keys are missing.
                 created_at = utc_from_timestamp(0).isoformat()
                 for device in old_data["devices"]:
-                    device.setdefault("model_id", None)
-                    device.setdefault("created_at", created_at)
-                    device.setdefault("modified_at", created_at)
+                    device["model_id"] = None
+                    device["created_at"] = device["modified_at"] = created_at
                 for device in old_data["deleted_devices"]:
-                    device.setdefault("created_at", created_at)
-                    device.setdefault("modified_at", created_at)
+                    device["created_at"] = device["modified_at"] = created_at
 
         if old_major_version > 1:
             raise NotImplementedError

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -993,15 +993,17 @@ async def test_migration_1_5_to_1_7(
 
 @pytest.mark.parametrize("load_registries", [False])
 @pytest.mark.usefixtures("freezer")
-async def test_migration_1_6_to_1_7(
+@pytest.mark.parametrize("version", [6, 7])
+async def test_migration_1_6_or_7_to_1_8(
     hass: HomeAssistant,
     hass_storage: dict[str, Any],
     mock_config_entry: MockConfigEntry,
+    version: int,
 ) -> None:
-    """Test migration from version 1.6 to 1.7."""
+    """Test migration from version 1.6/1.7 to 1.8."""
     hass_storage[dr.STORAGE_KEY] = {
         "version": 1,
-        "minor_version": 6,
+        "minor_version": version,
         "key": dr.STORAGE_KEY,
         "data": {
             "devices": [
@@ -1096,148 +1098,6 @@ async def test_migration_1_6_to_1_7(
                     "name": "name",
                     "model_id": None,
                     "modified_at": "1970-01-01T00:00:00+00:00",
-                    "name_by_user": None,
-                    "primary_config_entry": mock_config_entry.entry_id,
-                    "serial_number": None,
-                    "sw_version": "new_version",
-                    "via_device_id": None,
-                },
-                {
-                    "area_id": None,
-                    "config_entries": [None],
-                    "configuration_url": None,
-                    "connections": [],
-                    "created_at": "1970-01-01T00:00:00+00:00",
-                    "disabled_by": None,
-                    "entry_type": None,
-                    "hw_version": None,
-                    "id": "invalid-entry-type",
-                    "identifiers": [["serial", "mock-id-invalid-entry"]],
-                    "labels": ["blah"],
-                    "manufacturer": None,
-                    "model": None,
-                    "model_id": None,
-                    "modified_at": "1970-01-01T00:00:00+00:00",
-                    "name_by_user": None,
-                    "name": None,
-                    "primary_config_entry": None,
-                    "serial_number": None,
-                    "sw_version": None,
-                    "via_device_id": None,
-                },
-            ],
-            "deleted_devices": [],
-        },
-    }
-
-
-@pytest.mark.parametrize("load_registries", [False])
-@pytest.mark.usefixtures("freezer")
-async def test_migration_1_7_to_1_8(
-    hass: HomeAssistant,
-    hass_storage: dict[str, Any],
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test migration from version 1.7 to 1.8."""
-    hass_storage[dr.STORAGE_KEY] = {
-        "version": 1,
-        "minor_version": 6,
-        "key": dr.STORAGE_KEY,
-        "data": {
-            "devices": [
-                {
-                    "area_id": None,
-                    "config_entries": [mock_config_entry.entry_id],
-                    "configuration_url": None,
-                    "connections": [["Zigbee", "01.23.45.67.89"]],
-                    "created_at": "2024-01-01T01:00:00+00:00",
-                    "modified_at": "2024-01-01T01:00:00+00:00",
-                    "disabled_by": None,
-                    "entry_type": "service",
-                    "hw_version": "hw_version",
-                    "id": "abcdefghijklm",
-                    "identifiers": [["serial", "123456ABCDEF"]],
-                    "labels": ["blah"],
-                    "manufacturer": "manufacturer",
-                    "model": "model",
-                    "name": "name",
-                    "name_by_user": None,
-                    "primary_config_entry": mock_config_entry.entry_id,
-                    "serial_number": None,
-                    "sw_version": "new_version",
-                    "via_device_id": None,
-                },
-                {
-                    "area_id": None,
-                    "config_entries": [None],
-                    "configuration_url": None,
-                    "connections": [],
-                    "disabled_by": None,
-                    "entry_type": None,
-                    "hw_version": None,
-                    "id": "invalid-entry-type",
-                    "identifiers": [["serial", "mock-id-invalid-entry"]],
-                    "labels": ["blah"],
-                    "manufacturer": None,
-                    "model": None,
-                    "name_by_user": None,
-                    "primary_config_entry": None,
-                    "name": None,
-                    "serial_number": None,
-                    "sw_version": None,
-                    "via_device_id": None,
-                },
-            ],
-            "deleted_devices": [],
-        },
-    }
-
-    await dr.async_load(hass)
-    registry = dr.async_get(hass)
-
-    # Test data was loaded
-    entry = registry.async_get_or_create(
-        config_entry_id=mock_config_entry.entry_id,
-        connections={("Zigbee", "01.23.45.67.89")},
-        identifiers={("serial", "123456ABCDEF")},
-    )
-    assert entry.id == "abcdefghijklm"
-
-    # Update to trigger a store
-    entry = registry.async_get_or_create(
-        config_entry_id=mock_config_entry.entry_id,
-        connections={("Zigbee", "01.23.45.67.89")},
-        identifiers={("serial", "123456ABCDEF")},
-        sw_version="new_version",
-    )
-    assert entry.id == "abcdefghijklm"
-
-    # Check we store migrated data
-    await flush_store(registry._store)
-
-    assert hass_storage[dr.STORAGE_KEY] == {
-        "version": dr.STORAGE_VERSION_MAJOR,
-        "minor_version": dr.STORAGE_VERSION_MINOR,
-        "key": dr.STORAGE_KEY,
-        "data": {
-            "devices": [
-                {
-                    "area_id": None,
-                    "config_entries": [mock_config_entry.entry_id],
-                    "configuration_url": None,
-                    "connections": [["Zigbee", "01.23.45.67.89"]],
-                    "created_at": "2024-01-01T01:00:00+00:00",
-                    "disabled_by": None,
-                    "entry_type": "service",
-                    "hw_version": "hw_version",
-                    "id": "abcdefghijklm",
-                    "identifiers": [["serial", "123456ABCDEF"]],
-                    "labels": ["blah"],
-                    "manufacturer": "manufacturer",
-                    "model": "model",
-                    "name": "name",
-                    "model_id": None,
-                    "modified_at": "2024-01-01T01:00:00+00:00",
                     "name_by_user": None,
                     "primary_config_entry": mock_config_entry.entry_id,
                     "serial_number": None,

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -1131,6 +1131,148 @@ async def test_migration_1_6_to_1_7(
     }
 
 
+@pytest.mark.parametrize("load_registries", [False])
+@pytest.mark.usefixtures("freezer")
+async def test_migration_1_7_to_1_8(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test migration from version 1.7 to 1.8."""
+    hass_storage[dr.STORAGE_KEY] = {
+        "version": 1,
+        "minor_version": 6,
+        "key": dr.STORAGE_KEY,
+        "data": {
+            "devices": [
+                {
+                    "area_id": None,
+                    "config_entries": [mock_config_entry.entry_id],
+                    "configuration_url": None,
+                    "connections": [["Zigbee", "01.23.45.67.89"]],
+                    "created_at": "2024-01-01T01:00:00+00:00",
+                    "modified_at": "2024-01-01T01:00:00+00:00",
+                    "disabled_by": None,
+                    "entry_type": "service",
+                    "hw_version": "hw_version",
+                    "id": "abcdefghijklm",
+                    "identifiers": [["serial", "123456ABCDEF"]],
+                    "labels": ["blah"],
+                    "manufacturer": "manufacturer",
+                    "model": "model",
+                    "name": "name",
+                    "name_by_user": None,
+                    "primary_config_entry": mock_config_entry.entry_id,
+                    "serial_number": None,
+                    "sw_version": "new_version",
+                    "via_device_id": None,
+                },
+                {
+                    "area_id": None,
+                    "config_entries": [None],
+                    "configuration_url": None,
+                    "connections": [],
+                    "disabled_by": None,
+                    "entry_type": None,
+                    "hw_version": None,
+                    "id": "invalid-entry-type",
+                    "identifiers": [["serial", "mock-id-invalid-entry"]],
+                    "labels": ["blah"],
+                    "manufacturer": None,
+                    "model": None,
+                    "name_by_user": None,
+                    "primary_config_entry": None,
+                    "name": None,
+                    "serial_number": None,
+                    "sw_version": None,
+                    "via_device_id": None,
+                },
+            ],
+            "deleted_devices": [],
+        },
+    }
+
+    await dr.async_load(hass)
+    registry = dr.async_get(hass)
+
+    # Test data was loaded
+    entry = registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        connections={("Zigbee", "01.23.45.67.89")},
+        identifiers={("serial", "123456ABCDEF")},
+    )
+    assert entry.id == "abcdefghijklm"
+
+    # Update to trigger a store
+    entry = registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        connections={("Zigbee", "01.23.45.67.89")},
+        identifiers={("serial", "123456ABCDEF")},
+        sw_version="new_version",
+    )
+    assert entry.id == "abcdefghijklm"
+
+    # Check we store migrated data
+    await flush_store(registry._store)
+
+    assert hass_storage[dr.STORAGE_KEY] == {
+        "version": dr.STORAGE_VERSION_MAJOR,
+        "minor_version": dr.STORAGE_VERSION_MINOR,
+        "key": dr.STORAGE_KEY,
+        "data": {
+            "devices": [
+                {
+                    "area_id": None,
+                    "config_entries": [mock_config_entry.entry_id],
+                    "configuration_url": None,
+                    "connections": [["Zigbee", "01.23.45.67.89"]],
+                    "created_at": "2024-01-01T01:00:00+00:00",
+                    "disabled_by": None,
+                    "entry_type": "service",
+                    "hw_version": "hw_version",
+                    "id": "abcdefghijklm",
+                    "identifiers": [["serial", "123456ABCDEF"]],
+                    "labels": ["blah"],
+                    "manufacturer": "manufacturer",
+                    "model": "model",
+                    "name": "name",
+                    "model_id": None,
+                    "modified_at": "2024-01-01T01:00:00+00:00",
+                    "name_by_user": None,
+                    "primary_config_entry": mock_config_entry.entry_id,
+                    "serial_number": None,
+                    "sw_version": "new_version",
+                    "via_device_id": None,
+                },
+                {
+                    "area_id": None,
+                    "config_entries": [None],
+                    "configuration_url": None,
+                    "connections": [],
+                    "created_at": "1970-01-01T00:00:00+00:00",
+                    "disabled_by": None,
+                    "entry_type": None,
+                    "hw_version": None,
+                    "id": "invalid-entry-type",
+                    "identifiers": [["serial", "mock-id-invalid-entry"]],
+                    "labels": ["blah"],
+                    "manufacturer": None,
+                    "model": None,
+                    "model_id": None,
+                    "modified_at": "1970-01-01T00:00:00+00:00",
+                    "name_by_user": None,
+                    "name": None,
+                    "primary_config_entry": None,
+                    "serial_number": None,
+                    "sw_version": None,
+                    "via_device_id": None,
+                },
+            ],
+            "deleted_devices": [],
+        },
+    }
+
+
 async def test_removing_config_entries(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry
 ) -> None:


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Nightly current does not boot up because the device registry will have KeyError: created_at if the previous nightly was installed.

Rather than everyone having to make usb drives and fix their systems (I have 8 and its taking me about 45 minutes to recover each system) or manually patch their device registry in the dev containers, we can migrate again.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
