### PR TITLE
Fix Google Cloud TTS not respecting config values

### DIFF
--- a/homeassistant/components/google_cloud/helpers.py
+++ b/homeassistant/components/google_cloud/helpers.py
@@ -59,7 +59,10 @@ def tts_options_schema(
             vol.Optional(
                 CONF_GENDER,
                 description={"suggested_value": config_options.get(CONF_GENDER)},
-                default=texttospeech.SsmlVoiceGender.NEUTRAL.name,  # type: ignore[attr-defined]
+                default=config_options.get(
+                    CONF_GENDER,
+                    texttospeech.SsmlVoiceGender.NEUTRAL.name,  # type: ignore[attr-defined]
+                ),
             ): vol.All(
                 vol.Upper,
                 SelectSelector(
@@ -72,7 +75,7 @@ def tts_options_schema(
             vol.Optional(
                 CONF_VOICE,
                 description={"suggested_value": config_options.get(CONF_VOICE)},
-                default=DEFAULT_VOICE,
+                default=config_options.get(CONF_VOICE, DEFAULT_VOICE),
             ): SelectSelector(
                 SelectSelectorConfig(
                     mode=SelectSelectorMode.DROPDOWN,
@@ -82,7 +85,10 @@ def tts_options_schema(
             vol.Optional(
                 CONF_ENCODING,
                 description={"suggested_value": config_options.get(CONF_ENCODING)},
-                default=texttospeech.AudioEncoding.MP3.name,  # type: ignore[attr-defined]
+                default=config_options.get(
+                    CONF_ENCODING,
+                    texttospeech.AudioEncoding.MP3.name,  # type: ignore[attr-defined]
+                ),
             ): vol.All(
                 vol.Upper,
                 SelectSelector(
@@ -95,22 +101,22 @@ def tts_options_schema(
             vol.Optional(
                 CONF_SPEED,
                 description={"suggested_value": config_options.get(CONF_SPEED)},
-                default=1.0,
+                default=config_options.get(CONF_SPEED, 1.0),
             ): NumberSelector(NumberSelectorConfig(min=0.25, max=4.0, step=0.01)),
             vol.Optional(
                 CONF_PITCH,
                 description={"suggested_value": config_options.get(CONF_PITCH)},
-                default=0,
+                default=config_options.get(CONF_PITCH, 0),
             ): NumberSelector(NumberSelectorConfig(min=-20.0, max=20.0, step=0.1)),
             vol.Optional(
                 CONF_GAIN,
                 description={"suggested_value": config_options.get(CONF_GAIN)},
-                default=0,
+                default=config_options.get(CONF_GAIN, 0),
             ): NumberSelector(NumberSelectorConfig(min=-96.0, max=16.0, step=0.1)),
             vol.Optional(
                 CONF_PROFILES,
                 description={"suggested_value": config_options.get(CONF_PROFILES)},
-                default=[],
+                default=config_options.get(CONF_PROFILES, []),
             ): SelectSelector(
                 SelectSelectorConfig(
                     mode=SelectSelectorMode.DROPDOWN,
@@ -132,7 +138,7 @@ def tts_options_schema(
             vol.Optional(
                 CONF_TEXT_TYPE,
                 description={"suggested_value": config_options.get(CONF_TEXT_TYPE)},
-                default="text",
+                default=config_options.get(CONF_TEXT_TYPE, "text"),
             ): vol.All(
                 vol.Lower,
                 SelectSelector(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #123255
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
