### PR TITLE
Improve quality of ollama tool calling by repairing arguments

### DIFF
--- a/homeassistant/components/ollama/conversation.py
+++ b/homeassistant/components/ollama/conversation.py
@@ -88,11 +88,7 @@ def _parse_tool_args(arguments: dict[str, Any]) -> dict[str, Any]:
     small local tool use models. This will repair invalid json arguments and
     omit unnecessary arguments with empty values that will fail intent parsing.
     """
-    return {
-        k: _fix_invalid_arguments(v)
-        for k, v in arguments.items()
-        if v
-    }
+    return {k: _fix_invalid_arguments(v) for k, v in arguments.items() if v}
 
 
 class OllamaConversationEntity(

--- a/homeassistant/components/ollama/conversation.py
+++ b/homeassistant/components/ollama/conversation.py
@@ -63,6 +63,38 @@ def _format_tool(
     return {"type": "function", "function": tool_spec}
 
 
+def _fix_invalid_arguments(value: Any) -> Any:
+    """Attempt to repair incorrectly formatted json function arguments.
+
+    Small models (for example llama3.1 8B) may produce invalid argument values
+    which we attempt to repair here.
+    """
+    if not isinstance(value, str):
+        return value
+    if (value.startswith("[") and value.endswith("]")) or (
+        value.startswith("{") and value.endswith("}")
+    ):
+        try:
+            return json.loads(value)
+        except json.decoder.JSONDecodeError:
+            pass
+    return value
+
+
+def _parse_tool_args(arguments: dict[str, Any]) -> dict[str, Any]:
+    """Rewrite ollama tool arguments.
+
+    This function improves tool use quality by fixing common mistakes made by
+    small local tool use models. This will repair invalid json arguments and
+    omit unnecessary arguments with empty values that will fail intent parsing.
+    """
+    return {
+        k: _fix_invalid_arguments(v)
+        for k, v in arguments.items()
+        if v
+    }
+
+
 class OllamaConversationEntity(
     conversation.ConversationEntity, conversation.AbstractConversationAgent
 ):
@@ -255,7 +287,7 @@ class OllamaConversationEntity(
             for tool_call in tool_calls:
                 tool_input = llm.ToolInput(
                     tool_name=tool_call["function"]["name"],
-                    tool_args=tool_call["function"]["arguments"],
+                    tool_args=_parse_tool_args(tool_call["function"]["arguments"]),
                 )
                 _LOGGER.debug(
                     "Tool call: %s(%s)", tool_input.tool_name, tool_input.tool_args

--- a/tests/components/ollama/test_conversation.py
+++ b/tests/components/ollama/test_conversation.py
@@ -121,6 +121,7 @@ async def test_template_variables(
     ("tool_args", "expected_tool_args"),
     [
         ({"param1": "test_value"}, {"param1": "test_value"}),
+        ({"param1": 2}, {"param1": 2}),
         (
             {"param1": "test_value", "floor": ""},
             {"param1": "test_value"},  # Omit empty arguments
@@ -131,7 +132,7 @@ async def test_template_variables(
         ),
         (
             {"domain": "['light']"},
-            {"domain": "['light']"},  # Preserve invalid single quote json
+            {"domain": "['light']"},  # Preserve invalid json that can't be parsed
         ),
     ],
 )

--- a/tests/components/ollama/test_conversation.py
+++ b/tests/components/ollama/test_conversation.py
@@ -123,15 +123,17 @@ async def test_template_variables(
         ({"param1": "test_value"}, {"param1": "test_value"}),
         (
             {"param1": "test_value", "floor": ""},
-            {"param1": "test_value"}),  # Omit empty arguments
+            {"param1": "test_value"},  # Omit empty arguments
+        ),
         (
             {"domain": '["light"]'},
-            {"domain": ["light"]}),  # Repair invalid json arguments
+            {"domain": ["light"]},  # Repair invalid json arguments
+        ),
         (
             {"domain": "['light']"},
             {"domain": "['light']"},  # Preserve invalid single quote json
         ),
-    ]
+    ],
 )
 @patch("homeassistant.components.ollama.conversation.llm.AssistAPI._async_get_tools")
 async def test_function_call(

--- a/tests/components/ollama/test_conversation.py
+++ b/tests/components/ollama/test_conversation.py
@@ -1,5 +1,6 @@
 """Tests for the Ollama integration."""
 
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 from ollama import Message, ResponseError
@@ -116,12 +117,30 @@ async def test_template_variables(
     assert "The user id is 12345." in prompt
 
 
+@pytest.mark.parametrize(
+    ("tool_args", "expected_tool_args"),
+    [
+        ({"param1": "test_value"}, {"param1": "test_value"}),
+        (
+            {"param1": "test_value", "floor": ""},
+            {"param1": "test_value"}),  # Omit empty arguments
+        (
+            {"domain": '["light"]'},
+            {"domain": ["light"]}),  # Repair invalid json arguments
+        (
+            {"domain": "['light']"},
+            {"domain": "['light']"},  # Preserve invalid single quote json
+        ),
+    ]
+)
 @patch("homeassistant.components.ollama.conversation.llm.AssistAPI._async_get_tools")
 async def test_function_call(
     mock_get_tools,
     hass: HomeAssistant,
     mock_config_entry_with_assist: MockConfigEntry,
     mock_init_component,
+    tool_args: dict[str, Any],
+    expected_tool_args: dict[str, Any],
 ) -> None:
     """Test function call from the assistant."""
     agent_id = mock_config_entry_with_assist.entry_id
@@ -154,7 +173,7 @@ async def test_function_call(
                     {
                         "function": {
                             "name": "test_tool",
-                            "arguments": {"param1": "test_value"},
+                            "arguments": tool_args,
                         }
                     }
                 ],
@@ -183,7 +202,7 @@ async def test_function_call(
         hass,
         llm.ToolInput(
             tool_name="test_tool",
-            tool_args={"param1": "test_value"},
+            tool_args=expected_tool_args,
         ),
         llm.LLMContext(
             platform="ollama",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Improve ollama tool calling by repairing function arguments that are not formatted properly:
- omit empty arguments e.g. `floor: ""` which will fail intent parsing. 
- repair function arguments that are meant to be arrays or objects but were generated as strings e.g. `{"domain": "[\"vacuum\"]"}` but the model really meant `{"domain": ["vacuum"]}`.

Given this is a hack to workaround local model behavior, it is localized to the ollama integration instead of the llm helper.

This change improves llama3.1 tool quality by 22% on the [assist-mini](https://github.com/allenporter/home-assistant-datasets/tree/main/datasets/assist-mini) benchmark.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
