### PR TITLE
Simplify async_setup_entry in bluesound integration

### DIFF
--- a/homeassistant/components/bluesound/__init__.py
+++ b/homeassistant/components/bluesound/__init__.py
@@ -67,15 +67,4 @@ async def async_setup_entry(
 
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    player = None
-    for player in hass.data[DOMAIN]:
-        if player.unique_id == config_entry.unique_id:
-            break
-
-    if player is None:
-        return False
-
-    player.stop_polling()
-    hass.data[DOMAIN].remove(player)
-
     return await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)

--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -194,7 +194,6 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Bluesound entry."""
     bluesound_player = BluesoundPlayer(
-        hass,
         config_entry.data[CONF_HOST],
         config_entry.data[CONF_PORT],
         config_entry.runtime_data.player,
@@ -230,7 +229,6 @@ class BluesoundPlayer(MediaPlayerEntity):
 
     def __init__(
         self,
-        hass: HomeAssistant,
         host: str,
         port: int,
         player: Player,
@@ -238,7 +236,6 @@ class BluesoundPlayer(MediaPlayerEntity):
     ) -> None:
         """Initialize the media player."""
         self.host = host
-        self._hass = hass
         self.port = port
         self._polling_task: Task[None] | None = None  # The actual polling task.
         self._id = sync_status.id
@@ -296,7 +293,7 @@ class BluesoundPlayer(MediaPlayerEntity):
             master_id = f"{sync_status.master.ip}:{sync_status.master.port}"
             master_device = [
                 device
-                for device in self._hass.data[DATA_BLUESOUND]
+                for device in self.hass.data[DATA_BLUESOUND]
                 if device.id == master_id
             ]
 
@@ -334,7 +331,7 @@ class BluesoundPlayer(MediaPlayerEntity):
         """Start the polling task."""
         await super().async_added_to_hass()
 
-        self._polling_task = self._hass.async_create_task(self._start_poll_command())
+        self._polling_task = self.hass.async_create_task(self._start_poll_command())
 
     async def async_will_remove_from_hass(self) -> None:
         """Stop the polling task."""
@@ -344,7 +341,7 @@ class BluesoundPlayer(MediaPlayerEntity):
         if self._polling_task.cancel():
             await self._polling_task
 
-        self._hass.data[DATA_BLUESOUND].remove(self)
+        self.hass.data[DATA_BLUESOUND].remove(self)
 
     async def async_update(self) -> None:
         """Update internal status of the entity."""
@@ -408,7 +405,7 @@ class BluesoundPlayer(MediaPlayerEntity):
         """Trigger sync status update on all devices."""
         _LOGGER.debug("Trigger sync status on all devices")
 
-        for player in self._hass.data[DATA_BLUESOUND]:
+        for player in self.hass.data[DATA_BLUESOUND]:
             await player.force_update_sync_status()
 
     @Throttle(SYNC_STATUS_INTERVAL)
@@ -696,7 +693,7 @@ class BluesoundPlayer(MediaPlayerEntity):
         device_group = self._group_name.split("+")
 
         sorted_entities = sorted(
-            self._hass.data[DATA_BLUESOUND],
+            self.hass.data[DATA_BLUESOUND],
             key=lambda entity: entity.is_master,
             reverse=True,
         )

--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from asyncio import CancelledError
-from collections.abc import Callable
+from asyncio import CancelledError, Task
 from contextlib import suppress
 from datetime import datetime, timedelta
 import logging
@@ -31,15 +30,11 @@ from homeassistant.const import (
     CONF_HOSTS,
     CONF_NAME,
     CONF_PORT,
-    EVENT_HOMEASSISTANT_START,
-    EVENT_HOMEASSISTANT_STOP,
 )
 from homeassistant.core import (
     DOMAIN as HOMEASSISTANT_DOMAIN,
-    Event,
     HomeAssistant,
     ServiceCall,
-    callback,
 )
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.exceptions import ServiceValidationError
@@ -50,7 +45,6 @@ from homeassistant.helpers.device_registry import (
     format_mac,
 )
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import Throttle
 import homeassistant.util.dt as dt_util
@@ -121,59 +115,6 @@ SERVICE_TO_METHOD = {
         method="async_clear_timer", schema=BS_SCHEMA
     ),
 }
-
-
-def _add_player(
-    hass: HomeAssistant,
-    async_add_entities: AddEntitiesCallback,
-    host: str,
-    port: int,
-    player: Player,
-    sync_status: SyncStatus,
-):
-    """Add Bluesound players."""
-
-    @callback
-    def _init_bluesound_player(event: Event | None = None):
-        """Start polling."""
-        hass.async_create_task(bluesound_player.async_init())
-
-    @callback
-    def _start_polling(event: Event | None = None):
-        """Start polling."""
-        bluesound_player.start_polling()
-
-    @callback
-    def _stop_polling(event: Event | None = None):
-        """Stop polling."""
-        bluesound_player.stop_polling()
-
-    @callback
-    def _add_bluesound_player_cb():
-        """Add player after first sync fetch."""
-        if bluesound_player.id in [x.id for x in hass.data[DATA_BLUESOUND]]:
-            _LOGGER.warning("Player already added %s", bluesound_player.id)
-            return
-
-        hass.data[DATA_BLUESOUND].append(bluesound_player)
-        async_add_entities([bluesound_player])
-        _LOGGER.debug("Added device with name: %s", bluesound_player.name)
-
-        if hass.is_running:
-            _start_polling()
-        else:
-            hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, _start_polling)
-
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _stop_polling)
-
-    bluesound_player = BluesoundPlayer(
-        hass, host, port, player, sync_status, _add_bluesound_player_cb
-    )
-
-    if hass.is_running:
-        _init_bluesound_player()
-    else:
-        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, _init_bluesound_player)
 
 
 async def _async_import(hass: HomeAssistant, config: ConfigType) -> None:
@@ -252,17 +193,16 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Bluesound entry."""
-    host = config_entry.data[CONF_HOST]
-    port = config_entry.data[CONF_PORT]
-
-    _add_player(
+    bluesound_player = BluesoundPlayer(
         hass,
-        async_add_entities,
-        host,
-        port,
+        config_entry.data[CONF_HOST],
+        config_entry.data[CONF_PORT],
         config_entry.runtime_data.player,
         config_entry.runtime_data.sync_status,
     )
+
+    hass.data[DATA_BLUESOUND].append(bluesound_player)
+    async_add_entities([bluesound_player])
 
 
 async def async_setup_platform(
@@ -295,30 +235,26 @@ class BluesoundPlayer(MediaPlayerEntity):
         port: int,
         player: Player,
         sync_status: SyncStatus,
-        init_callback: Callable[[], None],
     ) -> None:
         """Initialize the media player."""
         self.host = host
         self._hass = hass
         self.port = port
-        self._polling_task = None  # The actual polling task.
-        self._id = None
+        self._polling_task: Task[None] | None = None  # The actual polling task.
+        self._id = sync_status.id
         self._last_status_update = None
-        self._sync_status: SyncStatus | None = None
+        self._sync_status = sync_status
         self._status: Status | None = None
         self._inputs: list[Input] = []
         self._presets: list[Preset] = []
         self._is_online = False
-        self._retry_remove = None
         self._muted = False
         self._master: BluesoundPlayer | None = None
         self._is_master = False
         self._group_name = None
         self._group_list: list[str] = []
-        self._bluesound_device_name = None
+        self._bluesound_device_name = sync_status.name
         self._player = player
-
-        self._init_callback = init_callback
 
         self._attr_unique_id = format_unique_id(sync_status.mac, port)
         # there should always be one player with the default port per mac
@@ -349,16 +285,11 @@ class BluesoundPlayer(MediaPlayerEntity):
         except ValueError:
             return -1
 
-    async def force_update_sync_status(self, on_updated_cb=None) -> bool:
+    async def force_update_sync_status(self) -> bool:
         """Update the internal status."""
         sync_status = await self._player.sync_status()
 
         self._sync_status = sync_status
-
-        if not self._id:
-            self._id = sync_status.id
-        if not self._bluesound_device_name:
-            self._bluesound_device_name = sync_status.name
 
         if sync_status.master is not None:
             self._is_master = False
@@ -380,8 +311,6 @@ class BluesoundPlayer(MediaPlayerEntity):
             slaves = self._sync_status.slaves
             self._is_master = slaves is not None
 
-        if on_updated_cb:
-            on_updated_cb()
         return True
 
     async def _start_poll_command(self):
@@ -401,32 +330,21 @@ class BluesoundPlayer(MediaPlayerEntity):
             _LOGGER.exception("Unexpected error in %s:%s", self.name, self.port)
             raise
 
-    def start_polling(self):
+    async def async_added_to_hass(self) -> None:
         """Start the polling task."""
+        await super().async_added_to_hass()
+
         self._polling_task = self._hass.async_create_task(self._start_poll_command())
 
-    def stop_polling(self):
+    async def async_will_remove_from_hass(self) -> None:
         """Stop the polling task."""
-        self._polling_task.cancel()
+        await super().async_will_remove_from_hass()
 
-    async def async_init(self, triggered=None):
-        """Initialize the player async."""
-        try:
-            if self._retry_remove is not None:
-                self._retry_remove()
-                self._retry_remove = None
+        assert self._polling_task is not None
+        if self._polling_task.cancel():
+            await self._polling_task
 
-            await self.force_update_sync_status(self._init_callback)
-        except (TimeoutError, ClientError):
-            _LOGGER.error("Node %s:%s is offline, retrying later", self.host, self.port)
-            self._retry_remove = async_track_time_interval(
-                self._hass, self.async_init, NODE_RETRY_INITIATION
-            )
-        except Exception:
-            _LOGGER.exception(
-                "Unexpected when initiating error in %s:%s", self.host, self.port
-            )
-            raise
+        self._hass.data[DATA_BLUESOUND].remove(self)
 
     async def async_update(self) -> None:
         """Update internal status of the entity."""
@@ -494,9 +412,9 @@ class BluesoundPlayer(MediaPlayerEntity):
             await player.force_update_sync_status()
 
     @Throttle(SYNC_STATUS_INTERVAL)
-    async def async_update_sync_status(self, on_updated_cb=None):
+    async def async_update_sync_status(self):
         """Update sync status."""
-        await self.force_update_sync_status(on_updated_cb)
+        await self.force_update_sync_status()
 
     @Throttle(UPDATE_CAPTURE_INTERVAL)
     async def async_update_captures(self) -> list[Input] | None:
@@ -615,7 +533,7 @@ class BluesoundPlayer(MediaPlayerEntity):
 
         if self._status is not None:
             volume = self._status.volume
-        if self.is_grouped and self._sync_status is not None:
+        if self.is_grouped:
             volume = self._sync_status.volume
 
         if volume is None:
@@ -630,7 +548,7 @@ class BluesoundPlayer(MediaPlayerEntity):
 
         if self._status is not None:
             mute = self._status.mute
-        if self.is_grouped and self._sync_status is not None:
+        if self.is_grouped:
             mute = self._sync_status.mute_volume is not None
 
         return mute


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!-- ## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The previously added external library and config_flow allow for some simplifications.

There was a `_add_player` method before, which handled the `SyncStatus` fetching and start/stop for background status fetching. This method was removed and replaced with:
- `SyncStatus` is already available at Entity creation. This removes the need for the late initialization of that value.
-  `async_added_to_hass` and `async_will_remove_from_hass` can be used to start and stop long-polling for changes


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
