### PR TITLE
Make ZHA load quirks earlier

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -117,6 +117,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     ha_zha_data.config_entry = config_entry
     zha_lib_data: ZHAData = create_zha_config(hass, ha_zha_data)
 
+    zha_gateway = await Gateway.async_from_config(zha_lib_data)
+
     # Load and cache device trigger information early
     device_registry = dr.async_get(hass)
     radio_mgr = ZhaRadioManager.from_config_entry(hass, config_entry)
@@ -140,7 +142,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     _LOGGER.debug("Trigger cache: %s", zha_lib_data.device_trigger_cache)
 
     try:
-        zha_gateway = await Gateway.async_from_config(zha_lib_data)
+        zha_gateway.async_initialize()
     except NetworkSettingsInconsistent as exc:
         await warn_on_inconsistent_network_settings(
             hass,

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -142,7 +142,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     _LOGGER.debug("Trigger cache: %s", zha_lib_data.device_trigger_cache)
 
     try:
-        zha_gateway.async_initialize()
+        await zha_gateway.async_initialize()
     except NetworkSettingsInconsistent as exc:
         await warn_on_inconsistent_network_settings(
             hass,

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -21,7 +21,7 @@
     "zha",
     "universal_silabs_flasher"
   ],
-  "requirements": ["universal-silabs-flasher==0.0.22", "zha==0.0.24"],
+  "requirements": ["universal-silabs-flasher==0.0.22", "zha==0.0.25"],
   "usb": [
     {
       "vid": "10C4",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2986,7 +2986,7 @@ zeroconf==0.132.2
 zeversolar==0.3.1
 
 # homeassistant.components.zha
-zha==0.0.24
+zha==0.0.25
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2360,7 +2360,7 @@ zeroconf==0.132.2
 zeversolar==0.3.1
 
 # homeassistant.components.zha
-zha==0.0.24
+zha==0.0.25
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.57.0

--- a/tests/components/zha/test_repairs.py
+++ b/tests/components/zha/test_repairs.py
@@ -148,7 +148,7 @@ async def test_multipan_firmware_repair(
             autospec=True,
         ),
         patch(
-            "homeassistant.components.zha.Gateway.async_from_config",
+            "homeassistant.components.zha.Gateway.async_initialize",
             side_effect=RuntimeError(),
         ),
         patch(
@@ -199,7 +199,7 @@ async def test_multipan_firmware_no_repair_on_probe_failure(
             autospec=True,
         ),
         patch(
-            "homeassistant.components.zha.Gateway.async_from_config",
+            "homeassistant.components.zha.Gateway.async_initialize",
             side_effect=RuntimeError(),
         ),
     ):
@@ -236,7 +236,7 @@ async def test_multipan_firmware_retry_on_probe_ezsp(
             autospec=True,
         ),
         patch(
-            "homeassistant.components.zha.Gateway.async_from_config",
+            "homeassistant.components.zha.Gateway.async_initialize",
             side_effect=RuntimeError(),
         ),
     ):
@@ -311,7 +311,7 @@ async def test_inconsistent_settings_keep_new(
     old_state = network_backup
 
     with patch(
-        "homeassistant.components.zha.Gateway.async_from_config",
+        "homeassistant.components.zha.Gateway.async_initialize",
         side_effect=NetworkSettingsInconsistent(
             message="Network settings are inconsistent",
             new_state=new_state,
@@ -390,7 +390,7 @@ async def test_inconsistent_settings_restore_old(
     old_state = network_backup
 
     with patch(
-        "homeassistant.components.zha.Gateway.async_from_config",
+        "homeassistant.components.zha.Gateway.async_initialize",
         side_effect=NetworkSettingsInconsistent(
             message="Network settings are inconsistent",
             new_state=new_state,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR addresses an issue where ZHA device triggers may not be available early enough for automations to properly setup. This bumps the ZHA lib to 0.0.25: https://github.com/zigpy/zha/releases/tag/0.0.25. This is needed to support this change. Essentially the loading of quirks is now done earlier and it is split out of the initialization of the Zigbee network / application.  If the integration fails to set up on the first shot (flaky stick, poor nwk conditions etc.) it prevents automations from finding triggers for ZHA devices:

```
Logger: homeassistant.components.automation.drukknop_slaapkamer_noor
Source: components/automation/__init__.py:842
integration: Automation (documentation, issues)
First occurred: 02:53:39 (1 occurrences)
Last logged: 02:53:39

Got error 'Unable to find trigger ('remote_button_short_press', 'remote_button_short_press')' when setting up triggers for Drukknop slaapkamer Noor
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
