### PR TITLE
Ensure legacy event foreign key is removed from the states table when a previous rebuild failed

### DIFF
--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -632,7 +632,7 @@ def _update_states_table_with_foreign_key_options(
 
 def _drop_foreign_key_constraints(
     session_maker: Callable[[], Session], engine: Engine, table: str, column: str
-) -> list[tuple[str, str, ReflectedForeignKeyConstraint]]:
+) -> tuple[bool, list[tuple[str, str, ReflectedForeignKeyConstraint]]]:
     """Drop foreign key constraints for a table on specific columns."""
     inspector = sqlalchemy.inspect(engine)
     dropped_constraints = [
@@ -649,6 +649,7 @@ def _drop_foreign_key_constraints(
         if foreign_key["name"] and foreign_key["constrained_columns"] == [column]
     ]
 
+    fk_remove_ok = True
     for drop in drops:
         with session_scope(session=session_maker()) as session:
             try:
@@ -660,8 +661,9 @@ def _drop_foreign_key_constraints(
                     TABLE_STATES,
                     column,
                 )
+                fk_remove_ok = False
 
-    return dropped_constraints
+    return fk_remove_ok, dropped_constraints
 
 
 def _restore_foreign_key_constraints(
@@ -1481,7 +1483,7 @@ class _SchemaVersion44Migrator(_SchemaVersionMigrator, target_version=44):
             for column in columns
             for dropped_constraint in _drop_foreign_key_constraints(
                 self.session_maker, self.engine, table, column
-            )
+            )[1]
         ]
         _LOGGER.debug("Dropped foreign key constraints: %s", dropped_constraints)
 
@@ -1958,10 +1960,8 @@ def cleanup_legacy_states_event_ids(instance: Recorder) -> bool:
             # so we have to rebuild the table
             fk_remove_ok = rebuild_sqlite_table(session_maker, instance.engine, States)
         else:
-            fk_remove_ok = bool(
-                _drop_foreign_key_constraints(
-                    session_maker, instance.engine, TABLE_STATES, "event_id"
-                )
+            fk_remove_ok, _ = _drop_foreign_key_constraints(
+                session_maker, instance.engine, TABLE_STATES, "event_id"
             )
         if fk_remove_ok:
             _drop_index(session_maker, "states", LEGACY_STATES_EVENT_ID_INDEX)

--- a/tests/components/recorder/test_migrate.py
+++ b/tests/components/recorder/test_migrate.py
@@ -748,7 +748,7 @@ def test_rebuild_sqlite_states_table(recorder_db_url: str) -> None:
         session.add(States(state="on"))
         session.commit()
 
-    migration.rebuild_sqlite_table(session_maker, engine, States)
+    assert migration.rebuild_sqlite_table(session_maker, engine, States) is True
 
     with session_scope(session=session_maker()) as session:
         assert session.query(States).count() == 1
@@ -776,13 +776,13 @@ def test_rebuild_sqlite_states_table_missing_fails(
         session.connection().execute(text("DROP TABLE states"))
         session.commit()
 
-    migration.rebuild_sqlite_table(session_maker, engine, States)
+    assert migration.rebuild_sqlite_table(session_maker, engine, States) is False
     assert "Error recreating SQLite table states" in caplog.text
     caplog.clear()
 
     # Now rebuild the events table to make sure the database did not
     # get corrupted
-    migration.rebuild_sqlite_table(session_maker, engine, Events)
+    assert migration.rebuild_sqlite_table(session_maker, engine, Events) is True
 
     with session_scope(session=session_maker()) as session:
         assert session.query(Events).count() == 1
@@ -812,7 +812,7 @@ def test_rebuild_sqlite_states_table_extra_columns(
             text("ALTER TABLE states ADD COLUMN extra_column TEXT")
         )
 
-    migration.rebuild_sqlite_table(session_maker, engine, States)
+    assert migration.rebuild_sqlite_table(session_maker, engine, States) is True
     assert "Error recreating SQLite table states" not in caplog.text
 
     with session_scope(session=session_maker()) as session:

--- a/tests/components/recorder/test_migrate.py
+++ b/tests/components/recorder/test_migrate.py
@@ -905,7 +905,7 @@ def test_drop_restore_foreign_key_constraints(recorder_db_url: str) -> None:
             for table, column in constraints_to_recreate
             for dropped_constraint in migration._drop_foreign_key_constraints(
                 session_maker, engine, table, column
-            )
+            )[1]
         ]
     assert dropped_constraints_1 == expected_dropped_constraints[db_engine]
 
@@ -917,7 +917,7 @@ def test_drop_restore_foreign_key_constraints(recorder_db_url: str) -> None:
             for table, column in constraints_to_recreate
             for dropped_constraint in migration._drop_foreign_key_constraints(
                 session_maker, engine, table, column
-            )
+            )[1]
         ]
     assert dropped_constraints_2 == []
 
@@ -936,7 +936,7 @@ def test_drop_restore_foreign_key_constraints(recorder_db_url: str) -> None:
             for table, column in constraints_to_recreate
             for dropped_constraint in migration._drop_foreign_key_constraints(
                 session_maker, engine, table, column
-            )
+            )[1]
         ]
     assert dropped_constraints_3 == expected_dropped_constraints[db_engine]
 

--- a/tests/components/recorder/test_v32_migration.py
+++ b/tests/components/recorder/test_v32_migration.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import pytest
 from sqlalchemy import create_engine, inspect
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from homeassistant.components import recorder
@@ -441,6 +442,171 @@ async def test_migrate_can_resume_ix_states_event_id_removed(
         assert instance.use_legacy_events_index is False
         assert "ix_states_entity_id_last_updated_ts" not in states_index_names
         assert "ix_states_event_id" not in states_index_names
+        assert await instance.async_add_executor_job(_get_event_id_foreign_keys) is None
+
+        await hass.async_stop()
+
+
+@pytest.mark.parametrize("enable_migrate_event_ids", [True])
+@pytest.mark.parametrize("persistent_database", [True])
+@pytest.mark.usefixtures("hass_storage")  # Prevent test hass from writing to storage
+async def test_out_of_disk_space_while_rebuild_states_table(
+    async_test_recorder: RecorderInstanceGenerator,
+    caplog: pytest.LogCaptureFixture,
+    recorder_db_url: str,
+) -> None:
+    """Test that we can recover from out of disk space while rebuilding the states table.
+
+    This case tests the migration still happens if
+    ix_states_event_id is removed from the states table.
+    """
+    importlib.import_module(SCHEMA_MODULE)
+    old_db_schema = sys.modules[SCHEMA_MODULE]
+    now = dt_util.utcnow()
+    one_second_past = now - timedelta(seconds=1)
+    mock_state = State(
+        "sensor.test",
+        "old",
+        {"last_reset": now.isoformat()},
+        last_changed=one_second_past,
+        last_updated=now,
+    )
+    state_changed_event = Event(
+        EVENT_STATE_CHANGED,
+        {
+            "entity_id": "sensor.test",
+            "old_state": None,
+            "new_state": mock_state,
+        },
+        EventOrigin.local,
+        time_fired_timestamp=now.timestamp(),
+    )
+    custom_event = Event(
+        "custom_event",
+        {"entity_id": "sensor.custom"},
+        EventOrigin.local,
+        time_fired_timestamp=now.timestamp(),
+    )
+    number_of_migrations = 5
+
+    def _get_event_id_foreign_keys():
+        assert instance.engine is not None
+        return next(
+            (
+                fk  # type: ignore[misc]
+                for fk in inspect(instance.engine).get_foreign_keys("states")
+                if fk["constrained_columns"] == ["event_id"]
+            ),
+            None,
+        )
+
+    def _get_states_index_names():
+        with session_scope(hass=hass) as session:
+            return inspect(session.connection()).get_indexes("states")
+
+    with (
+        patch.object(recorder, "db_schema", old_db_schema),
+        patch.object(
+            recorder.migration, "SCHEMA_VERSION", old_db_schema.SCHEMA_VERSION
+        ),
+        patch.object(core, "StatesMeta", old_db_schema.StatesMeta),
+        patch.object(core, "EventTypes", old_db_schema.EventTypes),
+        patch.object(core, "EventData", old_db_schema.EventData),
+        patch.object(core, "States", old_db_schema.States),
+        patch.object(core, "Events", old_db_schema.Events),
+        patch(CREATE_ENGINE_TARGET, new=_create_engine_test),
+        patch("homeassistant.components.recorder.Recorder._post_migrate_entity_ids"),
+        patch(
+            "homeassistant.components.recorder.migration.cleanup_legacy_states_event_ids"
+        ),
+    ):
+        async with (
+            async_test_home_assistant() as hass,
+            async_test_recorder(hass) as instance,
+        ):
+            await hass.async_block_till_done()
+            await async_wait_recording_done(hass)
+            await async_wait_recording_done(hass)
+
+            def _add_data():
+                with session_scope(hass=hass) as session:
+                    session.add(old_db_schema.Events.from_event(custom_event))
+                    session.add(old_db_schema.States.from_event(state_changed_event))
+
+            await instance.async_add_executor_job(_add_data)
+            await hass.async_block_till_done()
+            await instance.async_block_till_done()
+
+            await instance.async_add_executor_job(
+                migration._drop_index,
+                instance.get_session,
+                "states",
+                "ix_states_event_id",
+            )
+
+            states_indexes = await instance.async_add_executor_job(
+                _get_states_index_names
+            )
+            states_index_names = {index["name"] for index in states_indexes}
+            assert instance.use_legacy_events_index is True
+            assert (
+                await instance.async_add_executor_job(_get_event_id_foreign_keys)
+                is not None
+            )
+
+            await hass.async_stop()
+            await hass.async_block_till_done()
+
+    assert "ix_states_entity_id_last_updated_ts" in states_index_names
+
+    # Simulate out of disk space while rebuilding the states table by
+    # patching CreateTable to raise an exception
+    with patch(
+        "homeassistant.components.recorder.migration.CreateTable",
+        side_effect=SQLAlchemyError,
+    ):
+        async with (
+            async_test_home_assistant() as hass,
+            async_test_recorder(hass) as instance,
+        ):
+            await hass.async_block_till_done()
+
+            # We need to wait for all the migration tasks to complete
+            # before we can check the database.
+            for _ in range(number_of_migrations):
+                await instance.async_block_till_done()
+                await async_wait_recording_done(hass)
+
+            states_indexes = await instance.async_add_executor_job(
+                _get_states_index_names
+            )
+            states_index_names = {index["name"] for index in states_indexes}
+            assert instance.use_legacy_events_index is True
+            assert "Error recreating SQLite table states" in caplog.text
+            assert await instance.async_add_executor_job(_get_event_id_foreign_keys)
+
+            await hass.async_stop()
+
+    # Now run it again to verify the table rebuild tries again
+    caplog.clear()
+    async with (
+        async_test_home_assistant() as hass,
+        async_test_recorder(hass) as instance,
+    ):
+        await hass.async_block_till_done()
+
+        # We need to wait for all the migration tasks to complete
+        # before we can check the database.
+        for _ in range(number_of_migrations):
+            await instance.async_block_till_done()
+            await async_wait_recording_done(hass)
+
+        states_indexes = await instance.async_add_executor_job(_get_states_index_names)
+        states_index_names = {index["name"] for index in states_indexes}
+        assert instance.use_legacy_events_index is False
+        assert "ix_states_entity_id_last_updated_ts" not in states_index_names
+        assert "ix_states_event_id" not in states_index_names
+        assert "Rebuilding SQLite table states finished" in caplog.text
         assert await instance.async_add_executor_job(_get_event_id_foreign_keys) is None
 
         await hass.async_stop()

--- a/tests/components/recorder/test_v32_migration.py
+++ b/tests/components/recorder/test_v32_migration.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 import pytest
 from sqlalchemy import create_engine, inspect
-from sqlalchemy.exc import InternalError, SQLAlchemyError
+from sqlalchemy.exc import OperationalError, SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from homeassistant.components import recorder
@@ -569,7 +569,9 @@ async def test_out_of_disk_space_while_rebuild_states_table(
         ),
         patch(
             "homeassistant.components.recorder.migration.DropConstraint",
-            side_effect=InternalError,
+            side_effect=OperationalError(
+                None, None, OSError("No space left on device")
+            ),
         ),
     ):
         async with (

--- a/tests/components/recorder/test_v32_migration.py
+++ b/tests/components/recorder/test_v32_migration.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 import pytest
 from sqlalchemy import create_engine, inspect
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.exc import InternalError, SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from homeassistant.components import recorder
@@ -560,8 +560,8 @@ async def test_out_of_disk_space_while_rebuild_states_table(
     assert "ix_states_entity_id_last_updated_ts" in states_index_names
 
     # Simulate out of disk space while rebuilding the states table by
-    # - patching CreateTable to raise an exception for SQLite
-    # - patching DropConstraint to raise an exception for MySQL and PostgreSQL
+    # - patching CreateTable to raise SQLAlchemyError for SQLite
+    # - patching DropConstraint to raise InternalError for MySQL and PostgreSQL
     with (
         patch(
             "homeassistant.components.recorder.migration.CreateTable",
@@ -569,7 +569,7 @@ async def test_out_of_disk_space_while_rebuild_states_table(
         ),
         patch(
             "homeassistant.components.recorder.migration.DropConstraint",
-            side_effect=SQLAlchemyError,
+            side_effect=InternalError,
         ),
     ):
         async with (

--- a/tests/components/recorder/test_v32_migration.py
+++ b/tests/components/recorder/test_v32_migration.py
@@ -447,10 +447,10 @@ async def test_migrate_can_resume_ix_states_event_id_removed(
         await hass.async_stop()
 
 
+@pytest.mark.skip_on_db_engine(["mysql", "postgresql"])
 @pytest.mark.parametrize("enable_migrate_event_ids", [True])
 @pytest.mark.parametrize("persistent_database", [True])
 @pytest.mark.usefixtures("hass_storage")  # Prevent test hass from writing to storage
-@pytest.mark.skip_on_db_engine(["mysql", "postgresql"])
 async def test_out_of_disk_space_while_rebuild_states_table(
     async_test_recorder: RecorderInstanceGenerator,
     caplog: pytest.LogCaptureFixture,
@@ -622,10 +622,10 @@ async def test_out_of_disk_space_while_rebuild_states_table(
         await hass.async_stop()
 
 
+@pytest.mark.skip_on_db_engine(["sqlite"])
 @pytest.mark.parametrize("enable_migrate_event_ids", [True])
 @pytest.mark.parametrize("persistent_database", [True])
 @pytest.mark.usefixtures("hass_storage")  # Prevent test hass from writing to storage
-@pytest.mark.skip_on_db_engine(["sqlite"])
 async def test_out_of_disk_space_while_removing_foreign_key(
     async_test_recorder: RecorderInstanceGenerator,
     caplog: pytest.LogCaptureFixture,

--- a/tests/components/recorder/test_v32_migration.py
+++ b/tests/components/recorder/test_v32_migration.py
@@ -450,6 +450,7 @@ async def test_migrate_can_resume_ix_states_event_id_removed(
 @pytest.mark.parametrize("enable_migrate_event_ids", [True])
 @pytest.mark.parametrize("persistent_database", [True])
 @pytest.mark.usefixtures("hass_storage")  # Prevent test hass from writing to storage
+@pytest.mark.skip_on_db_engine(["mysql", "postgresql"])
 async def test_out_of_disk_space_while_rebuild_states_table(
     async_test_recorder: RecorderInstanceGenerator,
     caplog: pytest.LogCaptureFixture,
@@ -616,6 +617,174 @@ async def test_out_of_disk_space_while_rebuild_states_table(
         assert "ix_states_entity_id_last_updated_ts" not in states_index_names
         assert "ix_states_event_id" not in states_index_names
         assert "Rebuilding SQLite table states finished" in caplog.text
+        assert await instance.async_add_executor_job(_get_event_id_foreign_keys) is None
+
+        await hass.async_stop()
+
+
+@pytest.mark.parametrize("enable_migrate_event_ids", [True])
+@pytest.mark.parametrize("persistent_database", [True])
+@pytest.mark.usefixtures("hass_storage")  # Prevent test hass from writing to storage
+@pytest.mark.skip_on_db_engine(["sqlite"])
+async def test_out_of_disk_space_while_removing_foreign_key(
+    async_test_recorder: RecorderInstanceGenerator,
+    caplog: pytest.LogCaptureFixture,
+    recorder_db_url: str,
+) -> None:
+    """Test that we can recover from out of disk space while removing the foreign key.
+
+    This case tests the migration still happens if
+    ix_states_event_id is removed from the states table.
+    """
+    importlib.import_module(SCHEMA_MODULE)
+    old_db_schema = sys.modules[SCHEMA_MODULE]
+    now = dt_util.utcnow()
+    one_second_past = now - timedelta(seconds=1)
+    mock_state = State(
+        "sensor.test",
+        "old",
+        {"last_reset": now.isoformat()},
+        last_changed=one_second_past,
+        last_updated=now,
+    )
+    state_changed_event = Event(
+        EVENT_STATE_CHANGED,
+        {
+            "entity_id": "sensor.test",
+            "old_state": None,
+            "new_state": mock_state,
+        },
+        EventOrigin.local,
+        time_fired_timestamp=now.timestamp(),
+    )
+    custom_event = Event(
+        "custom_event",
+        {"entity_id": "sensor.custom"},
+        EventOrigin.local,
+        time_fired_timestamp=now.timestamp(),
+    )
+    number_of_migrations = 5
+
+    def _get_event_id_foreign_keys():
+        assert instance.engine is not None
+        return next(
+            (
+                fk  # type: ignore[misc]
+                for fk in inspect(instance.engine).get_foreign_keys("states")
+                if fk["constrained_columns"] == ["event_id"]
+            ),
+            None,
+        )
+
+    def _get_states_index_names():
+        with session_scope(hass=hass) as session:
+            return inspect(session.connection()).get_indexes("states")
+
+    with (
+        patch.object(recorder, "db_schema", old_db_schema),
+        patch.object(
+            recorder.migration, "SCHEMA_VERSION", old_db_schema.SCHEMA_VERSION
+        ),
+        patch.object(core, "StatesMeta", old_db_schema.StatesMeta),
+        patch.object(core, "EventTypes", old_db_schema.EventTypes),
+        patch.object(core, "EventData", old_db_schema.EventData),
+        patch.object(core, "States", old_db_schema.States),
+        patch.object(core, "Events", old_db_schema.Events),
+        patch(CREATE_ENGINE_TARGET, new=_create_engine_test),
+        patch("homeassistant.components.recorder.Recorder._post_migrate_entity_ids"),
+        patch(
+            "homeassistant.components.recorder.migration.cleanup_legacy_states_event_ids"
+        ),
+    ):
+        async with (
+            async_test_home_assistant() as hass,
+            async_test_recorder(hass) as instance,
+        ):
+            await hass.async_block_till_done()
+            await async_wait_recording_done(hass)
+            await async_wait_recording_done(hass)
+
+            def _add_data():
+                with session_scope(hass=hass) as session:
+                    session.add(old_db_schema.Events.from_event(custom_event))
+                    session.add(old_db_schema.States.from_event(state_changed_event))
+
+            await instance.async_add_executor_job(_add_data)
+            await hass.async_block_till_done()
+            await instance.async_block_till_done()
+
+            await instance.async_add_executor_job(
+                migration._drop_index,
+                instance.get_session,
+                "states",
+                "ix_states_event_id",
+            )
+
+            states_indexes = await instance.async_add_executor_job(
+                _get_states_index_names
+            )
+            states_index_names = {index["name"] for index in states_indexes}
+            assert instance.use_legacy_events_index is True
+            assert (
+                await instance.async_add_executor_job(_get_event_id_foreign_keys)
+                is not None
+            )
+
+            await hass.async_stop()
+            await hass.async_block_till_done()
+
+    assert "ix_states_entity_id_last_updated_ts" in states_index_names
+
+    # Simulate out of disk space while removing the foreign key from the states table by
+    # - patching DropConstraint to raise InternalError for MySQL and PostgreSQL
+    with (
+        patch(
+            "homeassistant.components.recorder.migration.DropConstraint",
+            side_effect=OperationalError(
+                None, None, OSError("No space left on device")
+            ),
+        ),
+    ):
+        async with (
+            async_test_home_assistant() as hass,
+            async_test_recorder(hass) as instance,
+        ):
+            await hass.async_block_till_done()
+
+            # We need to wait for all the migration tasks to complete
+            # before we can check the database.
+            for _ in range(number_of_migrations):
+                await instance.async_block_till_done()
+                await async_wait_recording_done(hass)
+
+            states_indexes = await instance.async_add_executor_job(
+                _get_states_index_names
+            )
+            states_index_names = {index["name"] for index in states_indexes}
+            assert instance.use_legacy_events_index is True
+            assert await instance.async_add_executor_job(_get_event_id_foreign_keys)
+
+            await hass.async_stop()
+
+    # Now run it again to verify the table rebuild tries again
+    caplog.clear()
+    async with (
+        async_test_home_assistant() as hass,
+        async_test_recorder(hass) as instance,
+    ):
+        await hass.async_block_till_done()
+
+        # We need to wait for all the migration tasks to complete
+        # before we can check the database.
+        for _ in range(number_of_migrations):
+            await instance.async_block_till_done()
+            await async_wait_recording_done(hass)
+
+        states_indexes = await instance.async_add_executor_job(_get_states_index_names)
+        states_index_names = {index["name"] for index in states_indexes}
+        assert instance.use_legacy_events_index is False
+        assert "ix_states_entity_id_last_updated_ts" not in states_index_names
+        assert "ix_states_event_id" not in states_index_names
         assert await instance.async_add_executor_job(_get_event_id_foreign_keys) is None
 
         await hass.async_stop()

--- a/tests/components/recorder/test_v32_migration.py
+++ b/tests/components/recorder/test_v32_migration.py
@@ -560,10 +560,17 @@ async def test_out_of_disk_space_while_rebuild_states_table(
     assert "ix_states_entity_id_last_updated_ts" in states_index_names
 
     # Simulate out of disk space while rebuilding the states table by
-    # patching CreateTable to raise an exception
-    with patch(
-        "homeassistant.components.recorder.migration.CreateTable",
-        side_effect=SQLAlchemyError,
+    # - patching CreateTable to raise an exception for SQLite
+    # - patching DropConstraint to raise an exception for MySQL and PostgreSQL
+    with (
+        patch(
+            "homeassistant.components.recorder.migration.CreateTable",
+            side_effect=SQLAlchemyError,
+        ),
+        patch(
+            "homeassistant.components.recorder.migration.DropConstraint",
+            side_effect=SQLAlchemyError,
+        ),
     ):
         async with (
             async_test_home_assistant() as hass,

--- a/tests/components/recorder/test_v32_migration.py
+++ b/tests/components/recorder/test_v32_migration.py
@@ -447,6 +447,7 @@ async def test_migrate_can_resume_ix_states_event_id_removed(
         await hass.async_stop()
 
 
+@pytest.mark.usefixtures("skip_by_db_engine")
 @pytest.mark.skip_on_db_engine(["mysql", "postgresql"])
 @pytest.mark.parametrize("enable_migrate_event_ids", [True])
 @pytest.mark.parametrize("persistent_database", [True])
@@ -622,6 +623,7 @@ async def test_out_of_disk_space_while_rebuild_states_table(
         await hass.async_stop()
 
 
+@pytest.mark.usefixtures("skip_by_db_engine")
 @pytest.mark.skip_on_db_engine(["sqlite"])
 @pytest.mark.parametrize("enable_migrate_event_ids", [True])
 @pytest.mark.parametrize("persistent_database", [True])


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If the system ran out of disk space removing the FK, it would fail. #121938 fixed that to try again, however that PR was made ineffective by #122069 since it will never reach the check since it no longer checks every time as the migration version is already set in the table.

To solve this, the migration version is incremented to 2, and the migration is no longer marked as done unless the rebuild /fk removal is successful.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #123348
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
