### PR TITLE
Avoid nesting sessions in recorder purge tests

### DIFF
--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -85,12 +85,12 @@ async def test_purge_big_database(hass: HomeAssistant, recorder_mock: Recorder) 
     with (
         patch.object(recorder_mock, "max_bind_vars", 72),
         patch.object(recorder_mock.database_engine, "max_bind_vars", 72),
-        session_scope(hass=hass) as session,
     ):
-        states = session.query(States)
-        state_attributes = session.query(StateAttributes)
-        assert states.count() == 72
-        assert state_attributes.count() == 3
+        with session_scope(hass=hass) as session:
+            states = session.query(States)
+            state_attributes = session.query(StateAttributes)
+            assert states.count() == 72
+            assert state_attributes.count() == 3
 
         purge_before = dt_util.utcnow() - timedelta(days=4)
 
@@ -102,8 +102,12 @@ async def test_purge_big_database(hass: HomeAssistant, recorder_mock: Recorder) 
             repack=False,
         )
         assert not finished
-        assert states.count() == 24
-        assert state_attributes.count() == 1
+
+        with session_scope(hass=hass) as session:
+            states = session.query(States)
+            state_attributes = session.query(StateAttributes)
+            assert states.count() == 24
+            assert state_attributes.count() == 1
 
 
 async def test_purge_old_states(hass: HomeAssistant, recorder_mock: Recorder) -> None:
@@ -122,24 +126,30 @@ async def test_purge_old_states(hass: HomeAssistant, recorder_mock: Recorder) ->
 
         events = session.query(Events).filter(Events.event_type == "state_changed")
         assert events.count() == 0
-        assert "test.recorder2" in recorder_mock.states_manager._last_committed_id
 
-        purge_before = dt_util.utcnow() - timedelta(days=4)
+    assert "test.recorder2" in recorder_mock.states_manager._last_committed_id
 
-        # run purge_old_data()
-        finished = purge_old_data(
-            recorder_mock,
-            purge_before,
-            states_batch_size=1,
-            events_batch_size=1,
-            repack=False,
-        )
-        assert not finished
+    purge_before = dt_util.utcnow() - timedelta(days=4)
+
+    # run purge_old_data()
+    finished = purge_old_data(
+        recorder_mock,
+        purge_before,
+        states_batch_size=1,
+        events_batch_size=1,
+        repack=False,
+    )
+    assert not finished
+
+    with session_scope(hass=hass) as session:
+        states = session.query(States)
+        state_attributes = session.query(StateAttributes)
         assert states.count() == 2
         assert state_attributes.count() == 1
 
-        assert "test.recorder2" in recorder_mock.states_manager._last_committed_id
+    assert "test.recorder2" in recorder_mock.states_manager._last_committed_id
 
+    with session_scope(hass=hass) as session:
         states_after_purge = list(session.query(States))
         # Since these states are deleted in batches, we can't guarantee the order
         # but we can look them up by state
@@ -150,27 +160,33 @@ async def test_purge_old_states(hass: HomeAssistant, recorder_mock: Recorder) ->
         assert dontpurgeme_5.old_state_id == dontpurgeme_4.state_id
         assert dontpurgeme_4.old_state_id is None
 
-        finished = purge_old_data(recorder_mock, purge_before, repack=False)
-        assert finished
+    finished = purge_old_data(recorder_mock, purge_before, repack=False)
+    assert finished
+
+    with session_scope(hass=hass) as session:
+        states = session.query(States)
+        state_attributes = session.query(StateAttributes)
         assert states.count() == 2
         assert state_attributes.count() == 1
 
-        assert "test.recorder2" in recorder_mock.states_manager._last_committed_id
+    assert "test.recorder2" in recorder_mock.states_manager._last_committed_id
 
-        # run purge_old_data again
-        purge_before = dt_util.utcnow()
-        finished = purge_old_data(
-            recorder_mock,
-            purge_before,
-            states_batch_size=1,
-            events_batch_size=1,
-            repack=False,
-        )
-        assert not finished
+    # run purge_old_data again
+    purge_before = dt_util.utcnow()
+    finished = purge_old_data(
+        recorder_mock,
+        purge_before,
+        states_batch_size=1,
+        events_batch_size=1,
+        repack=False,
+    )
+    assert not finished
+
+    with session_scope(hass=hass) as session:
         assert states.count() == 0
         assert state_attributes.count() == 0
 
-        assert "test.recorder2" not in recorder_mock.states_manager._last_committed_id
+    assert "test.recorder2" not in recorder_mock.states_manager._last_committed_id
 
     # Add some more states
     await _add_test_states(hass)
@@ -290,29 +306,39 @@ async def test_purge_old_events(hass: HomeAssistant, recorder_mock: Recorder) ->
         )
         assert events.count() == 6
 
-        purge_before = dt_util.utcnow() - timedelta(days=4)
+    purge_before = dt_util.utcnow() - timedelta(days=4)
 
-        # run purge_old_data()
-        finished = purge_old_data(
-            recorder_mock,
-            purge_before,
-            repack=False,
-            events_batch_size=1,
-            states_batch_size=1,
+    # run purge_old_data()
+    finished = purge_old_data(
+        recorder_mock,
+        purge_before,
+        repack=False,
+        events_batch_size=1,
+        states_batch_size=1,
+    )
+    assert not finished
+
+    with session_scope(hass=hass) as session:
+        events = session.query(Events).filter(
+            Events.event_type_id.in_(select_event_type_ids(TEST_EVENT_TYPES))
         )
-        assert not finished
         all_events = events.all()
         assert events.count() == 2, f"Should have 2 events left: {all_events}"
 
-        # we should only have 2 events left
-        finished = purge_old_data(
-            recorder_mock,
-            purge_before,
-            repack=False,
-            events_batch_size=1,
-            states_batch_size=1,
+    # we should only have 2 events left
+    finished = purge_old_data(
+        recorder_mock,
+        purge_before,
+        repack=False,
+        events_batch_size=1,
+        states_batch_size=1,
+    )
+    assert finished
+
+    with session_scope(hass=hass) as session:
+        events = session.query(Events).filter(
+            Events.event_type_id.in_(select_event_type_ids(TEST_EVENT_TYPES))
         )
-        assert finished
         assert events.count() == 2
 
 
@@ -327,26 +353,29 @@ async def test_purge_old_recorder_runs(
         recorder_runs = session.query(RecorderRuns)
         assert recorder_runs.count() == 7
 
-        purge_before = dt_util.utcnow()
+    purge_before = dt_util.utcnow()
 
-        # run purge_old_data()
-        finished = purge_old_data(
-            recorder_mock,
-            purge_before,
-            repack=False,
-            events_batch_size=1,
-            states_batch_size=1,
-        )
-        assert not finished
+    # run purge_old_data()
+    finished = purge_old_data(
+        recorder_mock,
+        purge_before,
+        repack=False,
+        events_batch_size=1,
+        states_batch_size=1,
+    )
+    assert not finished
 
-        finished = purge_old_data(
-            recorder_mock,
-            purge_before,
-            repack=False,
-            events_batch_size=1,
-            states_batch_size=1,
-        )
-        assert finished
+    finished = purge_old_data(
+        recorder_mock,
+        purge_before,
+        repack=False,
+        events_batch_size=1,
+        states_batch_size=1,
+    )
+    assert finished
+
+    with session_scope(hass=hass) as session:
+        recorder_runs = session.query(RecorderRuns)
         assert recorder_runs.count() == 1
 
 
@@ -361,14 +390,17 @@ async def test_purge_old_statistics_runs(
         statistics_runs = session.query(StatisticsRuns)
         assert statistics_runs.count() == 7
 
-        purge_before = dt_util.utcnow()
+    purge_before = dt_util.utcnow()
 
-        # run purge_old_data()
-        finished = purge_old_data(recorder_mock, purge_before, repack=False)
-        assert not finished
+    # run purge_old_data()
+    finished = purge_old_data(recorder_mock, purge_before, repack=False)
+    assert not finished
 
-        finished = purge_old_data(recorder_mock, purge_before, repack=False)
-        assert finished
+    finished = purge_old_data(recorder_mock, purge_before, repack=False)
+    assert finished
+
+    with session_scope(hass=hass) as session:
+        statistics_runs = session.query(StatisticsRuns)
         assert statistics_runs.count() == 1
 
 
@@ -1655,39 +1687,54 @@ async def test_purge_many_old_events(
             )
             assert events.count() == old_events_count * 6
 
-            purge_before = dt_util.utcnow() - timedelta(days=4)
+        purge_before = dt_util.utcnow() - timedelta(days=4)
 
-            # run purge_old_data()
-            finished = purge_old_data(
-                recorder_mock,
-                purge_before,
-                repack=False,
-                states_batch_size=3,
-                events_batch_size=3,
+        # run purge_old_data()
+        finished = purge_old_data(
+            recorder_mock,
+            purge_before,
+            repack=False,
+            states_batch_size=3,
+            events_batch_size=3,
+        )
+        assert not finished
+
+        with session_scope(hass=hass) as session:
+            events = session.query(Events).filter(
+                Events.event_type_id.in_(select_event_type_ids(TEST_EVENT_TYPES))
             )
-            assert not finished
             assert events.count() == old_events_count * 3
 
-            # we should only have 2 groups of events left
-            finished = purge_old_data(
-                recorder_mock,
-                purge_before,
-                repack=False,
-                states_batch_size=3,
-                events_batch_size=3,
+        # we should only have 2 groups of events left
+        finished = purge_old_data(
+            recorder_mock,
+            purge_before,
+            repack=False,
+            states_batch_size=3,
+            events_batch_size=3,
+        )
+        assert finished
+
+        with session_scope(hass=hass) as session:
+            events = session.query(Events).filter(
+                Events.event_type_id.in_(select_event_type_ids(TEST_EVENT_TYPES))
             )
-            assert finished
             assert events.count() == old_events_count * 2
 
-            # we should now purge everything
-            finished = purge_old_data(
-                recorder_mock,
-                dt_util.utcnow(),
-                repack=False,
-                states_batch_size=20,
-                events_batch_size=20,
+        # we should now purge everything
+        finished = purge_old_data(
+            recorder_mock,
+            dt_util.utcnow(),
+            repack=False,
+            states_batch_size=20,
+            events_batch_size=20,
+        )
+        assert finished
+
+        with session_scope(hass=hass) as session:
+            events = session.query(Events).filter(
+                Events.event_type_id.in_(select_event_type_ids(TEST_EVENT_TYPES))
             )
-            assert finished
             assert events.count() == 0
 
 
@@ -1762,37 +1809,61 @@ async def test_purge_old_events_purges_the_event_type_ids(
         assert events.count() == 30
         assert event_types.count() == 4
 
-        # run purge_old_data()
-        finished = purge_old_data(
-            recorder_mock,
-            far_past,
-            repack=False,
+    # run purge_old_data()
+    finished = purge_old_data(
+        recorder_mock,
+        far_past,
+        repack=False,
+    )
+    assert finished
+
+    with session_scope(hass=hass) as session:
+        events = session.query(Events).where(
+            Events.event_type_id.in_(test_event_type_ids)
         )
-        assert finished
+        event_types = session.query(EventTypes).where(
+            EventTypes.event_type_id.in_(test_event_type_ids)
+        )
         assert events.count() == 30
         # We should remove the unused event type
         assert event_types.count() == 3
 
-        assert "EVENT_TEST_UNUSED" not in recorder_mock.event_type_manager._id_map
+    assert "EVENT_TEST_UNUSED" not in recorder_mock.event_type_manager._id_map
 
-        # we should only have 10 events left since
-        # only one event type was recorded now
-        finished = purge_old_data(
-            recorder_mock,
-            utcnow,
-            repack=False,
+    # we should only have 10 events left since
+    # only one event type was recorded now
+    finished = purge_old_data(
+        recorder_mock,
+        utcnow,
+        repack=False,
+    )
+    assert finished
+
+    with session_scope(hass=hass) as session:
+        events = session.query(Events).where(
+            Events.event_type_id.in_(test_event_type_ids)
         )
-        assert finished
+        event_types = session.query(EventTypes).where(
+            EventTypes.event_type_id.in_(test_event_type_ids)
+        )
         assert events.count() == 10
         assert event_types.count() == 1
 
-        # Purge everything
-        finished = purge_old_data(
-            recorder_mock,
-            utcnow + timedelta(seconds=1),
-            repack=False,
+    # Purge everything
+    finished = purge_old_data(
+        recorder_mock,
+        utcnow + timedelta(seconds=1),
+        repack=False,
+    )
+    assert finished
+
+    with session_scope(hass=hass) as session:
+        events = session.query(Events).where(
+            Events.event_type_id.in_(test_event_type_ids)
         )
-        assert finished
+        event_types = session.query(EventTypes).where(
+            EventTypes.event_type_id.in_(test_event_type_ids)
+        )
         assert events.count() == 0
         assert event_types.count() == 0
 
@@ -1864,37 +1935,55 @@ async def test_purge_old_states_purges_the_state_metadata_ids(
         assert states.count() == 30
         assert states_meta.count() == 4
 
-        # run purge_old_data()
-        finished = purge_old_data(
-            recorder_mock,
-            far_past,
-            repack=False,
+    # run purge_old_data()
+    finished = purge_old_data(
+        recorder_mock,
+        far_past,
+        repack=False,
+    )
+    assert finished
+
+    with session_scope(hass=hass) as session:
+        states = session.query(States).where(States.metadata_id.in_(test_metadata_ids))
+        states_meta = session.query(StatesMeta).where(
+            StatesMeta.metadata_id.in_(test_metadata_ids)
         )
-        assert finished
         assert states.count() == 30
         # We should remove the unused entity_id
         assert states_meta.count() == 3
 
-        assert "sensor.unused" not in recorder_mock.event_type_manager._id_map
+    assert "sensor.unused" not in recorder_mock.event_type_manager._id_map
 
-        # we should only have 10 states left since
-        # only one event type was recorded now
-        finished = purge_old_data(
-            recorder_mock,
-            utcnow,
-            repack=False,
+    # we should only have 10 states left since
+    # only one event type was recorded now
+    finished = purge_old_data(
+        recorder_mock,
+        utcnow,
+        repack=False,
+    )
+    assert finished
+
+    with session_scope(hass=hass) as session:
+        states = session.query(States).where(States.metadata_id.in_(test_metadata_ids))
+        states_meta = session.query(StatesMeta).where(
+            StatesMeta.metadata_id.in_(test_metadata_ids)
         )
-        assert finished
         assert states.count() == 10
         assert states_meta.count() == 1
 
-        # Purge everything
-        finished = purge_old_data(
-            recorder_mock,
-            utcnow + timedelta(seconds=1),
-            repack=False,
+    # Purge everything
+    finished = purge_old_data(
+        recorder_mock,
+        utcnow + timedelta(seconds=1),
+        repack=False,
+    )
+    assert finished
+
+    with session_scope(hass=hass) as session:
+        states = session.query(States).where(States.metadata_id.in_(test_metadata_ids))
+        states_meta = session.query(StatesMeta).where(
+            StatesMeta.metadata_id.in_(test_metadata_ids)
         )
-        assert finished
         assert states.count() == 0
         assert states_meta.count() == 0
 

--- a/tests/components/recorder/test_purge_v32_schema.py
+++ b/tests/components/recorder/test_purge_v32_schema.py
@@ -96,17 +96,21 @@ async def test_purge_old_states(hass: HomeAssistant, recorder_mock: Recorder) ->
         assert events.count() == 0
         assert "test.recorder2" in recorder_mock.states_manager._last_committed_id
 
-        purge_before = dt_util.utcnow() - timedelta(days=4)
+    purge_before = dt_util.utcnow() - timedelta(days=4)
 
-        # run purge_old_data()
-        finished = purge_old_data(
-            recorder_mock,
-            purge_before,
-            states_batch_size=1,
-            events_batch_size=1,
-            repack=False,
-        )
-        assert not finished
+    # run purge_old_data()
+    finished = purge_old_data(
+        recorder_mock,
+        purge_before,
+        states_batch_size=1,
+        events_batch_size=1,
+        repack=False,
+    )
+    assert not finished
+
+    with session_scope(hass=hass) as session:
+        states = session.query(States)
+        state_attributes = session.query(StateAttributes)
         assert states.count() == 2
         assert state_attributes.count() == 1
 
@@ -122,23 +126,31 @@ async def test_purge_old_states(hass: HomeAssistant, recorder_mock: Recorder) ->
         assert dontpurgeme_5.old_state_id == dontpurgeme_4.state_id
         assert dontpurgeme_4.old_state_id is None
 
-        finished = purge_old_data(recorder_mock, purge_before, repack=False)
-        assert finished
+    finished = purge_old_data(recorder_mock, purge_before, repack=False)
+    assert finished
+
+    with session_scope(hass=hass) as session:
+        states = session.query(States)
+        state_attributes = session.query(StateAttributes)
         assert states.count() == 2
         assert state_attributes.count() == 1
 
         assert "test.recorder2" in recorder_mock.states_manager._last_committed_id
 
-        # run purge_old_data again
-        purge_before = dt_util.utcnow()
-        finished = purge_old_data(
-            recorder_mock,
-            purge_before,
-            states_batch_size=1,
-            events_batch_size=1,
-            repack=False,
-        )
-        assert not finished
+    # run purge_old_data again
+    purge_before = dt_util.utcnow()
+    finished = purge_old_data(
+        recorder_mock,
+        purge_before,
+        states_batch_size=1,
+        events_batch_size=1,
+        repack=False,
+    )
+    assert not finished
+
+    with session_scope(hass=hass) as session:
+        states = session.query(States)
+        state_attributes = session.query(StateAttributes)
         assert states.count() == 0
         assert state_attributes.count() == 0
 
@@ -270,26 +282,32 @@ async def test_purge_old_events(hass: HomeAssistant, recorder_mock: Recorder) ->
 
         purge_before = dt_util.utcnow() - timedelta(days=4)
 
-        # run purge_old_data()
-        finished = purge_old_data(
-            recorder_mock,
-            purge_before,
-            repack=False,
-            events_batch_size=1,
-            states_batch_size=1,
-        )
-        assert not finished
+    # run purge_old_data()
+    finished = purge_old_data(
+        recorder_mock,
+        purge_before,
+        repack=False,
+        events_batch_size=1,
+        states_batch_size=1,
+    )
+    assert not finished
+
+    with session_scope(hass=hass) as session:
+        events = session.query(Events).filter(Events.event_type.like("EVENT_TEST%"))
         assert events.count() == 2
 
-        # we should only have 2 events left
-        finished = purge_old_data(
-            recorder_mock,
-            purge_before,
-            repack=False,
-            events_batch_size=1,
-            states_batch_size=1,
-        )
-        assert finished
+    # we should only have 2 events left
+    finished = purge_old_data(
+        recorder_mock,
+        purge_before,
+        repack=False,
+        events_batch_size=1,
+        states_batch_size=1,
+    )
+    assert finished
+
+    with session_scope(hass=hass) as session:
+        events = session.query(Events).filter(Events.event_type.like("EVENT_TEST%"))
         assert events.count() == 2
 
 
@@ -306,26 +324,29 @@ async def test_purge_old_recorder_runs(
         recorder_runs = session.query(RecorderRuns)
         assert recorder_runs.count() == 7
 
-        purge_before = dt_util.utcnow()
+    purge_before = dt_util.utcnow()
 
-        # run purge_old_data()
-        finished = purge_old_data(
-            recorder_mock,
-            purge_before,
-            repack=False,
-            events_batch_size=1,
-            states_batch_size=1,
-        )
-        assert not finished
+    # run purge_old_data()
+    finished = purge_old_data(
+        recorder_mock,
+        purge_before,
+        repack=False,
+        events_batch_size=1,
+        states_batch_size=1,
+    )
+    assert not finished
 
-        finished = purge_old_data(
-            recorder_mock,
-            purge_before,
-            repack=False,
-            events_batch_size=1,
-            states_batch_size=1,
-        )
-        assert finished
+    finished = purge_old_data(
+        recorder_mock,
+        purge_before,
+        repack=False,
+        events_batch_size=1,
+        states_batch_size=1,
+    )
+    assert finished
+
+    with session_scope(hass=hass) as session:
+        recorder_runs = session.query(RecorderRuns)
         assert recorder_runs.count() == 1
 
 
@@ -342,14 +363,17 @@ async def test_purge_old_statistics_runs(
         statistics_runs = session.query(StatisticsRuns)
         assert statistics_runs.count() == 7
 
-        purge_before = dt_util.utcnow()
+    purge_before = dt_util.utcnow()
 
-        # run purge_old_data()
-        finished = purge_old_data(recorder_mock, purge_before, repack=False)
-        assert not finished
+    # run purge_old_data()
+    finished = purge_old_data(recorder_mock, purge_before, repack=False)
+    assert not finished
 
-        finished = purge_old_data(recorder_mock, purge_before, repack=False)
-        assert finished
+    finished = purge_old_data(recorder_mock, purge_before, repack=False)
+    assert finished
+
+    with session_scope(hass=hass) as session:
+        statistics_runs = session.query(StatisticsRuns)
         assert statistics_runs.count() == 1
 
 
@@ -945,39 +969,48 @@ async def test_purge_many_old_events(
             events = session.query(Events).filter(Events.event_type.like("EVENT_TEST%"))
             assert events.count() == old_events_count * 6
 
-            purge_before = dt_util.utcnow() - timedelta(days=4)
+        purge_before = dt_util.utcnow() - timedelta(days=4)
 
-            # run purge_old_data()
-            finished = purge_old_data(
-                recorder_mock,
-                purge_before,
-                repack=False,
-                states_batch_size=3,
-                events_batch_size=3,
-            )
-            assert not finished
+        # run purge_old_data()
+        finished = purge_old_data(
+            recorder_mock,
+            purge_before,
+            repack=False,
+            states_batch_size=3,
+            events_batch_size=3,
+        )
+        assert not finished
+
+        with session_scope(hass=hass) as session:
+            events = session.query(Events).filter(Events.event_type.like("EVENT_TEST%"))
             assert events.count() == old_events_count * 3
 
-            # we should only have 2 groups of events left
-            finished = purge_old_data(
-                recorder_mock,
-                purge_before,
-                repack=False,
-                states_batch_size=3,
-                events_batch_size=3,
-            )
-            assert finished
+        # we should only have 2 groups of events left
+        finished = purge_old_data(
+            recorder_mock,
+            purge_before,
+            repack=False,
+            states_batch_size=3,
+            events_batch_size=3,
+        )
+        assert finished
+
+        with session_scope(hass=hass) as session:
+            events = session.query(Events).filter(Events.event_type.like("EVENT_TEST%"))
             assert events.count() == old_events_count * 2
 
-            # we should now purge everything
-            finished = purge_old_data(
-                recorder_mock,
-                dt_util.utcnow(),
-                repack=False,
-                states_batch_size=20,
-                events_batch_size=20,
-            )
-            assert finished
+        # we should now purge everything
+        finished = purge_old_data(
+            recorder_mock,
+            dt_util.utcnow(),
+            repack=False,
+            states_batch_size=20,
+            events_batch_size=20,
+        )
+        assert finished
+
+        with session_scope(hass=hass) as session:
+            events = session.query(Events).filter(Events.event_type.like("EVENT_TEST%"))
             assert events.count() == 0
 
 
@@ -1038,39 +1071,65 @@ async def test_purge_can_mix_legacy_and_new_format(
         assert states_with_event_id.count() == 50
         assert states_without_event_id.count() == 51
 
-        purge_before = dt_util.utcnow() - timedelta(days=4)
-        finished = purge_old_data(
-            recorder_mock,
-            purge_before,
-            repack=False,
+    purge_before = dt_util.utcnow() - timedelta(days=4)
+    finished = purge_old_data(
+        recorder_mock,
+        purge_before,
+        repack=False,
+    )
+    assert not finished
+
+    with session_scope(hass=hass) as session:
+        states_with_event_id = session.query(States).filter(
+            States.event_id.is_not(None)
         )
-        assert not finished
+        states_without_event_id = session.query(States).filter(
+            States.event_id.is_(None)
+        )
         assert states_with_event_id.count() == 0
         assert states_without_event_id.count() == 51
-        # At this point all the legacy states are gone
-        # and we switch methods
-        purge_before = dt_util.utcnow() - timedelta(days=4)
-        finished = purge_old_data(
-            recorder_mock,
-            purge_before,
-            repack=False,
-            events_batch_size=1,
-            states_batch_size=1,
+
+    # At this point all the legacy states are gone
+    # and we switch methods
+    purge_before = dt_util.utcnow() - timedelta(days=4)
+    finished = purge_old_data(
+        recorder_mock,
+        purge_before,
+        repack=False,
+        events_batch_size=1,
+        states_batch_size=1,
+    )
+    # Since we only allow one iteration, we won't
+    # check if we are finished this loop similar
+    # to the legacy method
+    assert not finished
+
+    with session_scope(hass=hass) as session:
+        states_with_event_id = session.query(States).filter(
+            States.event_id.is_not(None)
         )
-        # Since we only allow one iteration, we won't
-        # check if we are finished this loop similar
-        # to the legacy method
-        assert not finished
+        states_without_event_id = session.query(States).filter(
+            States.event_id.is_(None)
+        )
         assert states_with_event_id.count() == 0
         assert states_without_event_id.count() == 1
-        finished = purge_old_data(
-            recorder_mock,
-            purge_before,
-            repack=False,
-            events_batch_size=100,
-            states_batch_size=100,
+
+    finished = purge_old_data(
+        recorder_mock,
+        purge_before,
+        repack=False,
+        events_batch_size=100,
+        states_batch_size=100,
+    )
+    assert finished
+
+    with session_scope(hass=hass) as session:
+        states_with_event_id = session.query(States).filter(
+            States.event_id.is_not(None)
         )
-        assert finished
+        states_without_event_id = session.query(States).filter(
+            States.event_id.is_(None)
+        )
         assert states_with_event_id.count() == 0
         assert states_without_event_id.count() == 1
         _add_state_without_event_linkage(
@@ -1078,12 +1137,21 @@ async def test_purge_can_mix_legacy_and_new_format(
         )
         assert states_with_event_id.count() == 0
         assert states_without_event_id.count() == 2
-        finished = purge_old_data(
-            recorder_mock,
-            purge_before,
-            repack=False,
+
+    finished = purge_old_data(
+        recorder_mock,
+        purge_before,
+        repack=False,
+    )
+    assert finished
+
+    with session_scope(hass=hass) as session:
+        states_with_event_id = session.query(States).filter(
+            States.event_id.is_not(None)
         )
-        assert finished
+        states_without_event_id = session.query(States).filter(
+            States.event_id.is_(None)
+        )
         # The broken state without a timestamp
         # does not prevent future purges. Its ignored.
         assert states_with_event_id.count() == 0
@@ -1185,39 +1253,65 @@ async def test_purge_can_mix_legacy_and_new_format_with_detached_state(
         assert states_with_event_id.count() == 52
         assert states_without_event_id.count() == 51
 
-        purge_before = dt_util.utcnow() - timedelta(days=4)
-        finished = purge_old_data(
-            recorder_mock,
-            purge_before,
-            repack=False,
+    purge_before = dt_util.utcnow() - timedelta(days=4)
+    finished = purge_old_data(
+        recorder_mock,
+        purge_before,
+        repack=False,
+    )
+    assert not finished
+
+    with session_scope(hass=hass) as session:
+        states_with_event_id = session.query(States).filter(
+            States.event_id.is_not(None)
         )
-        assert not finished
+        states_without_event_id = session.query(States).filter(
+            States.event_id.is_(None)
+        )
         assert states_with_event_id.count() == 0
         assert states_without_event_id.count() == 51
-        # At this point all the legacy states are gone
-        # and we switch methods
-        purge_before = dt_util.utcnow() - timedelta(days=4)
-        finished = purge_old_data(
-            recorder_mock,
-            purge_before,
-            repack=False,
-            events_batch_size=1,
-            states_batch_size=1,
+
+    # At this point all the legacy states are gone
+    # and we switch methods
+    purge_before = dt_util.utcnow() - timedelta(days=4)
+    finished = purge_old_data(
+        recorder_mock,
+        purge_before,
+        repack=False,
+        events_batch_size=1,
+        states_batch_size=1,
+    )
+    # Since we only allow one iteration, we won't
+    # check if we are finished this loop similar
+    # to the legacy method
+    assert not finished
+
+    with session_scope(hass=hass) as session:
+        states_with_event_id = session.query(States).filter(
+            States.event_id.is_not(None)
         )
-        # Since we only allow one iteration, we won't
-        # check if we are finished this loop similar
-        # to the legacy method
-        assert not finished
+        states_without_event_id = session.query(States).filter(
+            States.event_id.is_(None)
+        )
         assert states_with_event_id.count() == 0
         assert states_without_event_id.count() == 1
-        finished = purge_old_data(
-            recorder_mock,
-            purge_before,
-            repack=False,
-            events_batch_size=100,
-            states_batch_size=100,
+
+    finished = purge_old_data(
+        recorder_mock,
+        purge_before,
+        repack=False,
+        events_batch_size=100,
+        states_batch_size=100,
+    )
+    assert finished
+
+    with session_scope(hass=hass) as session:
+        states_with_event_id = session.query(States).filter(
+            States.event_id.is_not(None)
         )
-        assert finished
+        states_without_event_id = session.query(States).filter(
+            States.event_id.is_(None)
+        )
         assert states_with_event_id.count() == 0
         assert states_without_event_id.count() == 1
         _add_state_without_event_linkage(
@@ -1225,12 +1319,21 @@ async def test_purge_can_mix_legacy_and_new_format_with_detached_state(
         )
         assert states_with_event_id.count() == 0
         assert states_without_event_id.count() == 2
-        finished = purge_old_data(
-            recorder_mock,
-            purge_before,
-            repack=False,
+
+    finished = purge_old_data(
+        recorder_mock,
+        purge_before,
+        repack=False,
+    )
+    assert finished
+
+    with session_scope(hass=hass) as session:
+        states_with_event_id = session.query(States).filter(
+            States.event_id.is_not(None)
         )
-        assert finished
+        states_without_event_id = session.query(States).filter(
+            States.event_id.is_(None)
+        )
         # The broken state without a timestamp
         # does not prevent future purges. Its ignored.
         assert states_with_event_id.count() == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Avoid creating nested sessions in recorder purge tests

This fixes issues exposed by https://github.com/home-assistant/core/pull/122579

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
