### PR TITLE
Extend Matter select entity

### DIFF
--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -134,6 +134,9 @@
     "select": {
       "mode": {
         "name": "Mode"
+      },
+      "startup_on_off": {
+        "name": "Power-on behavior on Startup"
       }
     },
     "sensor": {

--- a/tests/components/matter/test_select.py
+++ b/tests/components/matter/test_select.py
@@ -107,3 +107,25 @@ async def test_microwave_select_entities(
     await trigger_subscription_callback(hass, matter_client)
     state = hass.states.get("select.microwave_oven_mode")
     assert state.state == "Defrost"
+
+
+@pytest.mark.parametrize("expected_lingering_tasks", [True])
+async def test_attribute_select_entities(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    light_node: MatterNode,
+) -> None:
+    """Test select entities are created for attribute based discovery schema(s)."""
+    entity_id = "select.mock_dimmable_light_power_on_behavior_on_startup"
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "Previous"
+    assert state.attributes["options"] == ["On", "Off", "Toggle", "Previous"]
+    assert (
+        state.attributes["friendly_name"]
+        == "Mock Dimmable Light Power-on behavior on Startup"
+    )
+    set_node_attribute(light_node, 1, 6, 16387, 1)
+    await trigger_subscription_callback(hass, matter_client)
+    state = hass.states.get(entity_id)
+    assert state.state == "On"


### PR DESCRIPTION
## Proposed change

- Implement a generic Select entity that simply maps a value from a cluster attribute and can use write attribute to set a new option.

- Include one reference implementation for "Startup On behavior" of the On cluster (to select if a device should turn on/off/restore when power is restored)


![Scherm­afbeelding 2024-07-24 om 11 11 53](https://github.com/user-attachments/assets/05c9bb36-3d13-4158-9977-f082e28474d7)



## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
