### PR TITLE
Drop violating rows before adding foreign constraints in DB schema 44 migration

### DIFF
--- a/homeassistant/components/recorder/db_schema.py
+++ b/homeassistant/components/recorder/db_schema.py
@@ -77,7 +77,7 @@ class LegacyBase(DeclarativeBase):
     """Base class for tables, used for schema migration."""
 
 
-SCHEMA_VERSION = 44
+SCHEMA_VERSION = 45
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -728,13 +728,13 @@ def _delete_foreign_key_violations(
     with session_scope(session=session_maker()) as session:
         session.execute(
             text(
-                f"DELETE FROM {table} "  # noqa: S608
+                f"DELETE FROM {table} t1"  # noqa: S608
                 "WHERE ("
-                f"  {table}.{column} IS NOT NULL AND"
+                f"  t1.{column} IS NOT NULL AND"
                 "  NOT EXISTS"
                 "    (SELECT 1 "
-                f"     FROM  {foreign_table} "
-                f"     WHERE {foreign_table}.{foreign_column} = {table}.{column}));"
+                f"     FROM  {foreign_table} t2"
+                f"     WHERE t2.{foreign_column} = t1.{column}));"
             )
         )
 

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -732,13 +732,15 @@ def _delete_foreign_key_violations(
             # MariaDB 11.6 and is not supported by MySQL. Those engines
             # instead support the from `DELETE t1 from table AS t1` which
             # is not supported by PostgreSQL and undocumented for MariaDB.
+            # The subquery (SELECT {foreign_column} from {foreign_table}) is
+            # to be compatible with old MySQL versions.
             text(
                 f"DELETE FROM {table}"  # noqa: S608
                 " WHERE ("
                 f" {table}.{column} IS NOT NULL AND"
                 "  NOT EXISTS"
                 "    (SELECT 1 "
-                f"     FROM  {foreign_table} AS t2"
+                f"     FROM  (SELECT {foreign_column} from {foreign_table}) AS t2"
                 f"     WHERE t2.{foreign_column} = {table}.{column}));"
             )
         )

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -681,6 +681,10 @@ def _restore_foreign_key_constraints(
             _LOGGER.info("Did not find a matching constraint for %s.%s", table, column)
             continue
 
+        if TYPE_CHECKING:
+            assert foreign_table is not None
+            assert foreign_column is not None
+
         # AddConstraint mutates the constraint passed to it, we need to
         # undo that to avoid changing the behavior of the table schema.
         # https://github.com/sqlalchemy/sqlalchemy/blob/96f1172812f858fead45cdc7874abac76f45b339/lib/sqlalchemy/sql/ddl.py#L746-L748
@@ -730,16 +734,14 @@ def _delete_foreign_key_violations(
     engine: Engine,
     table: str,
     column: str,
-    foreign_table: str | None,
-    foreign_column: str | None,
+    foreign_table: str,
+    foreign_column: str,
 ) -> None:
     """Remove rows which violate the constraints."""
     if engine.dialect.name not in (SupportedDialect.MYSQL, SupportedDialect.POSTGRESQL):
         raise RuntimeError(
             f"_delete_foreign_key_violations not supported for {engine.dialect.name}"
         )
-    if foreign_table is None:
-        return
 
     _LOGGER.warning(
         "Rows in table %s where %s references non existing %s.%s will be %s. "

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -729,7 +729,7 @@ def _delete_foreign_key_violations(
         session.execute(
             text(
                 f"DELETE FROM {table} t1"  # noqa: S608
-                "WHERE ("
+                " WHERE ("
                 f"  t1.{column} IS NOT NULL AND"
                 "  NOT EXISTS"
                 "    (SELECT 1 "

--- a/tests/components/recorder/test_migrate.py
+++ b/tests/components/recorder/test_migrate.py
@@ -925,7 +925,7 @@ def test_drop_restore_foreign_key_constraints(recorder_db_url: str) -> None:
     with Session(engine) as session:
         session_maker = Mock(return_value=session)
         migration._restore_foreign_key_constraints(
-            session_maker, engine, dropped_constraints_1
+            session_maker, engine, constraints_to_recreate
         )
 
     # Check we do find the constrained columns again (they are restored)

--- a/tests/components/recorder/test_migrate.py
+++ b/tests/components/recorder/test_migrate.py
@@ -1002,7 +1002,6 @@ def test_restore_foreign_key_constraints_with_integrity_error(
     assert len(connection.execute.mock_calls) == 2
     session.execute.assert_called_once()
     assert session.execute.mock_calls[0][1][0].text == (
-        "DELETE FROM events WHERE (  events.data_id IS NOT NULL AND  NOT EXISTS    "
-        "(SELECT 1      FROM  event_data      WHERE event_data.data_id = "
-        "events.data_id));"
+        "DELETE FROM events t1 WHERE (  t1.data_id IS NOT NULL AND  NOT EXISTS    "
+        "(SELECT 1      FROM  event_data t2     WHERE t2.data_id = t1.data_id));"
     )

--- a/tests/components/recorder/test_migrate.py
+++ b/tests/components/recorder/test_migrate.py
@@ -951,21 +951,7 @@ def test_restore_foreign_key_constraints_with_error(
     This is not supported on SQLite
     """
 
-    constraints_to_restore = [
-        (
-            "events",
-            "data_id",
-            {
-                "comment": None,
-                "constrained_columns": ["data_id"],
-                "name": "events_data_id_fkey",
-                "options": {},
-                "referred_columns": ["data_id"],
-                "referred_schema": None,
-                "referred_table": "event_data",
-            },
-        ),
-    ]
+    constraints_to_restore = [("events", "data_id")]
 
     connection = Mock()
     connection.execute = Mock(side_effect=InternalError(None, None, None))

--- a/tests/components/recorder/test_migrate.py
+++ b/tests/components/recorder/test_migrate.py
@@ -996,17 +996,19 @@ def test_restore_foreign_key_constraints_with_integrity_error(
                 session_maker, engine, table, column
             )
 
-    # Add a row violating the constraints
+    # Add rows violating the constraints
     with Session(engine) as session:
         for _, column, _, _, table_class in constraints:
             session.add(table_class(**{column: 123}))
             session.add(table_class())
-            session.commit()
+        # Insert a States row referencing the row with an invalid foreign reference
+        session.add(States(old_state_id=1))
+        session.commit()
 
-    # Check we could insert both rows
+    # Check we could insert the rows
     with Session(engine) as session:
-        for _, _, _, _, table_class in constraints:
-            assert session.query(table_class).count() == 2
+        assert session.query(Events).count() == 2
+        assert session.query(States).count() == 3
 
     # Restore constraints
     to_restore = [
@@ -1017,10 +1019,10 @@ def test_restore_foreign_key_constraints_with_integrity_error(
         session_maker = Mock(return_value=session)
         migration._restore_foreign_key_constraints(session_maker, engine, to_restore)
 
-    # Check the violating row has been deleted
+    # Check the violating row has been deleted from the Events table
     with Session(engine) as session:
-        for _, _, _, _, table_class in constraints:
-            assert session.query(table_class).count() == 1
+        assert session.query(Events).count() == 1
+        assert session.query(States).count() == 3
 
     engine.dispose()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Drop violating rows before adding foreign constraints when migration to recorder DB schema 44

There are multiple issues raised where the existing database has errors violating foreign key constraints, causing the schema migration to fail
This PR makes two changes:
- Remove rows which violate the foreign key constraints
- Make adding foreign key constraints deterministic

Fixes https://github.com/home-assistant/core/issues/123309

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
