### PR TITLE
Unsubscribe event listeners on remove of Ecovacs legacy bot entities

### DIFF
--- a/homeassistant/components/ecovacs/entity.py
+++ b/homeassistant/components/ecovacs/entity.py
@@ -137,12 +137,12 @@ class EcovacsLegacyEntity(Entity):
         self.error: str | None = None
         self._attr_unique_id = vacuum["did"]
 
-        if (name := vacuum.get("nick")) is None:
+        if (name := vacuum.get("deviceName")) is None:
             name = vacuum.get("name", vacuum["did"])
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, vacuum["did"])},
-            model=vacuum.get("deviceName"),
+            model=f"{vacuum['product_category']} {vacuum['model']}",
             name=name,
             serial_number=vacuum["did"],
         )

--- a/homeassistant/components/ecovacs/entity.py
+++ b/homeassistant/components/ecovacs/entity.py
@@ -10,6 +10,7 @@ from deebot_client.capabilities import Capabilities
 from deebot_client.device import Device
 from deebot_client.events import AvailabilityEvent
 from deebot_client.events.base import Event
+from sucks import EventListener, VacBot
 
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -120,3 +121,35 @@ class EcovacsCapabilityEntityDescription(
     """Ecovacs entity description."""
 
     capability_fn: Callable[[Capabilities], CapabilityEntity | None]
+
+
+class EcovacsLegacyEntity(Entity):
+    """Ecovacs legacy bot entity."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    def __init__(self, device: VacBot) -> None:
+        """Initialize the legacy Ecovacs entity."""
+        self.device = device
+        vacuum = self.device.vacuum
+
+        self.error: str | None = None
+        self._attr_unique_id = vacuum["did"]
+
+        if (name := vacuum.get("nick")) is None:
+            name = vacuum.get("name", vacuum["did"])
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, vacuum["did"])},
+            model=vacuum.get("deviceName"),
+            name=name,
+            serial_number=vacuum["did"],
+        )
+
+        self._event_listeners: list[EventListener] = []
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove event listeners on entity remove."""
+        for listener in self._event_listeners:
+            listener.unsubscribe()

--- a/homeassistant/components/ecovacs/entity.py
+++ b/homeassistant/components/ecovacs/entity.py
@@ -137,13 +137,13 @@ class EcovacsLegacyEntity(Entity):
         self.error: str | None = None
         self._attr_unique_id = vacuum["did"]
 
-        if (name := vacuum.get("deviceName")) is None:
-            name = vacuum.get("name", vacuum["did"])
+        if (name := vacuum.get("nick")) is None:
+            name = vacuum["did"]
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, vacuum["did"])},
             manufacturer="Ecovacs",
-            model=f"{vacuum['product_category']} {vacuum['model']}",
+            model=vacuum.get("deviceName"),
             name=name,
             serial_number=vacuum["did"],
         )

--- a/homeassistant/components/ecovacs/entity.py
+++ b/homeassistant/components/ecovacs/entity.py
@@ -132,7 +132,7 @@ class EcovacsLegacyEntity(Entity):
     def __init__(self, device: VacBot) -> None:
         """Initialize the legacy Ecovacs entity."""
         self.device = device
-        vacuum = self.device.vacuum
+        vacuum = device.vacuum
 
         self.error: str | None = None
         self._attr_unique_id = vacuum["did"]

--- a/homeassistant/components/ecovacs/entity.py
+++ b/homeassistant/components/ecovacs/entity.py
@@ -142,6 +142,7 @@ class EcovacsLegacyEntity(Entity):
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, vacuum["did"])},
+            manufacturer="Ecovacs",
             model=f"{vacuum['product_category']} {vacuum['model']}",
             name=name,
             serial_number=vacuum["did"],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This implements a base class for legacy Ecovacs bots (_`EcovacsLegacyEntity`_) and further cares about unsubscribing of event listeners on entity remove. While the later is also an improvement, both things are the pre-work for moving the current extra state attributes from the `vacuum` entity into own sensors.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
