### PR TITLE
Remove unused fixtures in UniFi tests

### DIFF
--- a/tests/components/unifi/conftest.py
+++ b/tests/components/unifi/conftest.py
@@ -295,7 +295,7 @@ async def fixture_config_entry_factory(
 
 @pytest.fixture(name="config_entry_setup")
 async def fixture_config_entry_setup(
-    hass: HomeAssistant, config_entry_factory: Callable[[], ConfigEntry]
+    config_entry_factory: Callable[[], ConfigEntry],
 ) -> ConfigEntry:
     """Fixture providing a set up instance of UniFi network integration."""
     return await config_entry_factory()

--- a/tests/components/unifi/test_config_flow.py
+++ b/tests/components/unifi/test_config_flow.py
@@ -37,7 +37,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from tests.common import MockConfigEntry
-from tests.test_util.aiohttp import AiohttpClientMocker
 
 CLIENTS = [{"mac": "00:00:00:00:00:01"}]
 
@@ -137,9 +136,7 @@ async def test_flow_works(hass: HomeAssistant, mock_discovery) -> None:
     }
 
 
-async def test_flow_works_negative_discovery(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
-) -> None:
+async def test_flow_works_negative_discovery(hass: HomeAssistant) -> None:
     """Test config flow with a negative outcome of async_discovery_unifi."""
     result = await hass.config_entries.flow.async_init(
         UNIFI_DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -535,9 +532,8 @@ async def test_form_ssdp(hass: HomeAssistant) -> None:
     }
 
 
-async def test_form_ssdp_aborts_if_host_already_exists(
-    hass: HomeAssistant, config_entry: ConfigEntry
-) -> None:
+@pytest.mark.usefixtures("config_entry")
+async def test_form_ssdp_aborts_if_host_already_exists(hass: HomeAssistant) -> None:
     """Test we abort if the host is already configured."""
     result = await hass.config_entries.flow.async_init(
         UNIFI_DOMAIN,
@@ -557,9 +553,8 @@ async def test_form_ssdp_aborts_if_host_already_exists(
     assert result["reason"] == "already_configured"
 
 
-async def test_form_ssdp_aborts_if_serial_already_exists(
-    hass: HomeAssistant, config_entry: ConfigEntry
-) -> None:
+@pytest.mark.usefixtures("config_entry")
+async def test_form_ssdp_aborts_if_serial_already_exists(hass: HomeAssistant) -> None:
     """Test we abort if the serial is already configured."""
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/unifi/test_init.py
+++ b/tests/components/unifi/test_init.py
@@ -24,7 +24,6 @@ from homeassistant.setup import async_setup_component
 from .conftest import DEFAULT_CONFIG_ENTRY_ID
 
 from tests.common import flush_store
-from tests.test_util.aiohttp import AiohttpClientMocker
 from tests.typing import WebSocketGenerator
 
 
@@ -35,7 +34,7 @@ async def test_setup_with_no_config(hass: HomeAssistant) -> None:
 
 
 async def test_setup_entry_fails_config_entry_not_ready(
-    hass: HomeAssistant, config_entry_factory: Callable[[], ConfigEntry]
+    config_entry_factory: Callable[[], ConfigEntry],
 ) -> None:
     """Failed authentication trigger a reauthentication flow."""
     with patch(
@@ -170,8 +169,6 @@ async def test_wireless_clients(
 )
 async def test_remove_config_entry_device(
     hass: HomeAssistant,
-    hass_storage: dict[str, Any],
-    aioclient_mock: AiohttpClientMocker,
     device_registry: dr.DeviceRegistry,
     config_entry_factory: Callable[[], ConfigEntry],
     client_payload: list[dict[str, Any]],

--- a/tests/components/unifi/test_services.py
+++ b/tests/components/unifi/test_services.py
@@ -289,7 +289,7 @@ async def test_services_handle_unloaded_config_entry(
     aioclient_mock: AiohttpClientMocker,
     device_registry: dr.DeviceRegistry,
     config_entry_setup: ConfigEntry,
-    clients_all_payload,
+    clients_all_payload: dict[str, Any],
 ) -> None:
     """Verify no call is made if config entry is unloaded."""
     await hass.config_entries.async_unload(config_entry_setup.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Removes the fixture completely or move to a pytest.mark.usefixtures

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
