### PR TITLE
Add missing application credential to Tesla Fleet

### DIFF
--- a/homeassistant/components/tesla_fleet/__init__.py
+++ b/homeassistant/components/tesla_fleet/__init__.py
@@ -13,6 +13,7 @@ from tesla_fleet_api.exceptions import (
     TeslaFleetError,
 )
 
+from homeassistant.components.application_credentials import ClientCredential
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_TOKEN, Platform
 from homeassistant.core import HomeAssistant
@@ -26,7 +27,9 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import DeviceInfo
 
-from .const import DOMAIN, LOGGER, MODELS
+from .application_credentials import TeslaOAuth2Implementation
+from .config_flow import OAuth2FlowHandler
+from .const import CLIENT_ID, DOMAIN, LOGGER, MODELS, NAME
 from .coordinator import (
     TeslaFleetEnergySiteInfoCoordinator,
     TeslaFleetEnergySiteLiveCoordinator,
@@ -50,6 +53,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -
     token = jwt.decode(access_token, options={"verify_signature": False})
     scopes = token["scp"]
     region = token["ou_code"].lower()
+
+    OAuth2FlowHandler.async_register_implementation(
+        hass,
+        TeslaOAuth2Implementation(hass, DOMAIN, ClientCredential(CLIENT_ID, "", NAME)),
+    )
 
     implementation = await async_get_config_entry_implementation(hass, entry)
     oauth_session = OAuth2Session(hass, entry, implementation)

--- a/homeassistant/components/tesla_fleet/application_credentials.py
+++ b/homeassistant/components/tesla_fleet/application_credentials.py
@@ -9,11 +9,7 @@ from homeassistant.components.application_credentials import ClientCredential
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow
 
-from .const import DOMAIN, SCOPES
-
-CLIENT_ID = "71b813eb-4a2e-483a-b831-4dec5cb9bf0d"
-AUTHORIZE_URL = "https://auth.tesla.com/oauth2/v3/authorize"
-TOKEN_URL = "https://auth.tesla.com/oauth2/v3/token"
+from .const import AUTHORIZE_URL, CLIENT_ID, DOMAIN, SCOPES, TOKEN_URL
 
 
 async def async_get_auth_implementation(

--- a/homeassistant/components/tesla_fleet/application_credentials.py
+++ b/homeassistant/components/tesla_fleet/application_credentials.py
@@ -5,11 +5,17 @@ import hashlib
 import secrets
 from typing import Any
 
-from homeassistant.components.application_credentials import ClientCredential
+from homeassistant.components.application_credentials import (
+    AuthImplementation,
+    AuthorizationServer,
+    ClientCredential,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow
 
-from .const import AUTHORIZE_URL, CLIENT_ID, DOMAIN, SCOPES, TOKEN_URL
+from .const import AUTHORIZE_URL, DOMAIN, SCOPES, TOKEN_URL
+
+AUTH_SERVER = AuthorizationServer(AUTHORIZE_URL, TOKEN_URL)
 
 
 async def async_get_auth_implementation(
@@ -19,15 +25,16 @@ async def async_get_auth_implementation(
     return TeslaOAuth2Implementation(
         hass,
         DOMAIN,
+        credential,
     )
 
 
-class TeslaOAuth2Implementation(config_entry_oauth2_flow.LocalOAuth2Implementation):
+class TeslaOAuth2Implementation(AuthImplementation):
     """Tesla Fleet API Open Source Oauth2 implementation."""
 
-    _name = "Tesla Fleet API"
-
-    def __init__(self, hass: HomeAssistant, domain: str) -> None:
+    def __init__(
+        self, hass: HomeAssistant, domain: str, credential: ClientCredential
+    ) -> None:
         """Initialize local auth implementation."""
         self.hass = hass
         self._domain = domain
@@ -41,10 +48,8 @@ class TeslaOAuth2Implementation(config_entry_oauth2_flow.LocalOAuth2Implementati
         super().__init__(
             hass,
             domain,
-            CLIENT_ID,
-            "",  # Implementation has no client secret
-            AUTHORIZE_URL,
-            TOKEN_URL,
+            credential,
+            AUTH_SERVER,
         )
 
     @property

--- a/homeassistant/components/tesla_fleet/config_flow.py
+++ b/homeassistant/components/tesla_fleet/config_flow.py
@@ -13,7 +13,7 @@ from homeassistant.config_entries import ConfigEntry, ConfigFlowResult
 from homeassistant.helpers import config_entry_oauth2_flow
 
 from .application_credentials import TeslaOAuth2Implementation
-from .const import CLIENT_ID, DOMAIN, LOGGER
+from .const import CLIENT_ID, DOMAIN, LOGGER, NAME
 
 
 class OAuth2FlowHandler(
@@ -36,7 +36,7 @@ class OAuth2FlowHandler(
         self.async_register_implementation(
             self.hass,
             TeslaOAuth2Implementation(
-                self.hass, DOMAIN, ClientCredential(CLIENT_ID, "", "Home Assistant")
+                self.hass, DOMAIN, ClientCredential(CLIENT_ID, "", NAME)
             ),
         )
 

--- a/homeassistant/components/tesla_fleet/config_flow.py
+++ b/homeassistant/components/tesla_fleet/config_flow.py
@@ -46,7 +46,7 @@ class OAuth2FlowHandler(
                 ClientCredential(CLIENT_ID, "", name="Home Assistant"),
             )
 
-        return await self.async_step_pick_implementation()
+        return super().async_step_user()
 
     async def async_oauth_create_entry(
         self,

--- a/homeassistant/components/tesla_fleet/config_flow.py
+++ b/homeassistant/components/tesla_fleet/config_flow.py
@@ -8,13 +8,11 @@ from typing import Any
 
 import jwt
 
-from homeassistant.components.application_credentials import (
-    ClientCredential,
-    async_import_client_credential,
-)
+from homeassistant.components.application_credentials import ClientCredential
 from homeassistant.config_entries import ConfigEntry, ConfigFlowResult
 from homeassistant.helpers import config_entry_oauth2_flow
 
+from .application_credentials import TeslaOAuth2Implementation
 from .const import CLIENT_ID, DOMAIN, LOGGER
 
 
@@ -35,16 +33,12 @@ class OAuth2FlowHandler(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a flow start."""
-        implementations = await config_entry_oauth2_flow.async_get_implementations(
-            self.hass, self.DOMAIN
+        self.async_register_implementation(
+            self.hass,
+            TeslaOAuth2Implementation(
+                self.hass, DOMAIN, ClientCredential(CLIENT_ID, "", "Home Assistant")
+            ),
         )
-        if not implementations:
-            # Create the Home Assistant specific "open source application" credential
-            await async_import_client_credential(
-                self.hass,
-                self.DOMAIN,
-                ClientCredential(CLIENT_ID, "", name="Home Assistant"),
-            )
 
         return await self.async_step_pick_implementation()
 

--- a/homeassistant/components/tesla_fleet/config_flow.py
+++ b/homeassistant/components/tesla_fleet/config_flow.py
@@ -8,14 +8,11 @@ from typing import Any
 
 import jwt
 
-from homeassistant.components.application_credentials import (
-    ClientCredential,
-    async_import_client_credential,
-)
 from homeassistant.config_entries import ConfigEntry, ConfigFlowResult
 from homeassistant.helpers import config_entry_oauth2_flow
 
-from .const import CLIENT_ID, DOMAIN, LOGGER
+from .application_credentials import TeslaOAuth2Implementation
+from .const import DOMAIN, LOGGER
 
 
 class OAuth2FlowHandler(
@@ -35,18 +32,12 @@ class OAuth2FlowHandler(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a flow start."""
-        implementations = await config_entry_oauth2_flow.async_get_implementations(
-            self.hass, self.DOMAIN
+        self.async_register_implementation(
+            self.hass,
+            TeslaOAuth2Implementation(self.hass, DOMAIN),
         )
-        if not implementations:
-            # Create the Home Assistant specific "open source application" credential
-            await async_import_client_credential(
-                self.hass,
-                self.DOMAIN,
-                ClientCredential(CLIENT_ID, "", name="Home Assistant"),
-            )
 
-        return super().async_step_user()
+        return await super().async_step_user()
 
     async def async_oauth_create_entry(
         self,

--- a/homeassistant/components/tesla_fleet/const.py
+++ b/homeassistant/components/tesla_fleet/const.py
@@ -13,6 +13,10 @@ CONF_REFRESH_TOKEN = "refresh_token"
 
 LOGGER = logging.getLogger(__package__)
 
+CLIENT_ID = "71b813eb-4a2e-483a-b831-4dec5cb9bf0d"
+AUTHORIZE_URL = "https://auth.tesla.com/oauth2/v3/authorize"
+TOKEN_URL = "https://auth.tesla.com/oauth2/v3/token"
+
 SCOPES = [
     Scope.OPENID,
     Scope.OFFLINE_ACCESS,

--- a/homeassistant/components/tesla_fleet/const.py
+++ b/homeassistant/components/tesla_fleet/const.py
@@ -13,6 +13,7 @@ CONF_REFRESH_TOKEN = "refresh_token"
 
 LOGGER = logging.getLogger(__package__)
 
+NAME = "Home Assistant"
 CLIENT_ID = "71b813eb-4a2e-483a-b831-4dec5cb9bf0d"
 AUTHORIZE_URL = "https://auth.tesla.com/oauth2/v3/authorize"
 TOKEN_URL = "https://auth.tesla.com/oauth2/v3/token"

--- a/tests/components/tesla_fleet/__init__.py
+++ b/tests/components/tesla_fleet/__init__.py
@@ -8,8 +8,7 @@ from homeassistant.components.application_credentials import (
     ClientCredential,
     async_import_client_credential,
 )
-from homeassistant.components.tesla_fleet.application_credentials import CLIENT_ID
-from homeassistant.components.tesla_fleet.const import DOMAIN
+from homeassistant.components.tesla_fleet.const import CLIENT_ID, DOMAIN
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er

--- a/tests/components/tesla_fleet/__init__.py
+++ b/tests/components/tesla_fleet/__init__.py
@@ -4,9 +4,16 @@ from unittest.mock import patch
 
 from syrupy import SnapshotAssertion
 
+from homeassistant.components.application_credentials import (
+    ClientCredential,
+    async_import_client_credential,
+)
+from homeassistant.components.tesla_fleet.application_credentials import CLIENT_ID
+from homeassistant.components.tesla_fleet.const import DOMAIN
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
@@ -17,6 +24,14 @@ async def setup_platform(
     platforms: list[Platform] | None = None,
 ) -> None:
     """Set up the Tesla Fleet platform."""
+
+    assert await async_setup_component(hass, "application_credentials", {})
+    await async_import_client_credential(
+        hass,
+        DOMAIN,
+        ClientCredential(CLIENT_ID, "", "Home Assistant"),
+        DOMAIN,
+    )
 
     config_entry.add_to_hass(hass)
 

--- a/tests/components/tesla_fleet/conftest.py
+++ b/tests/components/tesla_fleet/conftest.py
@@ -10,14 +10,7 @@ from unittest.mock import AsyncMock, patch
 import jwt
 import pytest
 
-from homeassistant.components.application_credentials import (
-    ClientCredential,
-    async_import_client_credential,
-)
-from homeassistant.components.tesla_fleet.application_credentials import CLIENT_ID
 from homeassistant.components.tesla_fleet.const import DOMAIN, SCOPES
-from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 
 from .const import LIVE_STATUS, PRODUCTS, SITE_INFO, VEHICLE_DATA, VEHICLE_ONLINE
 
@@ -68,18 +61,6 @@ def normal_config_entry(expires_at: int, scopes: list[str]) -> MockConfigEntry:
                 "scope": ",".join(scopes),
             },
         },
-    )
-
-
-@pytest.fixture(autouse=True)
-async def setup_credentials(hass: HomeAssistant) -> None:
-    """Fixture to setup credentials."""
-    assert await async_setup_component(hass, "application_credentials", {})
-    await async_import_client_credential(
-        hass,
-        DOMAIN,
-        ClientCredential(CLIENT_ID, ""),
-        DOMAIN,
     )
 
 

--- a/tests/components/tesla_fleet/test_config_flow.py
+++ b/tests/components/tesla_fleet/test_config_flow.py
@@ -5,12 +5,13 @@ from urllib.parse import parse_qs, urlparse
 
 import pytest
 
-from homeassistant.components.tesla_fleet.application_credentials import (
+from homeassistant.components.tesla_fleet.const import (
     AUTHORIZE_URL,
     CLIENT_ID,
+    DOMAIN,
+    SCOPES,
     TOKEN_URL,
 )
-from homeassistant.components.tesla_fleet.const import DOMAIN, SCOPES
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I didnt realise until testing in the beta that the `tesla_fleet` integration doesnt actually create its application credential automatically. This implements this on the config flow.

Basically a user shouldn't have to configure the application credentials because Home Assistant has an "open source" CLIENT_ID that can be reused by all users, and has no CLIENT_SECRET.

Please beta fix / 2024.8 milestone

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
