### PR TITLE
Add markdown removal for TTS

### DIFF
--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -20,6 +20,7 @@ from typing import Any, Final, TypedDict, final
 from aiohttp import web
 import mutagen
 from mutagen.id3 import ID3, TextFrame as ID3Text
+from strip_markdown import strip_markdown
 import voluptuous as vol
 
 from homeassistant.components import ffmpeg, websocket_api
@@ -77,6 +78,7 @@ __all__ = [
     "ATTR_PREFERRED_FORMAT",
     "ATTR_PREFERRED_SAMPLE_RATE",
     "ATTR_PREFERRED_SAMPLE_CHANNELS",
+    "ATTR_MARKDOWN",
     "CONF_LANG",
     "DEFAULT_CACHE_DIR",
     "generate_media_source_id",
@@ -95,6 +97,7 @@ ATTR_AUDIO_OUTPUT = "audio_output"
 ATTR_PREFERRED_FORMAT = "preferred_format"
 ATTR_PREFERRED_SAMPLE_RATE = "preferred_sample_rate"
 ATTR_PREFERRED_SAMPLE_CHANNELS = "preferred_sample_channels"
+ATTR_MARKDOWN = "markdown"
 ATTR_MEDIA_PLAYER_ENTITY_ID = "media_player_entity_id"
 ATTR_VOICE = "voice"
 
@@ -741,6 +744,10 @@ class SpeechManager:
             sample_channels = options.get(ATTR_PREFERRED_SAMPLE_CHANNELS)
         else:
             sample_channels = options.pop(ATTR_PREFERRED_SAMPLE_CHANNELS, None)
+
+        # Strip markdown unless the engine can handle it
+        if ATTR_MARKDOWN not in supported_options:
+            message = strip_markdown(message)
 
         async def get_tts_data() -> str:
             """Handle data available."""

--- a/homeassistant/components/tts/manifest.json
+++ b/homeassistant/components/tts/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "entity",
   "loggers": ["mutagen"],
   "quality_scale": "internal",
-  "requirements": ["mutagen==1.47.0"]
+  "requirements": ["mutagen==1.47.0", "strip-markdown==1.3"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -54,6 +54,7 @@ pyudev==0.24.1
 PyYAML==6.0.1
 requests==2.32.3
 SQLAlchemy==2.0.31
+strip-markdown==1.3
 typing-extensions>=4.12.2,<5.0
 ulid-transform==0.10.1
 urllib3>=1.26.5,<2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2669,6 +2669,9 @@ streamlabswater==1.0.1
 # homeassistant.components.traccar
 stringcase==1.2.0
 
+# homeassistant.components.tts
+strip-markdown==1.3
+
 # homeassistant.components.subaru
 subarulink==0.7.11
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2103,6 +2103,9 @@ streamlabswater==1.0.1
 # homeassistant.components.traccar
 stringcase==1.2.0
 
+# homeassistant.components.tts
+strip-markdown==1.3
+
 # homeassistant.components.subaru
 subarulink==0.7.11
 

--- a/tests/components/tts/common.py
+++ b/tests/components/tts/common.py
@@ -127,6 +127,8 @@ async def retrieve_media(
 class BaseProvider:
     """Test speech API provider."""
 
+    _attr_supported_options = ["voice", "age"]
+
     def __init__(self, lang: str) -> None:
         """Initialize test provider."""
         self._lang = lang
@@ -154,7 +156,7 @@ class BaseProvider:
     @property
     def supported_options(self) -> list[str]:
         """Return list of supported options like voice, emotions."""
-        return ["voice", "age"]
+        return self._attr_supported_options
 
     def get_tts_audio(
         self, message: str, language: str, options: dict[str, Any]

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -1443,7 +1443,7 @@ async def test_support_options(hass: HomeAssistant, setup: str, engine_id: str) 
 )
 @pytest.mark.parametrize(
     "markdown",
-    [(False,), (True,)],
+    [False, True],
 )
 async def test_strip_markdown(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Problem:
LLM may occasionally output markdown-formatted text even when explicitly told to produce plain text only. When this text is then used with Text-to-speech synthesizers, it may produce unexpected results.
Some TTS engines might actually need the formatting if they can emphasize something, display it, or remove themselves. However others will translate the markdown formatting into words, such as "underscore", "asterisk", etc.

This PR removes the markdown formatting by default. It also allows tts engines to opt-in for receiving raw data by setting a respective option (see `supported_options`).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
