### PR TITLE
Also migrate dsmr entries for devices with correct serial

### DIFF
--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -431,41 +431,42 @@ def rename_old_gas_to_mbus(
 ) -> None:
     """Rename old gas sensor to mbus variant."""
     dev_reg = dr.async_get(hass)
-    device_entry_v1 = dev_reg.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
-    if device_entry_v1 is not None:
-        device_id = device_entry_v1.id
+    for dev_id in (mbus_device_id, entry.entry_id):
+        device_entry_v1 = dev_reg.async_get_device(identifiers={(DOMAIN, dev_id)})
+        if device_entry_v1 is not None:
+            device_id = device_entry_v1.id
 
-        ent_reg = er.async_get(hass)
-        entries = er.async_entries_for_device(ent_reg, device_id)
+            ent_reg = er.async_get(hass)
+            entries = er.async_entries_for_device(ent_reg, device_id)
 
-        for entity in entries:
-            if entity.unique_id.endswith(
-                "belgium_5min_gas_meter_reading"
-            ) or entity.unique_id.endswith("hourly_gas_meter_reading"):
-                try:
-                    ent_reg.async_update_entity(
-                        entity.entity_id,
-                        new_unique_id=mbus_device_id,
-                        device_id=mbus_device_id,
-                    )
-                except ValueError:
-                    LOGGER.debug(
-                        "Skip migration of %s because it already exists",
-                        entity.entity_id,
-                    )
-                else:
-                    LOGGER.debug(
-                        "Migrated entity %s from unique id %s to %s",
-                        entity.entity_id,
-                        entity.unique_id,
-                        mbus_device_id,
-                    )
-        # Cleanup old device
-        dev_entities = er.async_entries_for_device(
-            ent_reg, device_id, include_disabled_entities=True
-        )
-        if not dev_entities:
-            dev_reg.async_remove_device(device_id)
+            for entity in entries:
+                if entity.unique_id.endswith(
+                    "belgium_5min_gas_meter_reading"
+                ) or entity.unique_id.endswith("hourly_gas_meter_reading"):
+                    try:
+                        ent_reg.async_update_entity(
+                            entity.entity_id,
+                            new_unique_id=mbus_device_id,
+                            device_id=mbus_device_id,
+                        )
+                    except ValueError:
+                        LOGGER.debug(
+                            "Skip migration of %s because it already exists",
+                            entity.entity_id,
+                        )
+                    else:
+                        LOGGER.debug(
+                            "Migrated entity %s from unique id %s to %s",
+                            entity.entity_id,
+                            entity.unique_id,
+                            mbus_device_id,
+                        )
+            # Cleanup old device
+            dev_entities = er.async_entries_for_device(
+                ent_reg, device_id, include_disabled_entities=True
+            )
+            if not dev_entities:
+                dev_reg.async_remove_device(device_id)
 
 
 def is_supported_description(

--- a/tests/components/dsmr/test_mbus_migration.py
+++ b/tests/components/dsmr/test_mbus_migration.py
@@ -219,6 +219,101 @@ async def test_migrate_hourly_gas_to_mbus(
     )
 
 
+async def test_migrate_gas_with_devid_to_mbus(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    dsmr_connection_fixture: tuple[MagicMock, MagicMock, MagicMock],
+) -> None:
+    """Test migration of unique_id."""
+    (connection_factory, transport, protocol) = dsmr_connection_fixture
+
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="/dev/ttyUSB0",
+        data={
+            "port": "/dev/ttyUSB0",
+            "dsmr_version": "5B",
+            "serial_id": "1234",
+            "serial_id_gas": "37464C4F32313139303333373331",
+        },
+        options={
+            "time_between_update": 0,
+        },
+    )
+
+    mock_entry.add_to_hass(hass)
+
+    old_unique_id = "37464C4F32313139303333373331_belgium_5min_gas_meter_reading"
+
+    device = device_registry.async_get_or_create(
+        config_entry_id=mock_entry.entry_id,
+        identifiers={(DOMAIN, "37464C4F32313139303333373331")},
+        name="Gas Meter",
+    )
+    await hass.async_block_till_done()
+
+    entity: er.RegistryEntry = entity_registry.async_get_or_create(
+        suggested_object_id="gas_meter_reading",
+        disabled_by=None,
+        domain=SENSOR_DOMAIN,
+        platform=DOMAIN,
+        device_id=device.id,
+        unique_id=old_unique_id,
+        config_entry=mock_entry,
+    )
+    assert entity.unique_id == old_unique_id
+    await hass.async_block_till_done()
+
+    telegram = Telegram()
+    telegram.add(
+        MBUS_DEVICE_TYPE,
+        CosemObject((0, 1), [{"value": "003", "unit": ""}]),
+        "MBUS_DEVICE_TYPE",
+    )
+    telegram.add(
+        MBUS_EQUIPMENT_IDENTIFIER,
+        CosemObject(
+            (0, 1),
+            [{"value": "37464C4F32313139303333373331", "unit": ""}],
+        ),
+        "MBUS_EQUIPMENT_IDENTIFIER",
+    )
+    telegram.add(
+        MBUS_METER_READING,
+        MBusObject(
+            (0, 1),
+            [
+                {"value": datetime.datetime.fromtimestamp(1551642213)},
+                {"value": Decimal(745.695), "unit": "m3"},
+            ],
+        ),
+        "MBUS_METER_READING",
+    )
+
+    assert await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    telegram_callback = connection_factory.call_args_list[0][0][2]
+
+    # simulate a telegram pushed from the smartmeter and parsed by dsmr_parser
+    telegram_callback(telegram)
+
+    # after receiving telegram entities need to have the chance to be created
+    await hass.async_block_till_done()
+
+    assert (
+        entity_registry.async_get_entity_id(SENSOR_DOMAIN, DOMAIN, old_unique_id)
+        is None
+    )
+    assert (
+        entity_registry.async_get_entity_id(
+            SENSOR_DOMAIN, DOMAIN, "37464C4F32313139303333373331"
+        )
+        == "sensor.gas_meter_reading"
+    )
+
+
 async def test_migrate_gas_to_mbus_exists(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,


### PR DESCRIPTION
When the dsmr code could not find the serial_nr for the gas meter, it creates the gas meter device with the entry_id as identifier.

But when there is a correct serial_nr, it will use that as identifier for the dsmr gas device.

Now the migration code did not take this into account, so migration to the new name failed since it didn't look for the device with correct serial_nr.

This commit fixes this and adds a test for this.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #123121
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
