### PR TITLE
Fix cleanup of orphan device entries in AVM Fritz!Tools

### DIFF
--- a/homeassistant/components/fritz/coordinator.py
+++ b/homeassistant/components/fritz/coordinator.py
@@ -666,7 +666,9 @@ class FritzBoxTools(DataUpdateCoordinator[UpdateCoordinatorDataType]):
                 entity_reg.async_remove(entity.entity_id)
 
         device_reg = dr.async_get(self.hass)
-        orphan_connections = {(CONNECTION_NETWORK_MAC, mac) for mac in orphan_macs}
+        orphan_connections = {
+            (CONNECTION_NETWORK_MAC, dr.format_mac(mac)) for mac in orphan_macs
+        }
         for device in dr.async_entries_for_config_entry(
             device_reg, config_entry.entry_id
         ):

--- a/tests/components/fritz/test_button.py
+++ b/tests/components/fritz/test_button.py
@@ -1,6 +1,6 @@
 """Tests for Fritz!Tools button platform."""
 
-import copy
+from copy import deepcopy
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -11,9 +11,15 @@ from homeassistant.components.fritz.const import DOMAIN, MeshRoles
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util.dt import utcnow
 
-from .const import MOCK_MESH_DATA, MOCK_NEW_DEVICE_NODE, MOCK_USER_DATA
+from .const import (
+    MOCK_HOST_ATTRIBUTES_DATA,
+    MOCK_MESH_DATA,
+    MOCK_NEW_DEVICE_NODE,
+    MOCK_USER_DATA,
+)
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -120,7 +126,7 @@ async def test_wol_button_new_device(
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
     entry.add_to_hass(hass)
 
-    mesh_data = copy.deepcopy(MOCK_MESH_DATA)
+    mesh_data = deepcopy(MOCK_MESH_DATA)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
     assert entry.state is ConfigEntryState.LOADED
@@ -148,7 +154,7 @@ async def test_wol_button_absent_for_mesh_slave(
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
     entry.add_to_hass(hass)
 
-    slave_mesh_data = copy.deepcopy(MOCK_MESH_DATA)
+    slave_mesh_data = deepcopy(MOCK_MESH_DATA)
     slave_mesh_data["nodes"][0]["mesh_role"] = MeshRoles.SLAVE
     fh_class_mock.get_mesh_topology.return_value = slave_mesh_data
 
@@ -170,7 +176,7 @@ async def test_wol_button_absent_for_non_lan_device(
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
     entry.add_to_hass(hass)
 
-    printer_wifi_data = copy.deepcopy(MOCK_MESH_DATA)
+    printer_wifi_data = deepcopy(MOCK_MESH_DATA)
     # initialization logic uses the connection type of the `node_interface_1_uid` pair of the printer
     # ni-230 is wifi interface of fritzbox
     printer_node_interface = printer_wifi_data["nodes"][1]["node_interfaces"][0]
@@ -184,3 +190,61 @@ async def test_wol_button_absent_for_non_lan_device(
 
     button = hass.states.get("button.printer_wake_on_lan")
     assert button is None
+
+
+async def test_cleanup_button(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    fc_class_mock,
+    fh_class_mock,
+) -> None:
+    """Test cleanup of orphan devices."""
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.state is ConfigEntryState.LOADED
+
+    # check if tracked device is registered properly
+    device = device_registry.async_get_device(
+        connections={("mac", "aa:bb:cc:00:11:22")}
+    )
+    assert device
+
+    entities = [
+        entity
+        for entity in er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+        if entity.unique_id.startswith("AA:BB:CC:00:11:22")
+    ]
+    assert entities
+    assert len(entities) == 3
+
+    # removed tracked device and trigger cleanup
+    host_attributes = deepcopy(MOCK_HOST_ATTRIBUTES_DATA)
+    host_attributes.pop(0)
+    fh_class_mock.get_hosts_attributes.return_value = host_attributes
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: "button.mock_title_cleanup"},
+        blocking=True,
+    )
+
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    # check if orphan tracked device is removed
+    device = device_registry.async_get_device(
+        connections={("mac", "aa:bb:cc:00:11:22")}
+    )
+    assert not device
+
+    entities = [
+        entity
+        for entity in er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+        if entity.unique_id.startswith("AA:BB:CC:00:11:22")
+    ]
+    assert not entities


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Device entry connections of type `mac` (_`CONNECTION_NETWORK_MAC`_) are normalized by the device entry registry which includes to lowercase them. The mac addresses returned by the fritzbox api are uppercase. So we need to ensure to search for normalized macs in device connections.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #106642
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
