### PR TITLE
Allow manual deletion of stale Schlage devices

### DIFF
--- a/homeassistant/components/schlage/__init__.py
+++ b/homeassistant/components/schlage/__init__.py
@@ -9,6 +9,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.device_registry import DeviceEntry
 
 from .const import DOMAIN
 from .coordinator import SchlageDataUpdateCoordinator
@@ -43,3 +44,13 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: DeviceEntry
+) -> bool:
+    """Remove config entry from a device if it's no longer present."""
+    coordinator: SchlageDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    return not device_entry.identifiers.intersection(
+        (DOMAIN, device_id) for device_id in coordinator.data.locks
+    )

--- a/homeassistant/components/schlage/binary_sensor.py
+++ b/homeassistant/components/schlage/binary_sensor.py
@@ -75,4 +75,6 @@ class SchlageBinarySensor(SchlageEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool | None:
         """Return true if the binary_sensor is on."""
+        if self._lock_data is None:
+            return None
         return self.entity_description.value_fn(self._lock_data)

--- a/homeassistant/components/schlage/lock.py
+++ b/homeassistant/components/schlage/lock.py
@@ -47,16 +47,19 @@ class SchlageLockEntity(SchlageEntity, LockEntity):
 
     def _update_attrs(self) -> None:
         """Update our internal state attributes."""
-        self._attr_is_locked = self._lock.is_locked
-        self._attr_is_jammed = self._lock.is_jammed
-        self._attr_changed_by = self._lock.last_changed_by()
+        self._attr_is_locked = self._lock.is_locked if self._lock else None
+        self._attr_is_jammed = self._lock.is_jammed if self._lock else None
+        if self._lock:
+            self._attr_changed_by = self._lock.last_changed_by()
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the device."""
+        assert self._lock is not None
         await self.hass.async_add_executor_job(self._lock.lock)
         await self.coordinator.async_request_refresh()
 
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the device."""
+        assert self._lock is not None
         await self.hass.async_add_executor_job(self._lock.unlock)
         await self.coordinator.async_request_refresh()

--- a/homeassistant/components/schlage/sensor.py
+++ b/homeassistant/components/schlage/sensor.py
@@ -64,5 +64,6 @@ class SchlageBatterySensor(SchlageEntity, SensorEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        self._attr_native_value = getattr(self._lock, self.entity_description.key)
+        if self._lock is not None:
+            self._attr_native_value = getattr(self._lock, self.entity_description.key)
         return super()._handle_coordinator_update()

--- a/homeassistant/components/schlage/switch.py
+++ b/homeassistant/components/schlage/switch.py
@@ -90,12 +90,15 @@ class SchlageSwitch(SchlageEntity, SwitchEntity):
         self._attr_unique_id = f"{device_id}_{self.entity_description.key}"
 
     @property
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """Return True if the switch is on."""
+        if self._lock is None:
+            return None
         return self.entity_description.value_fn(self._lock)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
+        assert self._lock is not None
         await self.hass.async_add_executor_job(
             partial(self.entity_description.on_fn, self._lock)
         )
@@ -103,6 +106,7 @@ class SchlageSwitch(SchlageEntity, SwitchEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
+        assert self._lock is not None
         await self.hass.async_add_executor_job(
             partial(self.entity_description.off_fn, self._lock)
         )


### PR DESCRIPTION
## Proposed change
This enables the manual device delete action in the UI by implementing `async_remove_config_entry_device`. In the process, some bugs were also addressed in the case where a lock is no longer returned by the API (e.g. if the user removes it via the Schlage app)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #123396
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
