### PR TITLE
Simplify vehicle polling in Tessie

### DIFF
--- a/homeassistant/components/tessie/coordinator.py
+++ b/homeassistant/components/tessie/coordinator.py
@@ -16,7 +16,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import TessieStatus
+from .const import TessieState
 
 # This matches the update interval Tessie performs server side
 TESSIE_SYNC_INTERVAL = 10
@@ -62,7 +62,7 @@ class TessieStateUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Tessie always returns cached data with a status of "online"
         # We need to check the timestamp to determine if the vehicle is actually asleep
         if data["vehicle_state"]["timestamp"] < (time() - 60) * 1000:
-            data["state"] = TessieStatus.ASLEEP
+            data["state"] = TessieState.ASLEEP
 
         self.data = flatten(data)
 
@@ -84,7 +84,7 @@ class TessieStateUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Tessie always returns cached data with a status of "online"
         # We need to check the timestamp to determine if the vehicle is actually asleep
         if vehicle["vehicle_state"]["timestamp"] < (time() - 60) * 1000:
-            vehicle["state"] = TessieStatus.ASLEEP
+            vehicle["state"] = TessieState.ASLEEP
 
         return flatten(vehicle)
 

--- a/homeassistant/components/tessie/coordinator.py
+++ b/homeassistant/components/tessie/coordinator.py
@@ -58,6 +58,12 @@ class TessieStateUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.api_key = api_key
         self.vin = vin
         self.session = async_get_clientsession(hass)
+
+        # Tessie always returns cached data with a status of "online"
+        # We need to check the timestamp to determine if the vehicle is actually asleep
+        if data["vehicle_state"]["timestamp"] < (time() - 60) * 1000:
+            data["state"] = TessieStatus.ASLEEP
+
         self.data = flatten(data)
 
     async def _async_update_data(self) -> dict[str, Any]:

--- a/homeassistant/components/tessie/coordinator.py
+++ b/homeassistant/components/tessie/coordinator.py
@@ -3,12 +3,13 @@
 from datetime import timedelta
 from http import HTTPStatus
 import logging
+from time import time
 from typing import Any
 
 from aiohttp import ClientResponseError
 from tesla_fleet_api import EnergySpecific
 from tesla_fleet_api.exceptions import InvalidToken, MissingToken, TeslaFleetError
-from tessie_api import get_state, get_status
+from tessie_api import get_state
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
@@ -62,16 +63,6 @@ class TessieStateUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def _async_update_data(self) -> dict[str, Any]:
         """Update vehicle data using Tessie API."""
         try:
-            status = await get_status(
-                session=self.session,
-                api_key=self.api_key,
-                vin=self.vin,
-            )
-            if status["status"] == TessieStatus.ASLEEP:
-                # Vehicle is asleep, no need to poll for data
-                self.data["state"] = status["status"]
-                return self.data
-
             vehicle = await get_state(
                 session=self.session,
                 api_key=self.api_key,
@@ -83,6 +74,11 @@ class TessieStateUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 # Auth Token is no longer valid
                 raise ConfigEntryAuthFailed from e
             raise
+
+        # Tessie always returns cached data with a status of "online"
+        # We need to check the timestamp to determine if the vehicle is actually asleep
+        if vehicle["vehicle_state"]["timestamp"] < (time() - 60) * 1000:
+            vehicle["state"] = TessieStatus.ASLEEP
 
         return flatten(vehicle)
 

--- a/tests/components/tessie/conftest.py
+++ b/tests/components/tessie/conftest.py
@@ -18,7 +18,6 @@ from .common import (
 )
 
 
-# Tessie
 @pytest.fixture(autouse=True)
 def mock_get_state():
     """Mock get_state function."""

--- a/tests/components/tessie/conftest.py
+++ b/tests/components/tessie/conftest.py
@@ -15,12 +15,10 @@ from .common import (
     SITE_INFO,
     TEST_STATE_OF_ALL_VEHICLES,
     TEST_VEHICLE_STATE_ONLINE,
-    TEST_VEHICLE_STATUS_AWAKE,
 )
 
+
 # Tessie
-
-
 @pytest.fixture(autouse=True)
 def mock_get_state():
     """Mock get_state function."""
@@ -29,16 +27,6 @@ def mock_get_state():
         return_value=TEST_VEHICLE_STATE_ONLINE,
     ) as mock_get_state:
         yield mock_get_state
-
-
-@pytest.fixture(autouse=True)
-def mock_get_status():
-    """Mock get_status function."""
-    with patch(
-        "homeassistant.components.tessie.coordinator.get_status",
-        return_value=TEST_VEHICLE_STATUS_AWAKE,
-    ) as mock_get_status:
-        yield mock_get_status
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/tessie/snapshots/test_binary_sensors.ambr
+++ b/tests/components/tessie/snapshots/test_binary_sensors.ambr
@@ -1069,7 +1069,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'on',
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensors[binary_sensor.test_tire_pressure_warning_front_left-entry]

--- a/tests/components/tessie/snapshots/test_diagnostics.ambr
+++ b/tests/components/tessie/snapshots/test_diagnostics.ambr
@@ -293,7 +293,7 @@
           'id': '**REDACTED**',
           'id_s': '**REDACTED**',
           'in_service': False,
-          'state': 'online',
+          'state': 'asleep',
           'tokens': '**REDACTED**',
           'user_id': '**REDACTED**',
           'vehicle_config_aux_park_lamps': 'Eu',

--- a/tests/components/tessie/test_coordinator.py
+++ b/tests/components/tessie/test_coordinator.py
@@ -1,6 +1,5 @@
 """Test the Tessie sensor platform."""
 
-from copy import deepcopy
 from datetime import timedelta
 from unittest.mock import AsyncMock
 
@@ -14,6 +13,7 @@ from homeassistant.components.tessie.coordinator import (
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 from .common import (
     ERROR_AUTH,
@@ -33,34 +33,37 @@ async def test_coordinator(
 ) -> None:
     """Tests that the coordinator updates vehicles."""
 
+    # Move to the fixtures timestamp
+    freezer.move_to(
+        dt_util.utc_from_timestamp(
+            TEST_VEHICLE_STATE_ONLINE["vehicle_state"]["timestamp"] / 1000
+        )
+    )
+
     await setup_platform(hass, [Platform.BINARY_SENSOR])
 
-    # Since the fixture data is old, the status will be offline
+    # The initial fixture state is offline
     assert hass.states.get("binary_sensor.test_status").state == STATE_OFF
 
     # Trigger a coordinator refresh
+    mock_get_state.reset_mock()
     freezer.tick(WAIT)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
     mock_get_state.assert_called_once()
 
-    # Since the fixture data is old, the status will be offline
-    assert hass.states.get("binary_sensor.test_status").state == STATE_OFF
-
-    # Update the fixture to be "current"
-    mock_get_state.reset_mock()
-    future = freezer.tick(WAIT)
-    data = deepcopy(TEST_VEHICLE_STATE_ONLINE)
-    data["vehicle_state"]["timestamp"] = int(future.timestamp() * 1000)
-    mock_get_state.return_value = data
+    # Since we moved to the date in the fixture, we will be online after a single wait
+    assert hass.states.get("binary_sensor.test_status").state == STATE_ON
 
     # Trigger a coordinator refresh
+    mock_get_state.reset_mock()
+    freezer.tick(timedelta(seconds=60))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
     mock_get_state.assert_called_once()
 
-    # Since the timestamp is now current, the state will be online
-    assert hass.states.get("binary_sensor.test_status").state == STATE_ON
+    # Since we have moved over 60 seconds past the fixture, we will be offline
+    assert hass.states.get("binary_sensor.test_status").state == STATE_OFF
 
 
 async def test_coordinator_clienterror(

--- a/tests/components/tessie/test_coordinator.py
+++ b/tests/components/tessie/test_coordinator.py
@@ -1,107 +1,82 @@
 """Test the Tessie sensor platform."""
 
 from datetime import timedelta
+from unittest.mock import AsyncMock
 
 from freezegun.api import FrozenDateTimeFactory
 from tesla_fleet_api.exceptions import Forbidden, InvalidToken
 
-from homeassistant.components.tessie import PLATFORMS
 from homeassistant.components.tessie.coordinator import (
     TESSIE_FLEET_API_SYNC_INTERVAL,
     TESSIE_SYNC_INTERVAL,
 )
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, Platform
+from homeassistant.const import STATE_OFF, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 
-from .common import (
-    ERROR_AUTH,
-    ERROR_CONNECTION,
-    ERROR_UNKNOWN,
-    TEST_VEHICLE_STATUS_ASLEEP,
-    setup_platform,
-)
+from .common import ERROR_AUTH, ERROR_CONNECTION, ERROR_UNKNOWN, setup_platform
 
 from tests.common import async_fire_time_changed
 
 WAIT = timedelta(seconds=TESSIE_SYNC_INTERVAL)
 
 
-async def test_coordinator_online(
-    hass: HomeAssistant, mock_get_state, mock_get_status, freezer: FrozenDateTimeFactory
-) -> None:
-    """Tests that the coordinator handles online vehicles."""
-
-    await setup_platform(hass, PLATFORMS)
-
-    freezer.tick(WAIT)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-    mock_get_status.assert_called_once()
-    mock_get_state.assert_called_once()
-    assert hass.states.get("binary_sensor.test_status").state == STATE_ON
-
-
-async def test_coordinator_asleep(
-    hass: HomeAssistant, mock_get_status, freezer: FrozenDateTimeFactory
-) -> None:
-    """Tests that the coordinator handles asleep vehicles."""
+async def test_coordinator(hass: HomeAssistant, freezer: FrozenDateTimeFactory) -> None:
+    """Tests that the coordinator updates vehicles."""
 
     await setup_platform(hass, [Platform.BINARY_SENSOR])
-    mock_get_status.return_value = TEST_VEHICLE_STATUS_ASLEEP
 
     freezer.tick(WAIT)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    mock_get_status.assert_called_once()
+
     assert hass.states.get("binary_sensor.test_status").state == STATE_OFF
 
 
 async def test_coordinator_clienterror(
-    hass: HomeAssistant, mock_get_status, freezer: FrozenDateTimeFactory
+    hass: HomeAssistant, mock_get_state: AsyncMock, freezer: FrozenDateTimeFactory
 ) -> None:
     """Tests that the coordinator handles client errors."""
 
-    mock_get_status.side_effect = ERROR_UNKNOWN
+    mock_get_state.side_effect = ERROR_UNKNOWN
     await setup_platform(hass, [Platform.BINARY_SENSOR])
 
     freezer.tick(WAIT)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    mock_get_status.assert_called_once()
+
     assert hass.states.get("binary_sensor.test_status").state == STATE_UNAVAILABLE
 
 
 async def test_coordinator_auth(
-    hass: HomeAssistant, mock_get_status, freezer: FrozenDateTimeFactory
+    hass: HomeAssistant, mock_get_state: AsyncMock, freezer: FrozenDateTimeFactory
 ) -> None:
     """Tests that the coordinator handles auth errors."""
 
-    mock_get_status.side_effect = ERROR_AUTH
+    mock_get_state.side_effect = ERROR_AUTH
     await setup_platform(hass, [Platform.BINARY_SENSOR])
 
     freezer.tick(WAIT)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    mock_get_status.assert_called_once()
 
 
 async def test_coordinator_connection(
-    hass: HomeAssistant, mock_get_status, freezer: FrozenDateTimeFactory
+    hass: HomeAssistant, mock_get_state: AsyncMock, freezer: FrozenDateTimeFactory
 ) -> None:
     """Tests that the coordinator handles connection errors."""
 
-    mock_get_status.side_effect = ERROR_CONNECTION
+    mock_get_state.side_effect = ERROR_CONNECTION
     await setup_platform(hass, [Platform.BINARY_SENSOR])
     freezer.tick(WAIT)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    mock_get_status.assert_called_once()
+
     assert hass.states.get("binary_sensor.test_status").state == STATE_UNAVAILABLE
 
 
 async def test_coordinator_live_error(
-    hass: HomeAssistant, mock_live_status, freezer: FrozenDateTimeFactory
+    hass: HomeAssistant, mock_live_status: AsyncMock, freezer: FrozenDateTimeFactory
 ) -> None:
     """Tests that the energy live coordinator handles fleet errors."""
 
@@ -117,7 +92,7 @@ async def test_coordinator_live_error(
 
 
 async def test_coordinator_info_error(
-    hass: HomeAssistant, mock_site_info, freezer: FrozenDateTimeFactory
+    hass: HomeAssistant, mock_site_info: AsyncMock, freezer: FrozenDateTimeFactory
 ) -> None:
     """Tests that the energy info coordinator handles fleet errors."""
 
@@ -135,7 +110,9 @@ async def test_coordinator_info_error(
     )
 
 
-async def test_coordinator_live_reauth(hass: HomeAssistant, mock_live_status) -> None:
+async def test_coordinator_live_reauth(
+    hass: HomeAssistant, mock_live_status: AsyncMock
+) -> None:
     """Tests that the energy live coordinator handles auth errors."""
 
     mock_live_status.side_effect = InvalidToken
@@ -143,7 +120,9 @@ async def test_coordinator_live_reauth(hass: HomeAssistant, mock_live_status) ->
     assert entry.state is ConfigEntryState.SETUP_ERROR
 
 
-async def test_coordinator_info_reauth(hass: HomeAssistant, mock_site_info) -> None:
+async def test_coordinator_info_reauth(
+    hass: HomeAssistant, mock_site_info: AsyncMock
+) -> None:
     """Tests that the energy info coordinator handles auth errors."""
 
     mock_site_info.side_effect = InvalidToken

--- a/tests/components/tessie/test_media_player.py
+++ b/tests/components/tessie/test_media_player.py
@@ -22,8 +22,6 @@ async def test_media_player(
     freezer: FrozenDateTimeFactory,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
-    mock_get_state,
-    mock_get_status,
 ) -> None:
     """Tests that the media player entity is correct when idle."""
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Speaking to the developer of Tessie, he suggested removing the status API call and simply observing the timestamp in the state response to identify when a vehicle is offline/asleep.

This PR removes the additional API call and simplifies the coordinator.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
