### PR TITLE
Add default warning for installing matter device updates

### DIFF
--- a/homeassistant/components/matter/update.py
+++ b/homeassistant/components/matter/update.py
@@ -178,7 +178,6 @@ class MatterUpdate(MatterEntity, UpdateEntity):
         else:
             # Check for updates when added the first time.
             await self.async_update()
-        await self.async_update()
 
     @property
     def extra_restore_state_data(self) -> MatterUpdateExtraStoredData:

--- a/homeassistant/components/matter/update.py
+++ b/homeassistant/components/matter/update.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from chip.clusters import Objects as clusters
 from matter_server.common.errors import UpdateCheckError, UpdateError
-from matter_server.common.models import MatterSoftwareVersion
+from matter_server.common.models import MatterSoftwareVersion, UpdateSource
 
 from homeassistant.components.update import (
     ATTR_LATEST_VERSION,
@@ -18,7 +18,7 @@ from homeassistant.components.update import (
     UpdateEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import STATE_ON, Platform
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -76,6 +76,12 @@ class MatterUpdate(MatterEntity, UpdateEntity):
     _attr_should_poll = True
     _software_update: MatterSoftwareVersion | None = None
     _cancel_update: CALLBACK_TYPE | None = None
+    _attr_supported_features = (
+        UpdateEntityFeature.INSTALL
+        | UpdateEntityFeature.PROGRESS
+        | UpdateEntityFeature.SPECIFIC_VERSION
+        | UpdateEntityFeature.RELEASE_NOTES
+    )
 
     @callback
     def _update_from_device(self) -> None:
@@ -84,16 +90,6 @@ class MatterUpdate(MatterEntity, UpdateEntity):
         self._attr_installed_version = self.get_matter_attribute_value(
             clusters.BasicInformation.Attributes.SoftwareVersionString
         )
-
-        if self.get_matter_attribute_value(
-            clusters.OtaSoftwareUpdateRequestor.Attributes.UpdatePossible
-        ):
-            self._attr_supported_features = (
-                UpdateEntityFeature.INSTALL
-                | UpdateEntityFeature.PROGRESS
-                | UpdateEntityFeature.SPECIFIC_VERSION
-            )
-
         update_state: clusters.OtaSoftwareUpdateRequestor.Enums.UpdateStateEnum = (
             self.get_matter_attribute_value(
                 clusters.OtaSoftwareUpdateRequestor.Attributes.UpdateState
@@ -133,8 +129,38 @@ class MatterUpdate(MatterEntity, UpdateEntity):
             self._software_update = update_information
             self._attr_latest_version = update_information.software_version_string
             self._attr_release_url = update_information.release_notes_url
+
         except UpdateCheckError as err:
             raise HomeAssistantError(f"Error finding applicable update: {err}") from err
+
+    async def async_release_notes(self) -> str | None:
+        """Return full release notes.
+
+        This is suitable for a long changelog that does not fit in the release_summary
+        property. The returned string can contain markdown.
+        """
+        if self._software_update is None:
+            return None
+        if self.state != STATE_ON:
+            return None
+
+        release_notes = ""
+
+        # insert extra heavy warning case the update is not from the main net
+        if self._software_update.update_source != UpdateSource.MAIN_NET_DCL:
+            release_notes += (
+                "\n\n<ha-alert alert-type='warning'>"
+                f"Update provided by {self._software_update.update_source.value}. "
+                "Installing this update is at your own risk and you may run into unexpected "
+                "problems such as the need to re-add and factory reset your device.</ha-alert>\n\n"
+            )
+        return release_notes + (
+            "\n\n<ha-alert alert-type='info'>The update process can take a while, "
+            "especially for battery powered devices. Please be patient and wait until the update "
+            "process is fully completed. Do not remove power from the device while it's updating. "
+            "The device may restart during the update process and be unavailable for several minutes."
+            "</ha-alert>\n\n"
+        )
 
     async def async_added_to_hass(self) -> None:
         """Call when the entity is added to hass."""
@@ -152,6 +178,7 @@ class MatterUpdate(MatterEntity, UpdateEntity):
         else:
             # Check for updates when added the first time.
             await self.async_update()
+        await self.async_update()
 
     @property
     def extra_restore_state_data(self) -> MatterUpdateExtraStoredData:
@@ -171,6 +198,11 @@ class MatterUpdate(MatterEntity, UpdateEntity):
         self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
         """Install a new software version."""
+
+        if not self.get_matter_attribute_value(
+            clusters.OtaSoftwareUpdateRequestor.Attributes.UpdatePossible
+        ):
+            raise HomeAssistantError("Device is not ready to install updates")
 
         software_version: str | int | None = version
         if self._software_update is not None and (


### PR DESCRIPTION
## Proposed change

Add a default warning text for installing Matter devices implemented as release notes text (ha-alert).
In case of an update that is not from main-net, we will display a somewhat more severe warning.

Also changed the supported features to a ststic class attributes as  it felt really weird to (ab)use that as some sort of state machine. These are just the features we support in our update entity implementation and HA itself takes care of the states (e.g. by offering install if an update is detected).

Update from stable source (main-net DCL):
![Scherm­afbeelding 2024-07-25 om 16 26 20](https://github.com/user-attachments/assets/61ea7499-e97c-4e8b-bbd4-3224c41470fa)

Update from untrusted/unstable source (test-net DCL, manual json):
![Scherm­afbeelding 2024-07-25 om 16 25 41](https://github.com/user-attachments/assets/f386b517-0b47-464a-af52-a5587b77731e)



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
