### PR TITLE
Use HOMEASSISTANT_DOMAIN alias for core DOMAIN in tests

### DIFF
--- a/tests/components/bmw_connected_drive/test_coordinator.py
+++ b/tests/components/bmw_connected_drive/test_coordinator.py
@@ -8,7 +8,7 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components.bmw_connected_drive import DOMAIN as BMW_DOMAIN
-from homeassistant.core import DOMAIN as HA_DOMAIN, HomeAssistant
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import UpdateFailed
@@ -118,6 +118,7 @@ async def test_init_reauth(
         await hass.async_block_till_done()
 
     reauth_issue = issue_registry.async_get_issue(
-        HA_DOMAIN, f"config_entry_reauth_{BMW_DOMAIN}_{config_entry.entry_id}"
+        HOMEASSISTANT_DOMAIN,
+        f"config_entry_reauth_{BMW_DOMAIN}_{config_entry.entry_id}",
     )
     assert reauth_issue.active is True

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -32,7 +32,12 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     EntityCategory,
 )
-from homeassistant.core import DOMAIN as HASS_DOMAIN, Context, HomeAssistant, callback
+from homeassistant.core import (
+    DOMAIN as HOMEASSISTANT_DOMAIN,
+    Context,
+    HomeAssistant,
+    callback,
+)
 from homeassistant.helpers import (
     area_registry as ar,
     device_registry as dr,
@@ -93,7 +98,7 @@ async def test_hidden_entities_skipped(
         "light", "demo", "1234", suggested_object_id="Test light", **er_kwargs
     )
     hass.states.async_set("light.test_light", "off")
-    calls = async_mock_service(hass, HASS_DOMAIN, "turn_on")
+    calls = async_mock_service(hass, HOMEASSISTANT_DOMAIN, "turn_on")
     result = await conversation.async_converse(
         hass, "turn on test light", None, Context(), None
     )

--- a/tests/components/feedreader/test_config_flow.py
+++ b/tests/components/feedreader/test_config_flow.py
@@ -13,7 +13,7 @@ from homeassistant.components.feedreader.const import (
 )
 from homeassistant.config_entries import SOURCE_RECONFIGURE, SOURCE_USER
 from homeassistant.const import CONF_URL
-from homeassistant.core import DOMAIN as HA_DOMAIN, HomeAssistant
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.setup import async_setup_component
@@ -128,7 +128,9 @@ async def test_import(
     assert config_entries[0].data == expected_data
     assert config_entries[0].options == expected_options
 
-    assert issue_registry.async_get_issue(HA_DOMAIN, "deprecated_yaml_feedreader")
+    assert issue_registry.async_get_issue(
+        HOMEASSISTANT_DOMAIN, "deprecated_yaml_feedreader"
+    )
 
 
 async def test_import_errors(

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -76,7 +76,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     UnitOfTemperature,
 )
-from homeassistant.core import DOMAIN as HA_DOMAIN, HomeAssistant, State
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant, State
 from homeassistant.util import color, dt as dt_util
 from homeassistant.util.unit_conversion import TemperatureConverter
 
@@ -186,12 +186,12 @@ async def test_onoff_group(hass: HomeAssistant) -> None:
 
     assert trt_off.query_attributes() == {"on": False}
 
-    on_calls = async_mock_service(hass, HA_DOMAIN, SERVICE_TURN_ON)
+    on_calls = async_mock_service(hass, HOMEASSISTANT_DOMAIN, SERVICE_TURN_ON)
     await trt_on.execute(trait.COMMAND_ONOFF, BASIC_DATA, {"on": True}, {})
     assert len(on_calls) == 1
     assert on_calls[0].data == {ATTR_ENTITY_ID: "group.bla"}
 
-    off_calls = async_mock_service(hass, HA_DOMAIN, SERVICE_TURN_OFF)
+    off_calls = async_mock_service(hass, HOMEASSISTANT_DOMAIN, SERVICE_TURN_OFF)
     await trt_on.execute(trait.COMMAND_ONOFF, BASIC_DATA, {"on": False}, {})
     assert len(off_calls) == 1
     assert off_calls[0].data == {ATTR_ENTITY_ID: "group.bla"}

--- a/tests/components/homeassistant/test_repairs.py
+++ b/tests/components/homeassistant/test_repairs.py
@@ -10,7 +10,7 @@ from homeassistant.components.repairs.websocket_api import (
     RepairsFlowIndexView,
     RepairsFlowResourceView,
 )
-from homeassistant.core import DOMAIN, HomeAssistant
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -23,7 +23,7 @@ async def test_integration_not_found_confirm_step(
     hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test the integration_not_found issue confirm step."""
-    assert await async_setup_component(hass, DOMAIN, {})
+    assert await async_setup_component(hass, HOMEASSISTANT_DOMAIN, {})
     await hass.async_block_till_done()
     assert await async_setup_component(hass, REPAIRS_DOMAIN, {REPAIRS_DOMAIN: {}})
     await hass.async_block_till_done()
@@ -49,7 +49,9 @@ async def test_integration_not_found_confirm_step(
     assert issue["translation_placeholders"] == {"domain": "test1"}
 
     url = RepairsFlowIndexView.url
-    resp = await http_client.post(url, json={"handler": DOMAIN, "issue_id": issue_id})
+    resp = await http_client.post(
+        url, json={"handler": HOMEASSISTANT_DOMAIN, "issue_id": issue_id}
+    )
     assert resp.status == HTTPStatus.OK
     data = await resp.json()
 
@@ -93,7 +95,7 @@ async def test_integration_not_found_ignore_step(
     hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test the integration_not_found issue ignore step."""
-    assert await async_setup_component(hass, DOMAIN, {})
+    assert await async_setup_component(hass, HOMEASSISTANT_DOMAIN, {})
     await hass.async_block_till_done()
     assert await async_setup_component(hass, REPAIRS_DOMAIN, {REPAIRS_DOMAIN: {}})
     await hass.async_block_till_done()
@@ -117,7 +119,9 @@ async def test_integration_not_found_ignore_step(
     assert issue["translation_placeholders"] == {"domain": "test1"}
 
     url = RepairsFlowIndexView.url
-    resp = await http_client.post(url, json={"handler": DOMAIN, "issue_id": issue_id})
+    resp = await http_client.post(
+        url, json={"handler": HOMEASSISTANT_DOMAIN, "issue_id": issue_id}
+    )
     assert resp.status == HTTPStatus.OK
     data = await resp.json()
 

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -17,7 +17,7 @@ from homeassistant.components.reolink import (
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_OFF, STATE_UNAVAILABLE, Platform
-from homeassistant.core import DOMAIN as HA_DOMAIN, HomeAssistant
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
 from homeassistant.helpers import (
     device_registry as dr,
     entity_registry as er,
@@ -143,13 +143,13 @@ async def test_credential_error_three(
 
     issue_id = f"config_entry_reauth_{const.DOMAIN}_{config_entry.entry_id}"
     for _ in range(NUM_CRED_ERRORS):
-        assert (HA_DOMAIN, issue_id) not in issue_registry.issues
+        assert (HOMEASSISTANT_DOMAIN, issue_id) not in issue_registry.issues
         async_fire_time_changed(
             hass, utcnow() + DEVICE_UPDATE_INTERVAL + timedelta(seconds=30)
         )
         await hass.async_block_till_done()
 
-    assert (HA_DOMAIN, issue_id) in issue_registry.issues
+    assert (HOMEASSISTANT_DOMAIN, issue_id) in issue_registry.issues
 
 
 async def test_entry_reloading(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,7 +32,11 @@ from homeassistant.const import (
     CONF_PACKAGES,
     __version__,
 )
-from homeassistant.core import DOMAIN as HA_DOMAIN, ConfigSource, HomeAssistant
+from homeassistant.core import (
+    DOMAIN as HOMEASSISTANT_DOMAIN,
+    ConfigSource,
+    HomeAssistant,
+)
 from homeassistant.exceptions import ConfigValidationError, HomeAssistantError
 from homeassistant.helpers import (
     check_config,
@@ -1066,7 +1070,9 @@ async def test_check_ha_config_file_wrong(mock_check, hass: HomeAssistant) -> No
     "hass_config",
     [
         {
-            HA_DOMAIN: {CONF_PACKAGES: {"pack_dict": {"input_boolean": {"ib1": None}}}},
+            HOMEASSISTANT_DOMAIN: {
+                CONF_PACKAGES: {"pack_dict": {"input_boolean": {"ib1": None}}}
+            },
             "input_boolean": {"ib2": None},
             "light": {"platform": "test"},
         }
@@ -1080,7 +1086,7 @@ async def test_async_hass_config_yaml_merge(
     conf = await config_util.async_hass_config_yaml(hass)
 
     assert merge_log_err.call_count == 0
-    assert conf[HA_DOMAIN].get(CONF_PACKAGES) is not None
+    assert conf[HOMEASSISTANT_DOMAIN].get(CONF_PACKAGES) is not None
     assert len(conf) == 3
     assert len(conf["input_boolean"]) == 2
     assert len(conf["light"]) == 1
@@ -1108,7 +1114,7 @@ async def test_merge(merge_log_err: MagicMock, hass: HomeAssistant) -> None:
         },
     }
     config = {
-        HA_DOMAIN: {CONF_PACKAGES: packages},
+        HOMEASSISTANT_DOMAIN: {CONF_PACKAGES: packages},
         "input_boolean": {"ib2": None},
         "light": {"platform": "test"},
         "automation": [],
@@ -1135,7 +1141,7 @@ async def test_merge_try_falsy(merge_log_err: MagicMock, hass: HomeAssistant) ->
         "pack_list2": {"light": OrderedDict()},
     }
     config = {
-        HA_DOMAIN: {CONF_PACKAGES: packages},
+        HOMEASSISTANT_DOMAIN: {CONF_PACKAGES: packages},
         "automation": {"do": "something"},
         "light": {"some": "light"},
     }
@@ -1158,7 +1164,7 @@ async def test_merge_new(merge_log_err: MagicMock, hass: HomeAssistant) -> None:
             "api": {},
         },
     }
-    config = {HA_DOMAIN: {CONF_PACKAGES: packages}}
+    config = {HOMEASSISTANT_DOMAIN: {CONF_PACKAGES: packages}}
     await config_util.merge_packages_config(hass, config, packages)
 
     assert merge_log_err.call_count == 0
@@ -1178,7 +1184,7 @@ async def test_merge_type_mismatch(
         "pack_2": {"light": {"ib1": None}},  # light gets merged - ensure_list
     }
     config = {
-        HA_DOMAIN: {CONF_PACKAGES: packages},
+        HOMEASSISTANT_DOMAIN: {CONF_PACKAGES: packages},
         "input_boolean": {"ib2": None},
         "input_select": [{"ib2": None}],
         "light": [{"platform": "two"}],
@@ -1196,13 +1202,13 @@ async def test_merge_once_only_keys(
 ) -> None:
     """Test if we have a merge for a comp that may occur only once. Keys."""
     packages = {"pack_2": {"api": None}}
-    config = {HA_DOMAIN: {CONF_PACKAGES: packages}, "api": None}
+    config = {HOMEASSISTANT_DOMAIN: {CONF_PACKAGES: packages}, "api": None}
     await config_util.merge_packages_config(hass, config, packages)
     assert config["api"] == OrderedDict()
 
     packages = {"pack_2": {"api": {"key_3": 3}}}
     config = {
-        HA_DOMAIN: {CONF_PACKAGES: packages},
+        HOMEASSISTANT_DOMAIN: {CONF_PACKAGES: packages},
         "api": {"key_1": 1, "key_2": 2},
     }
     await config_util.merge_packages_config(hass, config, packages)
@@ -1211,7 +1217,7 @@ async def test_merge_once_only_keys(
     # Duplicate keys error
     packages = {"pack_2": {"api": {"key": 2}}}
     config = {
-        HA_DOMAIN: {CONF_PACKAGES: packages},
+        HOMEASSISTANT_DOMAIN: {CONF_PACKAGES: packages},
         "api": {"key": 1},
     }
     await config_util.merge_packages_config(hass, config, packages)
@@ -1226,7 +1232,7 @@ async def test_merge_once_only_lists(hass: HomeAssistant) -> None:
         }
     }
     config = {
-        HA_DOMAIN: {CONF_PACKAGES: packages},
+        HOMEASSISTANT_DOMAIN: {CONF_PACKAGES: packages},
         "api": {"list_1": ["item_1"]},
     }
     await config_util.merge_packages_config(hass, config, packages)
@@ -1249,7 +1255,7 @@ async def test_merge_once_only_dictionaries(hass: HomeAssistant) -> None:
         }
     }
     config = {
-        HA_DOMAIN: {CONF_PACKAGES: packages},
+        HOMEASSISTANT_DOMAIN: {CONF_PACKAGES: packages},
         "api": {"dict_1": {"key_1": 1, "dict_1.1": {"key_1.1": 1.1}}},
     }
     await config_util.merge_packages_config(hass, config, packages)
@@ -1285,7 +1291,7 @@ async def test_merge_duplicate_keys(
     """Test if keys in dicts are duplicates."""
     packages = {"pack_1": {"input_select": {"ib1": None}}}
     config = {
-        HA_DOMAIN: {CONF_PACKAGES: packages},
+        HOMEASSISTANT_DOMAIN: {CONF_PACKAGES: packages},
         "input_select": {"ib1": 1},
     }
     await config_util.merge_packages_config(hass, config, packages)
@@ -1443,7 +1449,7 @@ async def test_merge_split_component_definition(hass: HomeAssistant) -> None:
         "pack_1": {"light one": {"l1": None}},
         "pack_2": {"light two": {"l2": None}, "light three": {"l3": None}},
     }
-    config = {HA_DOMAIN: {CONF_PACKAGES: packages}}
+    config = {HOMEASSISTANT_DOMAIN: {CONF_PACKAGES: packages}}
     await config_util.merge_packages_config(hass, config, packages)
 
     assert len(config) == 4
@@ -2332,7 +2338,7 @@ async def test_packages_schema_validation_error(
     ]
     assert error_records == snapshot
 
-    assert len(config[HA_DOMAIN][CONF_PACKAGES]) == 0
+    assert len(config[HOMEASSISTANT_DOMAIN][CONF_PACKAGES]) == 0
 
 
 def test_extract_domain_configs() -> None:

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -22,7 +22,12 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STARTED,
     EVENT_HOMEASSISTANT_STOP,
 )
-from homeassistant.core import DOMAIN as HA_DOMAIN, CoreState, HomeAssistant, callback
+from homeassistant.core import (
+    DOMAIN as HOMEASSISTANT_DOMAIN,
+    CoreState,
+    HomeAssistant,
+    callback,
+)
 from homeassistant.data_entry_flow import BaseServiceInfo, FlowResult, FlowResultType
 from homeassistant.exceptions import (
     ConfigEntryAuthFailed,
@@ -526,13 +531,13 @@ async def test_remove_entry_cancels_reauth(
     assert entry.state is config_entries.ConfigEntryState.SETUP_ERROR
 
     issue_id = f"config_entry_reauth_test_{entry.entry_id}"
-    assert issue_registry.async_get_issue(HA_DOMAIN, issue_id)
+    assert issue_registry.async_get_issue(HOMEASSISTANT_DOMAIN, issue_id)
 
     await manager.async_remove(entry.entry_id)
 
     flows = hass.config_entries.flow.async_progress_by_handler("test")
     assert len(flows) == 0
-    assert not issue_registry.async_get_issue(HA_DOMAIN, issue_id)
+    assert not issue_registry.async_get_issue(HOMEASSISTANT_DOMAIN, issue_id)
 
 
 async def test_remove_entry_handles_callback_error(
@@ -1189,14 +1194,14 @@ async def test_reauth_issue(
 
     assert len(issue_registry.issues) == 1
     issue_id = f"config_entry_reauth_test_{entry.entry_id}"
-    issue = issue_registry.async_get_issue(HA_DOMAIN, issue_id)
+    issue = issue_registry.async_get_issue(HOMEASSISTANT_DOMAIN, issue_id)
     assert issue == ir.IssueEntry(
         active=True,
         breaks_in_ha_version=None,
         created=ANY,
         data={"flow_id": flows[0]["flow_id"]},
         dismissed_version=None,
-        domain=HA_DOMAIN,
+        domain=HOMEASSISTANT_DOMAIN,
         is_fixable=False,
         is_persistent=False,
         issue_domain="test",
@@ -5098,7 +5103,7 @@ async def test_hashable_non_string_unique_id(
             {
                 "type": data_entry_flow.FlowResultType.ABORT,
                 "reason": "single_instance_allowed",
-                "translation_domain": HA_DOMAIN,
+                "translation_domain": HOMEASSISTANT_DOMAIN,
             },
         ),
     ],
@@ -5296,7 +5301,7 @@ async def test_avoid_adding_second_config_entry_on_single_config_entry(
         )
         assert result["type"] == data_entry_flow.FlowResultType.ABORT
         assert result["reason"] == "single_instance_allowed"
-        assert result["translation_domain"] == HA_DOMAIN
+        assert result["translation_domain"] == HOMEASSISTANT_DOMAIN
 
 
 async def test_in_progress_get_canceled_when_entry_is_created(

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -10,7 +10,12 @@ import voluptuous as vol
 
 from homeassistant import config_entries, loader, setup
 from homeassistant.const import EVENT_COMPONENT_LOADED, EVENT_HOMEASSISTANT_START
-from homeassistant.core import DOMAIN, CoreState, HomeAssistant, callback
+from homeassistant.core import (
+    DOMAIN as HOMEASSISTANT_DOMAIN,
+    CoreState,
+    HomeAssistant,
+    callback,
+)
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, discovery, translation
 from homeassistant.helpers.dispatcher import (
@@ -243,7 +248,9 @@ async def test_component_not_found(
     """setup_component should not crash if component doesn't exist."""
     assert await setup.async_setup_component(hass, "non_existing", {}) is False
     assert len(issue_registry.issues) == 1
-    issue = issue_registry.async_get_issue(DOMAIN, "integration_not_found.non_existing")
+    issue = issue_registry.async_get_issue(
+        HOMEASSISTANT_DOMAIN, "integration_not_found.non_existing"
+    )
     assert issue
     assert issue.translation_key == "integration_not_found"
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA
Currently, both `HA_DOMAIN` and `HOMEASSISTANT_DOMAIN` are used.
This aims to standardize to use only `HOMEASSISTANT_DOMAIN`, which will then be enforced by #122763

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
