### PR TITLE
Reolink Chime online status and ability to remove

### DIFF
--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -188,6 +188,41 @@ async def async_remove_config_entry_device(
     host: ReolinkHost = hass.data[DOMAIN][config_entry.entry_id].host
     (device_uid, ch, is_chime) = get_device_uid_and_ch(device, host)
 
+    if is_chime:
+        await host.api.get_state(cmd="GetDingDongList")
+        chime = host.api.chime(ch)
+        if chime is None or chime.connect_state < 0:
+            _LOGGER.debug(
+                "Removing Reolink chime %s with id %s, "
+                "since it is not coupled to %s anymore",
+                device.name,
+                ch,
+                host.api.nvr_name
+            )
+            return True
+
+        # remove the chime from the host
+        await chime.remove()
+        await host.api.get_state(cmd="GetDingDongList")
+        if chime.connect_state < 0:
+            _LOGGER.debug(
+                "Removed Reolink chime %s with id %s from %s",
+                device.name,
+                ch,
+                host.api.nvr_name
+            )
+            return True
+
+        _LOGGER.warning(
+            "Cannot remove Reolink chime %s with id %s, because it is still connected "
+            "to %s, please first remove the chime "
+            "in the reolink app",
+            device.name,
+            ch,
+            host.api.nvr_name
+        )
+        return False
+
     if not host.api.is_nvr or ch is None:
         _LOGGER.warning(
             "Cannot remove Reolink device %s, because it is not a camera connected "

--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -191,7 +191,7 @@ async def async_remove_config_entry_device(
     if is_chime:
         await host.api.get_state(cmd="GetDingDongList")
         chime = host.api.chime(ch)
-        if chime is None or chime.connect_state < 0:
+        if chime is None or chime.connect_state < 0 or chime.channel not in host.api.channels:
             _LOGGER.debug(
                 "Removing Reolink chime %s with id %s, "
                 "since it is not coupled to %s anymore",

--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -191,13 +191,18 @@ async def async_remove_config_entry_device(
     if is_chime:
         await host.api.get_state(cmd="GetDingDongList")
         chime = host.api.chime(ch)
-        if chime is None or chime.connect_state < 0 or chime.channel not in host.api.channels:
+        if (
+            chime is None
+            or chime.connect_state is None
+            or chime.connect_state < 0
+            or chime.channel not in host.api.channels
+        ):
             _LOGGER.debug(
                 "Removing Reolink chime %s with id %s, "
                 "since it is not coupled to %s anymore",
                 device.name,
                 ch,
-                host.api.nvr_name
+                host.api.nvr_name,
             )
             return True
 
@@ -209,7 +214,7 @@ async def async_remove_config_entry_device(
                 "Removed Reolink chime %s with id %s from %s",
                 device.name,
                 ch,
-                host.api.nvr_name
+                host.api.nvr_name,
             )
             return True
 
@@ -219,7 +224,7 @@ async def async_remove_config_entry_device(
             "in the reolink app",
             device.name,
             ch,
-            host.api.nvr_name
+            host.api.nvr_name,
         )
         return False
 

--- a/homeassistant/components/reolink/entity.py
+++ b/homeassistant/components/reolink/entity.py
@@ -190,3 +190,8 @@ class ReolinkChimeCoordinatorEntity(ReolinkChannelCoordinatorEntity):
             serial_number=str(chime.dev_id),
             configuration_url=self._conf_url,
         )
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self._chime.online and super().available

--- a/tests/components/reolink/test_select.py
+++ b/tests/components/reolink/test_select.py
@@ -33,8 +33,6 @@ async def test_floodlight_mode_select(
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test select entity with floodlight_mode."""
-    reolink_connect.whiteled_mode.return_value = 1
-    reolink_connect.whiteled_mode_list.return_value = ["off", "auto"]
     with patch("homeassistant.components.reolink.PLATFORMS", [Platform.SELECT]):
         assert await hass.config_entries.async_setup(config_entry.entry_id) is True
     await hass.async_block_till_done()
@@ -72,6 +70,14 @@ async def test_floodlight_mode_select(
             blocking=True,
         )
 
+    reolink_connect.whiteled_mode.return_value = -99  # invalid value
+    async_fire_time_changed(
+        hass, utcnow() + DEVICE_UPDATE_INTERVAL + timedelta(seconds=30)
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.is_state(entity_id, STATE_UNKNOWN)
+
 
 async def test_play_quick_reply_message(
     hass: HomeAssistant,
@@ -103,25 +109,10 @@ async def test_chime_select(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     reolink_connect: MagicMock,
+    test_chime: Chime,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test chime select entity."""
-    TEST_CHIME = Chime(
-        host=reolink_connect,
-        dev_id=12345678,
-        channel=0,
-    )
-    TEST_CHIME.name = "Test chime"
-    TEST_CHIME.volume = 3
-    TEST_CHIME.led_state = True
-    TEST_CHIME.event_info = {
-        "md": {"switch": 0, "musicId": 0},
-        "people": {"switch": 0, "musicId": 1},
-        "visitor": {"switch": 1, "musicId": 2},
-    }
-
-    reolink_connect.chime_list = [TEST_CHIME]
-
     with patch("homeassistant.components.reolink.PLATFORMS", [Platform.SELECT]):
         assert await hass.config_entries.async_setup(config_entry.entry_id) is True
     await hass.async_block_till_done()
@@ -131,16 +122,16 @@ async def test_chime_select(
     entity_id = f"{Platform.SELECT}.test_chime_visitor_ringtone"
     assert hass.states.is_state(entity_id, "pianokey")
 
-    TEST_CHIME.set_tone = AsyncMock()
+    test_chime.set_tone = AsyncMock()
     await hass.services.async_call(
         SELECT_DOMAIN,
         SERVICE_SELECT_OPTION,
         {ATTR_ENTITY_ID: entity_id, "option": "off"},
         blocking=True,
     )
-    TEST_CHIME.set_tone.assert_called_once()
+    test_chime.set_tone.assert_called_once()
 
-    TEST_CHIME.set_tone = AsyncMock(side_effect=ReolinkError("Test error"))
+    test_chime.set_tone = AsyncMock(side_effect=ReolinkError("Test error"))
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             SELECT_DOMAIN,
@@ -149,7 +140,7 @@ async def test_chime_select(
             blocking=True,
         )
 
-    TEST_CHIME.set_tone = AsyncMock(side_effect=InvalidParameterError("Test error"))
+    test_chime.set_tone = AsyncMock(side_effect=InvalidParameterError("Test error"))
     with pytest.raises(ServiceValidationError):
         await hass.services.async_call(
             SELECT_DOMAIN,
@@ -158,7 +149,7 @@ async def test_chime_select(
             blocking=True,
         )
 
-    TEST_CHIME.event_info = {}
+    test_chime.event_info = {}
     async_fire_time_changed(
         hass, utcnow() + DEVICE_UPDATE_INTERVAL + timedelta(seconds=30)
     )

--- a/tests/components/reolink/test_select.py
+++ b/tests/components/reolink/test_select.py
@@ -110,15 +110,15 @@ async def test_chime_select(
         host=reolink_connect,
         dev_id=12345678,
         channel=0,
-        name="Test chime",
-        event_info={
-            "md": {"switch": 0, "musicId": 0},
-            "people": {"switch": 0, "musicId": 1},
-            "visitor": {"switch": 1, "musicId": 2},
-        },
     )
+    TEST_CHIME.name = "Test chime"
     TEST_CHIME.volume = 3
     TEST_CHIME.led_state = True
+    TEST_CHIME.event_info = {
+        "md": {"switch": 0, "musicId": 0},
+        "people": {"switch": 0, "musicId": 1},
+        "visitor": {"switch": 1, "musicId": 2},
+    }
 
     reolink_connect.chime_list = [TEST_CHIME]
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Show the Reolink Chime entities as unavailable when the chime is not connected to the doorbell.
Allow to remove a Reolink Chime from HomeAssistant and the doorbell.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
