### PR TITLE
Event device triggers

### DIFF
--- a/homeassistant/components/event/const.py
+++ b/homeassistant/components/event/const.py
@@ -3,3 +3,5 @@
 DOMAIN = "event"
 ATTR_EVENT_TYPE = "event_type"
 ATTR_EVENT_TYPES = "event_types"
+CONF_SUBTYPE = "subtype"
+CONF_EVENT_TYPE = ATTR_EVENT_TYPE

--- a/homeassistant/components/event/device_trigger.py
+++ b/homeassistant/components/event/device_trigger.py
@@ -1,0 +1,167 @@
+"""Provides device triggers for event entities."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components.device_automation import (
+    DEVICE_TRIGGER_BASE_SCHEMA,
+    async_get_entity_registry_entry_or_raise,
+)
+from homeassistant.components.device_automation.exceptions import (
+    InvalidDeviceAutomationConfig,
+)
+from homeassistant.const import (
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_ENTITY_ID,
+    CONF_PLATFORM,
+    CONF_TYPE,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import (
+    CALLBACK_TYPE,
+    Event,
+    EventStateChangedData,
+    HassJob,
+    HomeAssistant,
+    callback,
+)
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    entity_registry as er,
+    translation,
+)
+from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
+from homeassistant.helpers.typing import ConfigType
+
+from .const import (
+    ATTR_EVENT_TYPE,
+    ATTR_EVENT_TYPES,
+    CONF_EVENT_TYPE,
+    CONF_SUBTYPE,
+    DOMAIN,
+)
+
+TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_ENTITY_ID): cv.entity_id_or_uuid,
+        vol.Required(CONF_TYPE): "event",
+        vol.Required(CONF_SUBTYPE): str,
+        vol.Required(CONF_EVENT_TYPE): str,
+    }
+)
+
+
+async def async_get_triggers(
+    hass: HomeAssistant, device_id: str
+) -> list[dict[str, Any]]:
+    """List device triggers."""
+    device_registry = dr.async_get(hass)
+    if device_registry.async_get(device_id) is None:
+        raise InvalidDeviceAutomationConfig(f"Device ID {device_id} is not valid")
+
+    return [
+        {
+            CONF_PLATFORM: "device",
+            CONF_DOMAIN: DOMAIN,
+            CONF_DEVICE_ID: device_id,
+            CONF_ENTITY_ID: entity.id,
+            CONF_TYPE: "event",
+            CONF_SUBTYPE: _async_translate_event_type(
+                hass,
+                event_type,
+                entity.domain,
+                entity.platform,
+                entity.translation_key,
+                entity.device_class,
+            ),
+            CONF_EVENT_TYPE: event_type,
+        }
+        for entity in er.async_entries_for_device(er.async_get(hass), device_id)
+        if entity.domain == DOMAIN and entity.capabilities
+        for event_type in entity.capabilities.get(ATTR_EVENT_TYPES, [])
+    ]
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: TriggerActionType,
+    trigger_info: TriggerInfo,
+) -> CALLBACK_TYPE:
+    """Listen for state changes based on configuration."""
+    trigger_data = trigger_info["trigger_data"]
+    entity_id = async_get_entity_registry_entry_or_raise(
+        hass, config[CONF_ENTITY_ID]
+    ).entity_id
+    job = HassJob(action)
+
+    @callback
+    def event_automation_listener(event: Event[EventStateChangedData]) -> None:
+        """Listen for state changes and calls action."""
+        entity = event.data["entity_id"]
+        from_state = event.data["old_state"]
+        to_state = event.data["new_state"]
+
+        if (
+            to_state
+            and to_state.state
+            not in (
+                STATE_UNAVAILABLE,
+                STATE_UNKNOWN,
+            )
+            and config[CONF_EVENT_TYPE] == to_state.attributes.get(ATTR_EVENT_TYPE)
+        ):
+            description = f"{entity} triggered {config[CONF_EVENT_TYPE]}"
+            hass.async_run_hass_job(
+                job,
+                {
+                    "trigger": {
+                        **trigger_data,
+                        "platform": "device",
+                        "entity_id": entity,
+                        "from_state": from_state,
+                        "to_state": to_state,
+                        CONF_EVENT_TYPE: config[CONF_EVENT_TYPE],
+                        "description": description,
+                    }
+                },
+                to_state.context if to_state else None,
+            )
+
+    return async_track_state_change_event(hass, entity_id, event_automation_listener)
+
+
+@callback
+def _async_translate_event_type(
+    hass: HomeAssistant,
+    event_type: str,
+    domain: str,
+    platform: str | None,
+    translation_key: str | None,
+    device_class: str | None,
+) -> str:
+    """Translate provided event type using cached translations for currently selected language."""
+    language = hass.config.language
+    if platform is not None and translation_key is not None:
+        localize_key = f"component.{platform}.entity.{domain}.{translation_key}.state_attributes.event_type.state.{event_type}"
+        translations = translation.async_get_cached_translations(
+            hass, language, "entity"
+        )
+        if localize_key in translations:
+            return translations[localize_key]
+
+    translations = translation.async_get_cached_translations(
+        hass, language, "entity_component"
+    )
+    localize_key = f"component.{domain}.entity_component.{"_" if device_class is None else device_class}.state_attributes.event_type.state.{event_type}"
+    if localize_key in translations:
+        return translations[localize_key]
+
+    return event_type

--- a/homeassistant/components/event/strings.json
+++ b/homeassistant/components/event/strings.json
@@ -21,5 +21,10 @@
     "motion": {
       "name": "Motion"
     }
+  },
+  "device_automation": {
+    "trigger_type": {
+      "event": "{entity_name} {subtype}"
+    }
   }
 }

--- a/tests/components/event/conftest.py
+++ b/tests/components/event/conftest.py
@@ -26,7 +26,9 @@ class MockEventEntity(MockEntity, EventEntity):
 
 
 @pytest.fixture
-async def mock_event_platform(hass: HomeAssistant) -> None:
+async def mock_event_platform(
+    hass: HomeAssistant, mock_event_entities: list[MockEventEntity]
+) -> None:
     """Mock the event entity platform."""
 
     async def async_setup_platform(
@@ -36,18 +38,22 @@ async def mock_event_platform(hass: HomeAssistant) -> None:
         discovery_info: DiscoveryInfoType | None = None,
     ) -> None:
         """Set up test event platform."""
-        async_add_entities(
-            [
-                MockEventEntity(
-                    name="doorbell",
-                    unique_id="unique_doorbell",
-                    event_types=["short_press", "long_press"],
-                ),
-            ]
-        )
+        async_add_entities(mock_event_entities)
 
     mock_platform(
         hass,
         f"{TEST_DOMAIN}.{DOMAIN}",
         MockPlatform(async_setup_platform=async_setup_platform),
     )
+
+
+@pytest.fixture
+def mock_event_entities() -> list[MockEventEntity]:
+    """Return mock binary sensors."""
+    return [
+        MockEventEntity(
+            name="doorbell",
+            unique_id="unique_doorbell",
+            event_types=["short_press", "long_press"],
+        ),
+    ]

--- a/tests/components/event/test_device_trigger.py
+++ b/tests/components/event/test_device_trigger.py
@@ -1,0 +1,182 @@
+"""The test for event device automation."""
+
+import pytest
+from pytest_unordered import unordered
+
+from homeassistant.components import automation
+from homeassistant.components.device_automation import DeviceAutomationType
+from homeassistant.components.event import DOMAIN
+from homeassistant.components.event.const import ATTR_EVENT_TYPE
+from homeassistant.const import CONF_PLATFORM, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.setup import async_setup_component
+import homeassistant.util.dt as dt_util
+
+from .conftest import MockEventEntity
+
+from tests.common import MockConfigEntry, async_get_device_automations
+
+
+@pytest.fixture(autouse=True, name="stub_blueprint_populate")
+def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
+    """Stub copying the blueprints to the config folder."""
+
+
+@pytest.mark.usefixtures("mock_event_platform")
+async def test_get_triggers(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    mock_event_entities: list[MockEventEntity],
+) -> None:
+    """Test that we get the expected triggers from an event entity."""
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
+
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    registry_entries: list[er.RegistryEntry] = [
+        entity_registry.async_get_or_create(
+            DOMAIN,
+            "test",
+            mock_event_entity.unique_id,
+            device_id=device_entry.id,
+        )
+        for mock_event_entity in mock_event_entities
+    ]
+
+    expected_triggers = [
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "device_id": device_entry.id,
+            "entity_id": entry.id,
+            "type": "event",
+            "subtype": event_type,
+            "event_type": event_type,
+            "metadata": {"secondary": False},
+        }
+        for entry in registry_entries
+        for event_type in ("short_press", "long_press")
+    ]
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
+    assert triggers == unordered(expected_triggers)
+
+
+@pytest.mark.usefixtures("mock_event_platform")
+async def test_if_fires_on_state_change(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    service_calls: list[ServiceCall],
+    mock_event_entities: list[MockEventEntity],
+) -> None:
+    """Test that event device triggers fire."""
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
+
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entry = entity_registry.async_get_or_create(
+        DOMAIN,
+        "test",
+        mock_event_entities[0].unique_id,
+        device_id=device_entry.id,
+    )
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": device_entry.id,
+                        "entity_id": entry.id,
+                        "type": "event",
+                        "event_type": "short_press",
+                        "subtype": "short_press",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": (
+                                "event {{ trigger.platform }}"
+                                " - {{ trigger.entity_id }}"
+                                " - {{ trigger.from_state.state }}"
+                                " - {{ trigger.to_state.state }}"
+                                " - {{ trigger.event_type }}"
+                            )
+                        },
+                    },
+                },
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": device_entry.id,
+                        "entity_id": entry.id,
+                        "type": "event",
+                        "event_type": "long_press",
+                        "subtype": "long_press",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": (
+                                "event {{ trigger.platform }}"
+                                " - {{ trigger.entity_id }}"
+                                " - {{ trigger.from_state.state }}"
+                                " - {{ trigger.to_state.state }}"
+                                " - {{ trigger.event_type }}"
+                            )
+                        },
+                    },
+                },
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(entry.entity_id).state is STATE_UNKNOWN
+    assert len(service_calls) == 0
+
+    short_press_time = dt_util.utcnow().isoformat(timespec="milliseconds")
+    hass.states.async_set(
+        entry.entity_id, short_press_time, {ATTR_EVENT_TYPE: "short_press"}
+    )
+    await hass.async_block_till_done()
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == (
+        "event device"
+        f" - {entry.entity_id}"
+        f" - {STATE_UNKNOWN}"
+        f" - {short_press_time}"
+        " - short_press"
+    )
+
+    long_press_time = dt_util.utcnow().isoformat(timespec="milliseconds")
+    hass.states.async_set(
+        entry.entity_id, long_press_time, {ATTR_EVENT_TYPE: "long_press"}
+    )
+    await hass.async_block_till_done()
+    assert len(service_calls) == 2
+    assert service_calls[1].data["some"] == (
+        "event device"
+        f" - {entry.entity_id}"
+        f" - {short_press_time}"
+        f" - {long_press_time}"
+        " - long_press"
+    )


### PR DESCRIPTION
## Proposed change

Add device trigger support to event entities

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
