### PR TITLE
Revert "Remove ESPHome legacy entity naming"

### DIFF
--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -176,7 +176,6 @@ ENTITY_CATEGORIES: EsphomeEnumMapper[EsphomeEntityCategory, EntityCategory | Non
 class EsphomeEntity(Entity, Generic[_InfoT, _StateT]):
     """Define a base esphome entity."""
 
-    _attr_has_entity_name = True
     _attr_should_poll = False
     _static_info: _InfoT
     _state: _StateT
@@ -201,6 +200,25 @@ class EsphomeEntity(Entity, Generic[_InfoT, _StateT]):
         self._attr_device_info = DeviceInfo(
             connections={(dr.CONNECTION_NETWORK_MAC, device_info.mac_address)}
         )
+        #
+        # If `friendly_name` is set, we use the Friendly naming rules, if
+        # `friendly_name` is not set we make an exception to the naming rules for
+        # backwards compatibility and use the Legacy naming rules.
+        #
+        # Friendly naming
+        # - Friendly name is prepended to entity names
+        # - Device Name is prepended to entity ids
+        # - Entity id is constructed from device name and object id
+        #
+        # Legacy naming
+        # - Device name is not prepended to entity names
+        # - Device name is not prepended to entity ids
+        # - Entity id is constructed from entity name
+        #
+        if not device_info.friendly_name:
+            return
+        self._attr_has_entity_name = True
+        self.entity_id = f"{domain}.{device_info.name}_{entity_info.object_id}"
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""

--- a/tests/components/esphome/test_alarm_control_panel.py
+++ b/tests/components/esphome/test_alarm_control_panel.py
@@ -58,7 +58,7 @@ async def test_generic_alarm_control_panel_requires_code(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("alarm_control_panel.test_my_alarm_control_panel")
+    state = hass.states.get("alarm_control_panel.test_myalarm_control_panel")
     assert state is not None
     assert state.state == STATE_ALARM_ARMED_AWAY
 
@@ -66,7 +66,7 @@ async def test_generic_alarm_control_panel_requires_code(
         ALARM_CONTROL_PANEL_DOMAIN,
         SERVICE_ALARM_ARM_AWAY,
         {
-            ATTR_ENTITY_ID: "alarm_control_panel.test_my_alarm_control_panel",
+            ATTR_ENTITY_ID: "alarm_control_panel.test_myalarm_control_panel",
             ATTR_CODE: 1234,
         },
         blocking=True,
@@ -80,7 +80,7 @@ async def test_generic_alarm_control_panel_requires_code(
         ALARM_CONTROL_PANEL_DOMAIN,
         SERVICE_ALARM_ARM_CUSTOM_BYPASS,
         {
-            ATTR_ENTITY_ID: "alarm_control_panel.test_my_alarm_control_panel",
+            ATTR_ENTITY_ID: "alarm_control_panel.test_myalarm_control_panel",
             ATTR_CODE: 1234,
         },
         blocking=True,
@@ -94,7 +94,7 @@ async def test_generic_alarm_control_panel_requires_code(
         ALARM_CONTROL_PANEL_DOMAIN,
         SERVICE_ALARM_ARM_HOME,
         {
-            ATTR_ENTITY_ID: "alarm_control_panel.test_my_alarm_control_panel",
+            ATTR_ENTITY_ID: "alarm_control_panel.test_myalarm_control_panel",
             ATTR_CODE: 1234,
         },
         blocking=True,
@@ -108,7 +108,7 @@ async def test_generic_alarm_control_panel_requires_code(
         ALARM_CONTROL_PANEL_DOMAIN,
         SERVICE_ALARM_ARM_NIGHT,
         {
-            ATTR_ENTITY_ID: "alarm_control_panel.test_my_alarm_control_panel",
+            ATTR_ENTITY_ID: "alarm_control_panel.test_myalarm_control_panel",
             ATTR_CODE: 1234,
         },
         blocking=True,
@@ -122,7 +122,7 @@ async def test_generic_alarm_control_panel_requires_code(
         ALARM_CONTROL_PANEL_DOMAIN,
         SERVICE_ALARM_ARM_VACATION,
         {
-            ATTR_ENTITY_ID: "alarm_control_panel.test_my_alarm_control_panel",
+            ATTR_ENTITY_ID: "alarm_control_panel.test_myalarm_control_panel",
             ATTR_CODE: 1234,
         },
         blocking=True,
@@ -136,7 +136,7 @@ async def test_generic_alarm_control_panel_requires_code(
         ALARM_CONTROL_PANEL_DOMAIN,
         SERVICE_ALARM_TRIGGER,
         {
-            ATTR_ENTITY_ID: "alarm_control_panel.test_my_alarm_control_panel",
+            ATTR_ENTITY_ID: "alarm_control_panel.test_myalarm_control_panel",
             ATTR_CODE: 1234,
         },
         blocking=True,
@@ -150,7 +150,7 @@ async def test_generic_alarm_control_panel_requires_code(
         ALARM_CONTROL_PANEL_DOMAIN,
         SERVICE_ALARM_DISARM,
         {
-            ATTR_ENTITY_ID: "alarm_control_panel.test_my_alarm_control_panel",
+            ATTR_ENTITY_ID: "alarm_control_panel.test_myalarm_control_panel",
             ATTR_CODE: 1234,
         },
         blocking=True,
@@ -193,14 +193,14 @@ async def test_generic_alarm_control_panel_no_code(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("alarm_control_panel.test_my_alarm_control_panel")
+    state = hass.states.get("alarm_control_panel.test_myalarm_control_panel")
     assert state is not None
     assert state.state == STATE_ALARM_ARMED_AWAY
 
     await hass.services.async_call(
         ALARM_CONTROL_PANEL_DOMAIN,
         SERVICE_ALARM_DISARM,
-        {ATTR_ENTITY_ID: "alarm_control_panel.test_my_alarm_control_panel"},
+        {ATTR_ENTITY_ID: "alarm_control_panel.test_myalarm_control_panel"},
         blocking=True,
     )
     mock_client.alarm_control_panel_command.assert_has_calls(
@@ -239,6 +239,6 @@ async def test_generic_alarm_control_panel_missing_state(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("alarm_control_panel.test_my_alarm_control_panel")
+    state = hass.states.get("alarm_control_panel.test_myalarm_control_panel")
     assert state is not None
     assert state.state == STATE_UNKNOWN

--- a/tests/components/esphome/test_binary_sensor.py
+++ b/tests/components/esphome/test_binary_sensor.py
@@ -74,7 +74,7 @@ async def test_binary_sensor_generic_entity(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("binary_sensor.test_my_binary_sensor")
+    state = hass.states.get("binary_sensor.test_mybinary_sensor")
     assert state is not None
     assert state.state == hass_state
 
@@ -105,7 +105,7 @@ async def test_status_binary_sensor(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("binary_sensor.test_my_binary_sensor")
+    state = hass.states.get("binary_sensor.test_mybinary_sensor")
     assert state is not None
     assert state.state == STATE_ON
 
@@ -135,7 +135,7 @@ async def test_binary_sensor_missing_state(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("binary_sensor.test_my_binary_sensor")
+    state = hass.states.get("binary_sensor.test_mybinary_sensor")
     assert state is not None
     assert state.state == STATE_UNKNOWN
 
@@ -165,12 +165,12 @@ async def test_binary_sensor_has_state_false(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("binary_sensor.test_my_binary_sensor")
+    state = hass.states.get("binary_sensor.test_mybinary_sensor")
     assert state is not None
     assert state.state == STATE_UNKNOWN
 
     mock_device.set_state(BinarySensorState(key=1, state=True, missing_state=False))
     await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.test_my_binary_sensor")
+    state = hass.states.get("binary_sensor.test_mybinary_sensor")
     assert state is not None
     assert state.state == STATE_ON

--- a/tests/components/esphome/test_button.py
+++ b/tests/components/esphome/test_button.py
@@ -29,22 +29,22 @@ async def test_button_generic_entity(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("button.test_my_button")
+    state = hass.states.get("button.test_mybutton")
     assert state is not None
     assert state.state == STATE_UNKNOWN
 
     await hass.services.async_call(
         BUTTON_DOMAIN,
         SERVICE_PRESS,
-        {ATTR_ENTITY_ID: "button.test_my_button"},
+        {ATTR_ENTITY_ID: "button.test_mybutton"},
         blocking=True,
     )
     mock_client.button_command.assert_has_calls([call(1)])
-    state = hass.states.get("button.test_my_button")
+    state = hass.states.get("button.test_mybutton")
     assert state is not None
     assert state.state != STATE_UNKNOWN
 
     await mock_device.mock_disconnect(False)
-    state = hass.states.get("button.test_my_button")
+    state = hass.states.get("button.test_mybutton")
     assert state is not None
     assert state.state == STATE_UNAVAILABLE

--- a/tests/components/esphome/test_camera.py
+++ b/tests/components/esphome/test_camera.py
@@ -53,7 +53,7 @@ async def test_camera_single_image(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("camera.test_my_camera")
+    state = hass.states.get("camera.test_mycamera")
     assert state is not None
     assert state.state == STATE_IDLE
 
@@ -63,9 +63,9 @@ async def test_camera_single_image(
     mock_client.request_single_image = _mock_camera_image
 
     client = await hass_client()
-    resp = await client.get("/api/camera_proxy/camera.test_my_camera")
+    resp = await client.get("/api/camera_proxy/camera.test_mycamera")
     await hass.async_block_till_done()
-    state = hass.states.get("camera.test_my_camera")
+    state = hass.states.get("camera.test_mycamera")
     assert state is not None
     assert state.state == STATE_IDLE
 
@@ -101,15 +101,15 @@ async def test_camera_single_image_unavailable_before_requested(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("camera.test_my_camera")
+    state = hass.states.get("camera.test_mycamera")
     assert state is not None
     assert state.state == STATE_IDLE
     await mock_device.mock_disconnect(False)
 
     client = await hass_client()
-    resp = await client.get("/api/camera_proxy/camera.test_my_camera")
+    resp = await client.get("/api/camera_proxy/camera.test_mycamera")
     await hass.async_block_till_done()
-    state = hass.states.get("camera.test_my_camera")
+    state = hass.states.get("camera.test_mycamera")
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
 
@@ -142,7 +142,7 @@ async def test_camera_single_image_unavailable_during_request(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("camera.test_my_camera")
+    state = hass.states.get("camera.test_mycamera")
     assert state is not None
     assert state.state == STATE_IDLE
 
@@ -152,9 +152,9 @@ async def test_camera_single_image_unavailable_during_request(
     mock_client.request_single_image = _mock_camera_image
 
     client = await hass_client()
-    resp = await client.get("/api/camera_proxy/camera.test_my_camera")
+    resp = await client.get("/api/camera_proxy/camera.test_mycamera")
     await hass.async_block_till_done()
-    state = hass.states.get("camera.test_my_camera")
+    state = hass.states.get("camera.test_mycamera")
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
 
@@ -187,7 +187,7 @@ async def test_camera_stream(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("camera.test_my_camera")
+    state = hass.states.get("camera.test_mycamera")
     assert state is not None
     assert state.state == STATE_IDLE
     remaining_responses = 3
@@ -203,9 +203,9 @@ async def test_camera_stream(
     mock_client.request_single_image = _mock_camera_image
 
     client = await hass_client()
-    resp = await client.get("/api/camera_proxy_stream/camera.test_my_camera")
+    resp = await client.get("/api/camera_proxy_stream/camera.test_mycamera")
     await hass.async_block_till_done()
-    state = hass.states.get("camera.test_my_camera")
+    state = hass.states.get("camera.test_mycamera")
     assert state is not None
     assert state.state == STATE_IDLE
 
@@ -247,16 +247,16 @@ async def test_camera_stream_unavailable(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("camera.test_my_camera")
+    state = hass.states.get("camera.test_mycamera")
     assert state is not None
     assert state.state == STATE_IDLE
 
     await mock_device.mock_disconnect(False)
 
     client = await hass_client()
-    await client.get("/api/camera_proxy_stream/camera.test_my_camera")
+    await client.get("/api/camera_proxy_stream/camera.test_mycamera")
     await hass.async_block_till_done()
-    state = hass.states.get("camera.test_my_camera")
+    state = hass.states.get("camera.test_mycamera")
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
 
@@ -287,7 +287,7 @@ async def test_camera_stream_with_disconnection(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("camera.test_my_camera")
+    state = hass.states.get("camera.test_mycamera")
     assert state is not None
     assert state.state == STATE_IDLE
     remaining_responses = 3
@@ -305,8 +305,8 @@ async def test_camera_stream_with_disconnection(
     mock_client.request_single_image = _mock_camera_image
 
     client = await hass_client()
-    await client.get("/api/camera_proxy_stream/camera.test_my_camera")
+    await client.get("/api/camera_proxy_stream/camera.test_mycamera")
     await hass.async_block_till_done()
-    state = hass.states.get("camera.test_my_camera")
+    state = hass.states.get("camera.test_mycamera")
     assert state is not None
     assert state.state == STATE_UNAVAILABLE

--- a/tests/components/esphome/test_climate.py
+++ b/tests/components/esphome/test_climate.py
@@ -78,14 +78,14 @@ async def test_climate_entity(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("climate.test_my_climate")
+    state = hass.states.get("climate.test_myclimate")
     assert state is not None
     assert state.state == HVACMode.COOL
 
     await hass.services.async_call(
         CLIMATE_DOMAIN,
         SERVICE_SET_TEMPERATURE,
-        {ATTR_ENTITY_ID: "climate.test_my_climate", ATTR_TEMPERATURE: 25},
+        {ATTR_ENTITY_ID: "climate.test_myclimate", ATTR_TEMPERATURE: 25},
         blocking=True,
     )
     mock_client.climate_command.assert_has_calls([call(key=1, target_temperature=25.0)])
@@ -130,14 +130,14 @@ async def test_climate_entity_with_step_and_two_point(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("climate.test_my_climate")
+    state = hass.states.get("climate.test_myclimate")
     assert state is not None
     assert state.state == HVACMode.COOL
 
     await hass.services.async_call(
         CLIMATE_DOMAIN,
         SERVICE_SET_TEMPERATURE,
-        {ATTR_ENTITY_ID: "climate.test_my_climate", ATTR_TEMPERATURE: 25},
+        {ATTR_ENTITY_ID: "climate.test_myclimate", ATTR_TEMPERATURE: 25},
         blocking=True,
     )
     mock_client.climate_command.assert_has_calls([call(key=1, target_temperature=25.0)])
@@ -147,7 +147,7 @@ async def test_climate_entity_with_step_and_two_point(
         CLIMATE_DOMAIN,
         SERVICE_SET_TEMPERATURE,
         {
-            ATTR_ENTITY_ID: "climate.test_my_climate",
+            ATTR_ENTITY_ID: "climate.test_myclimate",
             ATTR_HVAC_MODE: HVACMode.AUTO,
             ATTR_TARGET_TEMP_LOW: 20,
             ATTR_TARGET_TEMP_HIGH: 30,
@@ -209,14 +209,14 @@ async def test_climate_entity_with_step_and_target_temp(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("climate.test_my_climate")
+    state = hass.states.get("climate.test_myclimate")
     assert state is not None
     assert state.state == HVACMode.COOL
 
     await hass.services.async_call(
         CLIMATE_DOMAIN,
         SERVICE_SET_TEMPERATURE,
-        {ATTR_ENTITY_ID: "climate.test_my_climate", ATTR_TEMPERATURE: 25},
+        {ATTR_ENTITY_ID: "climate.test_myclimate", ATTR_TEMPERATURE: 25},
         blocking=True,
     )
     mock_client.climate_command.assert_has_calls([call(key=1, target_temperature=25.0)])
@@ -226,7 +226,7 @@ async def test_climate_entity_with_step_and_target_temp(
         CLIMATE_DOMAIN,
         SERVICE_SET_TEMPERATURE,
         {
-            ATTR_ENTITY_ID: "climate.test_my_climate",
+            ATTR_ENTITY_ID: "climate.test_myclimate",
             ATTR_HVAC_MODE: HVACMode.AUTO,
             ATTR_TARGET_TEMP_LOW: 20,
             ATTR_TARGET_TEMP_HIGH: 30,
@@ -249,7 +249,7 @@ async def test_climate_entity_with_step_and_target_temp(
         CLIMATE_DOMAIN,
         SERVICE_SET_HVAC_MODE,
         {
-            ATTR_ENTITY_ID: "climate.test_my_climate",
+            ATTR_ENTITY_ID: "climate.test_myclimate",
             ATTR_HVAC_MODE: HVACMode.HEAT,
         },
         blocking=True,
@@ -267,7 +267,7 @@ async def test_climate_entity_with_step_and_target_temp(
     await hass.services.async_call(
         CLIMATE_DOMAIN,
         SERVICE_SET_PRESET_MODE,
-        {ATTR_ENTITY_ID: "climate.test_my_climate", ATTR_PRESET_MODE: "away"},
+        {ATTR_ENTITY_ID: "climate.test_myclimate", ATTR_PRESET_MODE: "away"},
         blocking=True,
     )
     mock_client.climate_command.assert_has_calls(
@@ -283,7 +283,7 @@ async def test_climate_entity_with_step_and_target_temp(
     await hass.services.async_call(
         CLIMATE_DOMAIN,
         SERVICE_SET_PRESET_MODE,
-        {ATTR_ENTITY_ID: "climate.test_my_climate", ATTR_PRESET_MODE: "preset1"},
+        {ATTR_ENTITY_ID: "climate.test_myclimate", ATTR_PRESET_MODE: "preset1"},
         blocking=True,
     )
     mock_client.climate_command.assert_has_calls([call(key=1, custom_preset="preset1")])
@@ -292,7 +292,7 @@ async def test_climate_entity_with_step_and_target_temp(
     await hass.services.async_call(
         CLIMATE_DOMAIN,
         SERVICE_SET_FAN_MODE,
-        {ATTR_ENTITY_ID: "climate.test_my_climate", ATTR_FAN_MODE: FAN_HIGH},
+        {ATTR_ENTITY_ID: "climate.test_myclimate", ATTR_FAN_MODE: FAN_HIGH},
         blocking=True,
     )
     mock_client.climate_command.assert_has_calls(
@@ -303,7 +303,7 @@ async def test_climate_entity_with_step_and_target_temp(
     await hass.services.async_call(
         CLIMATE_DOMAIN,
         SERVICE_SET_FAN_MODE,
-        {ATTR_ENTITY_ID: "climate.test_my_climate", ATTR_FAN_MODE: "fan2"},
+        {ATTR_ENTITY_ID: "climate.test_myclimate", ATTR_FAN_MODE: "fan2"},
         blocking=True,
     )
     mock_client.climate_command.assert_has_calls([call(key=1, custom_fan_mode="fan2")])
@@ -312,7 +312,7 @@ async def test_climate_entity_with_step_and_target_temp(
     await hass.services.async_call(
         CLIMATE_DOMAIN,
         SERVICE_SET_SWING_MODE,
-        {ATTR_ENTITY_ID: "climate.test_my_climate", ATTR_SWING_MODE: SWING_BOTH},
+        {ATTR_ENTITY_ID: "climate.test_myclimate", ATTR_SWING_MODE: SWING_BOTH},
         blocking=True,
     )
     mock_client.climate_command.assert_has_calls(
@@ -362,7 +362,7 @@ async def test_climate_entity_with_humidity(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("climate.test_my_climate")
+    state = hass.states.get("climate.test_myclimate")
     assert state is not None
     assert state.state == HVACMode.AUTO
     attributes = state.attributes
@@ -374,7 +374,7 @@ async def test_climate_entity_with_humidity(
     await hass.services.async_call(
         CLIMATE_DOMAIN,
         SERVICE_SET_HUMIDITY,
-        {ATTR_ENTITY_ID: "climate.test_my_climate", ATTR_HUMIDITY: 23},
+        {ATTR_ENTITY_ID: "climate.test_myclimate", ATTR_HUMIDITY: 23},
         blocking=True,
     )
     mock_client.climate_command.assert_has_calls([call(key=1, target_humidity=23)])
@@ -422,7 +422,7 @@ async def test_climate_entity_with_inf_value(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("climate.test_my_climate")
+    state = hass.states.get("climate.test_myclimate")
     assert state is not None
     assert state.state == HVACMode.AUTO
     attributes = state.attributes
@@ -484,7 +484,7 @@ async def test_climate_entity_attributes(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("climate.test_my_climate")
+    state = hass.states.get("climate.test_myclimate")
     assert state is not None
     assert state.state == HVACMode.COOL
     assert state.attributes == snapshot(name="climate-entity-attributes")

--- a/tests/components/esphome/test_cover.py
+++ b/tests/components/esphome/test_cover.py
@@ -72,7 +72,7 @@ async def test_cover_entity(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("cover.test_my_cover")
+    state = hass.states.get("cover.test_mycover")
     assert state is not None
     assert state.state == STATE_OPENING
     assert state.attributes[ATTR_CURRENT_POSITION] == 50
@@ -81,7 +81,7 @@ async def test_cover_entity(
     await hass.services.async_call(
         COVER_DOMAIN,
         SERVICE_CLOSE_COVER,
-        {ATTR_ENTITY_ID: "cover.test_my_cover"},
+        {ATTR_ENTITY_ID: "cover.test_mycover"},
         blocking=True,
     )
     mock_client.cover_command.assert_has_calls([call(key=1, position=0.0)])
@@ -90,7 +90,7 @@ async def test_cover_entity(
     await hass.services.async_call(
         COVER_DOMAIN,
         SERVICE_OPEN_COVER,
-        {ATTR_ENTITY_ID: "cover.test_my_cover"},
+        {ATTR_ENTITY_ID: "cover.test_mycover"},
         blocking=True,
     )
     mock_client.cover_command.assert_has_calls([call(key=1, position=1.0)])
@@ -99,7 +99,7 @@ async def test_cover_entity(
     await hass.services.async_call(
         COVER_DOMAIN,
         SERVICE_SET_COVER_POSITION,
-        {ATTR_ENTITY_ID: "cover.test_my_cover", ATTR_POSITION: 50},
+        {ATTR_ENTITY_ID: "cover.test_mycover", ATTR_POSITION: 50},
         blocking=True,
     )
     mock_client.cover_command.assert_has_calls([call(key=1, position=0.5)])
@@ -108,7 +108,7 @@ async def test_cover_entity(
     await hass.services.async_call(
         COVER_DOMAIN,
         SERVICE_STOP_COVER,
-        {ATTR_ENTITY_ID: "cover.test_my_cover"},
+        {ATTR_ENTITY_ID: "cover.test_mycover"},
         blocking=True,
     )
     mock_client.cover_command.assert_has_calls([call(key=1, stop=True)])
@@ -117,7 +117,7 @@ async def test_cover_entity(
     await hass.services.async_call(
         COVER_DOMAIN,
         SERVICE_OPEN_COVER_TILT,
-        {ATTR_ENTITY_ID: "cover.test_my_cover"},
+        {ATTR_ENTITY_ID: "cover.test_mycover"},
         blocking=True,
     )
     mock_client.cover_command.assert_has_calls([call(key=1, tilt=1.0)])
@@ -126,7 +126,7 @@ async def test_cover_entity(
     await hass.services.async_call(
         COVER_DOMAIN,
         SERVICE_CLOSE_COVER_TILT,
-        {ATTR_ENTITY_ID: "cover.test_my_cover"},
+        {ATTR_ENTITY_ID: "cover.test_mycover"},
         blocking=True,
     )
     mock_client.cover_command.assert_has_calls([call(key=1, tilt=0.0)])
@@ -135,7 +135,7 @@ async def test_cover_entity(
     await hass.services.async_call(
         COVER_DOMAIN,
         SERVICE_SET_COVER_TILT_POSITION,
-        {ATTR_ENTITY_ID: "cover.test_my_cover", ATTR_TILT_POSITION: 50},
+        {ATTR_ENTITY_ID: "cover.test_mycover", ATTR_TILT_POSITION: 50},
         blocking=True,
     )
     mock_client.cover_command.assert_has_calls([call(key=1, tilt=0.5)])
@@ -145,7 +145,7 @@ async def test_cover_entity(
         CoverState(key=1, position=0.0, current_operation=CoverOperation.IDLE)
     )
     await hass.async_block_till_done()
-    state = hass.states.get("cover.test_my_cover")
+    state = hass.states.get("cover.test_mycover")
     assert state is not None
     assert state.state == STATE_CLOSED
 
@@ -153,7 +153,7 @@ async def test_cover_entity(
         CoverState(key=1, position=0.5, current_operation=CoverOperation.IS_CLOSING)
     )
     await hass.async_block_till_done()
-    state = hass.states.get("cover.test_my_cover")
+    state = hass.states.get("cover.test_mycover")
     assert state is not None
     assert state.state == STATE_CLOSING
 
@@ -161,7 +161,7 @@ async def test_cover_entity(
         CoverState(key=1, position=1.0, current_operation=CoverOperation.IDLE)
     )
     await hass.async_block_till_done()
-    state = hass.states.get("cover.test_my_cover")
+    state = hass.states.get("cover.test_mycover")
     assert state is not None
     assert state.state == STATE_OPEN
 
@@ -201,7 +201,7 @@ async def test_cover_entity_without_position(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("cover.test_my_cover")
+    state = hass.states.get("cover.test_mycover")
     assert state is not None
     assert state.state == STATE_OPENING
     assert ATTR_CURRENT_TILT_POSITION not in state.attributes

--- a/tests/components/esphome/test_date.py
+++ b/tests/components/esphome/test_date.py
@@ -35,14 +35,14 @@ async def test_generic_date_entity(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("date.test_my_date")
+    state = hass.states.get("date.test_mydate")
     assert state is not None
     assert state.state == "2024-12-31"
 
     await hass.services.async_call(
         DATE_DOMAIN,
         SERVICE_SET_VALUE,
-        {ATTR_ENTITY_ID: "date.test_my_date", ATTR_DATE: "1999-01-01"},
+        {ATTR_ENTITY_ID: "date.test_mydate", ATTR_DATE: "1999-01-01"},
         blocking=True,
     )
     mock_client.date_command.assert_has_calls([call(1, 1999, 1, 1)])
@@ -71,6 +71,6 @@ async def test_generic_date_missing_state(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("date.test_my_date")
+    state = hass.states.get("date.test_mydate")
     assert state is not None
     assert state.state == STATE_UNKNOWN

--- a/tests/components/esphome/test_datetime.py
+++ b/tests/components/esphome/test_datetime.py
@@ -35,7 +35,7 @@ async def test_generic_datetime_entity(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("datetime.test_my_datetime")
+    state = hass.states.get("datetime.test_mydatetime")
     assert state is not None
     assert state.state == "2024-04-16T12:34:56+00:00"
 
@@ -43,7 +43,7 @@ async def test_generic_datetime_entity(
         DATETIME_DOMAIN,
         SERVICE_SET_VALUE,
         {
-            ATTR_ENTITY_ID: "datetime.test_my_datetime",
+            ATTR_ENTITY_ID: "datetime.test_mydatetime",
             ATTR_DATETIME: "2000-01-01T01:23:45+00:00",
         },
         blocking=True,
@@ -74,6 +74,6 @@ async def test_generic_datetime_missing_state(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("datetime.test_my_datetime")
+    state = hass.states.get("datetime.test_mydatetime")
     assert state is not None
     assert state.state == STATE_UNKNOWN

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -69,10 +69,10 @@ async def test_entities_removed(
     entry = mock_device.entry
     entry_id = entry.entry_id
     storage_key = f"esphome.{entry_id}"
-    state = hass.states.get("binary_sensor.test_my_binary_sensor")
+    state = hass.states.get("binary_sensor.test_mybinary_sensor")
     assert state is not None
     assert state.state == STATE_ON
-    state = hass.states.get("binary_sensor.test_my_binary_sensor_to_be_removed")
+    state = hass.states.get("binary_sensor.test_mybinary_sensor_to_be_removed")
     assert state is not None
     assert state.state == STATE_ON
 
@@ -81,13 +81,13 @@ async def test_entities_removed(
 
     assert len(hass_storage[storage_key]["data"]["binary_sensor"]) == 2
 
-    state = hass.states.get("binary_sensor.test_my_binary_sensor")
+    state = hass.states.get("binary_sensor.test_mybinary_sensor")
     assert state is not None
     assert state.attributes[ATTR_RESTORED] is True
-    state = hass.states.get("binary_sensor.test_my_binary_sensor_to_be_removed")
+    state = hass.states.get("binary_sensor.test_mybinary_sensor_to_be_removed")
     assert state is not None
     reg_entry = entity_registry.async_get(
-        "binary_sensor.test_my_binary_sensor_to_be_removed"
+        "binary_sensor.test_mybinary_sensor_to_be_removed"
     )
     assert reg_entry is not None
     assert state.attributes[ATTR_RESTORED] is True
@@ -111,13 +111,13 @@ async def test_entities_removed(
         entry=entry,
     )
     assert mock_device.entry.entry_id == entry_id
-    state = hass.states.get("binary_sensor.test_my_binary_sensor")
+    state = hass.states.get("binary_sensor.test_mybinary_sensor")
     assert state is not None
     assert state.state == STATE_ON
-    state = hass.states.get("binary_sensor.test_my_binary_sensor_to_be_removed")
+    state = hass.states.get("binary_sensor.test_mybinary_sensor_to_be_removed")
     assert state is None
     reg_entry = entity_registry.async_get(
-        "binary_sensor.test_my_binary_sensor_to_be_removed"
+        "binary_sensor.test_mybinary_sensor_to_be_removed"
     )
     assert reg_entry is None
     await hass.config_entries.async_unload(entry.entry_id)
@@ -164,15 +164,15 @@ async def test_entities_removed_after_reload(
     entry = mock_device.entry
     entry_id = entry.entry_id
     storage_key = f"esphome.{entry_id}"
-    state = hass.states.get("binary_sensor.test_my_binary_sensor")
+    state = hass.states.get("binary_sensor.test_mybinary_sensor")
     assert state is not None
     assert state.state == STATE_ON
-    state = hass.states.get("binary_sensor.test_my_binary_sensor_to_be_removed")
+    state = hass.states.get("binary_sensor.test_mybinary_sensor_to_be_removed")
     assert state is not None
     assert state.state == STATE_ON
 
     reg_entry = entity_registry.async_get(
-        "binary_sensor.test_my_binary_sensor_to_be_removed"
+        "binary_sensor.test_mybinary_sensor_to_be_removed"
     )
     assert reg_entry is not None
 
@@ -181,15 +181,15 @@ async def test_entities_removed_after_reload(
 
     assert len(hass_storage[storage_key]["data"]["binary_sensor"]) == 2
 
-    state = hass.states.get("binary_sensor.test_my_binary_sensor")
+    state = hass.states.get("binary_sensor.test_mybinary_sensor")
     assert state is not None
     assert state.attributes[ATTR_RESTORED] is True
-    state = hass.states.get("binary_sensor.test_my_binary_sensor_to_be_removed")
+    state = hass.states.get("binary_sensor.test_mybinary_sensor_to_be_removed")
     assert state is not None
     assert state.attributes[ATTR_RESTORED] is True
 
     reg_entry = entity_registry.async_get(
-        "binary_sensor.test_my_binary_sensor_to_be_removed"
+        "binary_sensor.test_mybinary_sensor_to_be_removed"
     )
     assert reg_entry is not None
 
@@ -198,14 +198,14 @@ async def test_entities_removed_after_reload(
 
     assert len(hass_storage[storage_key]["data"]["binary_sensor"]) == 2
 
-    state = hass.states.get("binary_sensor.test_my_binary_sensor")
+    state = hass.states.get("binary_sensor.test_mybinary_sensor")
     assert state is not None
     assert ATTR_RESTORED not in state.attributes
-    state = hass.states.get("binary_sensor.test_my_binary_sensor_to_be_removed")
+    state = hass.states.get("binary_sensor.test_mybinary_sensor_to_be_removed")
     assert state is not None
     assert ATTR_RESTORED not in state.attributes
     reg_entry = entity_registry.async_get(
-        "binary_sensor.test_my_binary_sensor_to_be_removed"
+        "binary_sensor.test_mybinary_sensor_to_be_removed"
     )
     assert reg_entry is not None
 
@@ -236,28 +236,57 @@ async def test_entities_removed_after_reload(
             on_future.set_result(None)
 
     async_track_state_change_event(
-        hass, ["binary_sensor.test_my_binary_sensor"], _async_wait_for_on
+        hass, ["binary_sensor.test_mybinary_sensor"], _async_wait_for_on
     )
     await hass.async_block_till_done()
     async with asyncio.timeout(2):
         await on_future
 
     assert mock_device.entry.entry_id == entry_id
-    state = hass.states.get("binary_sensor.test_my_binary_sensor")
+    state = hass.states.get("binary_sensor.test_mybinary_sensor")
     assert state is not None
     assert state.state == STATE_ON
-    state = hass.states.get("binary_sensor.test_my_binary_sensor_to_be_removed")
+    state = hass.states.get("binary_sensor.test_mybinary_sensor_to_be_removed")
     assert state is None
 
     await hass.async_block_till_done()
 
     reg_entry = entity_registry.async_get(
-        "binary_sensor.test_my_binary_sensor_to_be_removed"
+        "binary_sensor.test_mybinary_sensor_to_be_removed"
     )
     assert reg_entry is None
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
     assert len(hass_storage[storage_key]["data"]["binary_sensor"]) == 1
+
+
+async def test_entity_info_object_ids(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: Callable[
+        [APIClient, list[EntityInfo], list[UserService], list[EntityState]],
+        Awaitable[MockESPHomeDevice],
+    ],
+) -> None:
+    """Test how object ids affect entity id."""
+    entity_info = [
+        BinarySensorInfo(
+            object_id="object_id_is_used",
+            key=1,
+            name="my binary_sensor",
+            unique_id="my_binary_sensor",
+        )
+    ]
+    states = []
+    user_service = []
+    await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+    )
+    state = hass.states.get("binary_sensor.test_object_id_is_used")
+    assert state is not None
 
 
 async def test_deep_sleep_device(
@@ -297,7 +326,7 @@ async def test_deep_sleep_device(
         states=states,
         device_info={"has_deep_sleep": True},
     )
-    state = hass.states.get("binary_sensor.test_my_binary_sensor")
+    state = hass.states.get("binary_sensor.test_mybinary_sensor")
     assert state is not None
     assert state.state == STATE_ON
     state = hass.states.get("sensor.test_my_sensor")
@@ -306,7 +335,7 @@ async def test_deep_sleep_device(
 
     await mock_device.mock_disconnect(False)
     await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.test_my_binary_sensor")
+    state = hass.states.get("binary_sensor.test_mybinary_sensor")
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
     state = hass.states.get("sensor.test_my_sensor")
@@ -316,7 +345,7 @@ async def test_deep_sleep_device(
     await mock_device.mock_connect()
     await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.test_my_binary_sensor")
+    state = hass.states.get("binary_sensor.test_mybinary_sensor")
     assert state is not None
     assert state.state == STATE_ON
     state = hass.states.get("sensor.test_my_sensor")
@@ -330,7 +359,7 @@ async def test_deep_sleep_device(
     mock_device.set_state(BinarySensorState(key=1, state=False, missing_state=False))
     mock_device.set_state(SensorState(key=3, state=56, missing_state=False))
     await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.test_my_binary_sensor")
+    state = hass.states.get("binary_sensor.test_mybinary_sensor")
     assert state is not None
     assert state.state == STATE_OFF
     state = hass.states.get("sensor.test_my_sensor")
@@ -339,7 +368,7 @@ async def test_deep_sleep_device(
 
     await mock_device.mock_disconnect(True)
     await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.test_my_binary_sensor")
+    state = hass.states.get("binary_sensor.test_mybinary_sensor")
     assert state is not None
     assert state.state == STATE_OFF
     state = hass.states.get("sensor.test_my_sensor")
@@ -350,7 +379,7 @@ async def test_deep_sleep_device(
     await hass.async_block_till_done()
     await mock_device.mock_disconnect(False)
     await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.test_my_binary_sensor")
+    state = hass.states.get("binary_sensor.test_mybinary_sensor")
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
     state = hass.states.get("sensor.test_my_sensor")
@@ -359,14 +388,14 @@ async def test_deep_sleep_device(
 
     await mock_device.mock_connect()
     await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.test_my_binary_sensor")
+    state = hass.states.get("binary_sensor.test_mybinary_sensor")
     assert state is not None
     assert state.state == STATE_ON
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
     await hass.async_block_till_done()
     # Verify we do not dispatch any more state updates or
     # availability updates after the stop event is fired
-    state = hass.states.get("binary_sensor.test_my_binary_sensor")
+    state = hass.states.get("binary_sensor.test_mybinary_sensor")
     assert state is not None
     assert state.state == STATE_ON
 
@@ -401,6 +430,6 @@ async def test_esphome_device_without_friendly_name(
         states=states,
         device_info={"friendly_name": None},
     )
-    state = hass.states.get("binary_sensor.test_my_binary_sensor")
+    state = hass.states.get("binary_sensor.my_binary_sensor")
     assert state is not None
     assert state.state == STATE_ON

--- a/tests/components/esphome/test_event.py
+++ b/tests/components/esphome/test_event.py
@@ -32,7 +32,7 @@ async def test_generic_event_entity(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("event.test_my_event")
+    state = hass.states.get("event.test_myevent")
     assert state is not None
     assert state.state == "2024-04-24T00:00:00.000+00:00"
     assert state.attributes["event_type"] == "type1"

--- a/tests/components/esphome/test_fan.py
+++ b/tests/components/esphome/test_fan.py
@@ -62,14 +62,14 @@ async def test_fan_entity_with_all_features_old_api(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("fan.test_my_fan")
+    state = hass.states.get("fan.test_myfan")
     assert state is not None
     assert state.state == STATE_ON
 
     await hass.services.async_call(
         FAN_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "fan.test_my_fan", ATTR_PERCENTAGE: 20},
+        {ATTR_ENTITY_ID: "fan.test_myfan", ATTR_PERCENTAGE: 20},
         blocking=True,
     )
     mock_client.fan_command.assert_has_calls(
@@ -80,7 +80,7 @@ async def test_fan_entity_with_all_features_old_api(
     await hass.services.async_call(
         FAN_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "fan.test_my_fan", ATTR_PERCENTAGE: 50},
+        {ATTR_ENTITY_ID: "fan.test_myfan", ATTR_PERCENTAGE: 50},
         blocking=True,
     )
     mock_client.fan_command.assert_has_calls(
@@ -91,7 +91,7 @@ async def test_fan_entity_with_all_features_old_api(
     await hass.services.async_call(
         FAN_DOMAIN,
         SERVICE_DECREASE_SPEED,
-        {ATTR_ENTITY_ID: "fan.test_my_fan"},
+        {ATTR_ENTITY_ID: "fan.test_myfan"},
         blocking=True,
     )
     mock_client.fan_command.assert_has_calls(
@@ -102,7 +102,7 @@ async def test_fan_entity_with_all_features_old_api(
     await hass.services.async_call(
         FAN_DOMAIN,
         SERVICE_INCREASE_SPEED,
-        {ATTR_ENTITY_ID: "fan.test_my_fan"},
+        {ATTR_ENTITY_ID: "fan.test_myfan"},
         blocking=True,
     )
     mock_client.fan_command.assert_has_calls(
@@ -113,7 +113,7 @@ async def test_fan_entity_with_all_features_old_api(
     await hass.services.async_call(
         FAN_DOMAIN,
         SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: "fan.test_my_fan"},
+        {ATTR_ENTITY_ID: "fan.test_myfan"},
         blocking=True,
     )
     mock_client.fan_command.assert_has_calls([call(key=1, state=False)])
@@ -122,7 +122,7 @@ async def test_fan_entity_with_all_features_old_api(
     await hass.services.async_call(
         FAN_DOMAIN,
         SERVICE_SET_PERCENTAGE,
-        {ATTR_ENTITY_ID: "fan.test_my_fan", ATTR_PERCENTAGE: 100},
+        {ATTR_ENTITY_ID: "fan.test_myfan", ATTR_PERCENTAGE: 100},
         blocking=True,
     )
     mock_client.fan_command.assert_has_calls(
@@ -166,14 +166,14 @@ async def test_fan_entity_with_all_features_new_api(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("fan.test_my_fan")
+    state = hass.states.get("fan.test_myfan")
     assert state is not None
     assert state.state == STATE_ON
 
     await hass.services.async_call(
         FAN_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "fan.test_my_fan", ATTR_PERCENTAGE: 20},
+        {ATTR_ENTITY_ID: "fan.test_myfan", ATTR_PERCENTAGE: 20},
         blocking=True,
     )
     mock_client.fan_command.assert_has_calls([call(key=1, speed_level=1, state=True)])
@@ -182,7 +182,7 @@ async def test_fan_entity_with_all_features_new_api(
     await hass.services.async_call(
         FAN_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "fan.test_my_fan", ATTR_PERCENTAGE: 50},
+        {ATTR_ENTITY_ID: "fan.test_myfan", ATTR_PERCENTAGE: 50},
         blocking=True,
     )
     mock_client.fan_command.assert_has_calls([call(key=1, speed_level=2, state=True)])
@@ -191,7 +191,7 @@ async def test_fan_entity_with_all_features_new_api(
     await hass.services.async_call(
         FAN_DOMAIN,
         SERVICE_DECREASE_SPEED,
-        {ATTR_ENTITY_ID: "fan.test_my_fan"},
+        {ATTR_ENTITY_ID: "fan.test_myfan"},
         blocking=True,
     )
     mock_client.fan_command.assert_has_calls([call(key=1, speed_level=2, state=True)])
@@ -200,7 +200,7 @@ async def test_fan_entity_with_all_features_new_api(
     await hass.services.async_call(
         FAN_DOMAIN,
         SERVICE_INCREASE_SPEED,
-        {ATTR_ENTITY_ID: "fan.test_my_fan"},
+        {ATTR_ENTITY_ID: "fan.test_myfan"},
         blocking=True,
     )
     mock_client.fan_command.assert_has_calls([call(key=1, speed_level=4, state=True)])
@@ -209,7 +209,7 @@ async def test_fan_entity_with_all_features_new_api(
     await hass.services.async_call(
         FAN_DOMAIN,
         SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: "fan.test_my_fan"},
+        {ATTR_ENTITY_ID: "fan.test_myfan"},
         blocking=True,
     )
     mock_client.fan_command.assert_has_calls([call(key=1, state=False)])
@@ -218,7 +218,7 @@ async def test_fan_entity_with_all_features_new_api(
     await hass.services.async_call(
         FAN_DOMAIN,
         SERVICE_SET_PERCENTAGE,
-        {ATTR_ENTITY_ID: "fan.test_my_fan", ATTR_PERCENTAGE: 100},
+        {ATTR_ENTITY_ID: "fan.test_myfan", ATTR_PERCENTAGE: 100},
         blocking=True,
     )
     mock_client.fan_command.assert_has_calls([call(key=1, speed_level=4, state=True)])
@@ -227,7 +227,7 @@ async def test_fan_entity_with_all_features_new_api(
     await hass.services.async_call(
         FAN_DOMAIN,
         SERVICE_SET_PERCENTAGE,
-        {ATTR_ENTITY_ID: "fan.test_my_fan", ATTR_PERCENTAGE: 0},
+        {ATTR_ENTITY_ID: "fan.test_myfan", ATTR_PERCENTAGE: 0},
         blocking=True,
     )
     mock_client.fan_command.assert_has_calls([call(key=1, state=False)])
@@ -236,7 +236,7 @@ async def test_fan_entity_with_all_features_new_api(
     await hass.services.async_call(
         FAN_DOMAIN,
         SERVICE_OSCILLATE,
-        {ATTR_ENTITY_ID: "fan.test_my_fan", ATTR_OSCILLATING: True},
+        {ATTR_ENTITY_ID: "fan.test_myfan", ATTR_OSCILLATING: True},
         blocking=True,
     )
     mock_client.fan_command.assert_has_calls([call(key=1, oscillating=True)])
@@ -245,7 +245,7 @@ async def test_fan_entity_with_all_features_new_api(
     await hass.services.async_call(
         FAN_DOMAIN,
         SERVICE_OSCILLATE,
-        {ATTR_ENTITY_ID: "fan.test_my_fan", ATTR_OSCILLATING: False},
+        {ATTR_ENTITY_ID: "fan.test_myfan", ATTR_OSCILLATING: False},
         blocking=True,
     )
     mock_client.fan_command.assert_has_calls([call(key=1, oscillating=False)])
@@ -254,7 +254,7 @@ async def test_fan_entity_with_all_features_new_api(
     await hass.services.async_call(
         FAN_DOMAIN,
         SERVICE_SET_DIRECTION,
-        {ATTR_ENTITY_ID: "fan.test_my_fan", ATTR_DIRECTION: "forward"},
+        {ATTR_ENTITY_ID: "fan.test_myfan", ATTR_DIRECTION: "forward"},
         blocking=True,
     )
     mock_client.fan_command.assert_has_calls(
@@ -265,7 +265,7 @@ async def test_fan_entity_with_all_features_new_api(
     await hass.services.async_call(
         FAN_DOMAIN,
         SERVICE_SET_DIRECTION,
-        {ATTR_ENTITY_ID: "fan.test_my_fan", ATTR_DIRECTION: "reverse"},
+        {ATTR_ENTITY_ID: "fan.test_myfan", ATTR_DIRECTION: "reverse"},
         blocking=True,
     )
     mock_client.fan_command.assert_has_calls(
@@ -276,7 +276,7 @@ async def test_fan_entity_with_all_features_new_api(
     await hass.services.async_call(
         FAN_DOMAIN,
         SERVICE_SET_PRESET_MODE,
-        {ATTR_ENTITY_ID: "fan.test_my_fan", ATTR_PRESET_MODE: "Preset1"},
+        {ATTR_ENTITY_ID: "fan.test_myfan", ATTR_PRESET_MODE: "Preset1"},
         blocking=True,
     )
     mock_client.fan_command.assert_has_calls([call(key=1, preset_mode="Preset1")])
@@ -308,14 +308,14 @@ async def test_fan_entity_with_no_features_new_api(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("fan.test_my_fan")
+    state = hass.states.get("fan.test_myfan")
     assert state is not None
     assert state.state == STATE_ON
 
     await hass.services.async_call(
         FAN_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "fan.test_my_fan"},
+        {ATTR_ENTITY_ID: "fan.test_myfan"},
         blocking=True,
     )
     mock_client.fan_command.assert_has_calls([call(key=1, state=True)])
@@ -324,7 +324,7 @@ async def test_fan_entity_with_no_features_new_api(
     await hass.services.async_call(
         FAN_DOMAIN,
         SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: "fan.test_my_fan"},
+        {ATTR_ENTITY_ID: "fan.test_myfan"},
         blocking=True,
     )
     mock_client.fan_command.assert_has_calls([call(key=1, state=False)])

--- a/tests/components/esphome/test_light.py
+++ b/tests/components/esphome/test_light.py
@@ -65,14 +65,14 @@ async def test_light_on_off(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("light.test_my_light")
+    state = hass.states.get("light.test_mylight")
     assert state is not None
     assert state.state == STATE_ON
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light"},
+        {ATTR_ENTITY_ID: "light.test_mylight"},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -105,14 +105,14 @@ async def test_light_brightness(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("light.test_my_light")
+    state = hass.states.get("light.test_mylight")
     assert state is not None
     assert state.state == STATE_ON
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light"},
+        {ATTR_ENTITY_ID: "light.test_mylight"},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -123,7 +123,7 @@ async def test_light_brightness(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_BRIGHTNESS: 127},
+        {ATTR_ENTITY_ID: "light.test_mylight", ATTR_BRIGHTNESS: 127},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -141,7 +141,7 @@ async def test_light_brightness(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_TRANSITION: 2},
+        {ATTR_ENTITY_ID: "light.test_mylight", ATTR_TRANSITION: 2},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -152,7 +152,7 @@ async def test_light_brightness(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_FLASH: FLASH_LONG},
+        {ATTR_ENTITY_ID: "light.test_mylight", ATTR_FLASH: FLASH_LONG},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -163,7 +163,7 @@ async def test_light_brightness(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_TRANSITION: 2},
+        {ATTR_ENTITY_ID: "light.test_mylight", ATTR_TRANSITION: 2},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -181,7 +181,7 @@ async def test_light_brightness(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_FLASH: FLASH_SHORT},
+        {ATTR_ENTITY_ID: "light.test_mylight", ATTR_FLASH: FLASH_SHORT},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -223,14 +223,14 @@ async def test_light_brightness_on_off(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("light.test_my_light")
+    state = hass.states.get("light.test_mylight")
     assert state is not None
     assert state.state == STATE_ON
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light"},
+        {ATTR_ENTITY_ID: "light.test_mylight"},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -248,7 +248,7 @@ async def test_light_brightness_on_off(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_BRIGHTNESS: 127},
+        {ATTR_ENTITY_ID: "light.test_mylight", ATTR_BRIGHTNESS: 127},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -293,14 +293,14 @@ async def test_light_legacy_white_converted_to_brightness(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("light.test_my_light")
+    state = hass.states.get("light.test_mylight")
     assert state is not None
     assert state.state == STATE_ON
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light"},
+        {ATTR_ENTITY_ID: "light.test_mylight"},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -351,7 +351,7 @@ async def test_light_legacy_white_with_rgb(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("light.test_my_light")
+    state = hass.states.get("light.test_mylight")
     assert state is not None
     assert state.state == STATE_ON
     assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == [
@@ -362,7 +362,7 @@ async def test_light_legacy_white_with_rgb(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_WHITE: 60},
+        {ATTR_ENTITY_ID: "light.test_mylight", ATTR_WHITE: 60},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -405,14 +405,14 @@ async def test_light_brightness_on_off_with_unknown_color_mode(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("light.test_my_light")
+    state = hass.states.get("light.test_mylight")
     assert state is not None
     assert state.state == STATE_ON
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light"},
+        {ATTR_ENTITY_ID: "light.test_mylight"},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -431,7 +431,7 @@ async def test_light_brightness_on_off_with_unknown_color_mode(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_BRIGHTNESS: 127},
+        {ATTR_ENTITY_ID: "light.test_mylight", ATTR_BRIGHTNESS: 127},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -476,14 +476,14 @@ async def test_light_on_and_brightness(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("light.test_my_light")
+    state = hass.states.get("light.test_mylight")
     assert state is not None
     assert state.state == STATE_ON
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light"},
+        {ATTR_ENTITY_ID: "light.test_mylight"},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -526,14 +526,14 @@ async def test_rgb_color_temp_light(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("light.test_my_light")
+    state = hass.states.get("light.test_mylight")
     assert state is not None
     assert state.state == STATE_ON
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light"},
+        {ATTR_ENTITY_ID: "light.test_mylight"},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -551,7 +551,7 @@ async def test_rgb_color_temp_light(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_BRIGHTNESS: 127},
+        {ATTR_ENTITY_ID: "light.test_mylight", ATTR_BRIGHTNESS: 127},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -570,7 +570,7 @@ async def test_rgb_color_temp_light(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_COLOR_TEMP_KELVIN: 2500},
+        {ATTR_ENTITY_ID: "light.test_mylight", ATTR_COLOR_TEMP_KELVIN: 2500},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -614,14 +614,14 @@ async def test_light_rgb(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("light.test_my_light")
+    state = hass.states.get("light.test_mylight")
     assert state is not None
     assert state.state == STATE_ON
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light"},
+        {ATTR_ENTITY_ID: "light.test_mylight"},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -640,7 +640,7 @@ async def test_light_rgb(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_BRIGHTNESS: 127},
+        {ATTR_ENTITY_ID: "light.test_mylight", ATTR_BRIGHTNESS: 127},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -661,7 +661,7 @@ async def test_light_rgb(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
         {
-            ATTR_ENTITY_ID: "light.test_my_light",
+            ATTR_ENTITY_ID: "light.test_mylight",
             ATTR_BRIGHTNESS: 127,
             ATTR_HS_COLOR: (100, 100),
         },
@@ -686,7 +686,7 @@ async def test_light_rgb(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_RGB_COLOR: (255, 255, 255)},
+        {ATTR_ENTITY_ID: "light.test_mylight", ATTR_RGB_COLOR: (255, 255, 255)},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -746,7 +746,7 @@ async def test_light_rgbw(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("light.test_my_light")
+    state = hass.states.get("light.test_mylight")
     assert state is not None
     assert state.state == STATE_ON
     assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == [ColorMode.RGBW]
@@ -755,7 +755,7 @@ async def test_light_rgbw(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light"},
+        {ATTR_ENTITY_ID: "light.test_mylight"},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -775,7 +775,7 @@ async def test_light_rgbw(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_BRIGHTNESS: 127},
+        {ATTR_ENTITY_ID: "light.test_mylight", ATTR_BRIGHTNESS: 127},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -797,7 +797,7 @@ async def test_light_rgbw(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
         {
-            ATTR_ENTITY_ID: "light.test_my_light",
+            ATTR_ENTITY_ID: "light.test_mylight",
             ATTR_BRIGHTNESS: 127,
             ATTR_HS_COLOR: (100, 100),
         },
@@ -824,7 +824,7 @@ async def test_light_rgbw(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_RGB_COLOR: (255, 255, 255)},
+        {ATTR_ENTITY_ID: "light.test_mylight", ATTR_RGB_COLOR: (255, 255, 255)},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -847,7 +847,7 @@ async def test_light_rgbw(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_RGBW_COLOR: (255, 255, 255, 255)},
+        {ATTR_ENTITY_ID: "light.test_mylight", ATTR_RGBW_COLOR: (255, 255, 255, 255)},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -917,7 +917,7 @@ async def test_light_rgbww_with_cold_warm_white_support(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("light.test_my_light")
+    state = hass.states.get("light.test_mylight")
     assert state is not None
     assert state.state == STATE_ON
     assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == [ColorMode.RGBWW]
@@ -927,7 +927,7 @@ async def test_light_rgbww_with_cold_warm_white_support(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light"},
+        {ATTR_ENTITY_ID: "light.test_mylight"},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -949,7 +949,7 @@ async def test_light_rgbww_with_cold_warm_white_support(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_BRIGHTNESS: 127},
+        {ATTR_ENTITY_ID: "light.test_mylight", ATTR_BRIGHTNESS: 127},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -973,7 +973,7 @@ async def test_light_rgbww_with_cold_warm_white_support(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
         {
-            ATTR_ENTITY_ID: "light.test_my_light",
+            ATTR_ENTITY_ID: "light.test_mylight",
             ATTR_BRIGHTNESS: 127,
             ATTR_HS_COLOR: (100, 100),
         },
@@ -1003,7 +1003,7 @@ async def test_light_rgbww_with_cold_warm_white_support(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_RGB_COLOR: (255, 255, 255)},
+        {ATTR_ENTITY_ID: "light.test_mylight", ATTR_RGB_COLOR: (255, 255, 255)},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -1029,7 +1029,7 @@ async def test_light_rgbww_with_cold_warm_white_support(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_RGBW_COLOR: (255, 255, 255, 255)},
+        {ATTR_ENTITY_ID: "light.test_mylight", ATTR_RGBW_COLOR: (255, 255, 255, 255)},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -1056,7 +1056,7 @@ async def test_light_rgbww_with_cold_warm_white_support(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
         {
-            ATTR_ENTITY_ID: "light.test_my_light",
+            ATTR_ENTITY_ID: "light.test_mylight",
             ATTR_RGBWW_COLOR: (255, 255, 255, 255, 255),
         },
         blocking=True,
@@ -1084,7 +1084,7 @@ async def test_light_rgbww_with_cold_warm_white_support(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_COLOR_TEMP_KELVIN: 2500},
+        {ATTR_ENTITY_ID: "light.test_mylight", ATTR_COLOR_TEMP_KELVIN: 2500},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -1154,7 +1154,7 @@ async def test_light_rgbww_without_cold_warm_white_support(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("light.test_my_light")
+    state = hass.states.get("light.test_mylight")
     assert state is not None
     assert state.state == STATE_ON
     assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == [ColorMode.RGBWW]
@@ -1164,7 +1164,7 @@ async def test_light_rgbww_without_cold_warm_white_support(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light"},
+        {ATTR_ENTITY_ID: "light.test_mylight"},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -1185,7 +1185,7 @@ async def test_light_rgbww_without_cold_warm_white_support(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_BRIGHTNESS: 127},
+        {ATTR_ENTITY_ID: "light.test_mylight", ATTR_BRIGHTNESS: 127},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -1208,7 +1208,7 @@ async def test_light_rgbww_without_cold_warm_white_support(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
         {
-            ATTR_ENTITY_ID: "light.test_my_light",
+            ATTR_ENTITY_ID: "light.test_mylight",
             ATTR_BRIGHTNESS: 127,
             ATTR_HS_COLOR: (100, 100),
         },
@@ -1237,7 +1237,7 @@ async def test_light_rgbww_without_cold_warm_white_support(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_RGB_COLOR: (255, 255, 255)},
+        {ATTR_ENTITY_ID: "light.test_mylight", ATTR_RGB_COLOR: (255, 255, 255)},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -1262,7 +1262,7 @@ async def test_light_rgbww_without_cold_warm_white_support(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_RGBW_COLOR: (255, 255, 255, 255)},
+        {ATTR_ENTITY_ID: "light.test_mylight", ATTR_RGBW_COLOR: (255, 255, 255, 255)},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -1288,7 +1288,7 @@ async def test_light_rgbww_without_cold_warm_white_support(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
         {
-            ATTR_ENTITY_ID: "light.test_my_light",
+            ATTR_ENTITY_ID: "light.test_mylight",
             ATTR_RGBWW_COLOR: (255, 255, 255, 255, 255),
         },
         blocking=True,
@@ -1315,7 +1315,7 @@ async def test_light_rgbww_without_cold_warm_white_support(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_COLOR_TEMP_KELVIN: 2500},
+        {ATTR_ENTITY_ID: "light.test_mylight", ATTR_COLOR_TEMP_KELVIN: 2500},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -1374,7 +1374,7 @@ async def test_light_color_temp(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("light.test_my_light")
+    state = hass.states.get("light.test_mylight")
     assert state is not None
     assert state.state == STATE_ON
     attributes = state.attributes
@@ -1387,7 +1387,7 @@ async def test_light_color_temp(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light"},
+        {ATTR_ENTITY_ID: "light.test_mylight"},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -1406,7 +1406,7 @@ async def test_light_color_temp(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: "light.test_my_light"},
+        {ATTR_ENTITY_ID: "light.test_mylight"},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls([call(key=1, state=False)])
@@ -1449,7 +1449,7 @@ async def test_light_color_temp_no_mireds_set(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("light.test_my_light")
+    state = hass.states.get("light.test_mylight")
     assert state is not None
     assert state.state == STATE_ON
     attributes = state.attributes
@@ -1462,7 +1462,7 @@ async def test_light_color_temp_no_mireds_set(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light"},
+        {ATTR_ENTITY_ID: "light.test_mylight"},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -1481,7 +1481,7 @@ async def test_light_color_temp_no_mireds_set(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_COLOR_TEMP_KELVIN: 6000},
+        {ATTR_ENTITY_ID: "light.test_mylight", ATTR_COLOR_TEMP_KELVIN: 6000},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -1501,7 +1501,7 @@ async def test_light_color_temp_no_mireds_set(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: "light.test_my_light"},
+        {ATTR_ENTITY_ID: "light.test_mylight"},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls([call(key=1, state=False)])
@@ -1551,7 +1551,7 @@ async def test_light_color_temp_legacy(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("light.test_my_light")
+    state = hass.states.get("light.test_mylight")
     assert state is not None
     assert state.state == STATE_ON
     attributes = state.attributes
@@ -1566,7 +1566,7 @@ async def test_light_color_temp_legacy(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light"},
+        {ATTR_ENTITY_ID: "light.test_mylight"},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -1585,7 +1585,7 @@ async def test_light_color_temp_legacy(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: "light.test_my_light"},
+        {ATTR_ENTITY_ID: "light.test_mylight"},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls([call(key=1, state=False)])
@@ -1637,7 +1637,7 @@ async def test_light_rgb_legacy(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("light.test_my_light")
+    state = hass.states.get("light.test_mylight")
     assert state is not None
     assert state.state == STATE_ON
     attributes = state.attributes
@@ -1647,7 +1647,7 @@ async def test_light_rgb_legacy(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light"},
+        {ATTR_ENTITY_ID: "light.test_mylight"},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -1663,7 +1663,7 @@ async def test_light_rgb_legacy(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: "light.test_my_light"},
+        {ATTR_ENTITY_ID: "light.test_mylight"},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls([call(key=1, state=False)])
@@ -1672,7 +1672,7 @@ async def test_light_rgb_legacy(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_RGB_COLOR: (255, 255, 255)},
+        {ATTR_ENTITY_ID: "light.test_mylight", ATTR_RGB_COLOR: (255, 255, 255)},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -1715,7 +1715,7 @@ async def test_light_effects(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("light.test_my_light")
+    state = hass.states.get("light.test_mylight")
     assert state is not None
     assert state.state == STATE_ON
     assert state.attributes[ATTR_EFFECT_LIST] == ["effect1", "effect2"]
@@ -1723,7 +1723,7 @@ async def test_light_effects(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_EFFECT: "effect1"},
+        {ATTR_ENTITY_ID: "light.test_mylight", ATTR_EFFECT: "effect1"},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -1782,7 +1782,7 @@ async def test_only_cold_warm_white_support(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("light.test_my_light")
+    state = hass.states.get("light.test_mylight")
     assert state is not None
     assert state.state == STATE_ON
     assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == [ColorMode.COLOR_TEMP]
@@ -1791,7 +1791,7 @@ async def test_only_cold_warm_white_support(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light"},
+        {ATTR_ENTITY_ID: "light.test_mylight"},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -1802,7 +1802,7 @@ async def test_only_cold_warm_white_support(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_BRIGHTNESS: 127},
+        {ATTR_ENTITY_ID: "light.test_mylight", ATTR_BRIGHTNESS: 127},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -1820,7 +1820,7 @@ async def test_only_cold_warm_white_support(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_COLOR_TEMP_KELVIN: 2500},
+        {ATTR_ENTITY_ID: "light.test_mylight", ATTR_COLOR_TEMP_KELVIN: 2500},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls(
@@ -1861,7 +1861,7 @@ async def test_light_no_color_modes(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("light.test_my_light")
+    state = hass.states.get("light.test_mylight")
     assert state is not None
     assert state.state == STATE_ON
     assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == [ColorMode.ONOFF]
@@ -1869,7 +1869,7 @@ async def test_light_no_color_modes(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_my_light"},
+        {ATTR_ENTITY_ID: "light.test_mylight"},
         blocking=True,
     )
     mock_client.light_command.assert_has_calls([call(key=1, state=True, color_mode=0)])

--- a/tests/components/esphome/test_lock.py
+++ b/tests/components/esphome/test_lock.py
@@ -39,14 +39,14 @@ async def test_lock_entity_no_open(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("lock.test_my_lock")
+    state = hass.states.get("lock.test_mylock")
     assert state is not None
     assert state.state == STATE_UNLOCKING
 
     await hass.services.async_call(
         LOCK_DOMAIN,
         SERVICE_LOCK,
-        {ATTR_ENTITY_ID: "lock.test_my_lock"},
+        {ATTR_ENTITY_ID: "lock.test_mylock"},
         blocking=True,
     )
     mock_client.lock_command.assert_has_calls([call(1, LockCommand.LOCK)])
@@ -73,7 +73,7 @@ async def test_lock_entity_start_locked(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("lock.test_my_lock")
+    state = hass.states.get("lock.test_mylock")
     assert state is not None
     assert state.state == STATE_LOCKED
 
@@ -100,14 +100,14 @@ async def test_lock_entity_supports_open(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("lock.test_my_lock")
+    state = hass.states.get("lock.test_mylock")
     assert state is not None
     assert state.state == STATE_LOCKING
 
     await hass.services.async_call(
         LOCK_DOMAIN,
         SERVICE_LOCK,
-        {ATTR_ENTITY_ID: "lock.test_my_lock"},
+        {ATTR_ENTITY_ID: "lock.test_mylock"},
         blocking=True,
     )
     mock_client.lock_command.assert_has_calls([call(1, LockCommand.LOCK)])
@@ -116,7 +116,7 @@ async def test_lock_entity_supports_open(
     await hass.services.async_call(
         LOCK_DOMAIN,
         SERVICE_UNLOCK,
-        {ATTR_ENTITY_ID: "lock.test_my_lock"},
+        {ATTR_ENTITY_ID: "lock.test_mylock"},
         blocking=True,
     )
     mock_client.lock_command.assert_has_calls([call(1, LockCommand.UNLOCK, None)])
@@ -125,7 +125,7 @@ async def test_lock_entity_supports_open(
     await hass.services.async_call(
         LOCK_DOMAIN,
         SERVICE_OPEN,
-        {ATTR_ENTITY_ID: "lock.test_my_lock"},
+        {ATTR_ENTITY_ID: "lock.test_mylock"},
         blocking=True,
     )
     mock_client.lock_command.assert_has_calls([call(1, LockCommand.OPEN)])

--- a/tests/components/esphome/test_media_player.py
+++ b/tests/components/esphome/test_media_player.py
@@ -62,7 +62,7 @@ async def test_media_player_entity(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("media_player.test_my_media_player")
+    state = hass.states.get("media_player.test_mymedia_player")
     assert state is not None
     assert state.state == "paused"
 
@@ -70,7 +70,7 @@ async def test_media_player_entity(
         MEDIA_PLAYER_DOMAIN,
         SERVICE_VOLUME_MUTE,
         {
-            ATTR_ENTITY_ID: "media_player.test_my_media_player",
+            ATTR_ENTITY_ID: "media_player.test_mymedia_player",
             ATTR_MEDIA_VOLUME_MUTED: True,
         },
         blocking=True,
@@ -84,7 +84,7 @@ async def test_media_player_entity(
         MEDIA_PLAYER_DOMAIN,
         SERVICE_VOLUME_MUTE,
         {
-            ATTR_ENTITY_ID: "media_player.test_my_media_player",
+            ATTR_ENTITY_ID: "media_player.test_mymedia_player",
             ATTR_MEDIA_VOLUME_MUTED: True,
         },
         blocking=True,
@@ -98,7 +98,7 @@ async def test_media_player_entity(
         MEDIA_PLAYER_DOMAIN,
         SERVICE_VOLUME_SET,
         {
-            ATTR_ENTITY_ID: "media_player.test_my_media_player",
+            ATTR_ENTITY_ID: "media_player.test_mymedia_player",
             ATTR_MEDIA_VOLUME_LEVEL: 0.5,
         },
         blocking=True,
@@ -110,7 +110,7 @@ async def test_media_player_entity(
         MEDIA_PLAYER_DOMAIN,
         SERVICE_MEDIA_PAUSE,
         {
-            ATTR_ENTITY_ID: "media_player.test_my_media_player",
+            ATTR_ENTITY_ID: "media_player.test_mymedia_player",
         },
         blocking=True,
     )
@@ -123,7 +123,7 @@ async def test_media_player_entity(
         MEDIA_PLAYER_DOMAIN,
         SERVICE_MEDIA_PLAY,
         {
-            ATTR_ENTITY_ID: "media_player.test_my_media_player",
+            ATTR_ENTITY_ID: "media_player.test_mymedia_player",
         },
         blocking=True,
     )
@@ -136,7 +136,7 @@ async def test_media_player_entity(
         MEDIA_PLAYER_DOMAIN,
         SERVICE_MEDIA_STOP,
         {
-            ATTR_ENTITY_ID: "media_player.test_my_media_player",
+            ATTR_ENTITY_ID: "media_player.test_mymedia_player",
         },
         blocking=True,
     )
@@ -207,7 +207,7 @@ async def test_media_player_entity_with_source(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("media_player.test_my_media_player")
+    state = hass.states.get("media_player.test_mymedia_player")
     assert state is not None
     assert state.state == "playing"
 
@@ -216,7 +216,7 @@ async def test_media_player_entity_with_source(
             MEDIA_PLAYER_DOMAIN,
             SERVICE_PLAY_MEDIA,
             {
-                ATTR_ENTITY_ID: "media_player.test_my_media_player",
+                ATTR_ENTITY_ID: "media_player.test_mymedia_player",
                 ATTR_MEDIA_CONTENT_TYPE: MediaType.MUSIC,
                 ATTR_MEDIA_CONTENT_ID: "media-source://local/xz",
             },
@@ -240,7 +240,7 @@ async def test_media_player_entity_with_source(
             MEDIA_PLAYER_DOMAIN,
             SERVICE_PLAY_MEDIA,
             {
-                ATTR_ENTITY_ID: "media_player.test_my_media_player",
+                ATTR_ENTITY_ID: "media_player.test_mymedia_player",
                 ATTR_MEDIA_CONTENT_TYPE: "audio/mp3",
                 ATTR_MEDIA_CONTENT_ID: "media-source://local/xy",
             },
@@ -256,7 +256,7 @@ async def test_media_player_entity_with_source(
         {
             "id": 1,
             "type": "media_player/browse_media",
-            "entity_id": "media_player.test_my_media_player",
+            "entity_id": "media_player.test_mymedia_player",
         }
     )
     response = await client.receive_json()
@@ -266,7 +266,7 @@ async def test_media_player_entity_with_source(
         MEDIA_PLAYER_DOMAIN,
         SERVICE_PLAY_MEDIA,
         {
-            ATTR_ENTITY_ID: "media_player.test_my_media_player",
+            ATTR_ENTITY_ID: "media_player.test_mymedia_player",
             ATTR_MEDIA_CONTENT_TYPE: MediaType.URL,
             ATTR_MEDIA_CONTENT_ID: "media-source://tts?message=hello",
             ATTR_MEDIA_ANNOUNCE: True,

--- a/tests/components/esphome/test_number.py
+++ b/tests/components/esphome/test_number.py
@@ -48,14 +48,14 @@ async def test_generic_number_entity(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("number.test_my_number")
+    state = hass.states.get("number.test_mynumber")
     assert state is not None
     assert state.state == "50"
 
     await hass.services.async_call(
         NUMBER_DOMAIN,
         SERVICE_SET_VALUE,
-        {ATTR_ENTITY_ID: "number.test_my_number", ATTR_VALUE: 50},
+        {ATTR_ENTITY_ID: "number.test_mynumber", ATTR_VALUE: 50},
         blocking=True,
     )
     mock_client.number_command.assert_has_calls([call(1, 50)])
@@ -89,7 +89,7 @@ async def test_generic_number_nan(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("number.test_my_number")
+    state = hass.states.get("number.test_mynumber")
     assert state is not None
     assert state.state == STATE_UNKNOWN
 
@@ -121,7 +121,7 @@ async def test_generic_number_with_unit_of_measurement_as_empty_string(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("number.test_my_number")
+    state = hass.states.get("number.test_mynumber")
     assert state is not None
     assert state.state == "42"
     assert ATTR_UNIT_OF_MEASUREMENT not in state.attributes
@@ -160,7 +160,7 @@ async def test_generic_number_entity_set_when_disconnected(
         await hass.services.async_call(
             NUMBER_DOMAIN,
             SERVICE_SET_VALUE,
-            {ATTR_ENTITY_ID: "number.test_my_number", ATTR_VALUE: 20},
+            {ATTR_ENTITY_ID: "number.test_mynumber", ATTR_VALUE: 20},
             blocking=True,
         )
     mock_client.number_command.reset_mock()

--- a/tests/components/esphome/test_select.py
+++ b/tests/components/esphome/test_select.py
@@ -59,14 +59,14 @@ async def test_select_generic_entity(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("select.test_my_select")
+    state = hass.states.get("select.test_myselect")
     assert state is not None
     assert state.state == "a"
 
     await hass.services.async_call(
         SELECT_DOMAIN,
         SERVICE_SELECT_OPTION,
-        {ATTR_ENTITY_ID: "select.test_my_select", ATTR_OPTION: "b"},
+        {ATTR_ENTITY_ID: "select.test_myselect", ATTR_OPTION: "b"},
         blocking=True,
     )
     mock_client.select_command.assert_has_calls([call(1, "b")])

--- a/tests/components/esphome/test_sensor.py
+++ b/tests/components/esphome/test_sensor.py
@@ -62,35 +62,35 @@ async def test_generic_numeric_sensor(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("sensor.test_my_sensor")
+    state = hass.states.get("sensor.test_mysensor")
     assert state is not None
     assert state.state == "50"
 
     # Test updating state
     mock_device.set_state(SensorState(key=1, state=60))
     await hass.async_block_till_done()
-    state = hass.states.get("sensor.test_my_sensor")
+    state = hass.states.get("sensor.test_mysensor")
     assert state is not None
     assert state.state == "60"
 
     # Test sending the same state again
     mock_device.set_state(SensorState(key=1, state=60))
     await hass.async_block_till_done()
-    state = hass.states.get("sensor.test_my_sensor")
+    state = hass.states.get("sensor.test_mysensor")
     assert state is not None
     assert state.state == "60"
 
     # Test we can still update after the same state
     mock_device.set_state(SensorState(key=1, state=70))
     await hass.async_block_till_done()
-    state = hass.states.get("sensor.test_my_sensor")
+    state = hass.states.get("sensor.test_mysensor")
     assert state is not None
     assert state.state == "70"
 
     # Test invalid data from the underlying api does not crash us
     mock_device.set_state(SensorState(key=1, state=object()))
     await hass.async_block_till_done()
-    state = hass.states.get("sensor.test_my_sensor")
+    state = hass.states.get("sensor.test_mysensor")
     assert state is not None
     assert state.state == "70"
 
@@ -120,11 +120,11 @@ async def test_generic_numeric_sensor_with_entity_category_and_icon(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("sensor.test_my_sensor")
+    state = hass.states.get("sensor.test_mysensor")
     assert state is not None
     assert state.state == "50"
     assert state.attributes[ATTR_ICON] == "mdi:leaf"
-    entry = entity_registry.async_get("sensor.test_my_sensor")
+    entry = entity_registry.async_get("sensor.test_mysensor")
     assert entry is not None
     # Note that ESPHome includes the EntityInfo type in the unique id
     # as this is not a 1:1 mapping to the entity platform (ie. text_sensor)
@@ -158,11 +158,11 @@ async def test_generic_numeric_sensor_state_class_measurement(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("sensor.test_my_sensor")
+    state = hass.states.get("sensor.test_mysensor")
     assert state is not None
     assert state.state == "50"
     assert state.attributes[ATTR_STATE_CLASS] == SensorStateClass.MEASUREMENT
-    entry = entity_registry.async_get("sensor.test_my_sensor")
+    entry = entity_registry.async_get("sensor.test_mysensor")
     assert entry is not None
     # Note that ESPHome includes the EntityInfo type in the unique id
     # as this is not a 1:1 mapping to the entity platform (ie. text_sensor)
@@ -193,7 +193,7 @@ async def test_generic_numeric_sensor_device_class_timestamp(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("sensor.test_my_sensor")
+    state = hass.states.get("sensor.test_mysensor")
     assert state is not None
     assert state.state == "2023-06-22T18:43:52+00:00"
 
@@ -222,7 +222,7 @@ async def test_generic_numeric_sensor_legacy_last_reset_convert(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("sensor.test_my_sensor")
+    state = hass.states.get("sensor.test_mysensor")
     assert state is not None
     assert state.state == "50"
     assert state.attributes[ATTR_STATE_CLASS] == SensorStateClass.TOTAL_INCREASING
@@ -248,7 +248,7 @@ async def test_generic_numeric_sensor_no_state(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("sensor.test_my_sensor")
+    state = hass.states.get("sensor.test_mysensor")
     assert state is not None
     assert state.state == STATE_UNKNOWN
 
@@ -273,7 +273,7 @@ async def test_generic_numeric_sensor_nan_state(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("sensor.test_my_sensor")
+    state = hass.states.get("sensor.test_mysensor")
     assert state is not None
     assert state.state == STATE_UNKNOWN
 
@@ -298,7 +298,7 @@ async def test_generic_numeric_sensor_missing_state(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("sensor.test_my_sensor")
+    state = hass.states.get("sensor.test_mysensor")
     assert state is not None
     assert state.state == STATE_UNKNOWN
 
@@ -325,7 +325,7 @@ async def test_generic_text_sensor(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("sensor.test_my_sensor")
+    state = hass.states.get("sensor.test_mysensor")
     assert state is not None
     assert state.state == "i am a teapot"
 
@@ -350,7 +350,7 @@ async def test_generic_text_sensor_missing_state(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("sensor.test_my_sensor")
+    state = hass.states.get("sensor.test_mysensor")
     assert state is not None
     assert state.state == STATE_UNKNOWN
 
@@ -378,7 +378,7 @@ async def test_generic_text_sensor_device_class_timestamp(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("sensor.test_my_sensor")
+    state = hass.states.get("sensor.test_mysensor")
     assert state is not None
     assert state.state == "2023-06-22T18:43:52+00:00"
     assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.TIMESTAMP
@@ -407,7 +407,7 @@ async def test_generic_text_sensor_device_class_date(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("sensor.test_my_sensor")
+    state = hass.states.get("sensor.test_mysensor")
     assert state is not None
     assert state.state == "2023-06-22"
     assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.DATE
@@ -434,7 +434,7 @@ async def test_generic_numeric_sensor_empty_string_uom(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("sensor.test_my_sensor")
+    state = hass.states.get("sensor.test_mysensor")
     assert state is not None
     assert state.state == "123"
     assert ATTR_UNIT_OF_MEASUREMENT not in state.attributes

--- a/tests/components/esphome/test_switch.py
+++ b/tests/components/esphome/test_switch.py
@@ -33,14 +33,14 @@ async def test_switch_generic_entity(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("switch.test_my_switch")
+    state = hass.states.get("switch.test_myswitch")
     assert state is not None
     assert state.state == STATE_ON
 
     await hass.services.async_call(
         SWITCH_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "switch.test_my_switch"},
+        {ATTR_ENTITY_ID: "switch.test_myswitch"},
         blocking=True,
     )
     mock_client.switch_command.assert_has_calls([call(1, True)])
@@ -48,7 +48,7 @@ async def test_switch_generic_entity(
     await hass.services.async_call(
         SWITCH_DOMAIN,
         SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: "switch.test_my_switch"},
+        {ATTR_ENTITY_ID: "switch.test_myswitch"},
         blocking=True,
     )
     mock_client.switch_command.assert_has_calls([call(1, False)])

--- a/tests/components/esphome/test_text.py
+++ b/tests/components/esphome/test_text.py
@@ -39,14 +39,14 @@ async def test_generic_text_entity(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("text.test_my_text")
+    state = hass.states.get("text.test_mytext")
     assert state is not None
     assert state.state == "hello world"
 
     await hass.services.async_call(
         TEXT_DOMAIN,
         SERVICE_SET_VALUE,
-        {ATTR_ENTITY_ID: "text.test_my_text", ATTR_VALUE: "goodbye"},
+        {ATTR_ENTITY_ID: "text.test_mytext", ATTR_VALUE: "goodbye"},
         blocking=True,
     )
     mock_client.text_command.assert_has_calls([call(1, "goodbye")])
@@ -79,7 +79,7 @@ async def test_generic_text_entity_no_state(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("text.test_my_text")
+    state = hass.states.get("text.test_mytext")
     assert state is not None
     assert state.state == STATE_UNKNOWN
 
@@ -110,6 +110,6 @@ async def test_generic_text_entity_missing_state(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("text.test_my_text")
+    state = hass.states.get("text.test_mytext")
     assert state is not None
     assert state.state == STATE_UNKNOWN

--- a/tests/components/esphome/test_time.py
+++ b/tests/components/esphome/test_time.py
@@ -35,14 +35,14 @@ async def test_generic_time_entity(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("time.test_my_time")
+    state = hass.states.get("time.test_mytime")
     assert state is not None
     assert state.state == "12:34:56"
 
     await hass.services.async_call(
         TIME_DOMAIN,
         SERVICE_SET_VALUE,
-        {ATTR_ENTITY_ID: "time.test_my_time", ATTR_TIME: "01:23:45"},
+        {ATTR_ENTITY_ID: "time.test_mytime", ATTR_TIME: "01:23:45"},
         blocking=True,
     )
     mock_client.time_command.assert_has_calls([call(1, 1, 23, 45)])
@@ -71,6 +71,6 @@ async def test_generic_time_missing_state(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("time.test_my_time")
+    state = hass.states.get("time.test_mytime")
     assert state is not None
     assert state.state == STATE_UNKNOWN

--- a/tests/components/esphome/test_update.py
+++ b/tests/components/esphome/test_update.py
@@ -464,7 +464,7 @@ async def test_generic_device_update_entity(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("update.test_my_update")
+    state = hass.states.get("update.test_myupdate")
     assert state is not None
     assert state.state == STATE_OFF
 
@@ -503,14 +503,14 @@ async def test_generic_device_update_entity_has_update(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("update.test_my_update")
+    state = hass.states.get("update.test_myupdate")
     assert state is not None
     assert state.state == STATE_ON
 
     await hass.services.async_call(
         UPDATE_DOMAIN,
         SERVICE_INSTALL,
-        {ATTR_ENTITY_ID: "update.test_my_update"},
+        {ATTR_ENTITY_ID: "update.test_myupdate"},
         blocking=True,
     )
 
@@ -528,7 +528,7 @@ async def test_generic_device_update_entity_has_update(
         )
     )
 
-    state = hass.states.get("update.test_my_update")
+    state = hass.states.get("update.test_myupdate")
     assert state is not None
     assert state.state == STATE_ON
     assert state.attributes["in_progress"] == 50
@@ -536,7 +536,7 @@ async def test_generic_device_update_entity_has_update(
     await hass.services.async_call(
         HOMEASSISTANT_DOMAIN,
         SERVICE_UPDATE_ENTITY,
-        {ATTR_ENTITY_ID: "update.test_my_update"},
+        {ATTR_ENTITY_ID: "update.test_myupdate"},
         blocking=True,
     )
 

--- a/tests/components/esphome/test_valve.py
+++ b/tests/components/esphome/test_valve.py
@@ -65,7 +65,7 @@ async def test_valve_entity(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("valve.test_my_valve")
+    state = hass.states.get("valve.test_myvalve")
     assert state is not None
     assert state.state == STATE_OPENING
     assert state.attributes[ATTR_CURRENT_POSITION] == 50
@@ -73,7 +73,7 @@ async def test_valve_entity(
     await hass.services.async_call(
         VALVE_DOMAIN,
         SERVICE_CLOSE_VALVE,
-        {ATTR_ENTITY_ID: "valve.test_my_valve"},
+        {ATTR_ENTITY_ID: "valve.test_myvalve"},
         blocking=True,
     )
     mock_client.valve_command.assert_has_calls([call(key=1, position=0.0)])
@@ -82,7 +82,7 @@ async def test_valve_entity(
     await hass.services.async_call(
         VALVE_DOMAIN,
         SERVICE_OPEN_VALVE,
-        {ATTR_ENTITY_ID: "valve.test_my_valve"},
+        {ATTR_ENTITY_ID: "valve.test_myvalve"},
         blocking=True,
     )
     mock_client.valve_command.assert_has_calls([call(key=1, position=1.0)])
@@ -91,7 +91,7 @@ async def test_valve_entity(
     await hass.services.async_call(
         VALVE_DOMAIN,
         SERVICE_SET_VALVE_POSITION,
-        {ATTR_ENTITY_ID: "valve.test_my_valve", ATTR_POSITION: 50},
+        {ATTR_ENTITY_ID: "valve.test_myvalve", ATTR_POSITION: 50},
         blocking=True,
     )
     mock_client.valve_command.assert_has_calls([call(key=1, position=0.5)])
@@ -100,7 +100,7 @@ async def test_valve_entity(
     await hass.services.async_call(
         VALVE_DOMAIN,
         SERVICE_STOP_VALVE,
-        {ATTR_ENTITY_ID: "valve.test_my_valve"},
+        {ATTR_ENTITY_ID: "valve.test_myvalve"},
         blocking=True,
     )
     mock_client.valve_command.assert_has_calls([call(key=1, stop=True)])
@@ -110,7 +110,7 @@ async def test_valve_entity(
         ValveState(key=1, position=0.0, current_operation=ValveOperation.IDLE)
     )
     await hass.async_block_till_done()
-    state = hass.states.get("valve.test_my_valve")
+    state = hass.states.get("valve.test_myvalve")
     assert state is not None
     assert state.state == STATE_CLOSED
 
@@ -118,7 +118,7 @@ async def test_valve_entity(
         ValveState(key=1, position=0.5, current_operation=ValveOperation.IS_CLOSING)
     )
     await hass.async_block_till_done()
-    state = hass.states.get("valve.test_my_valve")
+    state = hass.states.get("valve.test_myvalve")
     assert state is not None
     assert state.state == STATE_CLOSING
 
@@ -126,7 +126,7 @@ async def test_valve_entity(
         ValveState(key=1, position=1.0, current_operation=ValveOperation.IDLE)
     )
     await hass.async_block_till_done()
-    state = hass.states.get("valve.test_my_valve")
+    state = hass.states.get("valve.test_myvalve")
     assert state is not None
     assert state.state == STATE_OPEN
 
@@ -164,7 +164,7 @@ async def test_valve_entity_without_position(
         user_service=user_service,
         states=states,
     )
-    state = hass.states.get("valve.test_my_valve")
+    state = hass.states.get("valve.test_myvalve")
     assert state is not None
     assert state.state == STATE_OPENING
     assert ATTR_CURRENT_POSITION not in state.attributes
@@ -172,7 +172,7 @@ async def test_valve_entity_without_position(
     await hass.services.async_call(
         VALVE_DOMAIN,
         SERVICE_CLOSE_VALVE,
-        {ATTR_ENTITY_ID: "valve.test_my_valve"},
+        {ATTR_ENTITY_ID: "valve.test_myvalve"},
         blocking=True,
     )
     mock_client.valve_command.assert_has_calls([call(key=1, position=0.0)])
@@ -181,7 +181,7 @@ async def test_valve_entity_without_position(
     await hass.services.async_call(
         VALVE_DOMAIN,
         SERVICE_OPEN_VALVE,
-        {ATTR_ENTITY_ID: "valve.test_my_valve"},
+        {ATTR_ENTITY_ID: "valve.test_myvalve"},
         blocking=True,
     )
     mock_client.valve_command.assert_has_calls([call(key=1, position=1.0)])
@@ -191,6 +191,6 @@ async def test_valve_entity_without_position(
         ValveState(key=1, position=0.0, current_operation=ValveOperation.IDLE)
     )
     await hass.async_block_till_done()
-    state = hass.states.get("valve.test_my_valve")
+    state = hass.states.get("valve.test_myvalve")
     assert state is not None
     assert state.state == STATE_CLOSED


### PR DESCRIPTION
Reverts home-assistant/core#123436

This break the specifically for ESPHome implemented feature where the entity IDs in Home Assistant would match up as closely with the IDs set in ESPHome.

