### PR TITLE
 Add support for Tuya Wireless Switch entity

### DIFF
--- a/homeassistant/components/tuya/const.py
+++ b/homeassistant/components/tuya/const.py
@@ -56,6 +56,7 @@ PLATFORMS = [
     Platform.CAMERA,
     Platform.CLIMATE,
     Platform.COVER,
+    Platform.EVENT,
     Platform.FAN,
     Platform.HUMIDIFIER,
     Platform.LIGHT,
@@ -314,6 +315,15 @@ class DPCode(StrEnum):
     SWITCH_LED_1 = "switch_led_1"
     SWITCH_LED_2 = "switch_led_2"
     SWITCH_LED_3 = "switch_led_3"
+    SWITCH_MODE1 = "switch_mode1"
+    SWITCH_MODE2 = "switch_mode2"
+    SWITCH_MODE3 = "switch_mode3"
+    SWITCH_MODE4 = "switch_mode4"
+    SWITCH_MODE5 = "switch_mode5"
+    SWITCH_MODE6 = "switch_mode6"
+    SWITCH_MODE7 = "switch_mode7"
+    SWITCH_MODE8 = "switch_mode8"
+    SWITCH_MODE9 = "switch_mode9"
     SWITCH_NIGHT_LIGHT = "switch_night_light"
     SWITCH_SAVE_ENERGY = "switch_save_energy"
     SWITCH_SOUND = "switch_sound"  # Voice switch

--- a/homeassistant/components/tuya/event.py
+++ b/homeassistant/components/tuya/event.py
@@ -1,0 +1,147 @@
+"""Support for Tuya event entities."""
+
+from __future__ import annotations
+
+from tuya_sharing import CustomerDevice, Manager
+
+from homeassistant.components.event import (
+    EventDeviceClass,
+    EventEntity,
+    EventEntityDescription,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import TuyaConfigEntry
+from .const import TUYA_DISCOVERY_NEW, DPCode, DPType
+from .entity import TuyaEntity
+
+# All descriptions can be found here. Mostly the Enum data types in the
+# default status set of each category (that don't have a set instruction)
+# end up being events.
+# https://developer.tuya.com/en/docs/iot/standarddescription?id=K9i5ql6waswzq
+EVENTS: dict[str, tuple[EventEntityDescription, ...]] = {
+    # Wireless Switch
+    # https://developer.tuya.com/en/docs/iot/s?id=Kbeoa9fkv6brp
+    "wxkg": (
+        EventEntityDescription(
+            key=DPCode.SWITCH_MODE1,
+            device_class=EventDeviceClass.BUTTON,
+            translation_key="numbered_button",
+            translation_placeholders={"button_number": "1"},
+        ),
+        EventEntityDescription(
+            key=DPCode.SWITCH_MODE2,
+            device_class=EventDeviceClass.BUTTON,
+            translation_key="numbered_button",
+            translation_placeholders={"button_number": "2"},
+        ),
+        EventEntityDescription(
+            key=DPCode.SWITCH_MODE3,
+            device_class=EventDeviceClass.BUTTON,
+            translation_key="numbered_button",
+            translation_placeholders={"button_number": "3"},
+        ),
+        EventEntityDescription(
+            key=DPCode.SWITCH_MODE4,
+            device_class=EventDeviceClass.BUTTON,
+            translation_key="numbered_button",
+            translation_placeholders={"button_number": "4"},
+        ),
+        EventEntityDescription(
+            key=DPCode.SWITCH_MODE5,
+            device_class=EventDeviceClass.BUTTON,
+            translation_key="numbered_button",
+            translation_placeholders={"button_number": "5"},
+        ),
+        EventEntityDescription(
+            key=DPCode.SWITCH_MODE6,
+            device_class=EventDeviceClass.BUTTON,
+            translation_key="numbered_button",
+            translation_placeholders={"button_number": "6"},
+        ),
+        EventEntityDescription(
+            key=DPCode.SWITCH_MODE7,
+            device_class=EventDeviceClass.BUTTON,
+            translation_key="numbered_button",
+            translation_placeholders={"button_number": "7"},
+        ),
+        EventEntityDescription(
+            key=DPCode.SWITCH_MODE8,
+            device_class=EventDeviceClass.BUTTON,
+            translation_key="numbered_button",
+            translation_placeholders={"button_number": "8"},
+        ),
+        EventEntityDescription(
+            key=DPCode.SWITCH_MODE9,
+            device_class=EventDeviceClass.BUTTON,
+            translation_key="numbered_button",
+            translation_placeholders={"button_number": "9"},
+        ),
+    )
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: TuyaConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Tuya events dynamically through Tuya discovery."""
+    hass_data = entry.runtime_data
+
+    @callback
+    def async_discover_device(device_ids: list[str]) -> None:
+        """Discover and add a discovered Tuya binary sensor."""
+        entities: list[TuyaEventEntity] = []
+        for device_id in device_ids:
+            device = hass_data.manager.device_map[device_id]
+            if descriptions := EVENTS.get(device.category):
+                for description in descriptions:
+                    dpcode = description.key
+                    if dpcode in device.status:
+                        entities.append(
+                            TuyaEventEntity(device, hass_data.manager, description)
+                        )
+
+        async_add_entities(entities)
+
+    async_discover_device([*hass_data.manager.device_map])
+
+    entry.async_on_unload(
+        async_dispatcher_connect(hass, TUYA_DISCOVERY_NEW, async_discover_device)
+    )
+
+
+class TuyaEventEntity(TuyaEntity, EventEntity):
+    """Tuya Event Entity."""
+
+    entity_description: EventEntityDescription
+
+    def __init__(
+        self,
+        device: CustomerDevice,
+        device_manager: Manager,
+        description: EventEntityDescription,
+    ) -> None:
+        """Init Tuya event entity."""
+        super().__init__(device, device_manager)
+        self.entity_description = description
+        self._attr_unique_id = f"{super().unique_id}{description.key}"
+
+        if dpcode := self.find_dpcode(description.key, dptype=DPType.ENUM):
+            self._attr_event_types: list[str] = dpcode.range
+
+    async def _handle_state_update(
+        self, updated_status_properties: list[str] | None
+    ) -> None:
+        if (
+            updated_status_properties is None
+            or self.entity_description.key not in updated_status_properties
+        ):
+            return
+
+        value = self.device.status.get(self.entity_description.key)
+        self._trigger_event(value)
+        self.async_write_ha_state()

--- a/homeassistant/components/tuya/sensor.py
+++ b/homeassistant/components/tuya/sensor.py
@@ -1281,6 +1281,9 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
             state_class=SensorStateClass.MEASUREMENT,
         ),
     ),
+    # Wireless Switch
+    # https://developer.tuya.com/en/docs/iot/s?id=Kbeoa9fkv6brp
+    "wxkg": BATTERY_SENSORS,
 }
 
 # Socket (duplicate of `kg`)

--- a/homeassistant/components/tuya/strings.json
+++ b/homeassistant/components/tuya/strings.json
@@ -101,6 +101,20 @@
         "name": "Door 3"
       }
     },
+    "event": {
+      "numbered_button": {
+        "name": "Button {button_number}",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "click": "Clicked",
+              "double_click": "Double-clicked",
+              "press": "Long-pressed"
+            }
+          }
+        }
+      }
+    },
     "light": {
       "backlight": {
         "name": "Backlight"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

This change adds support for for Tuya wireless switches such as the one depicted below with which this change has been tested.

<img src="https://github.com/user-attachments/assets/b703f7ae-90aa-48e9-aec6-685db564a573" width="300">

![tuya-device-page](https://github.com/user-attachments/assets/4097200c-ce32-4e76-bee9-f79e82df827f)

This required a change in tuya-device-sharing-sdk. The relevant [pull request](https://github.com/tuya/tuya-device-sharing-sdk/pull/17) has been merged and released in a new version. Here's the [changelog for tuya-device-sharing-sdk on PyPI](https://pypi.org/project/tuya-device-sharing-sdk/#description:~:text=Release%20Note,updated_status_properties%20to%20SharingDeviceListener) and here's a [diff of all the code changes between the two versions](https://github.com/tuya/tuya-device-sharing-sdk/compare/1496fc3c24643d0045e722698cd34978ce2636d1..e3da82c3558988736b9a8b6df3cb810a4cb7eb1b)


## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
  - fixes #120460 
  - fixes #120458
  - fixes #120020
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/34174

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
