### PR TITLE
Bump ZHA lib to 0.0.24 and universal-silabs-flasher to 0.0.22

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -21,7 +21,7 @@
     "zha",
     "universal_silabs_flasher"
   ],
-  "requirements": ["universal-silabs-flasher==0.0.21", "zha==0.0.24"],
+  "requirements": ["universal-silabs-flasher==0.0.22", "zha==0.0.24"],
   "usb": [
     {
       "vid": "10C4",

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -21,7 +21,7 @@
     "zha",
     "universal_silabs_flasher"
   ],
-  "requirements": ["universal-silabs-flasher==0.0.21", "zha==0.0.23"],
+  "requirements": ["universal-silabs-flasher==0.0.21", "zha==0.0.24"],
   "usb": [
     {
       "vid": "10C4",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2983,7 +2983,7 @@ zeroconf==0.132.2
 zeversolar==0.3.1
 
 # homeassistant.components.zha
-zha==0.0.23
+zha==0.0.24
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.12

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2822,7 +2822,7 @@ unifi_ap==0.0.1
 unifiled==0.11
 
 # homeassistant.components.zha
-universal-silabs-flasher==0.0.21
+universal-silabs-flasher==0.0.22
 
 # homeassistant.components.upb
 upb-lib==0.5.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2357,7 +2357,7 @@ zeroconf==0.132.2
 zeversolar==0.3.1
 
 # homeassistant.components.zha
-zha==0.0.23
+zha==0.0.24
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.57.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2217,7 +2217,7 @@ ultraheat-api==0.5.7
 unifi-discovery==1.2.0
 
 # homeassistant.components.zha
-universal-silabs-flasher==0.0.21
+universal-silabs-flasher==0.0.22
 
 # homeassistant.components.upb
 upb-lib==0.5.8

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -154,6 +154,8 @@ async def zigpy_app_controller():
 
     app.state.node_info.nwk = 0x0000
     app.state.node_info.ieee = zigpy.types.EUI64.convert("00:15:8d:00:02:32:4f:32")
+    app.state.node_info.manufacturer = "Coordinator Manufacturer"
+    app.state.node_info.model = "Coordinator Model"
     app.state.network_info.pan_id = 0x1234
     app.state.network_info.extended_pan_id = app.state.node_info.ieee
     app.state.network_info.channel = 15


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR bumps the ZHA lib to 0.0.24: https://github.com/zigpy/zha/releases/tag/0.0.24

1. Prefer loading the coordinator information from node_info by @puddly in https://github.com/zigpy/zha/pull/88
2. Fix shades and keen vents by @dmulcahey in https://github.com/zigpy/zha/pull/104
3. Bump bellows from 0.39.1 to 0.40.2 by https://github.com/dependabot in https://github.com/zigpy/zha/pull/105
4. Bump zigpy from 0.64.3 to 0.65.0 by https://github.com/dependabot in https://github.com/zigpy/zha/pull/106
5. Clean up when removing a device from the network by @dmulcahey in https://github.com/zigpy/zha/pull/91
6. Add support for new FanEntityFeature flags by @dmulcahey in https://github.com/zigpy/zha/pull/100

universal-silabs-flasher 0.0.22: https://github.com/NabuCasa/universal-silabs-flasher/releases/tag/v0.0.22

1. Bump bellows to 0.40.0 by @puddly in https://github.com/NabuCasa/universal-silabs-flasher/pull/77

The PR also makes a slight test tweak to handle item # 1 above


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
