### PR TITLE
Add coverage for fixing missing params in the doorbird schedule

### DIFF
--- a/homeassistant/components/doorbird/device.py
+++ b/homeassistant/components/doorbird/device.py
@@ -103,9 +103,8 @@ class ConfiguredDoorBird:
     async def async_register_events(self) -> None:
         """Register events on device."""
         if not self.door_station_events:
-            # User may not have permission to get the favorites
+            # The config entry might not have any events configured yet
             return
-
         http_fav = await self._async_register_events()
         event_config = await self._async_get_event_config(http_fav)
         _LOGGER.debug("%s: Event config: %s", self.name, event_config)

--- a/tests/components/doorbird/__init__.py
+++ b/tests/components/doorbird/__init__.py
@@ -49,6 +49,7 @@ def get_mock_doorbird_api(
     schedule: list[DoorBirdScheduleEntry] | None = None,
     favorites: dict[str, dict[str, Any]] | None = None,
     favorites_side_effect: Exception | None = None,
+    change_schedule: tuple[bool, int] | None = None,
 ) -> DoorBird:
     """Return a mock DoorBirdAPI object with return values."""
     doorbirdapi_mock = MagicMock(spec_set=DoorBird)
@@ -60,7 +61,9 @@ def get_mock_doorbird_api(
         return_value=favorites,
     )
     type(doorbirdapi_mock).change_favorite = AsyncMock(return_value=True)
-    type(doorbirdapi_mock).change_schedule = AsyncMock(return_value=(True, 200))
+    type(doorbirdapi_mock).change_schedule = AsyncMock(
+        return_value=change_schedule or (True, 200)
+    )
     type(doorbirdapi_mock).schedule = AsyncMock(return_value=schedule)
     type(doorbirdapi_mock).energize_relay = AsyncMock(return_value=True)
     type(doorbirdapi_mock).turn_light_on = AsyncMock(return_value=True)

--- a/tests/components/doorbird/conftest.py
+++ b/tests/components/doorbird/conftest.py
@@ -47,6 +47,14 @@ def doorbird_schedule() -> list[DoorBirdScheduleEntry]:
 
 
 @pytest.fixture(scope="session")
+def doorbird_schedule_wrong_param() -> list[DoorBirdScheduleEntry]:
+    """Return a loaded DoorBird schedule fixture with an incorrect param."""
+    return DoorBirdScheduleEntry.parse_all(
+        load_json_value_fixture("schedule_wrong_param.json", "doorbird")
+    )
+
+
+@pytest.fixture(scope="session")
 def doorbird_favorites() -> dict[str, dict[str, Any]]:
     """Return a loaded DoorBird favorites fixture."""
     return load_json_value_fixture("favorites.json", "doorbird")
@@ -90,18 +98,21 @@ async def doorbird_mocker(
     async def _async_mock(
         entry: MockConfigEntry | None = None,
         api: DoorBird | None = None,
+        change_schedule: tuple[bool, int] | None = None,
         info: dict[str, Any] | None = None,
         info_side_effect: Exception | None = None,
         schedule: list[DoorBirdScheduleEntry] | None = None,
         favorites: dict[str, dict[str, Any]] | None = None,
         favorites_side_effect: Exception | None = None,
+        options: dict[str, Any] | None = None,
     ) -> MockDoorbirdEntry:
         """Create a MockDoorbirdEntry from defaults or specific values."""
         entry = entry or MockConfigEntry(
             domain=DOMAIN,
             unique_id="1CCAE3AAAAAA",
             data=VALID_CONFIG,
-            options={CONF_EVENTS: [DEFAULT_DOORBELL_EVENT, DEFAULT_MOTION_EVENT]},
+            options=options
+            or {CONF_EVENTS: [DEFAULT_DOORBELL_EVENT, DEFAULT_MOTION_EVENT]},
         )
         api = api or get_mock_doorbird_api(
             info=info or doorbird_info,
@@ -109,6 +120,7 @@ async def doorbird_mocker(
             schedule=schedule or doorbird_schedule,
             favorites=favorites or doorbird_favorites,
             favorites_side_effect=favorites_side_effect,
+            change_schedule=change_schedule,
         )
         entry.add_to_hass(hass)
         with patch_doorbird_api_entry_points(api):

--- a/tests/components/doorbird/fixtures/schedule_wrong_param.json
+++ b/tests/components/doorbird/fixtures/schedule_wrong_param.json
@@ -1,0 +1,67 @@
+[
+  {
+    "input": "doorbell",
+    "param": "99",
+    "output": [
+      {
+        "event": "notify",
+        "param": "",
+        "schedule": {
+          "weekdays": [
+            {
+              "to": "107999",
+              "from": "108000"
+            }
+          ]
+        }
+      },
+      {
+        "event": "http",
+        "param": "0",
+        "schedule": {
+          "weekdays": [
+            {
+              "to": "107999",
+              "from": "108000"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "input": "motion",
+    "param": "",
+    "output": [
+      {
+        "event": "notify",
+        "param": "",
+        "schedule": {
+          "weekdays": [
+            {
+              "to": "107999",
+              "from": "108000"
+            }
+          ]
+        }
+      },
+      {
+        "event": "http",
+        "param": "5",
+        "schedule": {
+          "weekdays": [
+            {
+              "to": "107999",
+              "from": "108000"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "input": "relay",
+    "param": "1",
+    "output": []
+  }
+]

--- a/tests/components/doorbird/test_device.py
+++ b/tests/components/doorbird/test_device.py
@@ -1,0 +1,59 @@
+"""Test DoorBird device."""
+
+from copy import deepcopy
+from http import HTTPStatus
+
+from doorbirdpy import DoorBirdScheduleEntry
+import pytest
+
+from homeassistant.components.doorbird.const import CONF_EVENTS
+from homeassistant.core import HomeAssistant
+
+from .conftest import DoorbirdMockerType
+
+
+async def test_no_configured_events(
+    hass: HomeAssistant,
+    doorbird_mocker: DoorbirdMockerType,
+) -> None:
+    """Test a doorbird with no events configured."""
+    await doorbird_mocker(options={CONF_EVENTS: []})
+    assert not hass.states.async_all("event")
+
+
+async def test_change_schedule_success(
+    doorbird_mocker: DoorbirdMockerType,
+    doorbird_schedule_wrong_param: list[DoorBirdScheduleEntry],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a doorbird when change_schedule fails."""
+    schedule_copy = deepcopy(doorbird_schedule_wrong_param)
+    mock_doorbird = await doorbird_mocker(schedule=schedule_copy)
+    assert "Unable to update schedule entry mydoorbird" not in caplog.text
+    assert mock_doorbird.api.change_schedule.call_count == 1
+    new_schedule: list[DoorBirdScheduleEntry] = (
+        mock_doorbird.api.change_schedule.call_args[0]
+    )
+    # Ensure the attempt to update the schedule to fix the incorrect
+    # param is made
+    assert new_schedule[-1].output[-1].param == "1"
+
+
+async def test_change_schedule_fails(
+    doorbird_mocker: DoorbirdMockerType,
+    doorbird_schedule_wrong_param: list[DoorBirdScheduleEntry],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a doorbird when change_schedule fails."""
+    schedule_copy = deepcopy(doorbird_schedule_wrong_param)
+    mock_doorbird = await doorbird_mocker(
+        schedule=schedule_copy, change_schedule=(False, HTTPStatus.UNAUTHORIZED)
+    )
+    assert "Unable to update schedule entry mydoorbird" in caplog.text
+    assert mock_doorbird.api.change_schedule.call_count == 1
+    new_schedule: list[DoorBirdScheduleEntry] = (
+        mock_doorbird.api.change_schedule.call_args[0]
+    )
+    # Ensure the attempt to update the schedule to fix the incorrect
+    # param is made
+    assert new_schedule[-1].output[-1].param == "1"


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add coverage for fixing missing params in the doorbird schedule

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
