### PR TITLE
Fix FritzBox sockets switch very slowly

### DIFF
--- a/homeassistant/components/fritzbox/switch.py
+++ b/homeassistant/components/fritzbox/switch.py
@@ -2,16 +2,18 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta
 from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import FritzBoxDeviceEntity
 from .const import DOMAIN
-from .coordinator import FritzboxConfigEntry
+from .coordinator import FritzboxConfigEntry, FritzboxDataUpdateCoordinator
 
 
 async def async_setup_entry(
@@ -43,21 +45,58 @@ async def async_setup_entry(
 class FritzboxSwitch(FritzBoxDeviceEntity, SwitchEntity):
     """The switch class for FRITZ!SmartHome switches."""
 
+    def __init__(
+        self,
+        coordinator: FritzboxDataUpdateCoordinator,
+        ain: str,
+        entity_description: EntityDescription | None = None,
+    ) -> None:
+        """Initialize the switch."""
+        self.current_switch_state = False
+        self.last_switch_time: datetime
+
+        super().__init__(coordinator, ain, entity_description)
+
     @property
     def is_on(self) -> bool:
         """Return true if the switch is on."""
-        return self.data.switch_state  # type: ignore [no-any-return]
+
+        # recognize if the physical switch is turned on or off
+        # we need to check time difference because of laziness of the fritzbox api
+        if self.last_switch_time:
+            time_diff = datetime.now() - self.last_switch_time
+            if (
+                time_diff >= timedelta(seconds=30)
+                and self.current_switch_state != self.data.switch_state
+            ):
+                self.current_switch_state = self.data.switch_state
+
+        return self.current_switch_state
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         self.check_lock_state()
+
         await self.hass.async_add_executor_job(self.data.set_switch_state_on)
+
+        # The switch state is not updated immediately after the switch is turned on.
+        # Therefore, we need to update the switch state manually.
+        self.current_switch_state = True
+        self.last_switch_time = datetime.now()
+
         await self.coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         self.check_lock_state()
+
         await self.hass.async_add_executor_job(self.data.set_switch_state_off)
+
+        # The switch state is not updated immediately after the switch is turned on.
+        # Therefore, we need to update the switch state manually.
+        self.current_switch_state = False
+        self.last_switch_time = datetime.now()
+
         await self.coordinator.async_refresh()
 
     def check_lock_state(self) -> None:

--- a/homeassistant/components/fritzbox/switch.py
+++ b/homeassistant/components/fritzbox/switch.py
@@ -52,10 +52,9 @@ class FritzboxSwitch(FritzBoxDeviceEntity, SwitchEntity):
         entity_description: EntityDescription | None = None,
     ) -> None:
         """Initialize the switch."""
-        self.current_switch_state: bool = False
-        self.last_switch_time: datetime = datetime.now()
-
         super().__init__(coordinator, ain, entity_description)
+        self.current_switch_state: bool = self.data.switch_state
+        self.last_switch_time: datetime = datetime.now()
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/fritzbox/switch.py
+++ b/homeassistant/components/fritzbox/switch.py
@@ -52,8 +52,8 @@ class FritzboxSwitch(FritzBoxDeviceEntity, SwitchEntity):
         entity_description: EntityDescription | None = None,
     ) -> None:
         """Initialize the switch."""
-        self.current_switch_state = False
-        self.last_switch_time: datetime
+        self.current_switch_state: bool = False
+        self.last_switch_time: datetime = datetime.now()
 
         super().__init__(coordinator, ain, entity_description)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

In this Pull request if fixed an issue for the FritzDect 301 which occurred in a state change of the switch component if the switch  pressed

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #113749
- This PR is related to issue:  #113749
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ x] The code change is tested and works locally.
- [ x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ x] There is no commented out code in this PR.
- [ x] I have followed the [development checklist][dev-checklist]
- [ x] I have followed the [perfect PR recommendations][perfect-pr]
- [ x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
