### PR TITLE
Update LLM prompt to improve quality for local LLMs

### DIFF
--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -363,7 +363,7 @@ class AssistAPI(API):
             prompt.append(
                 "An overview of the areas and the devices in this smart home:"
             )
-            prompt.append(yaml.dump(exposed_entities))
+            prompt.append(yaml.dump(list(exposed_entities.values())))
 
         return "\n".join(prompt)
 
@@ -477,6 +477,7 @@ def _get_exposed_entities(
 
         info: dict[str, Any] = {
             "names": ", ".join(names),
+            "domain": state.domain,
             "state": state.state,
         }
 

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -324,8 +324,7 @@ class AssistAPI(API):
             (
                 "When controlling Home Assistant always call the intent tools. "
                 "Use HassTurnOn to lock and HassTurnOff to unlock a lock. "
-                "When controlling a device, prefer passing just its name and its domain "
-                "(what comes before the dot in its entity id). "
+                "When controlling a device, prefer passing just name and domain. "
                 "When controlling an area, prefer passing just area name and domain."
             )
         ]

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -505,76 +505,6 @@ async def test_assist_api_prompt(
             suggested_area="Test Area 2",
         )
     )
-
-    exposed_entities = llm._get_exposed_entities(hass, llm_context.assistant)
-    assert exposed_entities == {
-        "light.1": {
-            "areas": "Test Area 2",
-            "domain": "light",
-            "names": "1",
-            "state": "unavailable",
-        },
-        entry1.entity_id: {
-            "names": "Kitchen",
-            "domain": "light",
-            "state": "on",
-            "attributes": {"temperature": "0.9", "humidity": "65"},
-        },
-        entry2.entity_id: {
-            "areas": "Test Area, Alternative name",
-            "names": "Living Room",
-            "domain": "light",
-            "state": "on",
-        },
-        "light.test_device": {
-            "areas": "Test Area, Alternative name",
-            "names": "Test Device",
-            "domain": "light",
-            "state": "unavailable",
-        },
-        "light.test_device_2": {
-            "areas": "Test Area 2",
-            "names": "Test Device 2",
-            "domain": "light",
-            "state": "unavailable",
-        },
-        "light.test_device_3": {
-            "areas": "Test Area 2",
-            "names": "Test Device 3",
-            "domain": "light",
-            "state": "unavailable",
-        },
-        "light.test_device_4": {
-            "areas": "Test Area 2",
-            "names": "Test Device 4",
-            "domain": "light",
-            "state": "unavailable",
-        },
-        "light.test_service": {
-            "areas": "Test Area, Alternative name",
-            "names": "Test Service",
-            "domain": "light",
-            "state": "unavailable",
-        },
-        "light.test_service_2": {
-            "areas": "Test Area, Alternative name",
-            "names": "Test Service",
-            "domain": "light",
-            "state": "unavailable",
-        },
-        "light.test_service_3": {
-            "areas": "Test Area, Alternative name",
-            "names": "Test Service",
-            "domain": "light",
-            "state": "unavailable",
-        },
-        "light.unnamed_device": {
-            "areas": "Test Area 2",
-            "names": "Unnamed Device",
-            "domain": "light",
-            "state": "unavailable",
-        },
-    }
     exposed_entities_prompt = """An overview of the areas and the devices in this smart home:
 - names: Kitchen
   domain: light
@@ -626,8 +556,7 @@ async def test_assist_api_prompt(
     first_part_prompt = (
         "When controlling Home Assistant always call the intent tools. "
         "Use HassTurnOn to lock and HassTurnOff to unlock a lock. "
-        "When controlling a device, prefer passing just its name and its domain "
-        "(what comes before the dot in its entity id). "
+        "When controlling a device, prefer passing just name and domain. "
         "When controlling an area, prefer passing just area name and domain."
     )
     no_timer_prompt = "This device is not able to start timers."

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -22,7 +22,6 @@ from homeassistant.helpers import (
     selector,
 )
 from homeassistant.setup import async_setup_component
-from homeassistant.util import yaml
 
 from tests.common import MockConfigEntry
 
@@ -511,64 +510,119 @@ async def test_assist_api_prompt(
     assert exposed_entities == {
         "light.1": {
             "areas": "Test Area 2",
+            "domain": "light",
             "names": "1",
             "state": "unavailable",
         },
         entry1.entity_id: {
             "names": "Kitchen",
+            "domain": "light",
             "state": "on",
             "attributes": {"temperature": "0.9", "humidity": "65"},
         },
         entry2.entity_id: {
             "areas": "Test Area, Alternative name",
             "names": "Living Room",
+            "domain": "light",
             "state": "on",
         },
         "light.test_device": {
             "areas": "Test Area, Alternative name",
             "names": "Test Device",
+            "domain": "light",
             "state": "unavailable",
         },
         "light.test_device_2": {
             "areas": "Test Area 2",
             "names": "Test Device 2",
+            "domain": "light",
             "state": "unavailable",
         },
         "light.test_device_3": {
             "areas": "Test Area 2",
             "names": "Test Device 3",
+            "domain": "light",
             "state": "unavailable",
         },
         "light.test_device_4": {
             "areas": "Test Area 2",
             "names": "Test Device 4",
+            "domain": "light",
             "state": "unavailable",
         },
         "light.test_service": {
             "areas": "Test Area, Alternative name",
             "names": "Test Service",
+            "domain": "light",
             "state": "unavailable",
         },
         "light.test_service_2": {
             "areas": "Test Area, Alternative name",
             "names": "Test Service",
+            "domain": "light",
             "state": "unavailable",
         },
         "light.test_service_3": {
             "areas": "Test Area, Alternative name",
             "names": "Test Service",
+            "domain": "light",
             "state": "unavailable",
         },
         "light.unnamed_device": {
             "areas": "Test Area 2",
             "names": "Unnamed Device",
+            "domain": "light",
             "state": "unavailable",
         },
     }
-    exposed_entities_prompt = (
-        "An overview of the areas and the devices in this smart home:\n"
-        + yaml.dump(exposed_entities)
-    )
+    exposed_entities_prompt = """An overview of the areas and the devices in this smart home:
+- names: Kitchen
+  domain: light
+  state: 'on'
+  attributes:
+    temperature: '0.9'
+    humidity: '65'
+- names: Living Room
+  domain: light
+  state: 'on'
+  areas: Test Area, Alternative name
+- names: Test Device
+  domain: light
+  state: unavailable
+  areas: Test Area, Alternative name
+- names: Test Service
+  domain: light
+  state: unavailable
+  areas: Test Area, Alternative name
+- names: Test Service
+  domain: light
+  state: unavailable
+  areas: Test Area, Alternative name
+- names: Test Service
+  domain: light
+  state: unavailable
+  areas: Test Area, Alternative name
+- names: Test Device 2
+  domain: light
+  state: unavailable
+  areas: Test Area 2
+- names: Test Device 3
+  domain: light
+  state: unavailable
+  areas: Test Area 2
+- names: Test Device 4
+  domain: light
+  state: unavailable
+  areas: Test Area 2
+- names: Unnamed Device
+  domain: light
+  state: unavailable
+  areas: Test Area 2
+- names: '1'
+  domain: light
+  state: unavailable
+  areas: Test Area 2
+"""
     first_part_prompt = (
         "When controlling Home Assistant always call the intent tools. "
         "Use HassTurnOn to lock and HassTurnOff to unlock a lock. "


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update the LLM prompt to improve quality for local LLMs.

The current prompt passes in entity ids which smaller LLMs want to pass in as an entity name. Entity ids are never used by intents, so they are now omitted.  The prompt also explains the domain as "(what comes before the dot in its entity id)" so now we also just include the domain in the prompt.

The tests are updated to assert on the prompt output rather than internal representation of exposed entities.

This change improves llama3.1 tool quality with ollama (#120454) by 15% on the [assist-mini](https://github.com/allenporter/home-assistant-datasets/tree/main/datasets/assist-mini) benchmark when combined with #122723

This should also improve quality for gpt-3.5 based on evaluation [findings from June](https://docs.google.com/presentation/d/1nL8hqv_158mzY1ZnlVN2PlCut5o-qdXV2XJ2GSL-Qzs/edit#slide=id.g2e7ad849e03_0_2).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
