### PR TITLE
Add the ability to order listeners

### DIFF
--- a/homeassistant/components/history/websocket_api.py
+++ b/homeassistant/components/history/websocket_api.py
@@ -32,6 +32,7 @@ from homeassistant.core import (
     valid_entity_id,
 )
 from homeassistant.helpers.event import (
+    CallbackOrder,
     async_track_point_in_utc_time,
     async_track_state_change_event,
 )
@@ -391,7 +392,9 @@ def _async_subscribe_events(
         target(event)
 
     subscriptions.append(
-        async_track_state_change_event(hass, entity_ids, _forward_state_events_filtered)
+        async_track_state_change_event(
+            hass, entity_ids, _forward_state_events_filtered, order=CallbackOrder.FIRST
+        )
     )
 
 

--- a/homeassistant/components/logbook/helpers.py
+++ b/homeassistant/components/logbook/helpers.py
@@ -25,7 +25,7 @@ from homeassistant.core import (
     split_entity_id,
 )
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.helpers.event import CallbackOrder, async_track_state_change_event
 from homeassistant.util.event_type import EventType
 
 from .const import ALWAYS_CONTINUOUS_DOMAINS, AUTOMATION_EVENTS, BUILT_IN_EVENTS, DOMAIN
@@ -200,7 +200,10 @@ def async_subscribe_events(
     if entity_ids:
         subscriptions.append(
             async_track_state_change_event(
-                hass, entity_ids, _forward_state_events_filtered
+                hass,
+                entity_ids,
+                _forward_state_events_filtered,
+                order=CallbackOrder.FIRST,
             )
         )
         return

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1667,11 +1667,10 @@ class EventBus:
         group: ListenGroup = ListenGroup.FIRST,
     ) -> CALLBACK_TYPE:
         """Listen for all events or events of a specific type."""
-        listen_group = (
-            self._first_listeners
-            if group is ListenGroup.FIRST
-            else self._last_listeners
-        )
+        if group is ListenGroup.FIRST:
+            listen_group = self._first_listeners
+        else:
+            listen_group = self._last_listeners
         listen_group[event_type].append(filterable_job)
         return functools.partial(
             self._async_remove_listener, listen_group, event_type, filterable_job

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1574,12 +1574,12 @@ class EventBus:
                 "Bus:Handling %s", _event_repr(event_type, origin, event_data)
             )
 
-        event: Event[_DataT] | None = None
         if not (listeners := self._listeners.get(event_type)):
             if event_type in EVENTS_EXCLUDED_FROM_MATCH_ALL:
                 return
             listeners = self._match_all_listeners
 
+        event: Event[_DataT] | None = None
         for job, event_filter in listeners.copy():
             if event_filter is not None:
                 try:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1677,8 +1677,8 @@ class EventBus:
     @callback
     def _build_all_listeners(self) -> None:
         """Rebuild the listeners dictionary."""
-        for this_event_type in set(chain(self._first_listeners, self._last_listeners)):
-            self._build_event_type_listeners(this_event_type)
+        for event_type in set(chain(self._first_listeners, self._last_listeners)):
+            self._build_event_type_listeners(event_type)
 
     @callback
     def _async_remove_all_listener(

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1575,12 +1575,12 @@ class EventBus:
             )
 
         event: Event[_DataT] | None = None
-        for job, event_filter in self._listeners.get(
-            event_type,
-            EMPTY_LIST
-            if event_type in EVENTS_EXCLUDED_FROM_MATCH_ALL
-            else self._match_all_listeners,
-        ).copy():
+        if not (listeners := self._listeners.get(event_type)):
+            if event_type in EVENTS_EXCLUDED_FROM_MATCH_ALL:
+                return
+            listeners = self._match_all_listeners
+
+        for job, event_filter in listeners.copy():
             if event_filter is not None:
                 try:
                     if event_data is None or not event_filter(event_data):

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1675,12 +1675,6 @@ class EventBus:
         return self._async_listen_filterable_job(event_type, filterable_job, group)
 
     @callback
-    def _build_all_listeners(self) -> None:
-        """Rebuild the listeners dictionary."""
-        for event_type in set(chain(self._first_listeners, self._last_listeners)):
-            self._build_event_type_listeners(event_type)
-
-    @callback
     def _async_remove_all_listener(
         self, filterable_job: _FilterableJobType[Any]
     ) -> None:
@@ -1709,6 +1703,12 @@ class EventBus:
         return functools.partial(
             self._async_remove_listener, listen_group, event_type, filterable_job
         )
+
+    @callback
+    def _build_all_listeners(self) -> None:
+        """Rebuild the listeners dictionary."""
+        for event_type in set(chain(self._first_listeners, self._last_listeners)):
+            self._build_event_type_listeners(event_type)
 
     def _build_event_type_listeners(self, event_type: EventType[Any] | str) -> None:
         """Build the listeners list for a specific event type."""

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1475,9 +1475,7 @@ class EventBus:
         # event bus. This is done to avoid having to build the list of listeners every
         # time an event is fired.
         #
-        self._listeners: defaultdict[
-            EventType[Any] | str, list[_FilterableJobType[Any]]
-        ] = defaultdict(list)
+        self._listeners: dict[EventType[Any] | str, list[_FilterableJobType[Any]]] = {}
 
         self._first_listeners: defaultdict[
             EventType[Any] | str, list[_FilterableJobType[Any]]
@@ -1716,11 +1714,15 @@ class EventBus:
             event_match_all_listeners = EMPTY_LIST
         else:
             event_match_all_listeners = self._match_all_listeners
-        self._listeners[event_type] = (
+
+        if new_listeners := (
             event_match_all_listeners
             + self._first_listeners.get(event_type, EMPTY_LIST)
             + self._last_listeners.get(event_type, EMPTY_LIST)
-        )
+        ):
+            self._listeners[event_type] = new_listeners
+        else:
+            self._listeners.pop(event_type, None)
 
     def listen_once(
         self,

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1677,18 +1677,8 @@ class EventBus:
     @callback
     def _rebuild_all_listeners(self) -> None:
         """Rebuild the listeners dictionary."""
-        match_all_listeners = self._match_all_listeners
         for this_event_type in set(chain(self._first_listeners, self._last_listeners)):
-            if this_event_type in EVENTS_EXCLUDED_FROM_MATCH_ALL:
-                event_match_all_listeners = EMPTY_LIST
-            else:
-                event_match_all_listeners = match_all_listeners
-
-            self._listeners[this_event_type] = (
-                event_match_all_listeners
-                + self._first_listeners.get(this_event_type, EMPTY_LIST)
-                + self._last_listeners.get(this_event_type, EMPTY_LIST)
-            )
+            self._rebuild_event_type_listeners(this_event_type)
 
     @callback
     def _async_remove_all_listener(

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1706,7 +1706,7 @@ class EventBus:
 
     @callback
     def _build_all_listeners(self) -> None:
-        """Rebuild the listeners dictionary."""
+        """Build the listeners dictionary for each event_type."""
         for event_type in set(chain(self._first_listeners, self._last_listeners)):
             self._build_event_type_listeners(event_type)
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1801,7 +1801,7 @@ class EventBus:
         try:
             listen_group[event_type].remove(filterable_job)
             # delete event_type list if empty
-            if not listen_group[event_type] and event_type != MATCH_ALL:
+            if not listen_group[event_type]:
                 listen_group.pop(event_type)
         except (KeyError, ValueError):
             # KeyError is key event_type listener did not exist

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -32,6 +32,7 @@ from homeassistant.core import (
     HassJob,
     HassJobType,
     HomeAssistant,
+    ListenGroup,
     State,
     callback,
     split_entity_id,
@@ -449,6 +450,7 @@ def _async_track_event(
             tracker.event_type,
             partial(tracker.dispatcher_callable, hass, callbacks),
             event_filter=partial(tracker.filter_callable, hass, callbacks),
+            group=ListenGroup.LAST,
         )
         event_data = _KeyedEventData(listener, callbacks)
         hass_data[tracker_key] = event_data

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -96,7 +96,12 @@ _StateEventDataT = TypeVar("_StateEventDataT", bound=EventStateEventData)
 
 
 class CallbackOrder(enum.Enum):
-    """Order to execute callbacks in."""
+    """Order to execute callbacks in.
+
+    If FIRST is used, the callback will be inserted at the beginning of the list.
+
+    If LAST is used, the callback will be appended to the end of the list.
+    """
 
     FIRST = "FIRST"
     LAST = "LAST"

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -4946,7 +4946,7 @@ async def test_async_track_state_change_event_runs_last(hass: HomeAssistant) -> 
 
     @ha.callback
     def state_changed(source: str, event: Event[EventStateChangedData]) -> None:
-        calls.append(source, event)
+        calls.append((source, event))
 
     async_track_state_change_event(
         hass, ["light.bowl"], partial(state_changed, "async_track_state_change_event")
@@ -4957,17 +4957,17 @@ async def test_async_track_state_change_event_runs_last(hass: HomeAssistant) -> 
     hass.bus.async_listen(
         ha.EVENT_STATE_CHANGED,
         partial(state_changed, "async_listen_last"),
-        order=ha.ListenGroup.LAST,
+        group=ha.ListenGroup.LAST,
     )
 
     hass.states.async_set("light.bowl", "on")
     await hass.async_block_till_done()
     assert len(calls) == 3
     assert calls[0][0] == "async_listen"
-    assert calls[0][1]["entity_id"] == "light.bowl"
+    assert calls[0][1].data["entity_id"] == "light.bowl"
 
     assert calls[1][0] == "async_track_state_change_event"
-    assert calls[1][1]["entity_id"] == "light.bowl"
+    assert calls[1][1].data["entity_id"] == "light.bowl"
 
     assert calls[2][0] == "async_listen_last"
-    assert calls[2][1]["entity_id"] == "light.bowl"
+    assert calls[2][1].data["entity_id"] == "light.bowl"

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -4948,13 +4948,13 @@ async def test_async_track_state_change_event_runs_last(hass: HomeAssistant) -> 
     def state_changed(source: str, event: Event[EventStateChangedData]) -> None:
         calls.append(source, event)
 
-    unsub_single = async_track_state_change_event(
+    async_track_state_change_event(
         hass, ["light.bowl"], partial(state_changed, "async_track_state_change_event")
     )
-    unsub_event_state_changed_first = hass.bus.async_listen(
+    hass.bus.async_listen(
         ha.EVENT_STATE_CHANGED, partial(state_changed, "async_listen")
     )
-    unsub_event_state_changed_last = hass.bus.async_listen(
+    hass.bus.async_listen(
         ha.EVENT_STATE_CHANGED,
         partial(state_changed, "async_listen_last"),
         order=ha.ListenGroup.LAST,
@@ -4971,7 +4971,3 @@ async def test_async_track_state_change_event_runs_last(hass: HomeAssistant) -> 
 
     assert calls[2][0] == "async_listen_last"
     assert calls[2][1]["entity_id"] == "light.bowl"
-
-    unsub_single()
-    unsub_event_state_changed_first()
-    unsub_event_state_changed_last()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

fixes #117781

alternative to https://github.com/home-assistant/core/pull/122710

In #117781, we see that an automation will change the state before it can be forwarded because the automation is in the listener list ahead of the state forwarder. This results in the first forwarded state being delivered after the next state change.  

If the UI was open and the WebSocket was connected before the automation was set up, everything would work as expected. If the WebSocket was attached after the automation listeners were added, the problem described above would occur.

We need to make sure the state is forwarded before anything modifies it and fires another state change event. Events were fired in the order the listeners were registered. We want anything explicitly listening to the event bus directly to fire before anything using the event helper to ensure any events being forwarded always get sent before additional state changes/side effects.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
