### PR TITLE
Fix Tibber get_prices when called with aware datetime

### DIFF
--- a/homeassistant/components/tibber/services.py
+++ b/homeassistant/components/tibber/services.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
-from datetime import date, datetime
+from datetime import datetime
 from functools import partial
 from typing import Any, Final
 
@@ -63,25 +63,24 @@ async def __get_prices(call: ServiceCall, *, hass: HomeAssistant) -> ServiceResp
         selected_data = [
             price
             for price in price_data
-            if price["start_time"].replace(tzinfo=None) >= start
-            and price["start_time"].replace(tzinfo=None) < end
+            if price["start_time"] >= start and price["start_time"] < end
         ]
         tibber_prices[home_nickname] = selected_data
 
     return {"prices": tibber_prices}
 
 
-def __get_date(date_input: str | None, mode: str | None) -> date | datetime:
+def __get_date(date_input: str | None, mode: str | None) -> datetime:
     """Get date."""
     if not date_input:
         if mode == "end":
             increment = dt.timedelta(days=1)
         else:
             increment = dt.timedelta()
-        return datetime.fromisoformat(dt_util.now().date().isoformat()) + increment
+        return dt_util.start_of_local_day() + increment
 
     if value := dt_util.parse_datetime(date_input):
-        return value
+        return dt_util.as_local(value)
 
     raise ServiceValidationError(
         "Invalid datetime provided.",

--- a/homeassistant/components/tibber/services.py
+++ b/homeassistant/components/tibber/services.py
@@ -61,9 +61,7 @@ async def __get_prices(call: ServiceCall, *, hass: HomeAssistant) -> ServiceResp
         ]
 
         selected_data = [
-            price
-            for price in price_data
-            if price["start_time"] >= start and price["start_time"] < end
+            price for price in price_data if start <= price["start_time"] < end
         ]
         tibber_prices[home_nickname] = selected_data
 

--- a/tests/components/tibber/test_services.py
+++ b/tests/components/tibber/test_services.py
@@ -11,8 +11,11 @@ from homeassistant.components.tibber.const import DOMAIN
 from homeassistant.components.tibber.services import PRICE_SERVICE_NAME, __get_prices
 from homeassistant.core import ServiceCall
 from homeassistant.exceptions import ServiceValidationError
+from homeassistant.util import dt as dt_util
 
-STARTTIME = dt.datetime.fromtimestamp(1615766400)
+STARTTIME = dt.datetime.fromtimestamp(1615766400).replace(
+    tzinfo=dt_util.get_default_time_zone()
+)
 
 
 def generate_mock_home_data():
@@ -238,6 +241,90 @@ async def test_get_prices_start_tomorrow(
                 },
                 {
                     "start_time": tomorrow + dt.timedelta(hours=1),
+                    "price": 0.46914,
+                    "level": "VERY_EXPENSIVE",
+                },
+            ],
+        }
+    }
+
+
+async def test_get_prices_with_timezone(
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test __get_prices with start date tomorrow."""
+    freezer.move_to(STARTTIME)
+    call = ServiceCall(
+        DOMAIN, PRICE_SERVICE_NAME, {"start": dt_util.start_of_local_day().isoformat()}
+    )
+
+    result = await __get_prices(call, hass=create_mock_hass())
+
+    assert result == {
+        "prices": {
+            "first_home": [
+                {
+                    "start_time": STARTTIME,
+                    "price": 0.46914,
+                    "level": "VERY_EXPENSIVE",
+                },
+                {
+                    "start_time": STARTTIME + dt.timedelta(hours=1),
+                    "price": 0.46914,
+                    "level": "VERY_EXPENSIVE",
+                },
+            ],
+            "second_home": [
+                {
+                    "start_time": STARTTIME,
+                    "price": 0.46914,
+                    "level": "VERY_EXPENSIVE",
+                },
+                {
+                    "start_time": STARTTIME + dt.timedelta(hours=1),
+                    "price": 0.46914,
+                    "level": "VERY_EXPENSIVE",
+                },
+            ],
+        }
+    }
+
+
+async def test_get_prices_without_timezone(
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test __get_prices with start date tomorrow."""
+    freezer.move_to(STARTTIME)
+    call = ServiceCall(
+        DOMAIN,
+        PRICE_SERVICE_NAME,
+        {"start": dt_util.start_of_local_day().replace(tzinfo=None).isoformat()},
+    )
+
+    result = await __get_prices(call, hass=create_mock_hass())
+
+    assert result == {
+        "prices": {
+            "first_home": [
+                {
+                    "start_time": STARTTIME,
+                    "price": 0.46914,
+                    "level": "VERY_EXPENSIVE",
+                },
+                {
+                    "start_time": STARTTIME + dt.timedelta(hours=1),
+                    "price": 0.46914,
+                    "level": "VERY_EXPENSIVE",
+                },
+            ],
+            "second_home": [
+                {
+                    "start_time": STARTTIME,
+                    "price": 0.46914,
+                    "level": "VERY_EXPENSIVE",
+                },
+                {
+                    "start_time": STARTTIME + dt.timedelta(hours=1),
                     "price": 0.46914,
                     "level": "VERY_EXPENSIVE",
                 },

--- a/tests/components/tibber/test_services.py
+++ b/tests/components/tibber/test_services.py
@@ -250,27 +250,18 @@ async def test_get_prices_start_tomorrow(
 
 
 @pytest.mark.parametrize(
-    ("start_time", "expect_it_to_work"),
+    "start_time",
     [
-        (STARTTIME.isoformat(), True),
-        (STARTTIME.replace(tzinfo=None).isoformat(), True),
-        (
-            (STARTTIME + dt.timedelta(hours=4))
-            .replace(tzinfo=dt.timezone(dt.timedelta(hours=4)))
-            .isoformat(),
-            True,
-        ),
-        ((STARTTIME + dt.timedelta(hours=4)).isoformat(), False),
-        (
-            (STARTTIME + dt.timedelta(hours=4)).replace(tzinfo=None).isoformat(),
-            False,
-        ),
+        STARTTIME.isoformat(),
+        STARTTIME.replace(tzinfo=None).isoformat(),
+        (STARTTIME + dt.timedelta(hours=4))
+        .replace(tzinfo=dt.timezone(dt.timedelta(hours=4)))
+        .isoformat(),
     ],
 )
 async def test_get_prices_with_timezones(
     freezer: FrozenDateTimeFactory,
     start_time: str,
-    expect_it_to_work: bool,
 ) -> None:
     """Test __get_prices with timezone and without."""
     freezer.move_to(STARTTIME)
@@ -278,37 +269,53 @@ async def test_get_prices_with_timezones(
 
     result = await __get_prices(call, hass=create_mock_hass())
 
-    if expect_it_to_work:
-        assert result == {
-            "prices": {
-                "first_home": [
-                    {
-                        "start_time": STARTTIME,
-                        "price": 0.46914,
-                        "level": "VERY_EXPENSIVE",
-                    },
-                    {
-                        "start_time": STARTTIME + dt.timedelta(hours=1),
-                        "price": 0.46914,
-                        "level": "VERY_EXPENSIVE",
-                    },
-                ],
-                "second_home": [
-                    {
-                        "start_time": STARTTIME,
-                        "price": 0.46914,
-                        "level": "VERY_EXPENSIVE",
-                    },
-                    {
-                        "start_time": STARTTIME + dt.timedelta(hours=1),
-                        "price": 0.46914,
-                        "level": "VERY_EXPENSIVE",
-                    },
-                ],
-            }
+    assert result == {
+        "prices": {
+            "first_home": [
+                {
+                    "start_time": STARTTIME,
+                    "price": 0.46914,
+                    "level": "VERY_EXPENSIVE",
+                },
+                {
+                    "start_time": STARTTIME + dt.timedelta(hours=1),
+                    "price": 0.46914,
+                    "level": "VERY_EXPENSIVE",
+                },
+            ],
+            "second_home": [
+                {
+                    "start_time": STARTTIME,
+                    "price": 0.46914,
+                    "level": "VERY_EXPENSIVE",
+                },
+                {
+                    "start_time": STARTTIME + dt.timedelta(hours=1),
+                    "price": 0.46914,
+                    "level": "VERY_EXPENSIVE",
+                },
+            ],
         }
-    else:
-        assert result == {"prices": {"first_home": [], "second_home": []}}
+    }
+
+
+@pytest.mark.parametrize(
+    "start_time",
+    [
+        (STARTTIME + dt.timedelta(hours=4)).isoformat(),
+        (STARTTIME + dt.timedelta(hours=4)).replace(tzinfo=None).isoformat(),
+    ],
+)
+async def test_get_prices_with_wrong_timezones(
+    freezer: FrozenDateTimeFactory,
+    start_time: str,
+) -> None:
+    """Test __get_prices with timezone and without, while expecting it to fail."""
+    freezer.move_to(STARTTIME)
+    call = ServiceCall(DOMAIN, PRICE_SERVICE_NAME, {"start": start_time})
+
+    result = await __get_prices(call, hass=create_mock_hass())
+    assert result == {"prices": {"first_home": [], "second_home": []}}
 
 
 async def test_get_prices_invalid_input() -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Change `tibber.get_prices` action to accept both aware and naive datetimes, in addition to simple dates.

I have implemented this by changing `__get_date()` to always output aware datetimes, and then modifying `__get_prices()` to work with that. Naive datetimes and simple dates are interpreted to be in the default timezone, by using `as_local()` from `homeassistant.utils.dt`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #123288
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
