### PR TITLE
Enable collections-named-tuple (PYI024) rule in ruff

### DIFF
--- a/homeassistant/components/ads/__init__.py
+++ b/homeassistant/components/ads/__init__.py
@@ -136,7 +136,7 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 
 # Tuple to hold data needed for notification
-NotificationItem = namedtuple(
+NotificationItem = namedtuple(  # noqa: PYI024
     "NotificationItem", "hnotify huser name plc_datatype callback"
 )
 

--- a/homeassistant/components/asuswrt/bridge.py
+++ b/homeassistant/components/asuswrt/bridge.py
@@ -52,7 +52,7 @@ SENSORS_TYPE_LOAD_AVG = "sensors_load_avg"
 SENSORS_TYPE_RATES = "sensors_rates"
 SENSORS_TYPE_TEMPERATURES = "sensors_temperatures"
 
-WrtDevice = namedtuple("WrtDevice", ["ip", "name", "connected_to"])
+WrtDevice = namedtuple("WrtDevice", ["ip", "name", "connected_to"])  # noqa: PYI024
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/bbox/device_tracker.py
+++ b/homeassistant/components/bbox/device_tracker.py
@@ -39,7 +39,7 @@ def get_scanner(hass: HomeAssistant, config: ConfigType) -> BboxDeviceScanner | 
     return scanner if scanner.success_init else None
 
 
-Device = namedtuple("Device", ["mac", "name", "ip", "last_update"])
+Device = namedtuple("Device", ["mac", "name", "ip", "last_update"])  # noqa: PYI024
 
 
 class BboxDeviceScanner(DeviceScanner):

--- a/homeassistant/components/bt_smarthub/device_tracker.py
+++ b/homeassistant/components/bt_smarthub/device_tracker.py
@@ -51,7 +51,7 @@ def _create_device(data):
     return _Device(ip_address, mac, host, status, name)
 
 
-_Device = namedtuple("_Device", ["ip_address", "mac", "host", "status", "name"])
+_Device = namedtuple("_Device", ["ip_address", "mac", "host", "status", "name"])  # noqa: PYI024
 
 
 class BTSmartHubScanner(DeviceScanner):

--- a/homeassistant/components/epic_games_store/calendar.py
+++ b/homeassistant/components/epic_games_store/calendar.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN, CalendarType
 from .coordinator import EGSCalendarUpdateCoordinator
 
-DateRange = namedtuple("DateRange", ["start", "end"])
+DateRange = namedtuple("DateRange", ["start", "end"])  # noqa: PYI024
 
 
 async def async_setup_entry(

--- a/homeassistant/components/fints/sensor.py
+++ b/homeassistant/components/fints/sensor.py
@@ -28,7 +28,7 @@ SCAN_INTERVAL = timedelta(hours=4)
 
 ICON = "mdi:currency-eur"
 
-BankCredentials = namedtuple("BankCredentials", "blz login pin url")
+BankCredentials = namedtuple("BankCredentials", "blz login pin url")  # noqa: PYI024
 
 CONF_BIN = "bank_identification_number"
 CONF_ACCOUNTS = "accounts"

--- a/homeassistant/components/hitron_coda/device_tracker.py
+++ b/homeassistant/components/hitron_coda/device_tracker.py
@@ -42,7 +42,7 @@ def get_scanner(
     return scanner if scanner.success_init else None
 
 
-Device = namedtuple("Device", ["mac", "name"])
+Device = namedtuple("Device", ["mac", "name"])  # noqa: PYI024
 
 
 class HitronCODADeviceScanner(DeviceScanner):

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -76,8 +76,8 @@ from .validators import check_config
 _LOGGER = logging.getLogger(__name__)
 
 
-ConfEntry = namedtuple("ConfEntry", "call_type attr func_name")
-RunEntry = namedtuple("RunEntry", "attr func")
+ConfEntry = namedtuple("ConfEntry", "call_type attr func_name")  # noqa: PYI024
+RunEntry = namedtuple("RunEntry", "attr func")  # noqa: PYI024
 PB_CALL = [
     ConfEntry(
         CALL_TYPE_COIL,

--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -46,7 +46,7 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-ENTRY = namedtuple(
+ENTRY = namedtuple(  # noqa: PYI024
     "ENTRY",
     [
         "struct_id",
@@ -60,7 +60,7 @@ ILLEGAL = "I"
 OPTIONAL = "O"
 DEMANDED = "D"
 
-PARM_IS_LEGAL = namedtuple(
+PARM_IS_LEGAL = namedtuple(  # noqa: PYI024
     "PARM_IS_LEGAL",
     [
         "count",

--- a/homeassistant/components/ness_alarm/__init__.py
+++ b/homeassistant/components/ness_alarm/__init__.py
@@ -44,7 +44,7 @@ DEFAULT_INFER_ARMING_STATE = False
 SIGNAL_ZONE_CHANGED = "ness_alarm.zone_changed"
 SIGNAL_ARMING_STATE_CHANGED = "ness_alarm.arming_state_changed"
 
-ZoneChangedData = namedtuple("ZoneChangedData", ["zone_id", "state"])
+ZoneChangedData = namedtuple("ZoneChangedData", ["zone_id", "state"])  # noqa: PYI024
 
 DEFAULT_ZONE_TYPE = BinarySensorDeviceClass.MOTION
 ZONE_SCHEMA = vol.Schema(

--- a/homeassistant/components/netio/switch.py
+++ b/homeassistant/components/netio/switch.py
@@ -38,7 +38,7 @@ CONF_OUTLETS = "outlets"
 
 DEFAULT_PORT = 1234
 DEFAULT_USERNAME = "admin"
-Device = namedtuple("Device", ["netio", "entities"])
+Device = namedtuple("Device", ["netio", "entities"])  # noqa: PYI024
 DEVICES: dict[str, Device] = {}
 
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)

--- a/homeassistant/components/tellstick/sensor.py
+++ b/homeassistant/components/tellstick/sensor.py
@@ -29,7 +29,7 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 _LOGGER = logging.getLogger(__name__)
 
-DatatypeDescription = namedtuple(
+DatatypeDescription = namedtuple(  # noqa: PYI024
     "DatatypeDescription", ["name", "unit", "device_class"]
 )
 

--- a/homeassistant/scripts/benchmark/__init__.py
+++ b/homeassistant/scripts/benchmark/__init__.py
@@ -322,7 +322,7 @@ def _create_state_changed_event_from_old_new(
     attributes_json = json.dumps(attributes, cls=JSONEncoder)
     if attributes_json == "null":
         attributes_json = "{}"
-    row = collections.namedtuple(
+    row = collections.namedtuple(  # noqa: PYI024
         "Row",
         [
             "event_type"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -820,7 +820,6 @@ ignore = [
     "PLE0605",
 
     # temporarily disabled
-    "PYI024", # Use typing.NamedTuple instead of collections.namedtuple
     "RET503",
     "RET501",
     "TRY002",

--- a/script/lint_and_test.py
+++ b/script/lint_and_test.py
@@ -20,7 +20,7 @@ except ImportError:
 
 
 RE_ASCII = re.compile(r"\033\[[^m]*m")
-Error = namedtuple("Error", ["file", "line", "col", "msg", "skip"])
+Error = namedtuple("Error", ["file", "line", "col", "msg", "skip"])  # noqa: PYI024
 
 PASS = "green"
 FAIL = "bold_red"

--- a/tests/components/hardware/test_websocket_api.py
+++ b/tests/components/hardware/test_websocket_api.py
@@ -61,7 +61,7 @@ async def test_system_status_subscription(
     response = await client.receive_json()
     assert response["success"]
 
-    VirtualMem = namedtuple("VirtualMemory", ["available", "percent", "total"])
+    VirtualMem = namedtuple("VirtualMemory", ["available", "percent", "total"])  # noqa: PYI024
     vmem = VirtualMem(10 * 1024**2, 50, 30 * 1024**2)
 
     with (

--- a/tests/components/jewish_calendar/__init__.py
+++ b/tests/components/jewish_calendar/__init__.py
@@ -8,7 +8,7 @@ from freezegun import freeze_time as alter_time  # noqa: F401
 from homeassistant.components import jewish_calendar
 import homeassistant.util.dt as dt_util
 
-_LatLng = namedtuple("_LatLng", ["lat", "lng"])
+_LatLng = namedtuple("_LatLng", ["lat", "lng"])  # noqa: PYI024
 
 HDATE_DEFAULT_ALTITUDE = 754
 NYC_LATLNG = _LatLng(40.7128, -74.0060)

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -328,7 +328,7 @@ def create_state_changed_event_from_old_new(
     if new_state is not None:
         attributes = new_state.get("attributes")
     attributes_json = json.dumps(attributes, cls=JSONEncoder)
-    row = collections.namedtuple(
+    row = collections.namedtuple(  # noqa: PYI024
         "Row",
         [
             "event_type",

--- a/tests/components/russound_rio/const.py
+++ b/tests/components/russound_rio/const.py
@@ -12,5 +12,5 @@ MOCK_CONFIG = {
     "port": PORT,
 }
 
-_CONTROLLER = namedtuple("Controller", ["mac_address", "controller_type"])
+_CONTROLLER = namedtuple("Controller", ["mac_address", "controller_type"])  # noqa: PYI024
 MOCK_CONTROLLERS = {1: _CONTROLLER(mac_address=HARDWARE_MAC, controller_type=MODEL)}

--- a/tests/components/tplink/__init__.py
+++ b/tests/components/tplink/__init__.py
@@ -39,7 +39,7 @@ from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, load_json_value_fixture
 
-ColorTempRange = namedtuple("ColorTempRange", ["min", "max"])
+ColorTempRange = namedtuple("ColorTempRange", ["min", "max"])  # noqa: PYI024
 
 MODULE = "homeassistant.components.tplink"
 MODULE_CONFIG_FLOW = "homeassistant.components.tplink.config_flow"


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, see https://docs.astral.sh/ruff/rules/collections-named-tuple/

Fresh take on #115332

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
