### PR TITLE
Add device info to legacy Ecovacs bots 

### DIFF
--- a/homeassistant/components/ecovacs/vacuum.py
+++ b/homeassistant/components/ecovacs/vacuum.py
@@ -26,6 +26,7 @@ from homeassistant.components.vacuum import (
 from homeassistant.core import HomeAssistant, SupportsResponse
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_platform
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.icon import icon_for_battery_level
 from homeassistant.util import slugify
@@ -75,6 +76,7 @@ class EcovacsLegacyVacuum(StateVacuumEntity):
     """Legacy Ecovacs vacuums."""
 
     _attr_fan_speed_list = [sucks.FAN_SPEED_NORMAL, sucks.FAN_SPEED_HIGH]
+    _attr_has_entity_name = True
     _attr_should_poll = False
     _attr_supported_features = (
         VacuumEntityFeature.BATTERY
@@ -95,7 +97,16 @@ class EcovacsLegacyVacuum(StateVacuumEntity):
 
         self.error: str | None = None
         self._attr_unique_id = vacuum["did"]
-        self._attr_name = vacuum.get("nick", vacuum["did"])
+
+        if (name := vacuum.get("nick")) is None:
+            name = vacuum.get("name", vacuum["did"])
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, vacuum["did"])},
+            model=vacuum.get("deviceName"),
+            name=name,
+            serial_number=vacuum["did"],
+        )
 
     async def async_added_to_hass(self) -> None:
         """Set up the event listeners now that hass is ready."""

--- a/tests/components/ecovacs/conftest.py
+++ b/tests/components/ecovacs/conftest.py
@@ -118,6 +118,27 @@ def mock_mqtt_client(mock_authenticator: Mock) -> Generator[Mock]:
 
 
 @pytest.fixture
+def mock_vacbot(device_fixture: str) -> Generator[Mock]:
+    """Mock the legacy VacBot."""
+    with patch(
+        "homeassistant.components.ecovacs.controller.VacBot",
+        autospec=True,
+    ) as mock:
+        vacbot = mock.return_value
+        vacbot.vacuum = load_json_object_fixture(
+            f"devices/{device_fixture}/device.json", DOMAIN
+        )
+        vacbot.statusEvents = Mock()
+        vacbot.batteryEvents = Mock()
+        vacbot.lifespanEvents = Mock()
+        vacbot.errorEvents = Mock()
+        vacbot.battery_status = None
+        vacbot.fan_speed = None
+        vacbot.components = {}
+        yield vacbot
+
+
+@pytest.fixture
 def mock_device_execute() -> Generator[AsyncMock]:
     """Mock the device execute function."""
     with patch.object(

--- a/tests/components/ecovacs/fixtures/devices/123/device.json
+++ b/tests/components/ecovacs/fixtures/devices/123/device.json
@@ -1,0 +1,23 @@
+{
+  "did": "E1234567890000000003",
+  "name": "E1234567890000000003",
+  "class": "123",
+  "resource": "atom",
+  "company": "eco-legacy",
+  "deviceName": "DEEBOT Slim2 Series",
+  "icon": "https://portal-ww.ecouser.net/api/pim/file/get/5d2c150dba13eb00013feaae",
+  "ota": false,
+  "UILogicId": "ECO_INTL_123",
+  "materialNo": "110-1639-0102",
+  "pid": "5cae9b201285190001685977",
+  "product_category": "DEEBOT",
+  "model": "Slim2",
+  "updateInfo": {
+    "needUpdate": false,
+    "changeLog": ""
+  },
+  "nick": null,
+  "homeSort": 9999,
+  "status": 2,
+  "otaUpgrade": {}
+}

--- a/tests/components/ecovacs/test_init.py
+++ b/tests/components/ecovacs/test_init.py
@@ -129,12 +129,15 @@ async def test_devices_in_dr(
         assert device_entry == snapshot(name=device.device_info["did"])
 
 
-@pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
+@pytest.mark.usefixtures(
+    "entity_registry_enabled_by_default", "mock_vacbot", "init_integration"
+)
 @pytest.mark.parametrize(
     ("device_fixture", "entities"),
     [
         ("yna5x1", 26),
         ("5xu9h3", 24),
+        ("123", 1),
     ],
 )
 async def test_all_entities_loaded(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
