### PR TITLE
ESPHome media proxy

### DIFF
--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from aioesphomeapi import APIClient
 
-from homeassistant.components import zeroconf
+from homeassistant.components import ffmpeg, zeroconf
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
@@ -15,12 +15,13 @@ from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
-from .const import CONF_NOISE_PSK, DOMAIN
+from .const import CONF_NOISE_PSK, DATA_FFMPEG_PROXY, DOMAIN
 from .dashboard import async_setup as async_setup_dashboard
 from .domain_data import DomainData
 
 # Import config flow so that it's added to the registry
 from .entry_data import ESPHomeConfigEntry, RuntimeEntryData
+from .ffmpeg_proxy import FFmpegProxyData, FFmpegProxyView
 from .manager import ESPHomeManager, cleanup_instance
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
@@ -30,7 +31,12 @@ CLIENT_INFO = f"Home Assistant {ha_version}"
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the esphome component."""
+    proxy_data = hass.data[DATA_FFMPEG_PROXY] = FFmpegProxyData()
+
     await async_setup_dashboard(hass)
+    hass.http.register_view(
+        FFmpegProxyView(ffmpeg.get_ffmpeg_manager(hass), proxy_data)
+    )
     return True
 
 

--- a/homeassistant/components/esphome/const.py
+++ b/homeassistant/components/esphome/const.py
@@ -18,3 +18,5 @@ PROJECT_URLS = {
     "esphome.bluetooth-proxy": "https://esphome.github.io/bluetooth-proxies/",
 }
 DEFAULT_URL = f"https://esphome.io/changelog/{STABLE_BLE_VERSION_STR}.html"
+
+DATA_FFMPEG_PROXY = f"{DOMAIN}.ffmpeg_proxy"

--- a/homeassistant/components/esphome/ffmpeg_proxy.py
+++ b/homeassistant/components/esphome/ffmpeg_proxy.py
@@ -138,7 +138,7 @@ class FFmpegProxyView(HomeAssistantView):
     schema = vol.Schema(
         {
             vol.Required("device_id"): cv.string,
-            vol.Required("url"): cv.url,
+            vol.Required("url"): cv.string,
             vol.Required("format"): cv.string,
             vol.Optional("rate"): cv.positive_int,
             vol.Optional("channels"): cv.positive_int,

--- a/homeassistant/components/esphome/ffmpeg_proxy.py
+++ b/homeassistant/components/esphome/ffmpeg_proxy.py
@@ -1,0 +1,178 @@
+"""HTTP view that converts audio from a URL to a preferred format."""
+
+import asyncio
+from collections import defaultdict
+from dataclasses import dataclass, field
+from http import HTTPStatus
+import logging
+from typing import Any
+
+from aiohttp import web
+from aiohttp.abc import AbstractStreamWriter, BaseRequest
+import voluptuous as vol
+
+from homeassistant.components.ffmpeg import FFmpegManager
+from homeassistant.components.http import HomeAssistantView
+from homeassistant.core import HomeAssistant
+import homeassistant.helpers.config_validation as cv
+
+from .const import DATA_FFMPEG_PROXY
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def async_allow_proxy_url(hass: HomeAssistant, device_id: str, url: str) -> None:
+    """Mark a URL as allowed for conversion by a specific device.
+
+    The URL will be removed from the allow list once it is requested in the HTTP
+    view.
+    """
+    data: FFmpegProxyData = hass.data[DATA_FFMPEG_PROXY]
+    data.device_urls[device_id].add(url)
+    _LOGGER.debug("URL allowed for device %s: %s", device_id, url)
+
+
+@dataclass
+class FFmpegProxyData:
+    """Data for ffmpeg proxy conversion."""
+
+    device_urls: dict[str, set[str]] = field(default_factory=lambda: defaultdict(set))
+
+
+class FFmpegConvertResponse(web.StreamResponse):
+    """HTTP streaming response that uses ffmpeg to convert audio from a URL."""
+
+    def __init__(
+        self,
+        manager: FFmpegManager,
+        url: str,
+        fmt: str,
+        rate: int | None,
+        channels: int | None,
+        chunk_size: int = 2048,
+    ) -> None:
+        """Initialize response.
+
+        Parameters
+        ----------
+        manager: FFmpegManager
+            ffmpeg manager
+        url: str
+            URL of source audio stream
+        fmt: str
+            Target format of audio (flac, mp3, wav, etc.)
+        rate: int, optional
+            Target sample rate in hertz (None = same as source)
+        channels: int, optional
+            Target number of channels (None = same as source)
+        chunk_size: int
+            Number of bytes to read from ffmpeg process at a time
+
+        """
+        super().__init__(status=200)
+        self.manager = manager
+        self.url = url
+        self.fmt = fmt
+        self.rate = rate
+        self.channels = channels
+        self.chunk_size = chunk_size
+
+    async def prepare(self, request: BaseRequest) -> AbstractStreamWriter | None:
+        """Stream url through ffmpeg conversion and out to HTTP client."""
+        writer = await super().prepare(request)
+        assert writer is not None
+
+        command_args = ["-i", self.url, "-f", self.fmt]
+
+        if self.rate is not None:
+            # Sample rate
+            command_args.extend(["-ar", str(self.rate)])
+
+        if self.channels is not None:
+            # Number of channels
+            command_args.extend(["-ac", str(self.channels)])
+
+        # Output to stdout
+        command_args.append("pipe:")
+
+        _LOGGER.debug("%s %s", self.manager.binary, " ".join(command_args))
+        proc = await asyncio.create_subprocess_exec(
+            self.manager.binary,
+            *command_args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        assert proc.stdout is not None
+        assert proc.stderr is not None
+        try:
+            # Pull audio chunks from ffmpeg and pass them to the HTTP client
+            while chunk := await proc.stdout.read(self.chunk_size):
+                await writer.write(chunk)
+
+            # Try to gracefully stop
+            proc.terminate()
+            await proc.wait()
+        finally:
+            await writer.write_eof()
+
+            if proc.returncode != 0:
+                # Process did not exit successfully
+                stderr_text = ""
+                while line := await proc.stderr.readline():
+                    stderr_text += line.decode()
+                _LOGGER.error(stderr_text)
+            else:
+                _LOGGER.debug("Conversion completed: %s", self.url)
+
+        return writer
+
+
+class FFmpegProxyView(HomeAssistantView):
+    """FFmpeg web view to convert audio and stream back to client."""
+
+    requires_auth = False
+    url = "/api/esphome/ffmpeg_proxy"
+    name = "api:esphome:ffmpeg_proxy"
+
+    schema = vol.Schema(
+        {
+            vol.Required("device_id"): cv.string,
+            vol.Required("url"): cv.url,
+            vol.Required("format"): cv.string,
+            vol.Optional("rate"): cv.positive_int,
+            vol.Optional("channels"): cv.positive_int,
+        }
+    )
+
+    def __init__(self, manager: FFmpegManager, data: FFmpegProxyData) -> None:
+        """Initialize an ffmpeg view."""
+        self.manager = manager
+        self.data = data
+
+    async def get(self, request: web.Request) -> web.StreamResponse:
+        """Start a get request."""
+
+        try:
+            query: dict[str, Any] = self.schema(dict(request.query))
+        except vol.Invalid as err:
+            _LOGGER.error("Query does not match schema: %s", err)
+            return web.Response(body=str(err), status=HTTPStatus.BAD_REQUEST)
+
+        device_id = query["device_id"]
+        url = query["url"]
+        fmt = query["format"]
+
+        rate: int | None = query.get("rate")
+        channels: int | None = query.get("channels")
+
+        try:
+            self.data.device_urls[device_id].remove(url)
+        except KeyError:
+            _LOGGER.error("URL is not allowed for device %s: %s", device_id, url)
+            return web.Response(body="URL not allowed", status=HTTPStatus.BAD_REQUEST)
+
+        # Stream converted audio back to client
+        return FFmpegConvertResponse(
+            self.manager, url=url, fmt=fmt, rate=rate, channels=channels
+        )

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -4,7 +4,7 @@
   "after_dependencies": ["zeroconf", "tag"],
   "codeowners": ["@OttoWinter", "@jesserockz", "@kbx81", "@bdraco"],
   "config_flow": true,
-  "dependencies": ["assist_pipeline", "bluetooth", "intent"],
+  "dependencies": ["assist_pipeline", "bluetooth", "intent", "ffmpeg", "http"],
   "dhcp": [
     {
       "registered_devices": true

--- a/homeassistant/components/media_player/browse_media.py
+++ b/homeassistant/components/media_player/browse_media.py
@@ -23,7 +23,7 @@ from homeassistant.helpers.network import (
 from .const import CONTENT_AUTH_EXPIRY_TIME, MediaClass, MediaType
 
 # Paths that we don't need to sign
-PATHS_WITHOUT_AUTH = ("/api/tts_proxy/",)
+PATHS_WITHOUT_AUTH = ("/api/tts_proxy/", "/api/esphome/ffmpeg_proxy/")
 
 
 @callback

--- a/tests/components/esphome/test_ffmpeg_proxy.py
+++ b/tests/components/esphome/test_ffmpeg_proxy.py
@@ -1,0 +1,127 @@
+"""Tests for ffmpeg proxy view."""
+
+from http import HTTPStatus
+import io
+import tempfile
+from urllib.request import pathname2url
+import wave
+
+import mutagen
+
+from homeassistant.components import esphome
+from homeassistant.components.esphome.ffmpeg_proxy import async_allow_proxy_url
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from tests.typing import ClientSessionGenerator
+
+
+async def test_proxy_view(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test proxy HTTP view for converting audio."""
+    device_id = "1234"
+
+    await async_setup_component(hass, esphome.DOMAIN, {esphome.DOMAIN: {}})
+    client = await hass_client()
+
+    with tempfile.NamedTemporaryFile(mode="wb+", suffix=".wav") as temp_file:
+        with wave.open(temp_file.name, "wb") as wav_file:
+            wav_file.setframerate(16000)
+            wav_file.setsampwidth(2)
+            wav_file.setnchannels(1)
+            wav_file.writeframes(bytes(16000 * 2))  # 1s
+
+        temp_file.seek(0)
+        wav_url = pathname2url(temp_file.name)
+        url = f"/api/esphome/ffmpeg_proxy?url={wav_url}&format=mp3&rate=22050&channels=2&device_id={device_id}"
+
+        # Should fail because we haven't allowed the URL yet
+        req = await client.get(url)
+        assert req.status == HTTPStatus.BAD_REQUEST
+
+        # Allow the URL
+        async_allow_proxy_url(hass, device_id, wav_url)
+
+        req = await client.get(url)
+        assert req.status == HTTPStatus.OK
+
+        mp3_data = await req.content.read()
+
+    # Verify conversion
+    with io.BytesIO(mp3_data) as mp3_io:
+        mp3_file = mutagen.File(mp3_io)
+        assert mp3_file.info.sample_rate == 22050
+        assert mp3_file.info.channels == 2
+
+        # About a second, but not exact
+        assert round(mp3_file.info.length, 0) == 1
+
+
+async def test_ffmpeg_error(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test proxy HTTP view with an ffmpeg error."""
+    device_id = "1234"
+
+    await async_setup_component(hass, esphome.DOMAIN, {esphome.DOMAIN: {}})
+    client = await hass_client()
+
+    # Try to convert a file that doesn't exist
+    missing_file = pathname2url("does-not-exist.wav")
+    url = (
+        f"/api/esphome/ffmpeg_proxy?url={missing_file}&format=mp3&device_id={device_id}"
+    )
+    async_allow_proxy_url(hass, device_id, missing_file)
+    req = await client.get(url)
+
+    # The HTTP status is OK because the ffmpeg process started, but no data is
+    # returned.
+    assert req.status == HTTPStatus.OK
+    mp3_data = await req.content.read()
+    assert not mp3_data
+
+
+async def test_view_schema(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test proxy HTTP view schema."""
+    device_id = "1234"
+
+    await async_setup_component(hass, esphome.DOMAIN, {esphome.DOMAIN: {}})
+    client = await hass_client()
+
+    url = "/api/esphome/ffmpeg_proxy"
+
+    with tempfile.NamedTemporaryFile(mode="wb+", suffix=".wav") as temp_file:
+        with wave.open(temp_file.name, "wb") as wav_file:
+            wav_file.setframerate(16000)
+            wav_file.setsampwidth(2)
+            wav_file.setnchannels(1)
+            wav_file.writeframes(bytes(16000 * 2))  # 1s
+
+        temp_file.seek(0)
+        wav_url = pathname2url(temp_file.name)
+
+        # Missing device id
+        req = await client.get(url)
+        assert req.status == HTTPStatus.BAD_REQUEST
+
+        # Missing url
+        url += f"?device_id={device_id}"
+        req = await client.get(url)
+        assert req.status == HTTPStatus.BAD_REQUEST
+
+        # Missing format
+        async_allow_proxy_url(hass, device_id, wav_url)
+        url += f"&url={wav_url}"
+        req = await client.get(url)
+        assert req.status == HTTPStatus.BAD_REQUEST
+
+        # Got everything
+        url += "&format=mp3"
+        req = await client.get(url)
+        assert req.status == HTTPStatus.OK

--- a/tests/components/esphome/test_ffmpeg_proxy.py
+++ b/tests/components/esphome/test_ffmpeg_proxy.py
@@ -28,7 +28,7 @@ async def test_async_create_proxy_url(hass: HomeAssistant) -> None:
     proxy_url = f"/api/esphome/ffmpeg_proxy/{device_id}/{convert_id}.{media_format}"
 
     with patch(
-        "homeassistant.components.esphome.ffmpeg_proxy.ulid.ulid",
+        "homeassistant.components.esphome.ffmpeg_proxy.secrets.token_urlsafe",
         return_value=convert_id,
     ):
         assert (
@@ -65,7 +65,7 @@ async def test_proxy_view(
 
         # Allow the URL
         with patch(
-            "homeassistant.components.esphome.ffmpeg_proxy.ulid.ulid",
+            "homeassistant.components.esphome.ffmpeg_proxy.secrets.token_urlsafe",
             return_value=convert_id,
         ):
             assert (

--- a/tests/components/esphome/test_media_player.py
+++ b/tests/components/esphome/test_media_player.py
@@ -18,7 +18,6 @@ from aioesphomeapi import (
 import pytest
 
 from homeassistant.components import media_source
-from homeassistant.components.esphome.ffmpeg_proxy import async_create_proxy_url
 from homeassistant.components.media_player import (
     ATTR_MEDIA_ANNOUNCE,
     ATTR_MEDIA_CONTENT_ID,
@@ -287,26 +286,6 @@ async def test_media_player_entity_with_source(
     mock_client.media_player_command.assert_has_calls(
         [call(1, media_url="media-source://tts?message=hello", announcement=True)]
     )
-
-
-async def test_async_create_proxy_url(hass: HomeAssistant) -> None:
-    """Test that async_create_proxy_url returns the correct format."""
-    assert await async_setup_component(hass, "esphome", {})
-
-    device_id = "test-device"
-    convert_id = "test-id"
-    media_format = "flac"
-    media_url = "http://127.0.0.1/test.mp3"
-    proxy_url = f"/api/esphome/ffmpeg_proxy/{device_id}/{convert_id}.{media_format}"
-
-    with patch(
-        "homeassistant.components.esphome.ffmpeg_proxy.ulid.ulid",
-        return_value=convert_id,
-    ):
-        assert (
-            async_create_proxy_url(hass, device_id, media_url, media_format)
-            == proxy_url
-        )
 
 
 async def test_media_player_proxy(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds an HTTP view to ESPHome that will allow devices to proxy media conversion through HA using ffmpeg. This will enable devices to support more media formats by having HA convert media to the device's preferred format, sample rate, etc.

To ensure that this web view is only used for the intended purposes, a function `async_create_proxy_url` must first be called by the ESPHome integration to add a URL to an allow list for a given device id. Once allowed, a URL of the form `/api/esphome/ffmpeg_proxy/<device_id>/<ulid>.<extension>` will stream the converted audio to the client.

A URL is only allowed to be requested once for a registered device. Once requested, `async_create_proxy_url` must be called again for each device id/url pair.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
