### PR TITLE
Less use of hass.data[DECONZ_DOMAIN] in deCONZ tests

### DIFF
--- a/tests/components/deconz/test_hub.py
+++ b/tests/components/deconz/test_hub.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import patch
 
-import pydeconz
 from pydeconz.websocket import State
 import pytest
 from syrupy import SnapshotAssertion
@@ -10,8 +9,7 @@ from syrupy import SnapshotAssertion
 from homeassistant.components import ssdp
 from homeassistant.components.deconz.config_flow import DECONZ_MANUFACTURERURL
 from homeassistant.components.deconz.const import DOMAIN as DECONZ_DOMAIN
-from homeassistant.components.deconz.errors import AuthenticationRequired, CannotConnect
-from homeassistant.components.deconz.hub import DeconzHub, get_deconz_api
+from homeassistant.components.deconz.hub import DeconzHub
 from homeassistant.components.ssdp import (
     ATTR_UPNP_MANUFACTURER_URL,
     ATTR_UPNP_SERIAL,
@@ -110,37 +108,3 @@ async def test_reset_after_successful_setup(
     await hass.async_block_till_done()
 
     assert result is True
-
-
-async def test_get_deconz_api(
-    hass: HomeAssistant, config_entry: MockConfigEntry
-) -> None:
-    """Successful call."""
-    with patch("pydeconz.DeconzSession.refresh_state", return_value=True):
-        assert await get_deconz_api(hass, config_entry)
-
-
-@pytest.mark.parametrize(
-    ("side_effect", "raised_exception"),
-    [
-        (TimeoutError, CannotConnect),
-        (pydeconz.RequestError, CannotConnect),
-        (pydeconz.ResponseError, CannotConnect),
-        (pydeconz.Unauthorized, AuthenticationRequired),
-    ],
-)
-async def test_get_deconz_api_fails(
-    hass: HomeAssistant,
-    config_entry: MockConfigEntry,
-    side_effect: Exception,
-    raised_exception: Exception,
-) -> None:
-    """Failed call."""
-    with (
-        patch(
-            "pydeconz.DeconzSession.refresh_state",
-            side_effect=side_effect,
-        ),
-        pytest.raises(raised_exception),
-    ):
-        assert await get_deconz_api(hass, config_entry)

--- a/tests/components/deconz/test_init.py
+++ b/tests/components/deconz/test_init.py
@@ -3,13 +3,15 @@
 import asyncio
 from unittest.mock import patch
 
-from homeassistant.components.deconz import (
-    DeconzHub,
-    async_setup_entry,
-    async_unload_entry,
+import pydeconz
+import pytest
+
+from homeassistant.components.deconz.const import (
+    CONF_MASTER_GATEWAY,
+    DOMAIN as DECONZ_DOMAIN,
 )
-from homeassistant.components.deconz.const import DOMAIN as DECONZ_DOMAIN
-from homeassistant.components.deconz.errors import AuthenticationRequired, CannotConnect
+from homeassistant.components.deconz.errors import AuthenticationRequired
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
 from .conftest import ConfigEntryFactoryType
@@ -17,35 +19,35 @@ from .conftest import ConfigEntryFactoryType
 from tests.common import MockConfigEntry
 
 
-async def setup_entry(hass: HomeAssistant, entry: MockConfigEntry) -> None:
-    """Test that setup entry works."""
-    with (
-        patch.object(DeconzHub, "async_setup", return_value=True),
-        patch.object(DeconzHub, "async_update_device_registry", return_value=True),
-    ):
-        assert await async_setup_entry(hass, entry) is True
+async def test_setup_entry(config_entry_setup: MockConfigEntry) -> None:
+    """Test successful setup of entry."""
+    assert config_entry_setup.state is ConfigEntryState.LOADED
+    assert config_entry_setup.options[CONF_MASTER_GATEWAY] is True
 
 
-async def test_setup_entry_successful(
-    hass: HomeAssistant, config_entry_setup: MockConfigEntry
+@pytest.mark.parametrize(
+    ("side_effect", "state"),
+    [
+        # Failed authentication trigger a reauthentication flow
+        (pydeconz.Unauthorized, ConfigEntryState.SETUP_ERROR),
+        # Connection fails
+        (TimeoutError, ConfigEntryState.SETUP_RETRY),
+        (pydeconz.RequestError, ConfigEntryState.SETUP_RETRY),
+        (pydeconz.ResponseError, ConfigEntryState.SETUP_RETRY),
+    ],
+)
+async def test_get_deconz_api_fails(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    side_effect: Exception,
+    state: ConfigEntryState,
 ) -> None:
-    """Test setup entry is successful."""
-    assert hass.data[DECONZ_DOMAIN]
-    assert config_entry_setup.entry_id in hass.data[DECONZ_DOMAIN]
-    assert hass.data[DECONZ_DOMAIN][config_entry_setup.entry_id].master
-
-
-async def test_setup_entry_fails_config_entry_not_ready(
-    hass: HomeAssistant, config_entry_factory: ConfigEntryFactoryType
-) -> None:
-    """Failed authentication trigger a reauthentication flow."""
-    with patch(
-        "homeassistant.components.deconz.get_deconz_api",
-        side_effect=CannotConnect,
-    ):
-        await config_entry_factory()
-
-    assert hass.data[DECONZ_DOMAIN] == {}
+    """Failed setup."""
+    config_entry.add_to_hass(hass)
+    with patch("pydeconz.DeconzSession.refresh_state", side_effect=side_effect):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+    assert config_entry.state == state
 
 
 async def test_setup_entry_fails_trigger_reauth_flow(
@@ -59,10 +61,9 @@ async def test_setup_entry_fails_trigger_reauth_flow(
         ),
         patch.object(hass.config_entries.flow, "async_init") as mock_flow_init,
     ):
-        await config_entry_factory()
+        config_entry = await config_entry_factory()
         mock_flow_init.assert_called_once()
-
-    assert hass.data[DECONZ_DOMAIN] == {}
+    assert config_entry.state == ConfigEntryState.SETUP_ERROR
 
 
 async def test_setup_entry_multiple_gateways(
@@ -79,19 +80,19 @@ async def test_setup_entry_multiple_gateways(
     )
     config_entry2 = await config_entry_factory(entry2)
 
-    assert len(hass.data[DECONZ_DOMAIN]) == 2
-    assert hass.data[DECONZ_DOMAIN][config_entry.entry_id].master
-    assert not hass.data[DECONZ_DOMAIN][config_entry2.entry_id].master
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert config_entry2.state is ConfigEntryState.LOADED
+    assert config_entry.options[CONF_MASTER_GATEWAY] is True
+    assert config_entry2.options[CONF_MASTER_GATEWAY] is False
 
 
 async def test_unload_entry(
     hass: HomeAssistant, config_entry_setup: MockConfigEntry
 ) -> None:
     """Test being able to unload an entry."""
-    assert hass.data[DECONZ_DOMAIN]
-
-    assert await async_unload_entry(hass, config_entry_setup)
-    assert not hass.data[DECONZ_DOMAIN]
+    assert config_entry_setup.state is ConfigEntryState.LOADED
+    assert await hass.config_entries.async_unload(config_entry_setup.entry_id)
+    assert config_entry_setup.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_unload_entry_multiple_gateways(
@@ -108,12 +109,12 @@ async def test_unload_entry_multiple_gateways(
     )
     config_entry2 = await config_entry_factory(entry2)
 
-    assert len(hass.data[DECONZ_DOMAIN]) == 2
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert config_entry2.state is ConfigEntryState.LOADED
 
-    assert await async_unload_entry(hass, config_entry)
-
-    assert len(hass.data[DECONZ_DOMAIN]) == 1
-    assert hass.data[DECONZ_DOMAIN][config_entry2.entry_id].master
+    assert await hass.config_entries.async_unload(config_entry.entry_id)
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
+    assert config_entry2.options[CONF_MASTER_GATEWAY] is True
 
 
 async def test_unload_entry_multiple_gateways_parallel(
@@ -130,11 +131,13 @@ async def test_unload_entry_multiple_gateways_parallel(
     )
     config_entry2 = await config_entry_factory(entry2)
 
-    assert len(hass.data[DECONZ_DOMAIN]) == 2
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert config_entry2.state is ConfigEntryState.LOADED
 
     await asyncio.gather(
         hass.config_entries.async_unload(config_entry.entry_id),
         hass.config_entries.async_unload(config_entry2.entry_id),
     )
 
-    assert len(hass.data[DECONZ_DOMAIN]) == 0
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
+    assert config_entry2.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/deconz/test_init.py
+++ b/tests/components/deconz/test_init.py
@@ -47,7 +47,7 @@ async def test_get_deconz_api_fails(
     with patch("pydeconz.DeconzSession.refresh_state", side_effect=side_effect):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
-    assert config_entry.state == state
+    assert config_entry.state is state
 
 
 async def test_setup_entry_fails_trigger_reauth_flow(
@@ -63,7 +63,7 @@ async def test_setup_entry_fails_trigger_reauth_flow(
     ):
         config_entry = await config_entry_factory()
         mock_flow_init.assert_called_once()
-    assert config_entry.state == ConfigEntryState.SETUP_ERROR
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_setup_entry_multiple_gateways(

--- a/tests/components/deconz/test_init.py
+++ b/tests/components/deconz/test_init.py
@@ -44,7 +44,10 @@ async def test_get_deconz_api_fails(
 ) -> None:
     """Failed setup."""
     config_entry.add_to_hass(hass)
-    with patch("pydeconz.DeconzSession.refresh_state", side_effect=side_effect):
+    with patch(
+        "homeassistant.components.deconz.hub.api.DeconzSession.refresh_state",
+        side_effect=side_effect,
+    ):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
     assert config_entry.state is state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Be less use of `hass.data[DECONZ_DOMAIN]` in preparation for runtime_data
Don't directly test `get_deconz_api`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
