### PR TITLE
Fix double template error for service data

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -665,6 +665,9 @@ def template(value: Any | None) -> template_helper.Template:
 
     template_value = template_helper.Template(str(value), async_get_hass_or_none())
 
+    if isinstance(value, template_helper.RenderedTemplateResultStrWrapper):
+        template_value.is_static = True
+
     try:
         template_value.ensure_valid()
     except TemplateError as ex:
@@ -682,6 +685,9 @@ def dynamic_template(value: Any | None) -> template_helper.Template:
         raise vol.Invalid("template value does not contain a dynamic template")
 
     template_value = template_helper.Template(str(value), async_get_hass_or_none())
+
+    if isinstance(value, template_helper.RenderedTemplateResultStrWrapper):
+        template_value.is_static = True
 
     try:
         template_value.ensure_valid()

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -319,6 +319,12 @@ RESULT_WRAPPERS: dict[type, type] = {kls: gen_result_wrapper(kls) for kls in _ty
 RESULT_WRAPPERS[tuple] = TupleWrapper
 
 
+class RenderedTemplateResultStrWrapper(str):
+    """Wrapper class to store template result string to avoid double renders."""
+
+    __slots__ = ()
+
+
 def _true(arg: str) -> bool:
     return True
 
@@ -618,7 +624,7 @@ class Template:
         except (ValueError, TypeError, SyntaxError, MemoryError):
             pass
 
-        return render_result
+        return RenderedTemplateResultStrWrapper(render_result)
 
     async def async_render_will_timeout(
         self,

--- a/tests/components/template/test_config_flow.py
+++ b/tests/components/template/test_config_flow.py
@@ -968,7 +968,7 @@ async def test_config_flow_preview_bad_state(
             "Sensor None has device class 'None', state class 'None' unit '°C' "
             "and suggested precision 'None' thus indicating it has a numeric "
             "value; however, it has the non-numeric value: 'unknown' (<class "
-            "'str'>)"
+            "'homeassistant.helpers.template.RenderedTemplateResultStrWrapper'>)"
         ),
     }
 


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

**Issue #109668 Summary:** Services that define `data` or `data_template` will attempt to render a template twice if the service also defines a `Schema` for the attribute with a template, i.e. `cv.template`. This works fine if a script/automation defines a template for which `is_static` is true, for instance, but results in an incorrect value when the template returns something that has templating characters in it (raising an error for an invalid template or just getting an incorrect value when the template is valid). See below for an example.

This change makes it so the value that's returned when a `Template` is rendered can be type-checked during [schema evaluation in the service call](https://github.com/home-assistant/core/blob/e1e64be3c9a2597ca17f77ba1ae6c8dbb063eef3/homeassistant/core.py#L2728). The validation can then mark the template that it creates as static so it won't be re-rendered.

This fixes https://github.com/home-assistant/core/issues/109668.

#### Example

I discovered this when trying to use the notify service to send information about errors appearing in the main log file. Some messages I'm trying to send include errors about failures in templates, and could be truncated. So, for example:

```yaml
service: notify.mobile_app_my_phone
data:
  title: Error in system log
  message: "The following error just occurred: {{ error }}"
```

When `error` is, for example, `Template variable warning: 'name' is undefined when rendering '{% set device_id =...`, message should result in:

```
The following error just occurred: Template variable warning: 'name' is undefined when rendering '{% set device_id =...
```

But the result is that a template error is generated since `message` is re-templated a second time (with the above, which isn't a valid template itself).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #109668
- This PR is related to issue:  #109668
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

**The above do not apply to this PR.**

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

**The above do not apply to this PR.**

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
