### PR TITLE
Replace ConfigEntry with MockConfigEntry in deCONZ tests

### DIFF
--- a/tests/components/deconz/conftest.py
+++ b/tests/components/deconz/conftest.py
@@ -219,7 +219,7 @@ async def fixture_config_entry_factory(
 
 @pytest.fixture(name="config_entry_setup")
 async def fixture_config_entry_setup(
-    config_entry_factory: Callable[[], Coroutine[Any, Any, MockConfigEntry]],
+    config_entry_factory: ConfigEntryFactoryType,
 ) -> MockConfigEntry:
     """Fixture providing a set up instance of deCONZ integration."""
     return await config_entry_factory()

--- a/tests/components/deconz/test_binary_sensor.py
+++ b/tests/components/deconz/test_binary_sensor.py
@@ -14,14 +14,13 @@ from homeassistant.components.deconz.const import (
     DOMAIN as DECONZ_DOMAIN,
 )
 from homeassistant.components.deconz.services import SERVICE_DEVICE_REFRESH
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .conftest import ConfigEntryFactoryType, WebsocketDataType
 
-from tests.common import snapshot_platform
+from tests.common import MockConfigEntry, snapshot_platform
 
 TEST_DATA = [
     (  # Alarm binary sensor
@@ -409,7 +408,9 @@ async def test_not_allow_clip_sensor(hass: HomeAssistant) -> None:
     ],
 )
 @pytest.mark.parametrize("config_entry_options", [{CONF_ALLOW_CLIP_SENSOR: True}])
-async def test_allow_clip_sensor(hass: HomeAssistant, config_entry_setup) -> None:
+async def test_allow_clip_sensor(
+    hass: HomeAssistant, config_entry_setup: MockConfigEntry
+) -> None:
     """Test that CLIP sensors can be allowed."""
 
     assert len(hass.states.async_all()) == 3
@@ -470,7 +471,7 @@ async def test_add_new_binary_sensor(
 async def test_add_new_binary_sensor_ignored_load_entities_on_service_call(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    config_entry_setup: ConfigEntry,
+    config_entry_setup: MockConfigEntry,
     deconz_payload: dict[str, Any],
     mock_requests: Callable[[str], None],
     sensor_ws_data: WebsocketDataType,
@@ -515,7 +516,7 @@ async def test_add_new_binary_sensor_ignored_load_entities_on_service_call(
 async def test_add_new_binary_sensor_ignored_load_entities_on_options_change(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    config_entry_setup: ConfigEntry,
+    config_entry_setup: MockConfigEntry,
     deconz_payload: dict[str, Any],
     mock_requests: Callable[[str], None],
     sensor_ws_data: WebsocketDataType,

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -27,7 +27,6 @@ from homeassistant.config_entries import (
     SOURCE_REAUTH,
     SOURCE_SSDP,
     SOURCE_USER,
-    ConfigEntry,
 )
 from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PORT, CONTENT_TYPE_JSON
 from homeassistant.core import HomeAssistant
@@ -35,6 +34,7 @@ from homeassistant.data_entry_flow import FlowResultType
 
 from .conftest import API_KEY, BRIDGE_ID
 
+from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 BAD_BRIDGEID = "0000000000000000"
@@ -225,7 +225,7 @@ async def test_manual_configuration_after_discovery_ResponseError(
 async def test_manual_configuration_update_configuration(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    config_entry_setup: ConfigEntry,
+    config_entry_setup: MockConfigEntry,
 ) -> None:
     """Test that manual configuration can update existing config entry."""
     aioclient_mock.get(
@@ -404,7 +404,7 @@ async def test_link_step_fails(
 async def test_reauth_flow_update_configuration(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    config_entry_setup: ConfigEntry,
+    config_entry_setup: MockConfigEntry,
 ) -> None:
     """Verify reauth flow can update gateway API key."""
     result = await hass.config_entries.flow.async_init(
@@ -484,7 +484,7 @@ async def test_flow_ssdp_discovery(
 
 
 async def test_ssdp_discovery_update_configuration(
-    hass: HomeAssistant, config_entry_setup: ConfigEntry
+    hass: HomeAssistant, config_entry_setup: MockConfigEntry
 ) -> None:
     """Test if a discovered bridge is configured but updates with new attributes."""
     with patch(
@@ -513,7 +513,7 @@ async def test_ssdp_discovery_update_configuration(
 
 
 async def test_ssdp_discovery_dont_update_configuration(
-    hass: HomeAssistant, config_entry_setup: ConfigEntry
+    hass: HomeAssistant, config_entry_setup: MockConfigEntry
 ) -> None:
     """Test if a discovered bridge has already been configured."""
 
@@ -538,7 +538,7 @@ async def test_ssdp_discovery_dont_update_configuration(
 
 @pytest.mark.parametrize("config_entry_source", [SOURCE_HASSIO])
 async def test_ssdp_discovery_dont_update_existing_hassio_configuration(
-    hass: HomeAssistant, config_entry_setup: ConfigEntry
+    hass: HomeAssistant, config_entry_setup: MockConfigEntry
 ) -> None:
     """Test to ensure the SSDP discovery does not update an Hass.io entry."""
     result = await hass.config_entries.flow.async_init(
@@ -608,7 +608,7 @@ async def test_flow_hassio_discovery(hass: HomeAssistant) -> None:
 
 async def test_hassio_discovery_update_configuration(
     hass: HomeAssistant,
-    config_entry_setup: ConfigEntry,
+    config_entry_setup: MockConfigEntry,
 ) -> None:
     """Test we can update an existing config entry."""
     with patch(
@@ -664,7 +664,7 @@ async def test_hassio_discovery_dont_update_configuration(hass: HomeAssistant) -
 
 
 async def test_option_flow(
-    hass: HomeAssistant, config_entry_setup: ConfigEntry
+    hass: HomeAssistant, config_entry_setup: MockConfigEntry
 ) -> None:
     """Test config flow options."""
     result = await hass.config_entries.options.async_init(config_entry_setup.entry_id)

--- a/tests/components/deconz/test_deconz_event.py
+++ b/tests/components/deconz/test_deconz_event.py
@@ -17,7 +17,6 @@ from homeassistant.components.deconz.deconz_event import (
     CONF_DECONZ_RELATIVE_ROTARY_EVENT,
     RELATIVE_ROTARY_DECONZ_TO_EVENT,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_DEVICE_ID,
     CONF_EVENT,
@@ -30,7 +29,7 @@ from homeassistant.helpers import device_registry as dr
 
 from .conftest import WebsocketDataType
 
-from tests.common import async_capture_events
+from tests.common import MockConfigEntry, async_capture_events
 
 
 @pytest.mark.parametrize(
@@ -78,7 +77,7 @@ from tests.common import async_capture_events
 async def test_deconz_events(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
-    config_entry_setup: ConfigEntry,
+    config_entry_setup: MockConfigEntry,
     sensor_ws_data: WebsocketDataType,
 ) -> None:
     """Test successful creation of deconz events."""
@@ -246,7 +245,7 @@ async def test_deconz_events(
 async def test_deconz_alarm_events(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
-    config_entry_setup: ConfigEntry,
+    config_entry_setup: MockConfigEntry,
     sensor_ws_data: WebsocketDataType,
 ) -> None:
     """Test successful creation of deconz alarm events."""
@@ -380,7 +379,7 @@ async def test_deconz_alarm_events(
 async def test_deconz_presence_events(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
-    config_entry_setup: ConfigEntry,
+    config_entry_setup: MockConfigEntry,
     sensor_ws_data: WebsocketDataType,
 ) -> None:
     """Test successful creation of deconz presence events."""
@@ -468,7 +467,7 @@ async def test_deconz_presence_events(
 async def test_deconz_relative_rotary_events(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
-    config_entry_setup: ConfigEntry,
+    config_entry_setup: MockConfigEntry,
     sensor_ws_data: WebsocketDataType,
 ) -> None:
     """Test successful creation of deconz relative rotary events."""
@@ -549,7 +548,7 @@ async def test_deconz_relative_rotary_events(
 async def test_deconz_events_bad_unique_id(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
-    config_entry_setup: ConfigEntry,
+    config_entry_setup: MockConfigEntry,
 ) -> None:
     """Verify no devices are created if unique id is bad or missing."""
     assert len(hass.states.async_all()) == 1

--- a/tests/components/deconz/test_device_trigger.py
+++ b/tests/components/deconz/test_device_trigger.py
@@ -18,7 +18,6 @@ from homeassistant.components.deconz.const import DOMAIN as DECONZ_DOMAIN
 from homeassistant.components.deconz.device_trigger import CONF_SUBTYPE
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL,
     ATTR_ENTITY_ID,
@@ -35,7 +34,7 @@ from homeassistant.setup import async_setup_component
 
 from .conftest import WebsocketDataType
 
-from tests.common import async_get_device_automations
+from tests.common import MockConfigEntry, async_get_device_automations
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
@@ -381,7 +380,7 @@ async def test_validate_trigger_unknown_device(hass: HomeAssistant) -> None:
 async def test_validate_trigger_unsupported_device(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
-    config_entry_setup: ConfigEntry,
+    config_entry_setup: MockConfigEntry,
 ) -> None:
     """Test unsupported device doesn't return a trigger config."""
     device = device_registry.async_get_or_create(
@@ -421,7 +420,7 @@ async def test_validate_trigger_unsupported_device(
 async def test_validate_trigger_unsupported_trigger(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
-    config_entry_setup: ConfigEntry,
+    config_entry_setup: MockConfigEntry,
 ) -> None:
     """Test unsupported trigger does not return a trigger config."""
     device = device_registry.async_get_or_create(
@@ -463,7 +462,7 @@ async def test_validate_trigger_unsupported_trigger(
 async def test_attach_trigger_no_matching_event(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
-    config_entry_setup: ConfigEntry,
+    config_entry_setup: MockConfigEntry,
 ) -> None:
     """Test no matching event for device doesn't return a trigger config."""
     device = device_registry.async_get_or_create(

--- a/tests/components/deconz/test_diagnostics.py
+++ b/tests/components/deconz/test_diagnostics.py
@@ -3,11 +3,11 @@
 from pydeconz.websocket import State
 from syrupy import SnapshotAssertion
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .conftest import WebsocketStateType
 
+from tests.common import MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
 
@@ -15,7 +15,7 @@ from tests.typing import ClientSessionGenerator
 async def test_entry_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
-    config_entry_setup: ConfigEntry,
+    config_entry_setup: MockConfigEntry,
     mock_websocket_state: WebsocketStateType,
     snapshot: SnapshotAssertion,
 ) -> None:

--- a/tests/components/deconz/test_fan.py
+++ b/tests/components/deconz/test_fan.py
@@ -13,7 +13,6 @@ from homeassistant.components.fan import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     STATE_OFF,
@@ -24,7 +23,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .conftest import WebsocketDataType
+from .conftest import ConfigEntryFactoryType, WebsocketDataType
 
 from tests.common import snapshot_platform
 from tests.test_util.aiohttp import AiohttpClientMocker
@@ -57,7 +56,7 @@ async def test_fans(
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
     aioclient_mock: AiohttpClientMocker,
-    config_entry_factory: ConfigEntry,
+    config_entry_factory: ConfigEntryFactoryType,
     mock_put_request: Callable[[str, str], AiohttpClientMocker],
     light_ws_data: WebsocketDataType,
 ) -> None:

--- a/tests/components/deconz/test_hub.py
+++ b/tests/components/deconz/test_hub.py
@@ -17,16 +17,18 @@ from homeassistant.components.ssdp import (
     ATTR_UPNP_SERIAL,
     ATTR_UPNP_UDN,
 )
-from homeassistant.config_entries import SOURCE_SSDP, ConfigEntry
+from homeassistant.config_entries import SOURCE_SSDP
 from homeassistant.const import STATE_OFF, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 from .conftest import BRIDGE_ID
 
+from tests.common import MockConfigEntry
+
 
 async def test_device_registry_entry(
-    config_entry_setup: ConfigEntry,
+    config_entry_setup: MockConfigEntry,
     device_registry: dr.DeviceRegistry,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -68,7 +70,7 @@ async def test_connection_status_signalling(
 
 
 async def test_update_address(
-    hass: HomeAssistant, config_entry_setup: ConfigEntry
+    hass: HomeAssistant, config_entry_setup: MockConfigEntry
 ) -> None:
     """Make sure that connection status triggers a dispatcher send."""
     gateway = DeconzHub.get_hub(hass, config_entry_setup)
@@ -99,7 +101,7 @@ async def test_update_address(
 
 
 async def test_reset_after_successful_setup(
-    hass: HomeAssistant, config_entry_setup: ConfigEntry
+    hass: HomeAssistant, config_entry_setup: MockConfigEntry
 ) -> None:
     """Make sure that connection status triggers a dispatcher send."""
     gateway = DeconzHub.get_hub(hass, config_entry_setup)
@@ -110,7 +112,9 @@ async def test_reset_after_successful_setup(
     assert result is True
 
 
-async def test_get_deconz_api(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+async def test_get_deconz_api(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
     """Successful call."""
     with patch("pydeconz.DeconzSession.refresh_state", return_value=True):
         assert await get_deconz_api(hass, config_entry)
@@ -127,7 +131,7 @@ async def test_get_deconz_api(hass: HomeAssistant, config_entry: ConfigEntry) ->
 )
 async def test_get_deconz_api_fails(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: MockConfigEntry,
     side_effect: Exception,
     raised_exception: Exception,
 ) -> None:

--- a/tests/components/deconz/test_init.py
+++ b/tests/components/deconz/test_init.py
@@ -10,7 +10,6 @@ from homeassistant.components.deconz import (
 )
 from homeassistant.components.deconz.const import DOMAIN as DECONZ_DOMAIN
 from homeassistant.components.deconz.errors import AuthenticationRequired, CannotConnect
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .conftest import ConfigEntryFactoryType
@@ -18,7 +17,7 @@ from .conftest import ConfigEntryFactoryType
 from tests.common import MockConfigEntry
 
 
-async def setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def setup_entry(hass: HomeAssistant, entry: MockConfigEntry) -> None:
     """Test that setup entry works."""
     with (
         patch.object(DeconzHub, "async_setup", return_value=True),
@@ -28,7 +27,7 @@ async def setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
 
 
 async def test_setup_entry_successful(
-    hass: HomeAssistant, config_entry_setup: ConfigEntry
+    hass: HomeAssistant, config_entry_setup: MockConfigEntry
 ) -> None:
     """Test setup entry is successful."""
     assert hass.data[DECONZ_DOMAIN]
@@ -86,7 +85,7 @@ async def test_setup_entry_multiple_gateways(
 
 
 async def test_unload_entry(
-    hass: HomeAssistant, config_entry_setup: ConfigEntry
+    hass: HomeAssistant, config_entry_setup: MockConfigEntry
 ) -> None:
     """Test being able to unload an entry."""
     assert hass.data[DECONZ_DOMAIN]

--- a/tests/components/deconz/test_light.py
+++ b/tests/components/deconz/test_light.py
@@ -27,7 +27,6 @@ from homeassistant.components.light import (
     ColorMode,
     LightEntityFeature,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_SUPPORTED_FEATURES,
@@ -41,7 +40,7 @@ from homeassistant.helpers import entity_registry as er
 
 from .conftest import ConfigEntryFactoryType, WebsocketDataType
 
-from tests.common import snapshot_platform
+from tests.common import MockConfigEntry, snapshot_platform
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
@@ -491,7 +490,7 @@ async def test_light_state_change(
 async def test_light_service_calls(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
-    config_entry_factory: Callable[[], ConfigEntry],
+    config_entry_factory: ConfigEntryFactoryType,
     light_payload: dict[str, Any],
     mock_put_request: Callable[[str, str], AiohttpClientMocker],
     input: dict[str, Any],
@@ -730,7 +729,7 @@ async def test_configuration_tool(hass: HomeAssistant) -> None:
 async def test_groups(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    config_entry_factory: Callable[[], ConfigEntry],
+    config_entry_factory: ConfigEntryFactoryType,
     group_payload: dict[str, Any],
     input: dict[str, list[str]],
     snapshot: SnapshotAssertion,
@@ -972,7 +971,7 @@ async def test_empty_group(hass: HomeAssistant) -> None:
 @pytest.mark.parametrize("config_entry_options", [{CONF_ALLOW_DECONZ_GROUPS: False}])
 async def test_disable_light_groups(
     hass: HomeAssistant,
-    config_entry_setup: ConfigEntry,
+    config_entry_setup: MockConfigEntry,
 ) -> None:
     """Test disallowing light groups work."""
     assert len(hass.states.async_all()) == 1

--- a/tests/components/deconz/test_lock.py
+++ b/tests/components/deconz/test_lock.py
@@ -9,7 +9,6 @@ from homeassistant.components.lock import (
     SERVICE_LOCK,
     SERVICE_UNLOCK,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     STATE_LOCKED,
@@ -20,6 +19,7 @@ from homeassistant.core import HomeAssistant
 
 from .conftest import WebsocketDataType
 
+from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
@@ -43,7 +43,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 )
 async def test_lock_from_light(
     hass: HomeAssistant,
-    config_entry_setup: ConfigEntry,
+    config_entry_setup: MockConfigEntry,
     mock_put_request: Callable[[str, str], AiohttpClientMocker],
     light_ws_data: WebsocketDataType,
 ) -> None:
@@ -118,7 +118,7 @@ async def test_lock_from_light(
 )
 async def test_lock_from_sensor(
     hass: HomeAssistant,
-    config_entry_setup: ConfigEntry,
+    config_entry_setup: MockConfigEntry,
     mock_put_request: Callable[[str, str], AiohttpClientMocker],
     sensor_ws_data: WebsocketDataType,
 ) -> None:

--- a/tests/components/deconz/test_services.py
+++ b/tests/components/deconz/test_services.py
@@ -21,13 +21,12 @@ from homeassistant.components.deconz.services import (
     SERVICE_REMOVE_ORPHANED_ENTRIES,
 )
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .test_hub import BRIDGE_ID
 
-from tests.common import async_capture_events
+from tests.common import MockConfigEntry, async_capture_events
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
@@ -329,7 +328,7 @@ async def test_remove_orphaned_entries_service(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    config_entry_setup: ConfigEntry,
+    config_entry_setup: MockConfigEntry,
 ) -> None:
     """Test service works and also don't remove more than expected."""
     device = device_registry.async_get_or_create(

--- a/tests/components/deconz/test_siren.py
+++ b/tests/components/deconz/test_siren.py
@@ -5,7 +5,6 @@ from collections.abc import Callable
 import pytest
 
 from homeassistant.components.siren import ATTR_DURATION, DOMAIN as SIREN_DOMAIN
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_TURN_OFF,
@@ -18,6 +17,7 @@ from homeassistant.core import HomeAssistant
 
 from .conftest import WebsocketDataType
 
+from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
@@ -34,7 +34,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 )
 async def test_sirens(
     hass: HomeAssistant,
-    config_entry_setup: ConfigEntry,
+    config_entry_setup: MockConfigEntry,
     light_ws_data: WebsocketDataType,
     mock_put_request: Callable[[str, str], AiohttpClientMocker],
 ) -> None:

--- a/tests/components/deconz/test_switch.py
+++ b/tests/components/deconz/test_switch.py
@@ -11,13 +11,13 @@ from homeassistant.components.switch import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .conftest import ConfigEntryFactoryType, WebsocketDataType
 
+from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
@@ -54,7 +54,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 )
 async def test_power_plugs(
     hass: HomeAssistant,
-    config_entry_setup: ConfigEntry,
+    config_entry_setup: MockConfigEntry,
     mock_put_request: Callable[[str, str], AiohttpClientMocker],
     light_ws_data: WebsocketDataType,
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replace ConfigEntry with MockConfigEntry
Also make sure to use ConfigEntryFactoryType

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
