### PR TITLE
Drop Matter Microwave Oven Mode select entity

### DIFF
--- a/homeassistant/components/matter/select.py
+++ b/homeassistant/components/matter/select.py
@@ -27,7 +27,6 @@ type SelectCluster = (
     | clusters.RvcRunMode
     | clusters.RvcCleanMode
     | clusters.DishwasherMode
-    | clusters.MicrowaveOvenMode
     | clusters.EnergyEvseMode
     | clusters.DeviceEnergyManagementMode
 )
@@ -197,18 +196,6 @@ DISCOVERY_SCHEMAS = [
         required_attributes=(
             clusters.DishwasherMode.Attributes.CurrentMode,
             clusters.DishwasherMode.Attributes.SupportedModes,
-        ),
-    ),
-    MatterDiscoverySchema(
-        platform=Platform.SELECT,
-        entity_description=MatterSelectEntityDescription(
-            key="MatterMicrowaveOvenMode",
-            translation_key="mode",
-        ),
-        entity_class=MatterModeSelectEntity,
-        required_attributes=(
-            clusters.MicrowaveOvenMode.Attributes.CurrentMode,
-            clusters.MicrowaveOvenMode.Attributes.SupportedModes,
         ),
     ),
     MatterDiscoverySchema(

--- a/tests/components/matter/test_select.py
+++ b/tests/components/matter/test_select.py
@@ -25,16 +25,6 @@ async def dimmable_light_node_fixture(
     )
 
 
-@pytest.fixture(name="microwave_oven_node")
-async def microwave_oven_node_fixture(
-    hass: HomeAssistant, matter_client: MagicMock
-) -> MatterNode:
-    """Fixture for a microwave oven node."""
-    return await setup_integration_with_node_fixture(
-        hass, "microwave-oven", matter_client
-    )
-
-
 # This tests needs to be adjusted to remove lingering tasks
 @pytest.mark.parametrize("expected_lingering_tasks", [True])
 async def test_mode_select_entities(
@@ -87,28 +77,6 @@ async def test_mode_select_entities(
 
 
 # This tests needs to be adjusted to remove lingering tasks
-@pytest.mark.parametrize("expected_lingering_tasks", [True])
-async def test_microwave_select_entities(
-    hass: HomeAssistant,
-    matter_client: MagicMock,
-    microwave_oven_node: MatterNode,
-) -> None:
-    """Test select entities are created for the MicrowaveOvenMode cluster attributes."""
-    state = hass.states.get("select.microwave_oven_mode")
-    assert state
-    assert state.state == "Normal"
-    assert state.attributes["options"] == [
-        "Normal",
-        "Defrost",
-    ]
-    # name should just be Mode (from the translation key)
-    assert state.attributes["friendly_name"] == "Microwave Oven Mode"
-    set_node_attribute(microwave_oven_node, 1, 94, 1, 1)
-    await trigger_subscription_callback(hass, matter_client)
-    state = hass.states.get("select.microwave_oven_mode")
-    assert state.state == "Defrost"
-
-
 @pytest.mark.parametrize("expected_lingering_tasks", [True])
 async def test_attribute_select_entities(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Microwave Oven Mode Cluster is of type Mode Base cluster, but it explicitly does not have a ChangeToMode command in Matter 1.3 (conformance X, which means disallowed).

We could use a enum sensor entity for the Microwave Oven Mode, but there is not a lot of value and the spec on this feature might still change. So drop the mode for now.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #123258
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
