### PR TITLE
Todoist service validation error consistency

### DIFF
--- a/homeassistant/components/todoist/strings.json
+++ b/homeassistant/components/todoist/strings.json
@@ -21,6 +21,9 @@
     }
   },
   "exceptions": {
+    "project_invalid": {
+      "message": "Invalid project name \"{project}\""
+    },
     "section_invalid": {
       "message": "Project \"{project}\" has no section \"{section}\""
     }

--- a/tests/components/todoist/test_calendar.py
+++ b/tests/components/todoist/test_calendar.py
@@ -23,6 +23,7 @@ from homeassistant.components.todoist.const import (
 )
 from homeassistant.const import CONF_TOKEN, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
 from homeassistant.util import dt as dt_util
@@ -268,6 +269,25 @@ async def test_create_task_service_call(hass: HomeAssistant, api: AsyncMock) -> 
     api.add_task.assert_called_with(
         "task", project_id=PROJECT_ID, labels=["Label1"], assignee_id="1"
     )
+
+
+async def test_create_task_service_call_raises(
+    hass: HomeAssistant, api: AsyncMock
+) -> None:
+    """Test adding an item to an invalid project raises an error."""
+
+    with pytest.raises(ServiceValidationError, match="project_invalid"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_NEW_TASK,
+            {
+                ASSIGNEE: "user",
+                CONTENT: "task",
+                LABELS: ["Label1"],
+                PROJECT_NAME: "Missing Project",
+            },
+            blocking=True,
+        )
 
 
 async def test_create_task_service_call_with_section(


### PR DESCRIPTION
## Proposed change

See https://github.com/home-assistant/core/pull/115671#issuecomment-2265332508 for context. Update `todoist.new_task` service code to throw ServiceValidationError for invalid project, as well as removing an unnecessary `.lower()` that's already covered by the schema definition.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
