### PR TITLE
Remove notify support for templates

### DIFF
--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -18,7 +18,6 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.restore_state import RestoreEntity
-from homeassistant.helpers.template import Template
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import dt as dt_util
 
@@ -39,7 +38,6 @@ from .legacy import (  # noqa: F401
     async_reload,
     async_reset_platform,
     async_setup_legacy,
-    check_templates_warn,
 )
 from .repairs import migrate_notify_issue  # noqa: F401
 
@@ -90,22 +88,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     async def persistent_notification(service: ServiceCall) -> None:
         """Send notification via the built-in persistent_notify integration."""
-        message: Template = service.data[ATTR_MESSAGE]
-        check_templates_warn(hass, message)
-
-        title = None
-        title_tpl: Template | None
-        if title_tpl := service.data.get(ATTR_TITLE):
-            check_templates_warn(hass, title_tpl)
-            title = title_tpl.async_render(parse_result=False)
+        message: str = service.data[ATTR_MESSAGE]
+        title: str | None = service.data.get(ATTR_TITLE)
 
         notification_id = None
         if data := service.data.get(ATTR_DATA):
             notification_id = data.get(pn.ATTR_NOTIFICATION_ID)
 
-        pn.async_create(
-            hass, message.async_render(parse_result=False), title, notification_id
-        )
+        pn.async_create(hass, message, title, notification_id)
 
     hass.services.async_register(
         DOMAIN,

--- a/homeassistant/components/notify/const.py
+++ b/homeassistant/components/notify/const.py
@@ -30,8 +30,8 @@ SERVICE_PERSISTENT_NOTIFICATION = "persistent_notification"
 
 NOTIFY_SERVICE_SCHEMA = vol.Schema(
     {
-        vol.Required(ATTR_MESSAGE): cv.template,
-        vol.Optional(ATTR_TITLE): cv.template,
+        vol.Required(ATTR_MESSAGE): cv.string,
+        vol.Optional(ATTR_TITLE): cv.string,
         vol.Optional(ATTR_TARGET): vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(ATTR_DATA): dict,
     }

--- a/tests/auth/mfa_modules/test_notify.py
+++ b/tests/auth/mfa_modules/test_notify.py
@@ -165,8 +165,7 @@ async def test_login_flow_validates_mfa(hass: HomeAssistant) -> None:
     assert notify_call.domain == "notify"
     assert notify_call.service == "test-notify"
     message = notify_call.data["message"]
-    message.hass = hass
-    assert MOCK_CODE in message.async_render()
+    assert MOCK_CODE in message
 
     with patch("pyotp.HOTP.verify", return_value=False):
         result = await hass.auth.login_flow.async_configure(
@@ -224,8 +223,7 @@ async def test_login_flow_validates_mfa(hass: HomeAssistant) -> None:
     assert notify_call.domain == "notify"
     assert notify_call.service == "test-notify"
     message = notify_call.data["message"]
-    message.hass = hass
-    assert MOCK_CODE in message.async_render()
+    assert MOCK_CODE in message
 
     with patch("pyotp.HOTP.verify", return_value=True):
         result = await hass.auth.login_flow.async_configure(
@@ -264,8 +262,7 @@ async def test_setup_user_notify_service(hass: HomeAssistant) -> None:
     assert notify_call.domain == "notify"
     assert notify_call.service == "test1"
     message = notify_call.data["message"]
-    message.hass = hass
-    assert MOCK_CODE in message.async_render()
+    assert MOCK_CODE in message
 
     with patch("pyotp.HOTP.at", return_value=MOCK_CODE_2):
         step = await flow.async_step_setup({"code": "invalid"})
@@ -281,8 +278,7 @@ async def test_setup_user_notify_service(hass: HomeAssistant) -> None:
     assert notify_call.domain == "notify"
     assert notify_call.service == "test1"
     message = notify_call.data["message"]
-    message.hass = hass
-    assert MOCK_CODE_2 in message.async_render()
+    assert MOCK_CODE_2 in message
 
     with patch("pyotp.HOTP.verify", return_value=True):
         step = await flow.async_step_setup({"code": MOCK_CODE_2})


### PR DESCRIPTION
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The notify service no longer accepts templates for `title` and `message`. This has been deprecated and planned for removal since December 2021. It affects component authors who invoke the service directly. End users who have templates in scripts and automations will not be affected as templates are still processed before the service is invoked.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

**Issue #109668 Summary:** Services that define `data` or `data_template` will attempt to render a template twice if the service also defines a `Schema` for the attribute with a template, i.e. `cv.template`. This works fine if a script/automation defines a template for which `is_static` is true, for instance, but results in an incorrect value when the template returns something that has templating characters in it (raising an error for an invalid template or just getting an incorrect value when the template is valid). See below for an example.

Services should therefore not use `cv.template`. (See #122567 for more discussion.)

This fixes https://github.com/home-assistant/core/issues/109668.

#### Example

I discovered this when trying to use the notify service to send information about errors appearing in the main log file. Some messages I'm trying to send include errors about failures in templates, and could be truncated. So, for example:

```yaml
service: notify.mobile_app_my_phone
data:
  title: Error in system log
  message: "The following error just occurred: {{ error }}"
```

When `error` is, for example, `Template variable warning: 'name' is undefined when rendering '{% set device_id =...`, message should result in:

```
The following error just occurred: Template variable warning: 'name' is undefined when rendering '{% set device_id =...
```

But the result is that a template error is generated since `message` is re-templated a second time (with the above, which isn't a valid template itself).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #109668
- This PR is related to issue:  #109668
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

**The above do not apply to this PR.**

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

**The above do not apply to this PR.**

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
