### PR TITLE
Replace ConfigEntry with MockConfigEntry in Axis tests

### DIFF
--- a/tests/components/axis/conftest.py
+++ b/tests/components/axis/conftest.py
@@ -85,7 +85,6 @@ def fixture_setup_entry() -> Generator[AsyncMock]:
 
 @pytest.fixture(name="config_entry")
 def fixture_config_entry(
-    hass: HomeAssistant,
     config_entry_data: MappingProxyType[str, Any],
     config_entry_options: MappingProxyType[str, Any],
     config_entry_version: int,

--- a/tests/components/axis/test_diagnostics.py
+++ b/tests/components/axis/test_diagnostics.py
@@ -3,11 +3,11 @@
 import pytest
 from syrupy import SnapshotAssertion
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .const import API_DISCOVERY_BASIC_DEVICE_INFO
 
+from tests.common import MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
 
@@ -16,7 +16,7 @@ from tests.typing import ClientSessionGenerator
 async def test_entry_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
-    config_entry_setup: ConfigEntry,
+    config_entry_setup: MockConfigEntry,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test config entry diagnostics."""

--- a/tests/components/axis/test_hub.py
+++ b/tests/components/axis/test_hub.py
@@ -14,7 +14,7 @@ from syrupy import SnapshotAssertion
 from homeassistant.components import axis, zeroconf
 from homeassistant.components.axis.const import DOMAIN as AXIS_DOMAIN
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
-from homeassistant.config_entries import SOURCE_ZEROCONF, ConfigEntry
+from homeassistant.config_entries import SOURCE_ZEROCONF
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
@@ -28,7 +28,7 @@ from .const import (
     NAME,
 )
 
-from tests.common import async_fire_mqtt_message
+from tests.common import MockConfigEntry, async_fire_mqtt_message
 from tests.typing import MqttMockHAClient
 
 
@@ -36,7 +36,7 @@ from tests.typing import MqttMockHAClient
     "api_discovery_items", [({}), (API_DISCOVERY_BASIC_DEVICE_INFO)]
 )
 async def test_device_registry_entry(
-    config_entry_setup: ConfigEntry,
+    config_entry_setup: MockConfigEntry,
     device_registry: dr.DeviceRegistry,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -83,7 +83,7 @@ async def test_device_support_mqtt_low_privilege(mqtt_mock: MqttMockHAClient) ->
 
 async def test_update_address(
     hass: HomeAssistant,
-    config_entry_setup: ConfigEntry,
+    config_entry_setup: MockConfigEntry,
     mock_requests: Callable[[str], None],
 ) -> None:
     """Test update address works."""
@@ -148,7 +148,7 @@ async def test_device_unavailable(
 
 @pytest.mark.usefixtures("mock_default_requests")
 async def test_device_not_accessible(
-    hass: HomeAssistant, config_entry: ConfigEntry
+    hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:
     """Failed setup schedules a retry of setup."""
     config_entry.add_to_hass(hass)
@@ -160,7 +160,7 @@ async def test_device_not_accessible(
 
 @pytest.mark.usefixtures("mock_default_requests")
 async def test_device_trigger_reauth_flow(
-    hass: HomeAssistant, config_entry: ConfigEntry
+    hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:
     """Failed authentication trigger a reauthentication flow."""
     config_entry.add_to_hass(hass)
@@ -178,7 +178,7 @@ async def test_device_trigger_reauth_flow(
 
 @pytest.mark.usefixtures("mock_default_requests")
 async def test_device_unknown_error(
-    hass: HomeAssistant, config_entry: ConfigEntry
+    hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:
     """Unknown errors are handled."""
     config_entry.add_to_hass(hass)

--- a/tests/components/axis/test_init.py
+++ b/tests/components/axis/test_init.py
@@ -5,17 +5,19 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from homeassistant.components import axis
-from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
+from tests.common import MockConfigEntry
 
-async def test_setup_entry(config_entry_setup: ConfigEntry) -> None:
+
+async def test_setup_entry(config_entry_setup: MockConfigEntry) -> None:
     """Test successful setup of entry."""
     assert config_entry_setup.state is ConfigEntryState.LOADED
 
 
 async def test_setup_entry_fails(
-    hass: HomeAssistant, config_entry: ConfigEntry
+    hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:
     """Test successful setup of entry."""
     config_entry.add_to_hass(hass)
@@ -32,7 +34,7 @@ async def test_setup_entry_fails(
 
 
 async def test_unload_entry(
-    hass: HomeAssistant, config_entry_setup: ConfigEntry
+    hass: HomeAssistant, config_entry_setup: MockConfigEntry
 ) -> None:
     """Test successful unload of entry."""
     assert config_entry_setup.state is ConfigEntryState.LOADED
@@ -42,7 +44,9 @@ async def test_unload_entry(
 
 
 @pytest.mark.parametrize("config_entry_version", [1])
-async def test_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+async def test_migrate_entry(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
     """Test successful migration of entry data."""
     config_entry.add_to_hass(hass)
     assert config_entry.version == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replace ConfigEntry with MockConfigEntry
Remove unused fixtures in Axis tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
