### PR TITLE
Fix QNAP sensors precision display

### DIFF
--- a/homeassistant/components/qnap/sensor.py
+++ b/homeassistant/components/qnap/sensor.py
@@ -371,7 +371,7 @@ class QNAPMemorySensor(QNAPSensor):
             return used
 
         if self.entity_description.key == "memory_percent_used":
-            return used / total * 100
+            return round(used / total * 100, self.entity_description.suggested_display_precision)
 
         return None
 
@@ -530,7 +530,7 @@ class QNAPVolumeSensor(QNAPSensor):
             return used_gb
 
         if self.entity_description.key == "volume_percentage_used":
-            return used_gb / total_gb * 100
+            return round(used_gb / total_gb * 100, self.entity_description.suggested_display_precision )
 
         return None
 

--- a/homeassistant/components/qnap/sensor.py
+++ b/homeassistant/components/qnap/sensor.py
@@ -371,7 +371,7 @@ class QNAPMemorySensor(QNAPSensor):
             return used
 
         if self.entity_description.key == "memory_percent_used":
-            return round(used / total * 100, self.entity_description.suggested_display_precision)
+            return round(used / total * 100, 2)
 
         return None
 
@@ -530,7 +530,7 @@ class QNAPVolumeSensor(QNAPSensor):
             return used_gb
 
         if self.entity_description.key == "volume_percentage_used":
-            return round(used_gb / total_gb * 100, self.entity_description.suggested_display_precision )
+            return round(used_gb / total_gb * 100, 2 )
 
         return None
 


### PR DESCRIPTION
https://github.com/home-assistant/core/issues/100550

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Before the fix:
```
(ha_venv3_12) thin620t:~/homeassistant_conf $curl -H @hass_header.txt http://192.168.1.32:8123/api/states/sensor.nas_volume_used_volume_1
{"entity_id":"sensor.nas_volume_used_volume_1","state":"76.5633825068075","attributes":{"state_class":"measurement","Volume Size":"1832.3 GiB","unit_of_measurement":"%","friendly_name":"md0 usage","icon":"mdi:database"},"last_changed":"2024-08-09T10:50:41.532555+00:00","last_reported":"2024-08-09T10:50:41.532555+00:00","last_updated":"2024-08-09T10:50:41.532555+00:00","context":{"id":"01J4VC66FWRMS4NRF6SANR0KSJ","parent_id":null,"user_id":null}}(ha_venv3_12) atticus@thin620t:~/homeassistant_conf $
```
After the fix:
```
(ha_venv3_12) thin620t:~/homeassistant_conf $curl -H @hass_header.txt http://192.168.1.32:8123/api/states/sensor.nas_volume_used_volume_1
{"entity_id":"sensor.nas_volume_used_volume_1","state":"77.0","attributes":{"state_class":"measurement","Volume Size":"1832.3 GiB","unit_of_measurement":"%","friendly_name":"md0 usage","icon":"mdi:database"},"last_changed":"2024-08-09T12:10:09.570451+00:00","last_reported":"2024-08-09T12:10:09.570451+00:00","last_updated":"2024-08-09T12:10:09.570451+00:00","context":{"id":"01J4VGQPS2FRWA94ZNZJCQ3XE6","parent_id":null,"user_id":null}}
(ha_venv3_12) thin620t:~/homeassistant_conf $

```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # https://github.com/home-assistant/core/issues/100550
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
