### PR TITLE
Replace pre-commit prettier with biomejs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,10 +33,11 @@ repos:
     rev: v1.35.1
     hooks:
       - id: yamllint
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.3
+  - repo: https://github.com/biomejs/pre-commit
+    rev: v0.4.0
     hooks:
-      - id: prettier
+      - id: biome-lint
+        additional_dependencies: ["@biomejs/biome@1.8.3"]
   - repo: https://github.com/cdce8p/python-typing-update
     rev: v0.6.0
     hooks:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,7 +1,0 @@
-*.md
-.strict-typing
-homeassistant/components/*/translations/*.json
-homeassistant/generated/*
-tests/components/lidarr/fixtures/initialize.js
-tests/components/lidarr/fixtures/initialize-wrong.js
-tests/fixtures/core/config/yaml_errors/

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,19 @@
+{
+  "files": {
+    "ignore": [
+	"*.md",
+	".strict-typing",
+	"homeassistant/components/*/translations/*.json",
+	"homeassistant/generated/*",
+	"tests/components/lidarr/fixtures/initialize.js",
+	"tests/components/lidarr/fixtures/initialize-wrong.js",
+	"tests/fixtures/core/config/yaml_errors/"
+	]
+  },
+  "json": {
+    "parser": {
+      "allowComments": true,
+      "allowTrailingCommas": true
+    }
+  }
+}

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -1,5 +1,7 @@
 # Automatically generated from .pre-commit-config.yaml by gen_requirements_all.py, do not edit
 
+@biomejs/biome@1.8.3
+biome-lint==0.4.0
 codespell==2.3.0
 ruff==0.5.6
 yamllint==1.35.1


### PR DESCRIPTION
## Breaking change
Not completely sure of the (potential) impact, thorough review advised. Running `pre-commit run all-files` and loosely using `npx` to run it locally does yield to the (former) `.prettierignore` files and with the additional loosening of JSON seems to work cleanly. (And yes, breaking a JSON nicely breaks pre-commit).

## Proposed change
Watching some commotion on smaller repo's/projects with auto-updating of pre-commit.ci and the earlier attempts at v4 versions, https://github.com/pre-commit/mirrors-prettier seems to have definitively thrown in the towel. Noticing `biome` as an alternative, including performance benefits, this could be a good alternative. Unless exploring dprint (ref https://github.com/home-assistant/core/pull/102929) would still be the desired path (though no search results after the above reference found)?

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.