### PR TITLE
Add support for Levoit EverestAir air purifiers

### DIFF
--- a/homeassistant/components/vesync/const.py
+++ b/homeassistant/components/vesync/const.py
@@ -23,6 +23,7 @@ DEV_TYPE_TO_HA = {
     "Core300S": "fan",
     "Core400S": "fan",
     "Core600S": "fan",
+    "EverestAir": "fan",
     "Vital200S": "fan",
     "Vital100S": "fan",
     "ESD16": "walldimmer",
@@ -59,4 +60,9 @@ SKU_TO_BASE_DEVICE = {
     "LAP-V102S-AASR": "Vital100S",  # Alt ID Model Vital100S
     "LAP-V102S-WEU": "Vital100S",  # Alt ID Model Vital100S
     "LAP-V102S-WUK": "Vital100S",  # Alt ID Model Vital100S
+    "EverestAir": "EverestAir",
+    "LAP-EL551S-AUS": "EverestAir",  # Alt ID Model EverestAir
+    "LAP-EL551S-AEUR": "EverestAir",  # Alt ID Model EverestAir
+    "LAP-EL551S-WEU": "EverestAir",  # Alt ID Model EverestAir
+    "LAP-EL551S-WUS": "EverestAir",  # Alt ID Model EverestAir
 }

--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -25,6 +25,7 @@ _LOGGER = logging.getLogger(__name__)
 FAN_MODE_AUTO = "auto"
 FAN_MODE_SLEEP = "sleep"
 FAN_MODE_PET = "pet"
+FAN_MODE_TURBO = "turbo"
 
 PRESET_MODES = {
     "LV-PUR131S": [FAN_MODE_AUTO, FAN_MODE_SLEEP],
@@ -32,6 +33,7 @@ PRESET_MODES = {
     "Core300S": [FAN_MODE_AUTO, FAN_MODE_SLEEP],
     "Core400S": [FAN_MODE_AUTO, FAN_MODE_SLEEP],
     "Core600S": [FAN_MODE_AUTO, FAN_MODE_SLEEP],
+    "EverestAir": [FAN_MODE_AUTO, FAN_MODE_SLEEP, FAN_MODE_TURBO],
     "Vital200S": [FAN_MODE_AUTO, FAN_MODE_SLEEP, FAN_MODE_PET],
     "Vital100S": [FAN_MODE_AUTO, FAN_MODE_SLEEP, FAN_MODE_PET],
 }
@@ -41,6 +43,7 @@ SPEED_RANGE = {  # off is not included
     "Core300S": (1, 3),
     "Core400S": (1, 4),
     "Core600S": (1, 4),
+    "EverestAir": (1, 3),
     "Vital200S": (1, 4),
     "Vital100S": (1, 4),
 }
@@ -125,7 +128,7 @@ class VeSyncFanHA(VeSyncDevice, FanEntity):
     @property
     def preset_mode(self) -> str | None:
         """Get the current preset mode."""
-        if self.smartfan.mode in (FAN_MODE_AUTO, FAN_MODE_SLEEP):
+        if self.smartfan.mode in (FAN_MODE_AUTO, FAN_MODE_SLEEP, FAN_MODE_TURBO):
             return self.smartfan.mode
         return None
 
@@ -192,6 +195,8 @@ class VeSyncFanHA(VeSyncDevice, FanEntity):
             self.smartfan.sleep_mode()
         elif preset_mode == FAN_MODE_PET:
             self.smartfan.pet_mode()
+        elif preset_mode == FAN_MODE_TURBO:
+            self.smartfan.turbo_mode()
 
         self.schedule_update_ha_state()
 

--- a/homeassistant/components/vesync/sensor.py
+++ b/homeassistant/components/vesync/sensor.py
@@ -72,6 +72,7 @@ FILTER_LIFE_SUPPORTED = [
     "Core300S",
     "Core400S",
     "Core600S",
+    "EverestAir",
     "Vital100S",
     "Vital200S",
 ]
@@ -83,7 +84,14 @@ AIR_QUALITY_SUPPORTED = [
     "Vital100S",
     "Vital200S",
 ]
-PM25_SUPPORTED = ["Core300S", "Core400S", "Core600S", "Vital100S", "Vital200S"]
+PM25_SUPPORTED = [
+    "Core300S",
+    "Core400S",
+    "Core600S",
+    "EverestAir",
+    "Vital100S",
+    "Vital200S",
+]
 
 SENSORS: tuple[VeSyncSensorEntityDescription, ...] = (
     VeSyncSensorEntityDescription(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Adding initial support for Levoit EverestAir air purifiers.  Fan speeds 1-3, auto, sleep, and turbo work as expected, as does on/off, filter life remaining and PM2.5.  Support for PM1.0, PM10, and Air Quality % not included at this time.

Resolves a closed/stale issue: https://github.com/home-assistant/core/issues/99553


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #99553
- This PR is related to issue: https://github.com/webdjoe/pyvesync/issues/170
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/34221

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
