### PR TITLE
Add number entity for Ecovacs mower cut direction

### DIFF
--- a/homeassistant/components/ecovacs/icons.json
+++ b/homeassistant/components/ecovacs/icons.json
@@ -43,6 +43,9 @@
       "clean_count": {
         "default": "mdi:counter"
       },
+      "cut_direction": {
+        "default": "mdi:angle-acute"
+      },
       "volume": {
         "default": "mdi:volume-high",
         "state": {

--- a/homeassistant/components/ecovacs/number.py
+++ b/homeassistant/components/ecovacs/number.py
@@ -7,14 +7,14 @@ from dataclasses import dataclass
 from typing import Generic
 
 from deebot_client.capabilities import CapabilitySet
-from deebot_client.events import CleanCountEvent, VolumeEvent
+from deebot_client.events import CleanCountEvent, CutDirectionEvent, VolumeEvent
 
 from homeassistant.components.number import (
     NumberEntity,
     NumberEntityDescription,
     NumberMode,
 )
-from homeassistant.const import EntityCategory
+from homeassistant.const import DEGREE, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -52,6 +52,18 @@ ENTITY_DESCRIPTIONS: tuple[EcovacsNumberEntityDescription, ...] = (
         native_min_value=0,
         native_max_value=10,
         native_step=1.0,
+    ),
+    EcovacsNumberEntityDescription[CutDirectionEvent](
+        capability_fn=lambda caps: caps.settings.cut_direction,
+        value_fn=lambda e: e.angle,
+        key="cut_direction",
+        translation_key="cut_direction",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.CONFIG,
+        native_min_value=0,
+        native_max_value=180,
+        native_step=1.0,
+        native_unit_of_measurement=DEGREE,
     ),
     EcovacsNumberEntityDescription[CleanCountEvent](
         capability_fn=lambda caps: caps.clean.count,

--- a/homeassistant/components/ecovacs/strings.json
+++ b/homeassistant/components/ecovacs/strings.json
@@ -91,6 +91,9 @@
       "clean_count": {
         "name": "Clean count"
       },
+      "cut_direction": {
+        "name": "Cut direction"
+      },
       "volume": {
         "name": "Volume"
       }

--- a/tests/components/ecovacs/snapshots/test_number.ambr
+++ b/tests/components/ecovacs/snapshots/test_number.ambr
@@ -1,4 +1,115 @@
 # serializer version: 1
+# name: test_number_entities[5xu9h3][number.goat_g1_cut_direction:entity-registry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 180,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.goat_g1_cut_direction',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Cut direction',
+    'platform': 'ecovacs',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'cut_direction',
+    'unique_id': '8516fbb1-17f1-4194-0000000_cut_direction',
+    'unit_of_measurement': '°',
+  })
+# ---
+# name: test_number_entities[5xu9h3][number.goat_g1_cut_direction:state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Goat G1 Cut direction',
+      'max': 180,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1.0,
+      'unit_of_measurement': '°',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.goat_g1_cut_direction',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '45',
+  })
+# ---
+# name: test_number_entities[5xu9h3][number.goat_g1_volume:entity-registry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 11,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.goat_g1_volume',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Volume',
+    'platform': 'ecovacs',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'volume',
+    'unique_id': '8516fbb1-17f1-4194-0000000_volume',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_number_entities[5xu9h3][number.goat_g1_volume:state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Goat G1 Volume',
+      'max': 11,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.goat_g1_volume',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '3',
+  })
+# ---
 # name: test_number_entities[yna5x1][number.ozmo_950_volume:entity-registry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/ecovacs/test_init.py
+++ b/tests/components/ecovacs/test_init.py
@@ -136,7 +136,7 @@ async def test_devices_in_dr(
     ("device_fixture", "entities"),
     [
         ("yna5x1", 26),
-        ("5xu9h3", 24),
+        ("5xu9h3", 25),
         ("123", 1),
     ],
 )

--- a/tests/components/ecovacs/test_number.py
+++ b/tests/components/ecovacs/test_number.py
@@ -3,8 +3,8 @@
 from dataclasses import dataclass
 
 from deebot_client.command import Command
-from deebot_client.commands.json import SetVolume
-from deebot_client.events import Event, VolumeEvent
+from deebot_client.commands.json import SetCutDirection, SetVolume
+from deebot_client.events import CutDirectionEvent, Event, VolumeEvent
 import pytest
 from syrupy import SnapshotAssertion
 
@@ -53,8 +53,23 @@ class NumberTestCase:
                 ),
             ],
         ),
+        (
+            "5xu9h3",
+            [
+                NumberTestCase(
+                    "number.goat_g1_volume", VolumeEvent(3, 11), "3", 7, SetVolume(7)
+                ),
+                NumberTestCase(
+                    "number.goat_g1_cut_direction",
+                    CutDirectionEvent(45),
+                    "45",
+                    97,
+                    SetCutDirection(97),
+                ),
+            ],
+        ),
     ],
-    ids=["yna5x1"],
+    ids=["yna5x1", "5xu9h3"],
 )
 async def test_number_entities(
     hass: HomeAssistant,
@@ -107,8 +122,12 @@ async def test_number_entities(
             "yna5x1",
             ["number.ozmo_950_volume"],
         ),
+        (
+            "5xu9h3",
+            ["number.goat_g1_cut_direction", "number.goat_g1_volume"],
+        ),
     ],
-    ids=["yna5x1"],
+    ids=["yna5x1", "5xu9h3"],
 )
 async def test_disabled_by_default_number_entities(
     hass: HomeAssistant, entity_registry: er.EntityRegistry, entity_ids: list[str]
@@ -125,6 +144,7 @@ async def test_disabled_by_default_number_entities(
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
+@pytest.mark.parametrize(("device_fixture"), ["yna5x1"])
 async def test_volume_maximum(
     hass: HomeAssistant,
     controller: EcovacsController,
@@ -147,3 +167,27 @@ async def test_volume_maximum(
     assert (state := hass.states.get(entity_id))
     assert state.state == "10"
     assert state.attributes["max"] == 20
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+@pytest.mark.parametrize(("device_fixture"), ["5xu9h3"])
+async def test_cut_direction_bounds(
+    hass: HomeAssistant,
+    controller: EcovacsController,
+) -> None:
+    """Test cut direction bounds."""
+    device = controller.devices[0]
+    event_bus = device.events
+    entity_id = "number.goat_g1_cut_direction"
+    assert (state := hass.states.get(entity_id))
+    assert state.attributes["max"] == 180
+
+    event_bus.notify(CutDirectionEvent(45))
+    await block_till_done(hass, event_bus)
+    assert (state := hass.states.get(entity_id))
+    assert state.state == "45"
+
+    event_bus.notify(CutDirectionEvent(17))
+    await block_till_done(hass, event_bus)
+    assert (state := hass.states.get(entity_id))
+    assert state.state == "17"

--- a/tests/components/ecovacs/test_number.py
+++ b/tests/components/ecovacs/test_number.py
@@ -167,27 +167,3 @@ async def test_volume_maximum(
     assert (state := hass.states.get(entity_id))
     assert state.state == "10"
     assert state.attributes["max"] == 20
-
-
-@pytest.mark.usefixtures("entity_registry_enabled_by_default")
-@pytest.mark.parametrize(("device_fixture"), ["5xu9h3"])
-async def test_cut_direction_bounds(
-    hass: HomeAssistant,
-    controller: EcovacsController,
-) -> None:
-    """Test cut direction bounds."""
-    device = controller.devices[0]
-    event_bus = device.events
-    entity_id = "number.goat_g1_cut_direction"
-    assert (state := hass.states.get(entity_id))
-    assert state.attributes["max"] == 180
-
-    event_bus.notify(CutDirectionEvent(45))
-    await block_till_done(hass, event_bus)
-    assert (state := hass.states.get(entity_id))
-    assert state.state == "45"
-
-    event_bus.notify(CutDirectionEvent(17))
-    await block_till_done(hass, event_bus)
-    assert (state := hass.states.get(entity_id))
-    assert state.state == "17"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add number entity for the mower cut direction.  The capability was [added to the underlying deebot client in 7.3.0](https://github.com/DeebotUniverse/client.py/releases/tag/7.3.0) so does not require any further package update.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33965

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
