### PR TITLE
Revert "Fix blocking I/O while validating config schema"

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -817,9 +817,7 @@ async def async_process_ha_core_config(hass: HomeAssistant, config: dict) -> Non
 
     This method is a coroutine.
     """
-    # CORE_CONFIG_SCHEMA is not async safe since it uses vol.IsDir
-    # so we need to run it in an executor job.
-    config = await hass.async_add_executor_job(CORE_CONFIG_SCHEMA, config)
+    config = CORE_CONFIG_SCHEMA(config)
 
     # Only load auth during startup.
     if not hasattr(hass, "auth"):
@@ -1535,15 +1533,9 @@ async def async_process_component_config(
             return IntegrationConfigInfo(None, config_exceptions)
 
     # No custom config validator, proceed with schema validation
-    if config_schema := getattr(component, "CONFIG_SCHEMA", None):
+    if hasattr(component, "CONFIG_SCHEMA"):
         try:
-            if domain in config:
-                # cv.isdir, cv.isfile, cv.isdevice are not async
-                # friendly so we need to run this in executor
-                schema = await hass.async_add_executor_job(config_schema, config)
-            else:
-                schema = config_schema(config)
-            return IntegrationConfigInfo(schema, [])
+            return IntegrationConfigInfo(component.CONFIG_SCHEMA(config), [])
         except vol.Invalid as exc:
             exc_info = ConfigExceptionInfo(
                 exc,


### PR DESCRIPTION
Reverts home-assistant/core#121263

The solution is not valid, we need to do schema validation in the event loop.
Instead, we should make the individual validators which do blocking I/O check if they execute in the event loop, and if they do, schedule the validation in an executor.

I'm tagging this for next point release because of https://github.com/home-assistant/core/issues/123251, and probably other similar issues.
fixes #123251 