### PR TITLE
Bump pyhomeworks to 1.0.0

### DIFF
--- a/homeassistant/components/homeworks/__init__.py
+++ b/homeassistant/components/homeworks/__init__.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 import logging
 from typing import Any
 
+from pyhomeworks import exceptions as hw_exceptions
 from pyhomeworks.pyhomeworks import HW_BUTTON_PRESSED, HW_BUTTON_RELEASED, Homeworks
 import voluptuous as vol
 
@@ -141,15 +142,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         dispatcher_send(hass, signal, msg_type, values)
 
     config = entry.options
+    controller = Homeworks(config[CONF_HOST], config[CONF_PORT], hw_callback)
     try:
-        controller = await hass.async_add_executor_job(
-            Homeworks, config[CONF_HOST], config[CONF_PORT], hw_callback
-        )
-    except (ConnectionError, OSError) as err:
+        await hass.async_add_executor_job(controller.connect)
+    except hw_exceptions.HomeworksException as err:
+        _LOGGER.debug("Failed to connect: %s", err, exc_info=True)
         raise ConfigEntryNotReady from err
+    controller.start()
 
     def cleanup(event: Event) -> None:
-        controller.close()
+        controller.stop()
 
     entry.async_on_unload(hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, cleanup))
 
@@ -176,7 +178,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         for keypad in data.keypads.values():
             keypad.unsubscribe()
 
-        await hass.async_add_executor_job(data.controller.close)
+        await hass.async_add_executor_job(data.controller.stop)
 
     return unload_ok
 

--- a/homeassistant/components/homeworks/config_flow.py
+++ b/homeassistant/components/homeworks/config_flow.py
@@ -6,6 +6,7 @@ from functools import partial
 import logging
 from typing import Any
 
+from pyhomeworks import exceptions as hw_exceptions
 from pyhomeworks.pyhomeworks import Homeworks
 import voluptuous as vol
 
@@ -128,18 +129,18 @@ async def _try_connection(user_input: dict[str, Any]) -> None:
             "Trying to connect to %s:%s", user_input[CONF_HOST], user_input[CONF_PORT]
         )
         controller = Homeworks(host, port, lambda msg_types, values: None)
+        controller.connect()
         controller.close()
-        controller.join()
 
     hass = async_get_hass()
     try:
         await hass.async_add_executor_job(
             _try_connect, user_input[CONF_HOST], user_input[CONF_PORT]
         )
-    except ConnectionError as err:
+    except hw_exceptions.HomeworksConnectionFailed as err:
         raise SchemaFlowError("connection_error") from err
     except Exception as err:
-        _LOGGER.exception("Caught unexpected exception")
+        _LOGGER.exception("Caught unexpected exception %s")
         raise SchemaFlowError("unknown_error") from err
 
 

--- a/homeassistant/components/homeworks/manifest.json
+++ b/homeassistant/components/homeworks/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/homeworks",
   "iot_class": "local_push",
   "loggers": ["pyhomeworks"],
-  "requirements": ["pyhomeworks==0.0.6"]
+  "requirements": ["pyhomeworks==1.0.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1903,7 +1903,7 @@ pyhiveapi==0.5.16
 pyhomematic==0.1.77
 
 # homeassistant.components.homeworks
-pyhomeworks==0.0.6
+pyhomeworks==1.0.0
 
 # homeassistant.components.ialarm
 pyialarm==2.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1517,7 +1517,7 @@ pyhiveapi==0.5.16
 pyhomematic==0.1.77
 
 # homeassistant.components.homeworks
-pyhomeworks==0.0.6
+pyhomeworks==1.0.0
 
 # homeassistant.components.ialarm
 pyialarm==2.2.0

--- a/tests/components/homeworks/test_config_flow.py
+++ b/tests/components/homeworks/test_config_flow.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import ANY, MagicMock
 
+from pyhomeworks import exceptions as hw_exceptions
 import pytest
 from pytest_unordered import unordered
 
@@ -55,7 +56,7 @@ async def test_user_flow(
     }
     mock_homeworks.assert_called_once_with("192.168.0.1", 1234, ANY)
     mock_controller.close.assert_called_once_with()
-    mock_controller.join.assert_called_once_with()
+    mock_controller.join.assert_not_called()
 
 
 async def test_user_flow_already_exists(
@@ -96,7 +97,10 @@ async def test_user_flow_already_exists(
 
 @pytest.mark.parametrize(
     ("side_effect", "error"),
-    [(ConnectionError, "connection_error"), (Exception, "unknown_error")],
+    [
+        (hw_exceptions.HomeworksConnectionFailed, "connection_error"),
+        (Exception, "unknown_error"),
+    ],
 )
 async def test_user_flow_cannot_connect(
     hass: HomeAssistant,

--- a/tests/components/homeworks/test_init.py
+++ b/tests/components/homeworks/test_init.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import ANY, MagicMock
 
+from pyhomeworks import exceptions as hw_exceptions
 from pyhomeworks.pyhomeworks import HW_BUTTON_PRESSED, HW_BUTTON_RELEASED
 import pytest
 
@@ -41,7 +42,9 @@ async def test_config_entry_not_ready(
     mock_homeworks: MagicMock,
 ) -> None:
     """Test the Homeworks configuration entry not ready."""
-    mock_homeworks.side_effect = ConnectionError
+    mock_homeworks.return_value.connect.side_effect = (
+        hw_exceptions.HomeworksConnectionFailed
+    )
 
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
@@ -187,4 +190,4 @@ async def test_cleanup_on_ha_shutdown(
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
     await hass.async_block_till_done()
 
-    mock_controller.close.assert_called_once_with()
+    mock_controller.stop.assert_called_once_with()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump pyhomeworks from 0.0.6 to 1.0.0 and make necessary code and test changes

Release notes:
 - https://github.com/dubnom/pyhomeworks/releases/tag/0.0.7
 - https://github.com/dubnom/pyhomeworks/releases/tag/0.0.8
 - https://github.com/dubnom/pyhomeworks/releases/tag/1.0.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
