### PR TITLE
Move lifespan attributes into own sensors for legacy Ecovacs bots

### DIFF
--- a/homeassistant/components/ecovacs/const.py
+++ b/homeassistant/components/ecovacs/const.py
@@ -21,6 +21,12 @@ SUPPORTED_LIFESPANS = (
     LifeSpan.ROUND_MOP,
 )
 
+LEGACY_SUPPORTED_LIFESPANS = (
+    "main_brush",
+    "side_brush",
+    "filter",
+)
+
 
 class InstanceMode(StrEnum):
     """Instance mode."""

--- a/homeassistant/components/ecovacs/controller.py
+++ b/homeassistant/components/ecovacs/controller.py
@@ -74,6 +74,8 @@ class EcovacsController:
             self._authenticator,
         )
 
+        self._added_legacy_entities: set[str] = set()
+
     async def initialize(self) -> None:
         """Init controller."""
         mqtt_config_verfied = False
@@ -116,6 +118,14 @@ class EcovacsController:
             await self._hass.async_add_executor_job(legacy_device.disconnect)
         await self._mqtt.disconnect()
         await self._authenticator.teardown()
+
+    def add_legacy_entity(self, device: VacBot, component: str) -> None:
+        """Add legacy entity."""
+        self._added_legacy_entities.add(f"{device.vacuum['did']}_{component}")
+
+    def legacy_entity_is_added(self, device: VacBot, component: str) -> bool:
+        """Check if legacy entity is added."""
+        return f"{device.vacuum['did']}_{component}" in self._added_legacy_entities
 
     @property
     def devices(self) -> list[Device]:

--- a/homeassistant/components/ecovacs/entity.py
+++ b/homeassistant/components/ecovacs/entity.py
@@ -150,6 +150,11 @@ class EcovacsLegacyEntity(Entity):
 
         self._event_listeners: list[EventListener] = []
 
+    @property
+    def available(self) -> bool:
+        """Return True if the entity is available."""
+        return super().available and self.state is not None
+
     async def async_will_remove_from_hass(self) -> None:
         """Remove event listeners on entity remove."""
         for listener in self._event_listeners:

--- a/homeassistant/components/ecovacs/sensor.py
+++ b/homeassistant/components/ecovacs/sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Generic
+from typing import Any, Generic
 
 from deebot_client.capabilities import CapabilityEvent, CapabilityLifeSpan
 from deebot_client.events import (
@@ -17,6 +17,7 @@ from deebot_client.events import (
     StatsEvent,
     TotalStatsEvent,
 )
+from sucks import VacBot
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -32,16 +33,17 @@ from homeassistant.const import (
     EntityCategory,
     UnitOfTime,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event as CoreEvent, HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
 from . import EcovacsConfigEntry
-from .const import SUPPORTED_LIFESPANS
+from .const import LEGACY_SUPPORTED_LIFESPANS, SUPPORTED_LIFESPANS
 from .entity import (
     EcovacsCapabilityEntityDescription,
     EcovacsDescriptionEntity,
     EcovacsEntity,
+    EcovacsLegacyEntity,
     EventT,
 )
 from .util import get_supported_entitites
@@ -158,6 +160,25 @@ LIFESPAN_ENTITY_DESCRIPTIONS = tuple(
 )
 
 
+@dataclass(kw_only=True, frozen=True)
+class EcovacsLegacyLifespanSensorEntityDescription(SensorEntityDescription):
+    """Ecovacs lifespan sensor entity description."""
+
+    component: str
+
+
+LEGACY_LIFESPAN_SENSORS = tuple(
+    EcovacsLegacyLifespanSensorEntityDescription(
+        component=component,
+        key=f"lifespan_{component}",
+        translation_key=f"lifespan_{component}",
+        native_unit_of_measurement=PERCENTAGE,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    )
+    for component in LEGACY_SUPPORTED_LIFESPANS
+)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: EcovacsConfigEntry,
@@ -182,6 +203,32 @@ async def async_setup_entry(
     )
 
     async_add_entities(entities)
+
+    @callback
+    def _add_legacy_entities(event: CoreEvent) -> None:
+        async_add_entities(
+            EcovacsLegacyLifespanSensor(device, description)
+            for device in controller.legacy_devices
+            for description in LEGACY_LIFESPAN_SENSORS
+            if description.component in device.components
+            and not controller.legacy_entity_is_added(device, description.component)
+        )
+        for device in controller.legacy_devices:
+            for description in LEGACY_LIFESPAN_SENSORS:
+                if description.component in device.components:
+                    controller.add_legacy_entity(device, description.component)
+
+    hass.bus.async_listen("ecovacs_legacy_lifespan_event", _add_legacy_entities)
+
+    def _fire_ecovacs_legacy_lifespan_event(_: Any) -> None:
+        hass.bus.fire("ecovacs_legacy_lifespan_event")
+
+    for device in controller.legacy_devices:
+        config_entry.async_on_unload(
+            device.lifespanEvents.subscribe(
+                _fire_ecovacs_legacy_lifespan_event
+            ).unsubscribe
+        )
 
 
 class EcovacsSensor(
@@ -253,3 +300,38 @@ class EcovacsErrorSensor(
             self.async_write_ha_state()
 
         self._subscribe(self._capability.event, on_event)
+
+
+class EcovacsLegacyLifespanSensor(EcovacsLegacyEntity, SensorEntity):
+    """Legacy Lifespan sensor."""
+
+    entity_description: EcovacsLegacyLifespanSensorEntityDescription
+
+    def __init__(
+        self,
+        device: VacBot,
+        description: EcovacsLegacyLifespanSensorEntityDescription,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(device)
+        self.entity_description = description
+        self._attr_unique_id = f"{device.vacuum['did']}_{description.key}"
+
+        if (value := device.components.get(description.component)) is not None:
+            value = int(value * 100)
+        self._attr_native_value = value
+
+    async def async_added_to_hass(self) -> None:
+        """Set up the event listeners now that hass is ready."""
+
+        def on_event() -> None:
+            if (
+                value := self.device.components.get(self.entity_description.component)
+            ) is not None:
+                value = int(value * 100)
+            self._attr_native_value = value
+            self.schedule_update_ha_state()
+
+        self._event_listeners.append(
+            self.device.lifespanEvents.subscribe(lambda _: on_event())
+        )

--- a/homeassistant/components/ecovacs/sensor.py
+++ b/homeassistant/components/ecovacs/sensor.py
@@ -324,7 +324,7 @@ class EcovacsLegacyLifespanSensor(EcovacsLegacyEntity, SensorEntity):
     async def async_added_to_hass(self) -> None:
         """Set up the event listeners now that hass is ready."""
 
-        def on_event() -> None:
+        def on_event(_: Any) -> None:
             if (
                 value := self.device.components.get(self.entity_description.component)
             ) is not None:
@@ -332,6 +332,4 @@ class EcovacsLegacyLifespanSensor(EcovacsLegacyEntity, SensorEntity):
             self._attr_native_value = value
             self.schedule_update_ha_state()
 
-        self._event_listeners.append(
-            self.device.lifespanEvents.subscribe(lambda _: on_event())
-        )
+        self._event_listeners.append(self.device.lifespanEvents.subscribe(on_event))

--- a/homeassistant/components/ecovacs/sensor.py
+++ b/homeassistant/components/ecovacs/sensor.py
@@ -33,7 +33,7 @@ from homeassistant.const import (
     EntityCategory,
     UnitOfTime,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
@@ -204,8 +204,7 @@ async def async_setup_entry(
 
     async_add_entities(entities)
 
-    @callback
-    def _add_legacy_entities(_: Any) -> None:
+    async def _add_legacy_entities() -> None:
         entities = []
         for device in controller.legacy_devices:
             for description in LEGACY_LIFESPAN_SENSORS:
@@ -221,15 +220,8 @@ async def async_setup_entry(
         if entities:
             async_add_entities(entities)
 
-    for device in controller.legacy_devices:
-        config_entry.async_on_unload(
-            device.lifespanEvents.subscribe(_add_legacy_entities).unsubscribe
-        )
-
-    hass.bus.async_listen("ecovacs_legacy_lifespan_event", _add_legacy_entities)
-
     def _fire_ecovacs_legacy_lifespan_event(_: Any) -> None:
-        hass.bus.fire("ecovacs_legacy_lifespan_event")
+        hass.create_task(_add_legacy_entities())
 
     for device in controller.legacy_devices:
         config_entry.async_on_unload(

--- a/homeassistant/components/ecovacs/strings.json
+++ b/homeassistant/components/ecovacs/strings.json
@@ -116,6 +116,9 @@
       "lifespan_lens_brush": {
         "name": "Lens brush lifespan"
       },
+      "lifespan_main_brush": {
+        "name": "[%key:component::ecovacs::entity::sensor::lifespan_brush::name%]"
+      },
       "lifespan_side_brush": {
         "name": "Side brush lifespan"
       },

--- a/homeassistant/components/ecovacs/vacuum.py
+++ b/homeassistant/components/ecovacs/vacuum.py
@@ -168,6 +168,7 @@ class EcovacsLegacyVacuum(EcovacsLegacyEntity, StateVacuumEntity):
         data: dict[str, Any] = {}
         data[ATTR_ERROR] = self.error
 
+        # these attributes are deprecated and can be removed in 2025.2
         for key, val in self.device.components.items():
             attr_name = ATTR_COMPONENT_PREFIX + key
             data[attr_name] = int(val * 100)

--- a/homeassistant/components/ecovacs/vacuum.py
+++ b/homeassistant/components/ecovacs/vacuum.py
@@ -143,11 +143,6 @@ class EcovacsLegacyVacuum(EcovacsLegacyEntity, StateVacuumEntity):
         return None
 
     @property
-    def available(self) -> bool:
-        """Return True if the vacuum is available."""
-        return super().available and self.state is not None
-
-    @property
     def battery_level(self) -> int | None:
         """Return the battery level of the vacuum cleaner."""
         if self.device.battery_status is not None:

--- a/tests/components/ecovacs/conftest.py
+++ b/tests/components/ecovacs/conftest.py
@@ -10,6 +10,7 @@ from deebot_client.device import Device
 from deebot_client.exceptions import ApiError
 from deebot_client.models import Credentials
 import pytest
+from sucks import EventEmitter
 
 from homeassistant.components.ecovacs import PLATFORMS
 from homeassistant.components.ecovacs.const import DOMAIN
@@ -128,10 +129,10 @@ def mock_vacbot(device_fixture: str) -> Generator[Mock]:
         vacbot.vacuum = load_json_object_fixture(
             f"devices/{device_fixture}/device.json", DOMAIN
         )
-        vacbot.statusEvents = Mock()
-        vacbot.batteryEvents = Mock()
-        vacbot.lifespanEvents = Mock()
-        vacbot.errorEvents = Mock()
+        vacbot.statusEvents = EventEmitter()
+        vacbot.batteryEvents = EventEmitter()
+        vacbot.lifespanEvents = EventEmitter()
+        vacbot.errorEvents = EventEmitter()
         vacbot.battery_status = None
         vacbot.fan_speed = None
         vacbot.components = {}

--- a/tests/components/ecovacs/conftest.py
+++ b/tests/components/ecovacs/conftest.py
@@ -175,7 +175,7 @@ async def init_integration(
         mock_config_entry.add_to_hass(hass)
 
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
         yield mock_config_entry
 
 

--- a/tests/components/ecovacs/snapshots/test_sensor.ambr
+++ b/tests/components/ecovacs/snapshots/test_sensor.ambr
@@ -1,4 +1,145 @@
 # serializer version: 1
+# name: test_legacy_sensors[123][sensor.e1234567890000000003_filter_lifespan:entity-registry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.e1234567890000000003_filter_lifespan',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Filter lifespan',
+    'platform': 'ecovacs',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'lifespan_filter',
+    'unique_id': 'E1234567890000000003_lifespan_filter',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_legacy_sensors[123][sensor.e1234567890000000003_filter_lifespan:state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'E1234567890000000003 Filter lifespan',
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.e1234567890000000003_filter_lifespan',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '40',
+  })
+# ---
+# name: test_legacy_sensors[123][sensor.e1234567890000000003_main_brush_lifespan:entity-registry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.e1234567890000000003_main_brush_lifespan',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Main brush lifespan',
+    'platform': 'ecovacs',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'lifespan_main_brush',
+    'unique_id': 'E1234567890000000003_lifespan_main_brush',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_legacy_sensors[123][sensor.e1234567890000000003_main_brush_lifespan:state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'E1234567890000000003 Main brush lifespan',
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.e1234567890000000003_main_brush_lifespan',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '80',
+  })
+# ---
+# name: test_legacy_sensors[123][sensor.e1234567890000000003_side_brush_lifespan:entity-registry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.e1234567890000000003_side_brush_lifespan',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Side brush lifespan',
+    'platform': 'ecovacs',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'lifespan_side_brush',
+    'unique_id': 'E1234567890000000003_lifespan_side_brush',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_legacy_sensors[123][sensor.e1234567890000000003_side_brush_lifespan:state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'E1234567890000000003 Side brush lifespan',
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.e1234567890000000003_side_brush_lifespan',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '60',
+  })
+# ---
 # name: test_sensors[5xu9h3][sensor.goat_g1_area_cleaned:entity-registry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/ecovacs/snapshots/test_sensor.ambr
+++ b/tests/components/ecovacs/snapshots/test_sensor.ambr
@@ -140,6 +140,13 @@
     'state': '60',
   })
 # ---
+# name: test_legacy_sensors[123][states]
+  list([
+    'sensor.e1234567890000000003_main_brush_lifespan',
+    'sensor.e1234567890000000003_side_brush_lifespan',
+    'sensor.e1234567890000000003_filter_lifespan',
+  ])
+# ---
 # name: test_sensors[5xu9h3][sensor.goat_g1_area_cleaned:entity-registry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/ecovacs/test_sensor.py
+++ b/tests/components/ecovacs/test_sensor.py
@@ -1,5 +1,7 @@
 """Tests for Ecovacs sensors."""
 
+from unittest.mock import Mock
+
 from deebot_client.event_bus import EventBus
 from deebot_client.events import (
     BatteryEvent,
@@ -163,7 +165,7 @@ async def test_legacy_sensors(
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
-    mock_vacbot,
+    mock_vacbot: Mock,
 ) -> None:
     """Test that sensor entity snapshots match."""
     mock_vacbot.components = {"main_brush": 0.8, "side_brush": 0.6, "filter": 0.4}

--- a/tests/components/ecovacs/test_sensor.py
+++ b/tests/components/ecovacs/test_sensor.py
@@ -152,3 +152,31 @@ async def test_disabled_by_default_sensors(
         ), f"Entity registry entry for {entity_id} is missing"
         assert entry.disabled
         assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+
+
+@pytest.mark.usefixtures(
+    "entity_registry_enabled_by_default", "mock_vacbot", "init_integration"
+)
+@pytest.mark.parametrize(("device_fixture"), ["123"])
+async def test_legacy_sensors(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    mock_vacbot,
+) -> None:
+    """Test that sensor entity snapshots match."""
+    mock_vacbot.components = {"main_brush": 0.8, "side_brush": 0.6, "filter": 0.4}
+    hass.bus.async_fire("ecovacs_legacy_lifespan_event")
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    for entity_id in hass.states.async_entity_ids():
+        assert (state := hass.states.get(entity_id)), f"State of {entity_id} is missing"
+        assert snapshot(name=f"{entity_id}:state") == state
+
+        assert (entity_entry := entity_registry.async_get(state.entity_id))
+        assert snapshot(name=f"{entity_id}:entity-registry") == entity_entry
+
+        assert entity_entry.device_id
+        assert (device_entry := device_registry.async_get(entity_entry.device_id))
+        assert device_entry.identifiers == {(DOMAIN, "E1234567890000000003")}

--- a/tests/components/ecovacs/test_sensor.py
+++ b/tests/components/ecovacs/test_sensor.py
@@ -167,8 +167,11 @@ async def test_legacy_sensors(
 ) -> None:
     """Test that sensor entity snapshots match."""
     mock_vacbot.components = {"main_brush": 0.8, "side_brush": 0.6, "filter": 0.4}
-    hass.bus.async_fire("ecovacs_legacy_lifespan_event")
+    mock_vacbot.lifespanEvents.notify("dummy_data")
     await hass.async_block_till_done(wait_background_tasks=True)
+
+    states = hass.states.async_entity_ids()
+    assert snapshot(name="states") == states
 
     for entity_id in hass.states.async_entity_ids():
         assert (state := hass.states.get(entity_id)), f"State of {entity_id} is missing"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The attributes on the vacuum entity for the lifespan of the main brush, side brush, and filter are deprecated and will be removed in 2025.2. These attributes are superseded by dedicated sensor entities.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The supported lifespan components once become available after the connection to the bot is established, therefore we need to subscribe to the corresponding `lifespanEvents` during `async_setup_entry` to call `async_add_entities` as soon as the lifespan components get accessable.

- needs #122732

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
