### PR TITLE
Replace pylint broad-exception-raised rule with ruff

### DIFF
--- a/homeassistant/components/fritz/coordinator.py
+++ b/homeassistant/components/fritz/coordinator.py
@@ -568,8 +568,7 @@ class FritzBoxTools(DataUpdateCoordinator[UpdateCoordinatorDataType]):
                     self.fritz_hosts.get_mesh_topology
                 )
             ):
-                # pylint: disable-next=broad-exception-raised
-                raise Exception("Mesh supported but empty topology reported")
+                raise Exception("Mesh supported but empty topology reported")  # noqa: TRY002
         except FritzActionError:
             self.mesh_role = MeshRoles.SLAVE
             # Avoid duplicating device trackers

--- a/homeassistant/components/starline/config_flow.py
+++ b/homeassistant/components/starline/config_flow.py
@@ -214,8 +214,7 @@ class StarlineFlowHandler(ConfigFlow, domain=DOMAIN):
                 self._captcha_image = data["captchaImg"]
                 return self._async_form_auth_captcha(error)
 
-            #  pylint: disable=broad-exception-raised
-            raise Exception(data)
+            raise Exception(data)  # noqa: TRY002
         except Exception as err:  # noqa: BLE001
             _LOGGER.error("Error auth user: %s", err)
             return self._async_form_auth_user(ERROR_AUTH_USER)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -312,6 +312,7 @@ disable = [
     "no-else-return", # RET505
     "broad-except", # BLE001
     "protected-access", # SLF001
+    "broad-exception-raised", # TRY002
     # "no-self-use", # PLR6301  # Optional plugin, not enabled
 
     # Handled by mypy
@@ -823,7 +824,6 @@ ignore = [
     "PYI024", # Use typing.NamedTuple instead of collections.namedtuple
     "RET503",
     "RET501",
-    "TRY002",
     "TRY301"
 ]
 

--- a/script/scaffold/templates/config_flow_helper/tests/test_config_flow.py
+++ b/script/scaffold/templates/config_flow_helper/tests/test_config_flow.py
@@ -59,7 +59,7 @@ def get_suggested(schema, key):
                 return None
             return k.description["suggested_value"]
     # Wanted key absent from schema
-    raise Exception
+    raise KeyError(f"Key `{key}` is missing from schema")
 
 
 @pytest.mark.parametrize("platform", ["sensor"])

--- a/tests/components/bluetooth/test_passive_update_processor.py
+++ b/tests/components/bluetooth/test_passive_update_processor.py
@@ -583,8 +583,7 @@ async def test_exception_from_update_method(
         nonlocal run_count
         run_count += 1
         if run_count == 2:
-            # pylint: disable-next=broad-exception-raised
-            raise Exception("Test exception")
+            raise Exception("Test exception")  # noqa: TRY002
         return GENERIC_PASSIVE_BLUETOOTH_DATA_UPDATE
 
     coordinator = PassiveBluetoothProcessorCoordinator(
@@ -1418,8 +1417,7 @@ async def test_exception_from_coordinator_update_method(
         nonlocal run_count
         run_count += 1
         if run_count == 2:
-            # pylint: disable-next=broad-exception-raised
-            raise Exception("Test exception")
+            raise Exception("Test exception")  # noqa: TRY002
         return {"test": "data"}
 
     @callback

--- a/tests/components/notify/test_legacy.py
+++ b/tests/components/notify/test_legacy.py
@@ -265,7 +265,7 @@ async def test_platform_setup_with_error(
 
     async def async_get_service(hass, config, discovery_info=None):
         """Return None for an invalid notify service."""
-        raise Exception("Setup error")  # pylint: disable=broad-exception-raised
+        raise Exception("Setup error")  # noqa: TRY002
 
     mock_notify_platform(
         hass, tmp_path, "testnotify", async_get_service=async_get_service

--- a/tests/components/profiler/test_init.py
+++ b/tests/components/profiler/test_init.py
@@ -181,7 +181,7 @@ async def test_dump_log_object(
 
         def __repr__(self):
             if self.fail:
-                raise Exception("failed")  # pylint: disable=broad-exception-raised
+                raise Exception("failed")  # noqa: TRY002
             return "<DumpLogDummy success>"
 
     obj1 = DumpLogDummy(False)

--- a/tests/components/roon/test_config_flow.py
+++ b/tests/components/roon/test_config_flow.py
@@ -48,7 +48,7 @@ class RoonApiMockException(RoonApiMock):
     @property
     def token(self):
         """Throw exception."""
-        raise Exception  # pylint: disable=broad-exception-raised
+        raise Exception  # noqa: TRY002
 
 
 class RoonDiscoveryMock:

--- a/tests/components/stt/test_legacy.py
+++ b/tests/components/stt/test_legacy.py
@@ -41,7 +41,7 @@ async def test_platform_setup_with_error(
         discovery_info: DiscoveryInfoType | None = None,
     ) -> Provider:
         """Raise exception during platform setup."""
-        raise Exception("Setup error")  # pylint: disable=broad-exception-raised
+        raise Exception("Setup error")  # noqa: TRY002
 
     mock_stt_platform(hass, tmp_path, "bad_stt", async_get_engine=async_get_engine)
 

--- a/tests/components/system_health/test_init.py
+++ b/tests/components/system_health/test_init.py
@@ -110,7 +110,7 @@ async def test_info_endpoint_register_callback_exc(
     """Test that the info endpoint requires auth."""
 
     async def mock_info(hass):
-        raise Exception("TEST ERROR")  # pylint: disable=broad-exception-raised
+        raise Exception("TEST ERROR")  # noqa: TRY002
 
     async_register_info(hass, "lovelace", mock_info)
     assert await async_setup_component(hass, "system_health", {})

--- a/tests/components/system_log/test_init.py
+++ b/tests/components/system_log/test_init.py
@@ -36,7 +36,7 @@ async def get_error_log(hass_ws_client):
 
 def _generate_and_log_exception(exception, log):
     try:
-        raise Exception(exception)  # pylint: disable=broad-exception-raised
+        raise Exception(exception)  # noqa: TRY002
     except Exception:
         _LOGGER.exception(log)
 

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -1016,7 +1016,7 @@ class MockProviderBoom(MockProvider):
     ) -> tts.TtsAudioType:
         """Load TTS dat."""
         # This should not be called, data should be fetched from cache
-        raise Exception("Boom!")  # pylint: disable=broad-exception-raised
+        raise Exception("Boom!")  # noqa: TRY002
 
 
 class MockEntityBoom(MockTTSEntity):
@@ -1027,7 +1027,7 @@ class MockEntityBoom(MockTTSEntity):
     ) -> tts.TtsAudioType:
         """Load TTS dat."""
         # This should not be called, data should be fetched from cache
-        raise Exception("Boom!")  # pylint: disable=broad-exception-raised
+        raise Exception("Boom!")  # noqa: TRY002
 
 
 @pytest.mark.parametrize("mock_provider", [MockProviderBoom(DEFAULT_LANG)])

--- a/tests/components/tts/test_legacy.py
+++ b/tests/components/tts/test_legacy.py
@@ -123,7 +123,7 @@ async def test_platform_setup_with_error(
             discovery_info: DiscoveryInfoType | None = None,
         ) -> Provider:
             """Raise exception during platform setup."""
-            raise Exception("Setup error")  # pylint: disable=broad-exception-raised
+            raise Exception("Setup error")  # noqa: TRY002
 
     mock_integration(hass, MockModule(domain="bad_tts"))
     mock_platform(hass, "bad_tts.tts", BadPlatform(mock_provider))

--- a/tests/helpers/test_dispatcher.py
+++ b/tests/helpers/test_dispatcher.py
@@ -188,8 +188,7 @@ async def test_callback_exception_gets_logged(
     @callback
     def bad_handler(*args):
         """Record calls."""
-        # pylint: disable-next=broad-exception-raised
-        raise Exception("This is a bad message callback")
+        raise Exception("This is a bad message callback")  # noqa: TRY002
 
     # wrap in partial to test message logging.
     async_dispatcher_connect(hass, "test", partial(bad_handler))
@@ -209,8 +208,7 @@ async def test_coro_exception_gets_logged(
 
     async def bad_async_handler(*args):
         """Record calls."""
-        # pylint: disable-next=broad-exception-raised
-        raise Exception("This is a bad message in a coro")
+        raise Exception("This is a bad message in a coro")  # noqa: TRY002
 
     # wrap in partial to test message logging.
     async_dispatcher_connect(hass, "test", bad_async_handler)

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -584,7 +584,7 @@ async def test_remove_entry_raises(
 
     async def mock_unload_entry(hass, entry):
         """Mock unload entry function."""
-        raise Exception("BROKEN")  # pylint: disable=broad-exception-raised
+        raise Exception("BROKEN")  # noqa: TRY002
 
     mock_integration(hass, MockModule("comp", async_unload_entry=mock_unload_entry))
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -424,11 +424,11 @@ async def test_async_get_hass_can_be_called(hass: HomeAssistant) -> None:
         try:
             if ha.async_get_hass() is hass:
                 return True
-            raise Exception  # pylint: disable=broad-exception-raised
+            raise Exception  # noqa: TRY002
         except HomeAssistantError:
             return False
 
-        raise Exception  # pylint: disable=broad-exception-raised
+        raise Exception  # noqa: TRY002
 
     # Test scheduling a coroutine which calls async_get_hass via hass.async_create_task
     async def _async_create_task() -> None:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -105,7 +105,7 @@ def test_run_does_not_block_forever_with_shielded_task(
             try:
                 await asyncio.sleep(2)
             except asyncio.CancelledError:
-                raise Exception  # pylint: disable=broad-exception-raised
+                raise Exception  # noqa: TRY002
 
         async def async_shielded(*_):
             try:
@@ -142,8 +142,7 @@ async def test_unhandled_exception_traceback(
 
     async def _unhandled_exception():
         raised.set()
-        # pylint: disable-next=broad-exception-raised
-        raise Exception("This is unhandled")
+        raise Exception("This is unhandled")  # noqa: TRY002
 
     try:
         hass.loop.set_debug(True)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -352,7 +352,7 @@ async def test_component_base_exception_setup(hass: HomeAssistant) -> None:
 
     def exception_setup(hass, config):
         """Raise exception."""
-        raise BaseException("fail!")
+        raise BaseException("fail!")  # noqa: TRY002
 
     mock_integration(hass, MockModule("comp", setup=exception_setup))
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -338,7 +338,7 @@ async def test_component_exception_setup(hass: HomeAssistant) -> None:
 
     def exception_setup(hass, config):
         """Raise exception."""
-        raise Exception("fail!")  # pylint: disable=broad-exception-raised
+        raise Exception("fail!")  # noqa: TRY002
 
     mock_integration(hass, MockModule("comp", setup=exception_setup))
 
@@ -352,7 +352,7 @@ async def test_component_base_exception_setup(hass: HomeAssistant) -> None:
 
     def exception_setup(hass, config):
         """Raise exception."""
-        raise BaseException("fail!")  # pylint: disable=broad-exception-raised
+        raise BaseException("fail!")
 
     mock_integration(hass, MockModule("comp", setup=exception_setup))
 
@@ -372,8 +372,7 @@ async def test_component_setup_with_validation_and_dependency(
         """Test that config is passed in."""
         if config.get("comp_a", {}).get("valid", False):
             return True
-        # pylint: disable-next=broad-exception-raised
-        raise Exception(f"Config not passed in: {config}")
+        raise Exception(f"Config not passed in: {config}")  # noqa: TRY002
 
     platform = MockPlatform()
 

--- a/tests/util/test_logging.py
+++ b/tests/util/test_logging.py
@@ -80,8 +80,7 @@ async def test_async_create_catching_coro(
     """Test exception logging of wrapped coroutine."""
 
     async def job():
-        # pylint: disable-next=broad-exception-raised
-        raise Exception("This is a bad coroutine")
+        raise Exception("This is a bad coroutine")  # noqa: TRY002
 
     hass.async_create_task(logging_util.async_create_catching_coro(job()))
     await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA
new https://docs.astral.sh/ruff/rules/raise-vanilla-class/
old https://pylint.pycqa.org/en/latest/user_guide/messages/warning/broad-exception-raised.html

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
