### PR TITLE
Bump aiohue to version 4.7.2

### DIFF
--- a/homeassistant/components/hue/manifest.json
+++ b/homeassistant/components/hue/manifest.json
@@ -11,6 +11,6 @@
   "iot_class": "local_push",
   "loggers": ["aiohue"],
   "quality_scale": "platinum",
-  "requirements": ["aiohue==4.7.1"],
+  "requirements": ["aiohue==4.7.2"],
   "zeroconf": ["_hue._tcp.local."]
 }

--- a/homeassistant/components/hue/v2/hue_event.py
+++ b/homeassistant/components/hue/v2/hue_event.py
@@ -55,7 +55,7 @@ async def async_setup_hue_events(bridge: HueBridge):
             CONF_ID: slugify(f"{hue_device.metadata.name} Button"),
             CONF_DEVICE_ID: device.id,  # type: ignore[union-attr]
             CONF_UNIQUE_ID: hue_resource.id,
-            CONF_TYPE: hue_resource.button.last_event.value,
+            CONF_TYPE: hue_resource.button.button_report.event.value,
             CONF_SUBTYPE: hue_resource.metadata.control_id,
         }
         hass.bus.async_fire(ATTR_HUE_EVENT, data)
@@ -79,7 +79,7 @@ async def async_setup_hue_events(bridge: HueBridge):
         data = {
             CONF_DEVICE_ID: device.id,  # type: ignore[union-attr]
             CONF_UNIQUE_ID: hue_resource.id,
-            CONF_TYPE: hue_resource.relative_rotary.last_event.action.value,
+            CONF_TYPE: hue_resource.relative_rotary.rotary_report.action.value,
             CONF_SUBTYPE: hue_resource.relative_rotary.last_event.rotation.direction.value,
             CONF_DURATION: hue_resource.relative_rotary.last_event.rotation.duration,
             CONF_STEPS: hue_resource.relative_rotary.last_event.rotation.steps,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -258,7 +258,7 @@ aioharmony==0.2.10
 aiohomekit==3.2.0
 
 # homeassistant.components.hue
-aiohue==4.7.1
+aiohue==4.7.2
 
 # homeassistant.components.imap
 aioimaplib==1.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -240,7 +240,7 @@ aioharmony==0.2.10
 aiohomekit==3.2.0
 
 # homeassistant.components.hue
-aiohue==4.7.1
+aiohue==4.7.2
 
 # homeassistant.components.imap
 aioimaplib==1.1.0

--- a/tests/components/hue/fixtures/v2_resources.json
+++ b/tests/components/hue/fixtures/v2_resources.json
@@ -1487,6 +1487,10 @@
     "on": {
       "on": true
     },
+    "owner": {
+      "rid": "7cee478d-6455-483a-9e32-9f9fdcbcc4f6",
+      "rtype": "zone"
+    },
     "type": "grouped_light"
   },
   {
@@ -1498,6 +1502,10 @@
     "on": {
       "on": true
     },
+    "owner": {
+      "rid": "7cee478d-6455-483a-9e32-9f9fdcbcc4f6",
+      "rtype": "zone"
+    },
     "type": "grouped_light"
   },
   {
@@ -1508,6 +1516,10 @@
     "id_v1": "/groups/3",
     "on": {
       "on": false
+    },
+    "owner": {
+      "rid": "7cee478d-6455-483a-9e32-9f9fdcbcc4f6",
+      "rtype": "zone"
     },
     "type": "grouped_light"
   },

--- a/tests/components/hue/test_device_trigger_v2.py
+++ b/tests/components/hue/test_device_trigger_v2.py
@@ -31,7 +31,12 @@ async def test_hue_event(
 
     # Emit button update event
     btn_event = {
-        "button": {"last_event": "initial_press"},
+        "button": {
+            "button_report": {
+                "event": "initial_press",
+                "updated": "2021-10-01T12:00:00Z",
+            }
+        },
         "id": "c658d3d8-a013-4b81-8ac6-78b248537e70",
         "metadata": {"control_id": 1},
         "type": "button",
@@ -44,7 +49,7 @@ async def test_hue_event(
     assert len(events) == 1
     assert events[0].data["id"] == "wall_switch_with_2_controls_button"
     assert events[0].data["unique_id"] == btn_event["id"]
-    assert events[0].data["type"] == btn_event["button"]["last_event"]
+    assert events[0].data["type"] == btn_event["button"]["button_report"]["event"]
     assert events[0].data["subtype"] == btn_event["metadata"]["control_id"]
 
 


### PR DESCRIPTION
## Proposed change

Bump aiohue to [version 4.7.2](https://github.com/home-assistant-libs/aiohue/releases/tag/4.7.2) which contains several small bugfixes for reported issues.


## Type of change

- [X] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issues: 

fixes #122290 
fixes #120507
fixes #110836
fixes #117316 


- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
