### PR TITLE
Address post-merge reviews for KNX integration

### DIFF
--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -302,7 +302,7 @@ class KNXModule:
         self.entry = entry
 
         self.project = KNXProject(hass=hass, entry=entry)
-        self.config_store = KNXConfigStore(hass=hass, entry=entry)
+        self.config_store = KNXConfigStore(hass=hass, config_entry=entry)
 
         self.xknx = XKNX(
             connection_config=self.connection_config(),

--- a/homeassistant/components/knx/binary_sensor.py
+++ b/homeassistant/components/knx/binary_sensor.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from xknx import XKNX
 from xknx.devices import BinarySensor as XknxBinarySensor
 
 from homeassistant import config_entries
@@ -23,6 +22,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType
 
+from . import KNXModule
 from .const import ATTR_COUNTER, ATTR_SOURCE, DATA_KNX_CONFIG, DOMAIN
 from .knx_entity import KnxEntity
 from .schema import BinarySensorSchema
@@ -34,11 +34,11 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the KNX binary sensor platform."""
-    xknx: XKNX = hass.data[DOMAIN].xknx
+    knx_module: KNXModule = hass.data[DOMAIN]
     config: ConfigType = hass.data[DATA_KNX_CONFIG]
 
     async_add_entities(
-        KNXBinarySensor(xknx, entity_config)
+        KNXBinarySensor(knx_module, entity_config)
         for entity_config in config[Platform.BINARY_SENSOR]
     )
 
@@ -48,11 +48,12 @@ class KNXBinarySensor(KnxEntity, BinarySensorEntity, RestoreEntity):
 
     _device: XknxBinarySensor
 
-    def __init__(self, xknx: XKNX, config: ConfigType) -> None:
+    def __init__(self, knx_module: KNXModule, config: ConfigType) -> None:
         """Initialize of KNX binary sensor."""
         super().__init__(
+            knx_module=knx_module,
             device=XknxBinarySensor(
-                xknx,
+                xknx=knx_module.xknx,
                 name=config[CONF_NAME],
                 group_address_state=config[BinarySensorSchema.CONF_STATE_ADDRESS],
                 invert=config[BinarySensorSchema.CONF_INVERT],
@@ -62,7 +63,7 @@ class KNXBinarySensor(KnxEntity, BinarySensorEntity, RestoreEntity):
                 ],
                 context_timeout=config.get(BinarySensorSchema.CONF_CONTEXT_TIMEOUT),
                 reset_after=config.get(BinarySensorSchema.CONF_RESET_AFTER),
-            )
+            ),
         )
         self._attr_entity_category = config.get(CONF_ENTITY_CATEGORY)
         self._attr_device_class = config.get(CONF_DEVICE_CLASS)

--- a/homeassistant/components/knx/button.py
+++ b/homeassistant/components/knx/button.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from xknx import XKNX
 from xknx.devices import RawValue as XknxRawValue
 
 from homeassistant import config_entries
@@ -12,6 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType
 
+from . import KNXModule
 from .const import CONF_PAYLOAD_LENGTH, DATA_KNX_CONFIG, DOMAIN, KNX_ADDRESS
 from .knx_entity import KnxEntity
 
@@ -22,11 +22,12 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the KNX binary sensor platform."""
-    xknx: XKNX = hass.data[DOMAIN].xknx
+    knx_module: KNXModule = hass.data[DOMAIN]
     config: ConfigType = hass.data[DATA_KNX_CONFIG]
 
     async_add_entities(
-        KNXButton(xknx, entity_config) for entity_config in config[Platform.BUTTON]
+        KNXButton(knx_module, entity_config)
+        for entity_config in config[Platform.BUTTON]
     )
 
 
@@ -35,15 +36,16 @@ class KNXButton(KnxEntity, ButtonEntity):
 
     _device: XknxRawValue
 
-    def __init__(self, xknx: XKNX, config: ConfigType) -> None:
+    def __init__(self, knx_module: KNXModule, config: ConfigType) -> None:
         """Initialize a KNX button."""
         super().__init__(
+            knx_module=knx_module,
             device=XknxRawValue(
-                xknx,
+                xknx=knx_module.xknx,
                 name=config[CONF_NAME],
                 payload_length=config[CONF_PAYLOAD_LENGTH],
                 group_address=config[KNX_ADDRESS],
-            )
+            ),
         )
         self._payload = config[CONF_PAYLOAD]
         self._attr_entity_category = config.get(CONF_ENTITY_CATEGORY)

--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
-from xknx import XKNX
 from xknx.devices import Cover as XknxCover
 
 from homeassistant import config_entries
@@ -26,6 +25,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType
 
+from . import KNXModule
 from .const import DATA_KNX_CONFIG, DOMAIN
 from .knx_entity import KnxEntity
 from .schema import CoverSchema
@@ -37,10 +37,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up cover(s) for KNX platform."""
-    xknx: XKNX = hass.data[DOMAIN].xknx
+    knx_module: KNXModule = hass.data[DOMAIN]
     config: list[ConfigType] = hass.data[DATA_KNX_CONFIG][Platform.COVER]
 
-    async_add_entities(KNXCover(xknx, entity_config) for entity_config in config)
+    async_add_entities(KNXCover(knx_module, entity_config) for entity_config in config)
 
 
 class KNXCover(KnxEntity, CoverEntity):
@@ -48,11 +48,12 @@ class KNXCover(KnxEntity, CoverEntity):
 
     _device: XknxCover
 
-    def __init__(self, xknx: XKNX, config: ConfigType) -> None:
+    def __init__(self, knx_module: KNXModule, config: ConfigType) -> None:
         """Initialize the cover."""
         super().__init__(
+            knx_module=knx_module,
             device=XknxCover(
-                xknx,
+                xknx=knx_module.xknx,
                 name=config[CONF_NAME],
                 group_address_long=config.get(CoverSchema.CONF_MOVE_LONG_ADDRESS),
                 group_address_short=config.get(CoverSchema.CONF_MOVE_SHORT_ADDRESS),
@@ -70,7 +71,7 @@ class KNXCover(KnxEntity, CoverEntity):
                 invert_updown=config[CoverSchema.CONF_INVERT_UPDOWN],
                 invert_position=config[CoverSchema.CONF_INVERT_POSITION],
                 invert_angle=config[CoverSchema.CONF_INVERT_ANGLE],
-            )
+            ),
         )
         self._unsubscribe_auto_updater: Callable[[], None] | None = None
 

--- a/homeassistant/components/knx/date.py
+++ b/homeassistant/components/knx/date.py
@@ -22,6 +22,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType
 
+from . import KNXModule
 from .const import (
     CONF_RESPOND_TO_READ,
     CONF_STATE_ADDRESS,
@@ -39,10 +40,12 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up entities for KNX platform."""
-    xknx: XKNX = hass.data[DOMAIN].xknx
+    knx_module: KNXModule = hass.data[DOMAIN]
     config: list[ConfigType] = hass.data[DATA_KNX_CONFIG][Platform.DATE]
 
-    async_add_entities(KNXDateEntity(xknx, entity_config) for entity_config in config)
+    async_add_entities(
+        KNXDateEntity(knx_module, entity_config) for entity_config in config
+    )
 
 
 def _create_xknx_device(xknx: XKNX, config: ConfigType) -> XknxDateDevice:
@@ -63,9 +66,12 @@ class KNXDateEntity(KnxEntity, DateEntity, RestoreEntity):
 
     _device: XknxDateDevice
 
-    def __init__(self, xknx: XKNX, config: ConfigType) -> None:
+    def __init__(self, knx_module: KNXModule, config: ConfigType) -> None:
         """Initialize a KNX time."""
-        super().__init__(_create_xknx_device(xknx, config))
+        super().__init__(
+            knx_module=knx_module,
+            device=_create_xknx_device(knx_module.xknx, config),
+        )
         self._attr_entity_category = config.get(CONF_ENTITY_CATEGORY)
         self._attr_unique_id = str(self._device.remote_value.group_address)
 

--- a/homeassistant/components/knx/datetime.py
+++ b/homeassistant/components/knx/datetime.py
@@ -23,6 +23,7 @@ from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType
 import homeassistant.util.dt as dt_util
 
+from . import KNXModule
 from .const import (
     CONF_RESPOND_TO_READ,
     CONF_STATE_ADDRESS,
@@ -40,11 +41,11 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up entities for KNX platform."""
-    xknx: XKNX = hass.data[DOMAIN].xknx
+    knx_module: KNXModule = hass.data[DOMAIN]
     config: list[ConfigType] = hass.data[DATA_KNX_CONFIG][Platform.DATETIME]
 
     async_add_entities(
-        KNXDateTimeEntity(xknx, entity_config) for entity_config in config
+        KNXDateTimeEntity(knx_module, entity_config) for entity_config in config
     )
 
 
@@ -66,9 +67,12 @@ class KNXDateTimeEntity(KnxEntity, DateTimeEntity, RestoreEntity):
 
     _device: XknxDateTimeDevice
 
-    def __init__(self, xknx: XKNX, config: ConfigType) -> None:
+    def __init__(self, knx_module: KNXModule, config: ConfigType) -> None:
         """Initialize a KNX time."""
-        super().__init__(_create_xknx_device(xknx, config))
+        super().__init__(
+            knx_module=knx_module,
+            device=_create_xknx_device(knx_module.xknx, config),
+        )
         self._attr_entity_category = config.get(CONF_ENTITY_CATEGORY)
         self._attr_unique_id = str(self._device.remote_value.group_address)
 

--- a/homeassistant/components/knx/knx_entity.py
+++ b/homeassistant/components/knx/knx_entity.py
@@ -22,8 +22,9 @@ class KnxEntity(Entity):
 
     _attr_should_poll = False
 
-    def __init__(self, device: XknxDevice) -> None:
+    def __init__(self, knx_module: KNXModule, device: XknxDevice) -> None:
         """Set up device."""
+        self._knx_module = knx_module
         self._device = device
 
     @property
@@ -34,8 +35,7 @@ class KnxEntity(Entity):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        knx_module: KNXModule = self.hass.data[DOMAIN]
-        return knx_module.connected
+        return self._knx_module.connected
 
     async def async_update(self) -> None:
         """Request a state update from KNX bus."""
@@ -63,11 +63,6 @@ class KnxUIEntity(KnxEntity):
     """Representation of a KNX UI entity."""
 
     _attr_unique_id: str
-
-    def __init__(self, knx_module: KNXModule, device: XknxDevice) -> None:
-        """Initialize of KNX UI entity."""
-        self._knx_module = knx_module
-        super().__init__(device)
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks when entity added to hass."""

--- a/homeassistant/components/knx/light.py
+++ b/homeassistant/components/knx/light.py
@@ -65,10 +65,10 @@ async def async_setup_entry(
     knx_module: KNXModule = hass.data[DOMAIN]
 
     entities: list[KnxEntity] = []
-    if yaml_config := hass.data[DATA_KNX_CONFIG].get(Platform.LIGHT):
+    if yaml_platform_config := hass.data[DATA_KNX_CONFIG].get(Platform.LIGHT):
         entities.extend(
-            KnxYamlLight(knx_module.xknx, entity_config)
-            for entity_config in yaml_config
+            KnxYamlLight(knx_module, entity_config)
+            for entity_config in yaml_platform_config
         )
     if ui_config := knx_module.config_store.data["entities"].get(Platform.LIGHT):
         entities.extend(
@@ -524,9 +524,12 @@ class KnxYamlLight(_KnxLight, KnxEntity):
 
     _device: XknxLight
 
-    def __init__(self, xknx: XKNX, config: ConfigType) -> None:
+    def __init__(self, knx_module: KNXModule, config: ConfigType) -> None:
         """Initialize of KNX light."""
-        super().__init__(_create_yaml_light(xknx, config))
+        super().__init__(
+            knx_module=knx_module,
+            device=_create_yaml_light(knx_module.xknx, config),
+        )
         self._attr_max_color_temp_kelvin: int = config[LightSchema.CONF_MAX_KELVIN]
         self._attr_min_color_temp_kelvin: int = config[LightSchema.CONF_MIN_KELVIN]
         self._attr_entity_category = config.get(CONF_ENTITY_CATEGORY)

--- a/homeassistant/components/knx/light.py
+++ b/homeassistant/components/knx/light.py
@@ -27,7 +27,7 @@ import homeassistant.util.color as color_util
 
 from . import KNXModule
 from .const import CONF_SYNC_STATE, DATA_KNX_CONFIG, DOMAIN, KNX_ADDRESS, ColorTempModes
-from .knx_entity import KnxEntity
+from .knx_entity import KnxEntity, KnxUIEntity
 from .schema import LightSchema
 from .storage.const import (
     CONF_COLOR_TEMP_MAX,
@@ -294,7 +294,7 @@ def _create_ui_light(xknx: XKNX, knx_config: ConfigType, name: str) -> XknxLight
     )
 
 
-class _KnxLight(KnxEntity, LightEntity):
+class _KnxLight(LightEntity):
     """Representation of a KNX light."""
 
     _attr_max_color_temp_kelvin: int
@@ -519,7 +519,7 @@ class _KnxLight(KnxEntity, LightEntity):
         await self._device.set_off()
 
 
-class KnxYamlLight(_KnxLight):
+class KnxYamlLight(_KnxLight, KnxEntity):
     """Representation of a KNX light."""
 
     _device: XknxLight
@@ -543,20 +543,21 @@ class KnxYamlLight(_KnxLight):
         )
 
 
-class KnxUiLight(_KnxLight):
+class KnxUiLight(_KnxLight, KnxUIEntity):
     """Representation of a KNX light."""
 
-    _device: XknxLight
     _attr_has_entity_name = True
+    _device: XknxLight
 
     def __init__(
         self, knx_module: KNXModule, unique_id: str, config: ConfigType
     ) -> None:
         """Initialize of KNX light."""
         super().__init__(
-            _create_ui_light(
+            knx_module=knx_module,
+            device=_create_ui_light(
                 knx_module.xknx, config[DOMAIN], config[CONF_ENTITY][CONF_NAME]
-            )
+            ),
         )
         self._attr_max_color_temp_kelvin: int = config[DOMAIN][CONF_COLOR_TEMP_MAX]
         self._attr_min_color_temp_kelvin: int = config[DOMAIN][CONF_COLOR_TEMP_MIN]
@@ -565,5 +566,3 @@ class KnxUiLight(_KnxLight):
         self._attr_unique_id = unique_id
         if device_info := config[CONF_ENTITY].get(CONF_DEVICE_INFO):
             self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, device_info)})
-
-        knx_module.config_store.entities[unique_id] = self

--- a/homeassistant/components/knx/notify.py
+++ b/homeassistant/components/knx/notify.py
@@ -18,6 +18,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
+from . import KNXModule
 from .const import DATA_KNX_CONFIG, DOMAIN, KNX_ADDRESS
 from .knx_entity import KnxEntity
 
@@ -44,7 +45,7 @@ async def async_get_service(
 
 
 class KNXNotificationService(BaseNotificationService):
-    """Implement demo notification service."""
+    """Implement notification service."""
 
     def __init__(self, devices: list[XknxNotification]) -> None:
         """Initialize the service."""
@@ -86,10 +87,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up notify(s) for KNX platform."""
-    xknx: XKNX = hass.data[DOMAIN].xknx
+    knx_module: KNXModule = hass.data[DOMAIN]
     config: list[ConfigType] = hass.data[DATA_KNX_CONFIG][Platform.NOTIFY]
 
-    async_add_entities(KNXNotify(xknx, entity_config) for entity_config in config)
+    async_add_entities(KNXNotify(knx_module, entity_config) for entity_config in config)
 
 
 def _create_notification_instance(xknx: XKNX, config: ConfigType) -> XknxNotification:
@@ -107,9 +108,12 @@ class KNXNotify(KnxEntity, NotifyEntity):
 
     _device: XknxNotification
 
-    def __init__(self, xknx: XKNX, config: ConfigType) -> None:
+    def __init__(self, knx_module: KNXModule, config: ConfigType) -> None:
         """Initialize a KNX notification."""
-        super().__init__(_create_notification_instance(xknx, config))
+        super().__init__(
+            knx_module=knx_module,
+            device=_create_notification_instance(knx_module.xknx, config),
+        )
         self._attr_entity_category = config.get(CONF_ENTITY_CATEGORY)
         self._attr_unique_id = str(self._device.remote_value.group_address)
 

--- a/homeassistant/components/knx/number.py
+++ b/homeassistant/components/knx/number.py
@@ -22,6 +22,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType
 
+from . import KNXModule
 from .const import (
     CONF_RESPOND_TO_READ,
     CONF_STATE_ADDRESS,
@@ -39,10 +40,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up number(s) for KNX platform."""
-    xknx: XKNX = hass.data[DOMAIN].xknx
+    knx_module: KNXModule = hass.data[DOMAIN]
     config: list[ConfigType] = hass.data[DATA_KNX_CONFIG][Platform.NUMBER]
 
-    async_add_entities(KNXNumber(xknx, entity_config) for entity_config in config)
+    async_add_entities(KNXNumber(knx_module, entity_config) for entity_config in config)
 
 
 def _create_numeric_value(xknx: XKNX, config: ConfigType) -> NumericValue:
@@ -62,9 +63,12 @@ class KNXNumber(KnxEntity, RestoreNumber):
 
     _device: NumericValue
 
-    def __init__(self, xknx: XKNX, config: ConfigType) -> None:
+    def __init__(self, knx_module: KNXModule, config: ConfigType) -> None:
         """Initialize a KNX number."""
-        super().__init__(_create_numeric_value(xknx, config))
+        super().__init__(
+            knx_module=knx_module,
+            device=_create_numeric_value(knx_module.xknx, config),
+        )
         self._attr_native_max_value = config.get(
             NumberSchema.CONF_MAX,
             self._device.sensor_value.dpt_class.value_max,

--- a/homeassistant/components/knx/project.py
+++ b/homeassistant/components/knx/project.py
@@ -8,9 +8,11 @@ from typing import Final
 
 from xknx import XKNX
 from xknx.dpt import DPTBase
+from xknx.telegram.address import DeviceAddressableType
 from xknxproject import XKNXProj
 from xknxproject.models import (
     Device,
+    DPTType,
     GroupAddress as GroupAddressModel,
     KNXProject as KNXProjectModel,
     ProjectInfo,
@@ -89,7 +91,7 @@ class KNXProject:
             self.devices = project["devices"]
             self.info = project["info"]
             xknx.group_address_dpt.clear()
-            xknx_ga_dict = {}
+            xknx_ga_dict: dict[DeviceAddressableType, DPTType] = {}
 
             for ga_model in project["group_addresses"].values():
                 ga_info = _create_group_address_info(ga_model)
@@ -97,7 +99,7 @@ class KNXProject:
                 if (dpt_model := ga_model.get("dpt")) is not None:
                     xknx_ga_dict[ga_model["address"]] = dpt_model
 
-            xknx.group_address_dpt.set(xknx_ga_dict)  # type: ignore[arg-type]
+            xknx.group_address_dpt.set(xknx_ga_dict)
 
             _LOGGER.debug(
                 "Loaded KNX project data with %s group addresses from storage",

--- a/homeassistant/components/knx/scene.py
+++ b/homeassistant/components/knx/scene.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from xknx import XKNX
 from xknx.devices import Scene as XknxScene
 
 from homeassistant import config_entries
@@ -14,6 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType
 
+from . import KNXModule
 from .const import DATA_KNX_CONFIG, DOMAIN, KNX_ADDRESS
 from .knx_entity import KnxEntity
 from .schema import SceneSchema
@@ -25,10 +25,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up scene(s) for KNX platform."""
-    xknx: XKNX = hass.data[DOMAIN].xknx
+    knx_module: KNXModule = hass.data[DOMAIN]
     config: list[ConfigType] = hass.data[DATA_KNX_CONFIG][Platform.SCENE]
 
-    async_add_entities(KNXScene(xknx, entity_config) for entity_config in config)
+    async_add_entities(KNXScene(knx_module, entity_config) for entity_config in config)
 
 
 class KNXScene(KnxEntity, Scene):
@@ -36,15 +36,16 @@ class KNXScene(KnxEntity, Scene):
 
     _device: XknxScene
 
-    def __init__(self, xknx: XKNX, config: ConfigType) -> None:
+    def __init__(self, knx_module: KNXModule, config: ConfigType) -> None:
         """Init KNX scene."""
         super().__init__(
+            knx_module=knx_module,
             device=XknxScene(
-                xknx,
+                xknx=knx_module.xknx,
                 name=config[CONF_NAME],
                 group_address=config[KNX_ADDRESS],
                 scene_number=config[SceneSchema.CONF_SCENE_NUMBER],
-            )
+            ),
         )
         self._attr_entity_category = config.get(CONF_ENTITY_CATEGORY)
         self._attr_unique_id = (

--- a/homeassistant/components/knx/select.py
+++ b/homeassistant/components/knx/select.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType
 
+from . import KNXModule
 from .const import (
     CONF_PAYLOAD_LENGTH,
     CONF_RESPOND_TO_READ,
@@ -39,10 +40,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up select(s) for KNX platform."""
-    xknx: XKNX = hass.data[DOMAIN].xknx
+    knx_module: KNXModule = hass.data[DOMAIN]
     config: list[ConfigType] = hass.data[DATA_KNX_CONFIG][Platform.SELECT]
 
-    async_add_entities(KNXSelect(xknx, entity_config) for entity_config in config)
+    async_add_entities(KNXSelect(knx_module, entity_config) for entity_config in config)
 
 
 def _create_raw_value(xknx: XKNX, config: ConfigType) -> RawValue:
@@ -63,9 +64,12 @@ class KNXSelect(KnxEntity, SelectEntity, RestoreEntity):
 
     _device: RawValue
 
-    def __init__(self, xknx: XKNX, config: ConfigType) -> None:
+    def __init__(self, knx_module: KNXModule, config: ConfigType) -> None:
         """Initialize a KNX select."""
-        super().__init__(_create_raw_value(xknx, config))
+        super().__init__(
+            knx_module=knx_module,
+            device=_create_raw_value(knx_module.xknx, config),
+        )
         self._option_payloads: dict[str, int] = {
             option[SelectSchema.CONF_OPTION]: option[CONF_PAYLOAD]
             for option in config[SelectSchema.CONF_OPTIONS]

--- a/homeassistant/components/knx/sensor.py
+++ b/homeassistant/components/knx/sensor.py
@@ -116,17 +116,17 @@ async def async_setup_entry(
 ) -> None:
     """Set up sensor(s) for KNX platform."""
     knx_module: KNXModule = hass.data[DOMAIN]
-
-    async_add_entities(
+    entities: list[SensorEntity] = []
+    entities.extend(
         KNXSystemSensor(knx_module, description)
         for description in SYSTEM_ENTITY_DESCRIPTIONS
     )
-
     config: list[ConfigType] = hass.data[DATA_KNX_CONFIG].get(Platform.SENSOR)
     if config:
-        async_add_entities(
-            KNXSensor(knx_module.xknx, entity_config) for entity_config in config
+        entities.extend(
+            KNXSensor(knx_module, entity_config) for entity_config in config
         )
+    async_add_entities(entities)
 
 
 def _create_sensor(xknx: XKNX, config: ConfigType) -> XknxSensor:
@@ -146,9 +146,12 @@ class KNXSensor(KnxEntity, SensorEntity):
 
     _device: XknxSensor
 
-    def __init__(self, xknx: XKNX, config: ConfigType) -> None:
+    def __init__(self, knx_module: KNXModule, config: ConfigType) -> None:
         """Initialize of a KNX sensor."""
-        super().__init__(_create_sensor(xknx, config))
+        super().__init__(
+            knx_module=knx_module,
+            device=_create_sensor(knx_module.xknx, config),
+        )
         if device_class := config.get(CONF_DEVICE_CLASS):
             self._attr_device_class = device_class
         else:

--- a/homeassistant/components/knx/switch.py
+++ b/homeassistant/components/knx/switch.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from xknx import XKNX
 from xknx.devices import Switch as XknxSwitch
 
 from homeassistant import config_entries
@@ -54,10 +53,10 @@ async def async_setup_entry(
     knx_module: KNXModule = hass.data[DOMAIN]
 
     entities: list[KnxEntity] = []
-    if yaml_config := hass.data[DATA_KNX_CONFIG].get(Platform.SWITCH):
+    if yaml_platform_config := hass.data[DATA_KNX_CONFIG].get(Platform.SWITCH):
         entities.extend(
-            KnxYamlSwitch(knx_module.xknx, entity_config)
-            for entity_config in yaml_config
+            KnxYamlSwitch(knx_module, entity_config)
+            for entity_config in yaml_platform_config
         )
     if ui_config := knx_module.config_store.data["entities"].get(Platform.SWITCH):
         entities.extend(
@@ -108,17 +107,18 @@ class KnxYamlSwitch(_KnxSwitch, KnxEntity):
 
     _device: XknxSwitch
 
-    def __init__(self, xknx: XKNX, config: ConfigType) -> None:
+    def __init__(self, knx_module: KNXModule, config: ConfigType) -> None:
         """Initialize of KNX switch."""
         super().__init__(
+            knx_module=knx_module,
             device=XknxSwitch(
-                xknx,
+                xknx=knx_module.xknx,
                 name=config[CONF_NAME],
                 group_address=config[KNX_ADDRESS],
                 group_address_state=config.get(SwitchSchema.CONF_STATE_ADDRESS),
                 respond_to_read=config[CONF_RESPOND_TO_READ],
                 invert=config[SwitchSchema.CONF_INVERT],
-            )
+            ),
         )
         self._attr_entity_category = config.get(CONF_ENTITY_CATEGORY)
         self._attr_device_class = config.get(CONF_DEVICE_CLASS)

--- a/homeassistant/components/knx/text.py
+++ b/homeassistant/components/knx/text.py
@@ -22,6 +22,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType
 
+from . import KNXModule
 from .const import (
     CONF_RESPOND_TO_READ,
     CONF_STATE_ADDRESS,
@@ -38,10 +39,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up sensor(s) for KNX platform."""
-    xknx: XKNX = hass.data[DOMAIN].xknx
+    knx_module: KNXModule = hass.data[DOMAIN]
     config: list[ConfigType] = hass.data[DATA_KNX_CONFIG][Platform.TEXT]
 
-    async_add_entities(KNXText(xknx, entity_config) for entity_config in config)
+    async_add_entities(KNXText(knx_module, entity_config) for entity_config in config)
 
 
 def _create_notification(xknx: XKNX, config: ConfigType) -> XknxNotification:
@@ -62,9 +63,12 @@ class KNXText(KnxEntity, TextEntity, RestoreEntity):
     _device: XknxNotification
     _attr_native_max = 14
 
-    def __init__(self, xknx: XKNX, config: ConfigType) -> None:
+    def __init__(self, knx_module: KNXModule, config: ConfigType) -> None:
         """Initialize a KNX text."""
-        super().__init__(_create_notification(xknx, config))
+        super().__init__(
+            knx_module=knx_module,
+            device=_create_notification(knx_module.xknx, config),
+        )
         self._attr_mode = config[CONF_MODE]
         self._attr_pattern = (
             r"[\u0000-\u00ff]*"  # Latin-1

--- a/homeassistant/components/knx/time.py
+++ b/homeassistant/components/knx/time.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from datetime import time as dt_time
-from typing import Final
 
 from xknx import XKNX
 from xknx.devices import TimeDevice as XknxTimeDevice
@@ -23,6 +22,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType
 
+from . import KNXModule
 from .const import (
     CONF_RESPOND_TO_READ,
     CONF_STATE_ADDRESS,
@@ -33,8 +33,6 @@ from .const import (
 )
 from .knx_entity import KnxEntity
 
-_TIME_TRANSLATION_FORMAT: Final = "%H:%M:%S"
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -42,10 +40,12 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up entities for KNX platform."""
-    xknx: XKNX = hass.data[DOMAIN].xknx
+    knx_module: KNXModule = hass.data[DOMAIN]
     config: list[ConfigType] = hass.data[DATA_KNX_CONFIG][Platform.TIME]
 
-    async_add_entities(KNXTimeEntity(xknx, entity_config) for entity_config in config)
+    async_add_entities(
+        KNXTimeEntity(knx_module, entity_config) for entity_config in config
+    )
 
 
 def _create_xknx_device(xknx: XKNX, config: ConfigType) -> XknxTimeDevice:
@@ -66,9 +66,12 @@ class KNXTimeEntity(KnxEntity, TimeEntity, RestoreEntity):
 
     _device: XknxTimeDevice
 
-    def __init__(self, xknx: XKNX, config: ConfigType) -> None:
+    def __init__(self, knx_module: KNXModule, config: ConfigType) -> None:
         """Initialize a KNX time."""
-        super().__init__(_create_xknx_device(xknx, config))
+        super().__init__(
+            knx_module=knx_module,
+            device=_create_xknx_device(knx_module.xknx, config),
+        )
         self._attr_entity_category = config.get(CONF_ENTITY_CATEGORY)
         self._attr_unique_id = str(self._device.remote_value.group_address)
 

--- a/homeassistant/components/knx/weather.py
+++ b/homeassistant/components/knx/weather.py
@@ -19,6 +19,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType
 
+from . import KNXModule
 from .const import DATA_KNX_CONFIG, DOMAIN
 from .knx_entity import KnxEntity
 from .schema import WeatherSchema
@@ -30,10 +31,12 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up switch(es) for KNX platform."""
-    xknx: XKNX = hass.data[DOMAIN].xknx
+    knx_module: KNXModule = hass.data[DOMAIN]
     config: list[ConfigType] = hass.data[DATA_KNX_CONFIG][Platform.WEATHER]
 
-    async_add_entities(KNXWeather(xknx, entity_config) for entity_config in config)
+    async_add_entities(
+        KNXWeather(knx_module, entity_config) for entity_config in config
+    )
 
 
 def _create_weather(xknx: XKNX, config: ConfigType) -> XknxWeather:
@@ -80,9 +83,12 @@ class KNXWeather(KnxEntity, WeatherEntity):
     _attr_native_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_native_wind_speed_unit = UnitOfSpeed.METERS_PER_SECOND
 
-    def __init__(self, xknx: XKNX, config: ConfigType) -> None:
+    def __init__(self, knx_module: KNXModule, config: ConfigType) -> None:
         """Initialize of a KNX sensor."""
-        super().__init__(_create_weather(xknx, config))
+        super().__init__(
+            knx_module=knx_module,
+            device=_create_weather(knx_module.xknx, config),
+        )
         self._attr_unique_id = str(self._device._temperature.group_address_state)  # noqa: SLF001
         self._attr_entity_category = config.get(CONF_ENTITY_CATEGORY)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
1163e34586bfd388a6a95f197a1af2d7a38f78ad -> https://github.com/home-assistant/core/pull/122342#discussion_r1693879840
Entities now get passed a reference to the `KNXModule` object instead of the `XKNX` object. This is used to pass an added entities unique_id to `self._knx_module.config_store` (instead of passing the Entity reference) and additionaly avoids calling `hass.data[DOMAIN]` in `available()` property. The PR has grown quite big because of that since all platforms had to be changed. Adding UI Entitiy variants additionally to YAML variants will be easier now though.
This is where the relevant stuff happens: https://github.com/home-assistant/core/blob/19fe4f03bdab265d1470a623077156de5796e3c1/homeassistant/components/knx/knx_entity.py#L71-L77 and changes in `storage/config_store.py`.

the other commits are a minor typing improvement and some cleanup regarding the previous commit
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
