### PR TITLE
Extend the functionalities and statuses of lawn_mower integration

### DIFF
--- a/homeassistant/components/lawn_mower/__init__.py
+++ b/homeassistant/components/lawn_mower/__init__.py
@@ -16,8 +16,11 @@ from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     DOMAIN,
+    SERVICE_CANCEL,
     SERVICE_DOCK,
+    SERVICE_FIXED_MOWING,
     SERVICE_PAUSE,
+    SERVICE_RESUME,
     SERVICE_START_MOWING,
     LawnMowerActivity,
     LawnMowerEntityFeature,
@@ -48,6 +51,18 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     )
     component.async_register_entity_service(
         SERVICE_DOCK, {}, "async_dock", [LawnMowerEntityFeature.DOCK]
+    )
+    component.async_register_entity_service(
+        SERVICE_RESUME, {}, "async_resume", [LawnMowerEntityFeature.RESUME]
+    )
+    component.async_register_entity_service(
+        SERVICE_CANCEL, {}, "async_cancel", [LawnMowerEntityFeature.CANCEL]
+    )
+    component.async_register_entity_service(
+        SERVICE_FIXED_MOWING,
+        {},
+        "async_fixed_mowing",
+        [LawnMowerEntityFeature.FIXED_MOWING],
     )
 
     return True
@@ -101,11 +116,11 @@ class LawnMowerEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         return self._attr_supported_features
 
     def start_mowing(self) -> None:
-        """Start or resume mowing."""
+        """Start mowing."""
         raise NotImplementedError
 
     async def async_start_mowing(self) -> None:
-        """Start or resume mowing."""
+        """Start mowing."""
         await self.hass.async_add_executor_job(self.start_mowing)
 
     def dock(self) -> None:
@@ -123,3 +138,27 @@ class LawnMowerEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     async def async_pause(self) -> None:
         """Pause the lawn mower."""
         await self.hass.async_add_executor_job(self.pause)
+
+    def resume(self) -> None:
+        """Resume mowing."""
+        raise NotImplementedError
+
+    async def async_resume(self) -> None:
+        """Resume mowing."""
+        await self.hass.async_add_executor_job(self.resume)
+
+    def cancel(self) -> None:
+        """Cancel/Stop lawn mowing."""
+        raise NotImplementedError
+
+    async def async_cancel(self) -> None:
+        """Cancel/Stop lawn mowing."""
+        await self.hass.async_add_executor_job(self.cancel)
+
+    def fixed_mowing(self) -> None:
+        """Start mowing around a fixed spot."""
+        raise NotImplementedError
+
+    async def async_fixed_mowing(self) -> None:
+        """Start mowing around a fixed spot."""
+        await self.hass.async_add_executor_job(self.fixed_mowing)

--- a/homeassistant/components/lawn_mower/const.py
+++ b/homeassistant/components/lawn_mower/const.py
@@ -18,6 +18,33 @@ class LawnMowerActivity(StrEnum):
     DOCKED = "docked"
     """Device is docked."""
 
+    STANDBY = "standby"
+    """Device is in standby state."""
+
+    CHARGING = "charging"
+    """Device is charging."""
+
+    EMERGENCY = "manualy stopped"
+    """Device is stopped."""
+
+    LOCKED = "locked"
+    """Device is Locked by the UI"""
+
+    PARK = "returning"
+    """Device is returning to the docking station."""
+
+    CHARGING_WITH_TASK_SUSPEND = "charging"
+    """Device is got an additional task but it is hanged until charged."""
+
+    FIXED_MOWING = "spot mowing"
+    """Device is mowing around a fixed spot."""
+
+    UPDATA = "docked"
+    """Device exchange some data while it is docked."""
+
+    SELF_TEST = "docked"
+    """Device makes some diagnostics while it is docked."""
+
 
 class LawnMowerEntityFeature(IntFlag):
     """Supported features of the lawn mower entity."""
@@ -25,6 +52,10 @@ class LawnMowerEntityFeature(IntFlag):
     START_MOWING = 1
     PAUSE = 2
     DOCK = 4
+    RESUME = 8
+    CANCEL = 16
+    FIXED_MOWING = 32
+
 
 
 DOMAIN = "lawn_mower"
@@ -32,3 +63,6 @@ DOMAIN = "lawn_mower"
 SERVICE_START_MOWING = "start_mowing"
 SERVICE_PAUSE = "pause"
 SERVICE_DOCK = "dock"
+SERVICE_RESUME = "resume"
+SERVICE_CANCEL = "cancel"
+SERVICE_FIXED_MOWING = "fixed_mowing"

--- a/homeassistant/components/lawn_mower/icons.json
+++ b/homeassistant/components/lawn_mower/icons.json
@@ -7,6 +7,9 @@
   "services": {
     "dock": "mdi:home-import-outline",
     "pause": "mdi:pause",
-    "start_mowing": "mdi:play"
+    "resume": "mdi:play-pause",
+    "cancel": "mdi:stop",
+    "start_mowing": "mdi:play",
+    "fixed_mowing": "mdi:target-variant"
   }
 }

--- a/homeassistant/components/lawn_mower/services.yaml
+++ b/homeassistant/components/lawn_mower/services.yaml
@@ -20,3 +20,24 @@ pause:
       domain: lawn_mower
       supported_features:
         - lawn_mower.LawnMowerEntityFeature.PAUSE
+
+resume:
+  target:
+    entity:
+      domain: lawn_mower
+      supported_features:
+        - lawn_mower.LawnMowerEntityFeature.RESUME
+
+cancel:
+  target:
+    entity:
+      domain: lawn_mower
+      supported_features:
+        - lawn_mower.LawnMowerEntityFeature.CANCEL
+
+fixed_mowing:
+  target:
+    entity:
+      domain: lawn_mower
+      supported_features:
+        - lawn_mower.LawnMowerEntityFeature.FIXED_MOWING

--- a/homeassistant/components/lawn_mower/strings.json
+++ b/homeassistant/components/lawn_mower/strings.json
@@ -5,9 +5,15 @@
       "name": "[%key:component::lawn_mower::title%]",
       "state": {
         "error": "Error",
-        "paused": "[%key:common::state::paused%]",
+        "paused": "Paused",
         "mowing": "Mowing",
-        "docked": "Docked"
+        "docked": "Docked",
+        "standby": "Standby",
+        "charging": "Charging",
+        "manually stopped": "Manually stopped",
+        "locked": "Locked",
+        "returning": "Returning",
+        "spot mowing": "Spot mowing"
       }
     }
   },
@@ -16,9 +22,21 @@
       "name": "Start mowing",
       "description": "Starts the mowing task."
     },
+    "fixed_mowing": {
+      "name": "Start spot mowing",
+      "description": "Starts the fixed spot mowing task."
+    },
     "dock": {
       "name": "Return to dock",
       "description": "Stops the mowing task and returns to the dock."
+    },
+    "cancel": {
+      "name": "Cancel mowing",
+      "description": "Cancel the mowing task."
+    },
+    "resume": {
+      "name": "Resume mowing",
+      "description": "Resume the paused task."
     },
     "pause": {
       "name": "Pause",

--- a/tests/components/lawn_mower/test_init.py
+++ b/tests/components/lawn_mower/test_init.py
@@ -138,6 +138,17 @@ async def test_sync_start_mowing(hass: HomeAssistant) -> None:
     assert lawn_mower.start_mowing.called
 
 
+async def test_sync_fixed_mowing(hass: HomeAssistant) -> None:
+    """Test if async fixed_mowing calls sync fixed_mowing."""
+    lawn_mower = MockLawnMowerEntity()
+    lawn_mower.hass = hass
+
+    lawn_mower.fixed_mowing = MagicMock()
+    await lawn_mower.async_fixed_mowing()
+
+    assert lawn_mower.fixed_mowing.called
+
+
 async def test_sync_dock(hass: HomeAssistant) -> None:
     """Test if async dock calls sync dock."""
     lawn_mower = MockLawnMowerEntity()
@@ -160,6 +171,28 @@ async def test_sync_pause(hass: HomeAssistant) -> None:
     assert lawn_mower.pause.called
 
 
+async def test_sync_resume(hass: HomeAssistant) -> None:
+    """Test if async resume calls sync resume."""
+    lawn_mower = MockLawnMowerEntity()
+    lawn_mower.hass = hass
+
+    lawn_mower.resume = MagicMock()
+    await lawn_mower.async_resume()
+
+    assert lawn_mower.resume.called
+
+
+async def test_sync_cancel(hass: HomeAssistant) -> None:
+    """Test if async cancel calls sync cancel."""
+    lawn_mower = MockLawnMowerEntity()
+    lawn_mower.hass = hass
+
+    lawn_mower.cancel = MagicMock()
+    await lawn_mower.async_cancel()
+
+    assert lawn_mower.cancel.called
+
+
 async def test_lawn_mower_default(hass: HomeAssistant) -> None:
     """Test lawn mower entity with defaults."""
     lawn_mower = MockLawnMowerEntity()
@@ -177,3 +210,4 @@ async def test_lawn_mower_state(hass: HomeAssistant) -> None:
     lawn_mower.start_mowing()
 
     assert lawn_mower.state == str(LawnMowerActivity.MOWING)
+


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
This PR adds possibility to handle several additional statuses and add more basic functions such as resume, cancel, and spot mowing.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/34100

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
