### PR TITLE
Improve test coverage for AVM Fritz!Smarthome

### DIFF
--- a/homeassistant/components/fritzbox/light.py
+++ b/homeassistant/components/fritzbox/light.py
@@ -72,7 +72,7 @@ class FritzboxLight(FritzBoxDeviceEntity, LightEntity):
         return self.data.level  # type: ignore [no-any-return]
 
     @property
-    def hs_color(self) -> tuple[float, float] | None:
+    def hs_color(self) -> tuple[float, float]:
         """Return the hs color value."""
         hue = self.data.hue
         saturation = self.data.saturation

--- a/homeassistant/components/fritzbox/light.py
+++ b/homeassistant/components/fritzbox/light.py
@@ -74,9 +74,6 @@ class FritzboxLight(FritzBoxDeviceEntity, LightEntity):
     @property
     def hs_color(self) -> tuple[float, float] | None:
         """Return the hs color value."""
-        if self.data.color_mode != COLOR_MODE:
-            return None
-
         hue = self.data.hue
         saturation = self.data.saturation
 

--- a/tests/components/fritzbox/__init__.py
+++ b/tests/components/fritzbox/__init__.py
@@ -115,6 +115,13 @@ class FritzDeviceClimateMock(FritzEntityBaseMock):
     scheduled_preset = PRESET_ECO
 
 
+class FritzDeviceClimateWithoutTempSensorMock(FritzDeviceClimateMock):
+    """Mock of a AVM Fritz!Box climate device without exposing temperature sensor."""
+
+    temperature = None
+    has_temperature_sensor = False
+
+
 class FritzDeviceSensorMock(FritzEntityBaseMock):
     """Mock of a AVM Fritz!Box sensor device."""
 
@@ -187,3 +194,9 @@ class FritzDeviceCoverMock(FritzEntityBaseMock):
     has_thermostat = False
     has_blind = True
     levelpercentage = 0
+
+
+class FritzDeviceCoverUnknownPositionMock(FritzDeviceCoverMock):
+    """Mock of a AVM Fritz!Box cover device with unknown position."""
+
+    levelpercentage = None

--- a/tests/components/fritzbox/test_climate.py
+++ b/tests/components/fritzbox/test_climate.py
@@ -46,7 +46,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.util.dt as dt_util
 
-from . import FritzDeviceClimateMock, set_devices, setup_config_entry
+from . import (
+    FritzDeviceClimateMock,
+    FritzDeviceClimateWithoutTempSensorMock,
+    set_devices,
+    setup_config_entry,
+)
 from .const import CONF_FAKE_NAME, MOCK_CONFIG
 
 from tests.common import async_fire_time_changed
@@ -160,6 +165,18 @@ async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
     )
     assert state
     assert state.state == PRESET_COMFORT
+
+
+async def test_hkr_wo_temperature_sensor(hass: HomeAssistant, fritz: Mock) -> None:
+    """Test hkr without exposing dedicated temperature sensor data block."""
+    device = FritzDeviceClimateWithoutTempSensorMock()
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
+
+    state = hass.states.get(ENTITY_ID)
+    assert state
+    assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 18.0
 
 
 async def test_target_temperature_on(hass: HomeAssistant, fritz: Mock) -> None:

--- a/tests/components/fritzbox/test_cover.py
+++ b/tests/components/fritzbox/test_cover.py
@@ -3,7 +3,12 @@
 from datetime import timedelta
 from unittest.mock import Mock, call
 
-from homeassistant.components.cover import ATTR_CURRENT_POSITION, ATTR_POSITION, DOMAIN
+from homeassistant.components.cover import (
+    ATTR_CURRENT_POSITION,
+    ATTR_POSITION,
+    DOMAIN,
+    STATE_OPEN,
+)
 from homeassistant.components.fritzbox.const import DOMAIN as FB_DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -12,11 +17,17 @@ from homeassistant.const import (
     SERVICE_OPEN_COVER,
     SERVICE_SET_COVER_POSITION,
     SERVICE_STOP_COVER,
+    STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
-from . import FritzDeviceCoverMock, set_devices, setup_config_entry
+from . import (
+    FritzDeviceCoverMock,
+    FritzDeviceCoverUnknownPositionMock,
+    set_devices,
+    setup_config_entry,
+)
 from .const import CONF_FAKE_NAME, MOCK_CONFIG
 
 from tests.common import async_fire_time_changed
@@ -33,7 +44,20 @@ async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
 
     state = hass.states.get(ENTITY_ID)
     assert state
+    assert state.state == STATE_OPEN
     assert state.attributes[ATTR_CURRENT_POSITION] == 100
+
+
+async def test_unknown_position(hass: HomeAssistant, fritz: Mock) -> None:
+    """Test cover with unknown position."""
+    device = FritzDeviceCoverUnknownPositionMock()
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
+
+    state = hass.states.get(ENTITY_ID)
+    assert state
+    assert state.state == STATE_UNKNOWN
 
 
 async def test_open_cover(hass: HomeAssistant, fritz: Mock) -> None:

--- a/tests/components/fritzbox/test_light.py
+++ b/tests/components/fritzbox/test_light.py
@@ -12,12 +12,14 @@ from homeassistant.components.fritzbox.const import (
 )
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
+    ATTR_COLOR_MODE,
     ATTR_COLOR_TEMP_KELVIN,
     ATTR_HS_COLOR,
     ATTR_MAX_COLOR_TEMP_KELVIN,
     ATTR_MIN_COLOR_TEMP_KELVIN,
     ATTR_SUPPORTED_COLOR_MODES,
     DOMAIN,
+    ColorMode,
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -56,9 +58,11 @@ async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
     assert state
     assert state.state == STATE_ON
     assert state.attributes[ATTR_FRIENDLY_NAME] == "fake_name"
+    assert state.attributes[ATTR_COLOR_MODE] == ColorMode.COLOR_TEMP
     assert state.attributes[ATTR_COLOR_TEMP_KELVIN] == 2700
     assert state.attributes[ATTR_MIN_COLOR_TEMP_KELVIN] == 2700
     assert state.attributes[ATTR_MAX_COLOR_TEMP_KELVIN] == 6500
+    assert state.attributes[ATTR_HS_COLOR] == (28.395, 65.723)
     assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == ["color_temp", "hs"]
 
 
@@ -99,6 +103,9 @@ async def test_setup_non_color_non_level(hass: HomeAssistant, fritz: Mock) -> No
     assert state.attributes[ATTR_FRIENDLY_NAME] == "fake_name"
     assert ATTR_BRIGHTNESS not in state.attributes
     assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == ["onoff"]
+    assert state.attributes[ATTR_COLOR_MODE] == ColorMode.ONOFF
+    assert state.attributes.get(ATTR_COLOR_TEMP_KELVIN) is None
+    assert state.attributes.get(ATTR_HS_COLOR) is None
 
 
 async def test_setup_color(hass: HomeAssistant, fritz: Mock) -> None:
@@ -120,6 +127,8 @@ async def test_setup_color(hass: HomeAssistant, fritz: Mock) -> None:
     assert state
     assert state.state == STATE_ON
     assert state.attributes[ATTR_FRIENDLY_NAME] == "fake_name"
+    assert state.attributes[ATTR_COLOR_MODE] == ColorMode.HS
+    assert state.attributes[ATTR_COLOR_TEMP_KELVIN] is None
     assert state.attributes[ATTR_BRIGHTNESS] == 100
     assert state.attributes[ATTR_HS_COLOR] == (100, 70)
     assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == ["color_temp", "hs"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
**before**
```
--------- coverage: platform linux, python 3.12.4-final-0 -----------
Name                                                 Stmts   Miss  Cover   Missing
----------------------------------------------------------------------------------
homeassistant/components/fritzbox/__init__.py           65      1    98%   56
homeassistant/components/fritzbox/binary_sensor.py      34      0   100%
homeassistant/components/fritzbox/button.py             31      0   100%
homeassistant/components/fritzbox/climate.py           131      1    99%   125
homeassistant/components/fritzbox/config_flow.py       136      0   100%
homeassistant/components/fritzbox/const.py              15      0   100%
homeassistant/components/fritzbox/coordinator.py        88      0   100%
homeassistant/components/fritzbox/cover.py              43      1    98%   69
homeassistant/components/fritzbox/diagnostics.py        13      0   100%
homeassistant/components/fritzbox/light.py              92      2    98%   78, 130
homeassistant/components/fritzbox/model.py              14      0   100%
homeassistant/components/fritzbox/sensor.py             66      0   100%
homeassistant/components/fritzbox/switch.py             35      0   100%
----------------------------------------------------------------------------------
TOTAL                                                  763      5    99%
```

**after**
```
---------- coverage: platform linux, python 3.12.4-final-0 -----------
Name                                                 Stmts   Miss  Cover   Missing
----------------------------------------------------------------------------------
homeassistant/components/fritzbox/__init__.py           65      0   100%
homeassistant/components/fritzbox/binary_sensor.py      34      0   100%
homeassistant/components/fritzbox/button.py             31      0   100%
homeassistant/components/fritzbox/climate.py           131      0   100%
homeassistant/components/fritzbox/config_flow.py       136      0   100%
homeassistant/components/fritzbox/const.py              15      0   100%
homeassistant/components/fritzbox/coordinator.py        88      0   100%
homeassistant/components/fritzbox/cover.py              43      0   100%
homeassistant/components/fritzbox/diagnostics.py        13      0   100%
homeassistant/components/fritzbox/light.py              90      0   100%
homeassistant/components/fritzbox/model.py              14      0   100%
homeassistant/components/fritzbox/sensor.py             66      0   100%
homeassistant/components/fritzbox/switch.py             35      0   100%
----------------------------------------------------------------------------------
TOTAL                                                  761      0   100%
```

**todo**

- [x] homeassistant/components/fritzbox/light.py:78 **SOLVED** -> a392a8c
  https://github.com/home-assistant/core/blob/6baee603a5d1396e78bfc9a384ed5545be0d34e0/homeassistant/components/fritzbox/light.py#L75-L83
  not sure how to test properties of Entiy objects (_not corresponding state objects_) :thinking: 

- [x] homeassistant/components/fritzbox/light.py:130
  @flabbamann do you remember about possible circumstances for this raise?
  https://github.com/home-assistant/core/blob/6baee603a5d1396e78bfc9a384ed5545be0d34e0/homeassistant/components/fritzbox/light.py#L130-L133

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
