### PR TITLE
Add Airtouch5 cover tests

### DIFF
--- a/tests/components/airtouch5/__init__.py
+++ b/tests/components/airtouch5/__init__.py
@@ -1,1 +1,13 @@
 """Tests for the Airtouch 5 integration."""
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
+    """Fixture for setting up the component."""
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/components/airtouch5/conftest.py
+++ b/tests/components/airtouch5/conftest.py
@@ -3,7 +3,21 @@
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
+from airtouch5py.data_packet_factory import DataPacketFactory
+from airtouch5py.packets.ac_ability import AcAbility
+from airtouch5py.packets.ac_status import AcFanSpeed, AcMode, AcPowerState, AcStatus
+from airtouch5py.packets.zone_name import ZoneName
+from airtouch5py.packets.zone_status import (
+    ControlMethod,
+    ZonePowerState,
+    ZoneStatusZone,
+)
 import pytest
+
+from homeassistant.components.airtouch5.const import DOMAIN
+from homeassistant.const import CONF_HOST
+
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture
@@ -13,3 +27,107 @@ def mock_setup_entry() -> Generator[AsyncMock]:
         "homeassistant.components.airtouch5.async_setup_entry", return_value=True
     ) as mock_setup_entry:
         yield mock_setup_entry
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Mock the config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="1.1.1.1",
+        data={
+            CONF_HOST: "1.1.1.1",
+        },
+    )
+
+
+@pytest.fixture
+def mock_airtouch5_client() -> Generator[AsyncMock]:
+    """Mock an Airtouch5 client."""
+
+    with (
+        patch(
+            "homeassistant.components.airtouch5.Airtouch5SimpleClient",
+            autospec=True,
+        ) as mock_client,
+        patch(
+            "homeassistant.components.airtouch5.config_flow.Airtouch5SimpleClient",
+            new=mock_client,
+        ),
+    ):
+        client = mock_client.return_value
+
+        # Default values for the tests using this mock :
+        client.data_packet_factory = DataPacketFactory()
+        client.ac = [
+            AcAbility(
+                ac_number=1,
+                ac_name="AC 1",
+                start_zone_number=1,
+                zone_count=2,
+                supports_mode_cool=True,
+                supports_mode_fan=True,
+                supports_mode_dry=True,
+                supports_mode_heat=True,
+                supports_mode_auto=True,
+                supports_fan_speed_intelligent_auto=True,
+                supports_fan_speed_turbo=True,
+                supports_fan_speed_powerful=True,
+                supports_fan_speed_high=True,
+                supports_fan_speed_medium=True,
+                supports_fan_speed_low=True,
+                supports_fan_speed_quiet=True,
+                supports_fan_speed_auto=True,
+                min_cool_set_point=15,
+                max_cool_set_point=25,
+                min_heat_set_point=20,
+                max_heat_set_point=30,
+            )
+        ]
+        client.latest_ac_status = {
+            1: AcStatus(
+                ac_power_state=AcPowerState.ON,
+                ac_number=1,
+                ac_mode=AcMode.AUTO,
+                ac_fan_speed=AcFanSpeed.AUTO,
+                ac_setpoint=24,
+                turbo_active=False,
+                bypass_active=False,
+                spill_active=False,
+                timer_set=False,
+                temperature=24,
+                error_code=0,
+            )
+        }
+
+        client.zones = [ZoneName(1, "Zone 1"), ZoneName(2, "Zone 2")]
+        client.latest_zone_status = {
+            1: ZoneStatusZone(
+                zone_power_state=ZonePowerState.ON,
+                zone_number=1,
+                control_method=ControlMethod.PERCENTAGE_CONTROL,
+                open_percentage=0.9,
+                set_point=24,
+                has_sensor=False,
+                temperature=24,
+                spill_active=False,
+                is_low_battery=False,
+            ),
+            2: ZoneStatusZone(
+                zone_power_state=ZonePowerState.ON,
+                zone_number=1,
+                control_method=ControlMethod.TEMPERATURE_CONTROL,
+                open_percentage=1,
+                set_point=24,
+                has_sensor=True,
+                temperature=24,
+                spill_active=False,
+                is_low_battery=False,
+            ),
+        }
+
+        client.connection_state_callbacks = []
+        client.zone_status_callbacks = []
+        client.ac_status_callbacks = []
+
+        yield client

--- a/tests/components/airtouch5/snapshots/test_cover.ambr
+++ b/tests/components/airtouch5/snapshots/test_cover.ambr
@@ -1,0 +1,99 @@
+# serializer version: 1
+# name: test_all_entities[cover.zone_1_damper-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.zone_1_damper',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.DAMPER: 'damper'>,
+    'original_icon': None,
+    'original_name': 'Damper',
+    'platform': 'airtouch5',
+    'previous_unique_id': None,
+    'supported_features': <CoverEntityFeature: 7>,
+    'translation_key': 'damper',
+    'unique_id': 'zone_1_open_percentage',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[cover.zone_1_damper-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_position': 90,
+      'device_class': 'damper',
+      'friendly_name': 'Zone 1 Damper',
+      'supported_features': <CoverEntityFeature: 7>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.zone_1_damper',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'open',
+  })
+# ---
+# name: test_all_entities[cover.zone_2_damper-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.zone_2_damper',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.DAMPER: 'damper'>,
+    'original_icon': None,
+    'original_name': 'Damper',
+    'platform': 'airtouch5',
+    'previous_unique_id': None,
+    'supported_features': <CoverEntityFeature: 7>,
+    'translation_key': 'damper',
+    'unique_id': 'zone_2_open_percentage',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[cover.zone_2_damper-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_position': 100,
+      'device_class': 'damper',
+      'friendly_name': 'Zone 2 Damper',
+      'supported_features': <CoverEntityFeature: 7>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.zone_2_damper',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'open',
+  })
+# ---

--- a/tests/components/airtouch5/test_cover.py
+++ b/tests/components/airtouch5/test_cover.py
@@ -1,0 +1,143 @@
+"""Tests for the Airtouch5 cover platform."""
+
+from collections.abc import Callable
+from unittest.mock import AsyncMock, patch
+
+from airtouch5py.packets.zone_status import (
+    ControlMethod,
+    ZonePowerState,
+    ZoneStatusZone,
+)
+from syrupy import SnapshotAssertion
+
+from homeassistant.components.cover import (
+    ATTR_CURRENT_POSITION,
+    ATTR_POSITION,
+    DOMAIN as COVER_DOMAIN,
+    SERVICE_CLOSE_COVER,
+    SERVICE_OPEN_COVER,
+    SERVICE_SET_COVER_POSITION,
+    STATE_OPEN,
+)
+from homeassistant.const import ATTR_ENTITY_ID, STATE_CLOSED, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+COVER_ENTITY_ID = "cover.zone_1_damper"
+
+
+async def test_all_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_airtouch5_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test all entities."""
+
+    with patch("homeassistant.components.airtouch5.PLATFORMS", [Platform.COVER]):
+        await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_cover_actions(
+    hass: HomeAssistant,
+    mock_airtouch5_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the actions of the Airtouch5 covers."""
+
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_CLOSE_COVER,
+        {ATTR_ENTITY_ID: COVER_ENTITY_ID},
+        blocking=True,
+    )
+    mock_airtouch5_client.send_packet.assert_called_once()
+    mock_airtouch5_client.reset_mock()
+
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_OPEN_COVER,
+        {ATTR_ENTITY_ID: COVER_ENTITY_ID},
+        blocking=True,
+    )
+    mock_airtouch5_client.send_packet.assert_called_once()
+    mock_airtouch5_client.reset_mock()
+
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_SET_COVER_POSITION,
+        {ATTR_ENTITY_ID: COVER_ENTITY_ID, ATTR_POSITION: 50},
+        blocking=True,
+    )
+    mock_airtouch5_client.send_packet.assert_called_once()
+    mock_airtouch5_client.reset_mock()
+
+
+async def test_cover_callbacks(
+    hass: HomeAssistant,
+    mock_airtouch5_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the callbacks of the Airtouch5 covers."""
+
+    await setup_integration(hass, mock_config_entry)
+
+    # We find the callback method on the mock client
+    zone_status_callback: Callable[[dict[int, ZoneStatusZone]], None] = (
+        mock_airtouch5_client.zone_status_callbacks[2]
+    )
+
+    # Define a method to simply call it
+    async def _call_zone_status_callback(open_percentage: int) -> None:
+        zsz = ZoneStatusZone(
+            zone_power_state=ZonePowerState.ON,
+            zone_number=1,
+            control_method=ControlMethod.PERCENTAGE_CONTROL,
+            open_percentage=open_percentage,
+            set_point=None,
+            has_sensor=False,
+            temperature=None,
+            spill_active=False,
+            is_low_battery=False,
+        )
+        zone_status_callback({1: zsz})
+        await hass.async_block_till_done()
+
+    # And call it to effectively launch the callback as the server would do
+
+    # Partly open
+    await _call_zone_status_callback(0.7)
+    state = hass.states.get(COVER_ENTITY_ID)
+    assert state
+    assert state.state == STATE_OPEN
+    assert state.attributes.get(ATTR_CURRENT_POSITION) == 70
+
+    # Fully open
+    await _call_zone_status_callback(1)
+    state = hass.states.get(COVER_ENTITY_ID)
+    assert state
+    assert state.state == STATE_OPEN
+    assert state.attributes.get(ATTR_CURRENT_POSITION) == 100
+
+    # Fully closed
+    await _call_zone_status_callback(0.0)
+    state = hass.states.get(COVER_ENTITY_ID)
+    assert state
+    assert state.state == STATE_CLOSED
+    assert state.attributes.get(ATTR_CURRENT_POSITION) == 0
+
+    # Partly reopened
+    await _call_zone_status_callback(0.3)
+    state = hass.states.get(COVER_ENTITY_ID)
+    assert state
+    assert state.state == STATE_OPEN
+    assert state.attributes.get(ATTR_CURRENT_POSITION) == 30


### PR DESCRIPTION
## Proposed change
Adding tests to the Airtouch5 cover platform.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/122462
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33940

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
