### PR TITLE
Add device _info to bluesound integration

### DIFF
--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -44,6 +44,7 @@ from homeassistant.core import (
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv, issue_registry as ir
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -313,6 +314,14 @@ class BluesoundPlayer(MediaPlayerEntity):
         self._player = player
 
         self._init_callback = init_callback
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, format_unique_id(sync_status.mac, port))},
+            name=sync_status.name,
+            manufacturer=sync_status.brand,
+            model=sync_status.model_name,
+            model_id=sync_status.model,
+        )
 
     @staticmethod
     def _try_get_index(string, search_string):

--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -300,7 +300,6 @@ class BluesoundPlayer(MediaPlayerEntity):
         self._hass = hass
         self.port = port
         self._polling_task = None  # The actual polling task.
-        self._name = sync_status.name
         self._id = None
         self._last_status_update = None
         self._sync_status: SyncStatus | None = None
@@ -356,12 +355,10 @@ class BluesoundPlayer(MediaPlayerEntity):
 
         self._sync_status = sync_status
 
-        if not self._name:
-            self._name = sync_status.name if sync_status.name else self.host
         if not self._id:
             self._id = sync_status.id
         if not self._bluesound_device_name:
-            self._bluesound_device_name = self._name
+            self._bluesound_device_name = sync_status.name
 
         if sync_status.master is not None:
             self._is_master = False
@@ -483,7 +480,10 @@ class BluesoundPlayer(MediaPlayerEntity):
             self._last_status_update = None
             self._status = None
             self.async_write_ha_state()
-            _LOGGER.info("Client connection error, marking %s as offline", self._name)
+            _LOGGER.info(
+                "Client connection error, marking %s as offline",
+                self._bluesound_device_name,
+            )
             raise
 
     async def async_trigger_sync_on_all(self):

--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -391,7 +391,7 @@ class BluesoundPlayer(MediaPlayerEntity):
                 await self.async_update_status()
 
         except (TimeoutError, ClientError):
-            _LOGGER.info("Node %s:%s is offline, retrying later", self.name, self.port)
+            _LOGGER.error("Node %s:%s is offline, retrying later", self.name, self.port)
             await asyncio.sleep(NODE_OFFLINE_CHECK_TIMEOUT)
             self.start_polling()
 
@@ -418,7 +418,7 @@ class BluesoundPlayer(MediaPlayerEntity):
 
             await self.force_update_sync_status(self._init_callback)
         except (TimeoutError, ClientError):
-            _LOGGER.info("Node %s:%s is offline, retrying later", self.host, self.port)
+            _LOGGER.error("Node %s:%s is offline, retrying later", self.host, self.port)
             self._retry_remove = async_track_time_interval(
                 self._hass, self.async_init, NODE_RETRY_INITIATION
             )

--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -480,7 +480,7 @@ class BluesoundPlayer(MediaPlayerEntity):
             self._last_status_update = None
             self._status = None
             self.async_write_ha_state()
-            _LOGGER.info(
+            _LOGGER.error(
                 "Client connection error, marking %s as offline",
                 self._bluesound_device_name,
             )

--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -319,6 +319,8 @@ class BluesoundPlayer(MediaPlayerEntity):
 
         self._init_callback = init_callback
 
+        self._attr_has_entity_name = True
+        self._attr_name = None
         self._attr_unique_id = format_unique_id(sync_status.mac, port)
         # there should always be one player with the default port per mac
         if port is DEFAULT_PORT:
@@ -637,11 +639,6 @@ class BluesoundPlayer(MediaPlayerEntity):
     def id(self) -> str | None:
         """Get id of device."""
         return self._id
-
-    @property
-    def name(self) -> str | None:
-        """Return the name of the device."""
-        return self._name
 
     @property
     def bluesound_device_name(self) -> str | None:

--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -285,6 +285,8 @@ class BluesoundPlayer(MediaPlayerEntity):
     """Representation of a Bluesound Player."""
 
     _attr_media_content_type = MediaType.MUSIC
+    _attr_has_entity_name = True
+    _attr_name = None
 
     def __init__(
         self,
@@ -318,8 +320,6 @@ class BluesoundPlayer(MediaPlayerEntity):
 
         self._init_callback = init_callback
 
-        self._attr_has_entity_name = True
-        self._attr_name = None
         self._attr_unique_id = format_unique_id(sync_status.mac, port)
         # there should always be one player with the default port per mac
         if port is DEFAULT_PORT:

--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -44,7 +44,11 @@ from homeassistant.core import (
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv, issue_registry as ir
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import (
+    CONNECTION_NETWORK_MAC,
+    DeviceInfo,
+    format_mac,
+)
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -316,13 +320,25 @@ class BluesoundPlayer(MediaPlayerEntity):
         self._init_callback = init_callback
 
         self._attr_unique_id = format_unique_id(sync_status.mac, port)
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, format_unique_id(sync_status.mac, port))},
-            name=sync_status.name,
-            manufacturer=sync_status.brand,
-            model=sync_status.model_name,
-            model_id=sync_status.model,
-        )
+        # there should always be one player with the default port per mac
+        if port is DEFAULT_PORT:
+            self._attr_device_info = DeviceInfo(
+                identifiers={(DOMAIN, format_mac(sync_status.mac))},
+                connections={(CONNECTION_NETWORK_MAC, format_mac(sync_status.mac))},
+                name=sync_status.name,
+                manufacturer=sync_status.brand,
+                model=sync_status.model_name,
+                model_id=sync_status.model,
+            )
+        else:
+            self._attr_device_info = DeviceInfo(
+                identifiers={(DOMAIN, format_unique_id(sync_status.mac, port))},
+                name=sync_status.name,
+                manufacturer=sync_status.brand,
+                model=sync_status.model_name,
+                model_id=sync_status.model,
+                via_device=(DOMAIN, format_mac(sync_status.mac)),
+            )
 
     @staticmethod
     def _try_get_index(string, search_string):

--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -315,6 +315,7 @@ class BluesoundPlayer(MediaPlayerEntity):
 
         self._init_callback = init_callback
 
+        self._attr_unique_id = format_unique_id(sync_status.mac, port)
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, format_unique_id(sync_status.mac, port))},
             name=sync_status.name,
@@ -466,12 +467,6 @@ class BluesoundPlayer(MediaPlayerEntity):
             self.async_write_ha_state()
             _LOGGER.info("Client connection error, marking %s as offline", self._name)
             raise
-
-    @property
-    def unique_id(self) -> str:
-        """Return an unique ID."""
-        assert self._sync_status is not None
-        return format_unique_id(self._sync_status.mac, self.port)
 
     async def async_trigger_sync_on_all(self):
         """Trigger sync status update on all devices."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--## Breaking change
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds a `DeviceInfo` to the media_player entity.

I also removed the custom `unique_id` method and replaced it with `_attr_unique_id`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
