### PR TITLE
Use finished speaking detection in ESPHome/Wyoming

### DIFF
--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -505,6 +505,9 @@ class AudioSettings:
     samples_per_chunk: int | None = None
     """Number of samples that will be in each audio chunk (None for no chunking)."""
 
+    silence_seconds: float = 0.5
+    """Seconds of silence after voice command has ended."""
+
     def __post_init__(self) -> None:
         """Verify settings post-initialization."""
         if (self.noise_suppression_level < 0) or (self.noise_suppression_level > 4):
@@ -909,7 +912,9 @@ class PipelineRun:
             # Transcribe audio stream
             stt_vad: VoiceCommandSegmenter | None = None
             if self.audio_settings.is_vad_enabled:
-                stt_vad = VoiceCommandSegmenter()
+                stt_vad = VoiceCommandSegmenter(
+                    silence_seconds=self.audio_settings.silence_seconds
+                )
 
             result = await self.stt_provider.async_process_audio_stream(
                 metadata,

--- a/homeassistant/components/assist_pipeline/vad.py
+++ b/homeassistant/components/assist_pipeline/vad.py
@@ -80,7 +80,7 @@ class VoiceCommandSegmenter:
     speech_seconds: float = 0.3
     """Seconds of speech before voice command has started."""
 
-    silence_seconds: float = 0.5
+    silence_seconds: float = 1.0
     """Seconds of silence after voice command has ended."""
 
     timeout_seconds: float = 15.0

--- a/homeassistant/components/esphome/select.py
+++ b/homeassistant/components/esphome/select.py
@@ -83,7 +83,7 @@ class EsphomeAssistPipelineSelect(EsphomeAssistEntity, AssistPipelineSelect):
 
 
 class EsphomeVadSensitivitySelect(EsphomeAssistEntity, VadSensitivitySelect):
-    """VAD sensitivity selector for VoIP devices."""
+    """VAD sensitivity selector for ESPHome devices."""
 
     def __init__(self, hass: HomeAssistant, entry_data: RuntimeEntryData) -> None:
         """Initialize a VAD sensitivity selector."""

--- a/homeassistant/components/esphome/voice_assistant.py
+++ b/homeassistant/components/esphome/voice_assistant.py
@@ -34,6 +34,7 @@ from homeassistant.components.assist_pipeline.error import (
     WakeWordDetectionAborted,
     WakeWordDetectionError,
 )
+from homeassistant.components.assist_pipeline.vad import VadSensitivity
 from homeassistant.components.intent.timers import TimerEventType, TimerInfo
 from homeassistant.components.media_player import async_process_play_media_url
 from homeassistant.core import Context, HomeAssistant, callback
@@ -243,6 +244,11 @@ class VoiceAssistantPipeline:
                     auto_gain_dbfs=audio_settings.auto_gain,
                     volume_multiplier=audio_settings.volume_multiplier,
                     is_vad_enabled=bool(flags & VoiceAssistantCommandFlag.USE_VAD),
+                    silence_seconds=VadSensitivity.to_seconds(
+                        pipeline_select.get_vad_sensitivity(
+                            self.hass, DOMAIN, self.device_info.mac_address
+                        )
+                    ),
                 ),
             )
 

--- a/homeassistant/components/wyoming/devices.py
+++ b/homeassistant/components/wyoming/devices.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 
+from homeassistant.components.assist_pipeline.vad import VadSensitivity
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 
@@ -23,6 +24,7 @@ class SatelliteDevice:
     noise_suppression_level: int = 0
     auto_gain: int = 0
     volume_multiplier: float = 1.0
+    vad_sensitivity: VadSensitivity = VadSensitivity.DEFAULT
 
     _is_active_listener: Callable[[], None] | None = None
     _is_muted_listener: Callable[[], None] | None = None
@@ -74,6 +76,14 @@ class SatelliteDevice:
         """Set auto gain amount."""
         if volume_multiplier != self.volume_multiplier:
             self.volume_multiplier = volume_multiplier
+            if self._audio_settings_listener is not None:
+                self._audio_settings_listener()
+
+    @callback
+    def set_vad_sensitivity(self, vad_sensitivity: VadSensitivity) -> None:
+        """Set VAD sensitivity."""
+        if vad_sensitivity != self.vad_sensitivity:
+            self.vad_sensitivity = vad_sensitivity
             if self._audio_settings_listener is not None:
                 self._audio_settings_listener()
 
@@ -139,4 +149,11 @@ class SatelliteDevice:
         ent_reg = er.async_get(hass)
         return ent_reg.async_get_entity_id(
             "number", DOMAIN, f"{self.satellite_id}-volume_multiplier"
+        )
+
+    def get_vad_sensitivity_entity_id(self, hass: HomeAssistant) -> str | None:
+        """Return entity id for VAD sensitivity."""
+        ent_reg = er.async_get(hass)
+        return ent_reg.async_get_entity_id(
+            "select", DOMAIN, f"{self.satellite_id}-vad_sensitivity"
         )

--- a/homeassistant/components/wyoming/satellite.py
+++ b/homeassistant/components/wyoming/satellite.py
@@ -25,6 +25,7 @@ from wyoming.wake import Detect, Detection
 
 from homeassistant.components import assist_pipeline, intent, stt, tts
 from homeassistant.components.assist_pipeline import select as pipeline_select
+from homeassistant.components.assist_pipeline.vad import VadSensitivity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import Context, HomeAssistant, callback
 
@@ -409,6 +410,9 @@ class WyomingSatellite:
                     noise_suppression_level=self.device.noise_suppression_level,
                     auto_gain_dbfs=self.device.auto_gain,
                     volume_multiplier=self.device.volume_multiplier,
+                    silence_seconds=VadSensitivity.to_seconds(
+                        self.device.vad_sensitivity
+                    ),
                 ),
                 device_id=self.device.device_id,
                 wake_word_phrase=wake_word_phrase,

--- a/homeassistant/components/wyoming/select.py
+++ b/homeassistant/components/wyoming/select.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Final
 
-from homeassistant.components.assist_pipeline.select import AssistPipelineSelect
+from homeassistant.components.assist_pipeline.select import (
+    AssistPipelineSelect,
+    VadSensitivitySelect,
+)
+from homeassistant.components.assist_pipeline.vad import VadSensitivity
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
@@ -45,6 +49,7 @@ async def async_setup_entry(
         [
             WyomingSatellitePipelineSelect(hass, device),
             WyomingSatelliteNoiseSuppressionLevelSelect(device),
+            WyomingSatelliteVadSensitivitySelect(hass, device),
         ]
     )
 
@@ -92,3 +97,21 @@ class WyomingSatelliteNoiseSuppressionLevelSelect(
         self._attr_current_option = option
         self.async_write_ha_state()
         self._device.set_noise_suppression_level(_NOISE_SUPPRESSION_LEVEL[option])
+
+
+class WyomingSatelliteVadSensitivitySelect(
+    WyomingSatelliteEntity, VadSensitivitySelect
+):
+    """VAD sensitivity selector for Wyoming satellites."""
+
+    def __init__(self, hass: HomeAssistant, device: SatelliteDevice) -> None:
+        """Initialize a VAD sensitivity selector."""
+        self.device = device
+
+        WyomingSatelliteEntity.__init__(self, device)
+        VadSensitivitySelect.__init__(self, hass, device.satellite_id)
+
+    async def async_select_option(self, option: str) -> None:
+        """Select an option."""
+        await super().async_select_option(option)
+        self.device.set_vad_sensitivity(VadSensitivity(option))

--- a/homeassistant/components/wyoming/strings.json
+++ b/homeassistant/components/wyoming/strings.json
@@ -46,6 +46,14 @@
           "high": "High",
           "max": "Max"
         }
+      },
+      "vad_sensitivity": {
+        "name": "[%key:component::assist_pipeline::entity::select::vad_sensitivity::name%]",
+        "state": {
+          "default": "[%key:component::assist_pipeline::entity::select::vad_sensitivity::state::default%]",
+          "aggressive": "[%key:component::assist_pipeline::entity::select::vad_sensitivity::state::aggressive%]",
+          "relaxed": "[%key:component::assist_pipeline::entity::select::vad_sensitivity::state::relaxed%]"
+        }
       }
     },
     "switch": {

--- a/tests/components/wyoming/test_select.py
+++ b/tests/components/wyoming/test_select.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 from homeassistant.components import assist_pipeline
 from homeassistant.components.assist_pipeline.pipeline import PipelineData
 from homeassistant.components.assist_pipeline.select import OPTION_PREFERRED
+from homeassistant.components.assist_pipeline.vad import VadSensitivity
 from homeassistant.components.wyoming.devices import SatelliteDevice
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -140,3 +141,50 @@ async def test_noise_suppression_level_select(
     )
 
     assert satellite_device.noise_suppression_level == 2
+
+
+async def test_vad_sensitivity_select(
+    hass: HomeAssistant,
+    satellite_config_entry: ConfigEntry,
+    satellite_device: SatelliteDevice,
+) -> None:
+    """Test VAD sensitivity select."""
+    vs_entity_id = satellite_device.get_vad_sensitivity_entity_id(hass)
+    assert vs_entity_id
+
+    state = hass.states.get(vs_entity_id)
+    assert state is not None
+    assert state.state == VadSensitivity.DEFAULT
+    assert satellite_device.vad_sensitivity == VadSensitivity.DEFAULT
+
+    # Change setting
+    with patch.object(satellite_device, "set_vad_sensitivity") as mock_vs_changed:
+        await hass.services.async_call(
+            "select",
+            "select_option",
+            {"entity_id": vs_entity_id, "option": VadSensitivity.AGGRESSIVE.value},
+            blocking=True,
+        )
+
+        state = hass.states.get(vs_entity_id)
+        assert state is not None
+        assert state.state == VadSensitivity.AGGRESSIVE.value
+
+        # set function should have been called
+        mock_vs_changed.assert_called_once_with(VadSensitivity.AGGRESSIVE)
+
+    # test restore
+    satellite_device = await reload_satellite(hass, satellite_config_entry.entry_id)
+
+    state = hass.states.get(vs_entity_id)
+    assert state is not None
+    assert state.state == VadSensitivity.AGGRESSIVE.value
+
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {"entity_id": vs_entity_id, "option": VadSensitivity.RELAXED.value},
+        blocking=True,
+    )
+
+    assert satellite_device.vad_sensitivity == VadSensitivity.RELAXED


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The "finished speaking detection" setting for a voice satellite controls how much silence to wait for before a voice command is considered finished. While ESPHome devices had this setting, it was not actually being used. Wyoming satellites were missing this setting completely.

This PR:
* Makes the existing ESPHome "finished speaking detection" setting work correctly
* Adds a new "finished speaking detection" setting for Wyoming satellites

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
