### PR TITLE
Bump ZHA library to 0.0.29

### DIFF
--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -15,6 +15,7 @@ import re
 import time
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Concatenate, NamedTuple, ParamSpec, TypeVar, cast
+from zoneinfo import ZoneInfo
 
 import voluptuous as vol
 from zha.application.const import (
@@ -1273,6 +1274,7 @@ def create_zha_config(hass: HomeAssistant, ha_zha_data: HAZHAData) -> ZHAData:
             quirks_configuration=quirks_config,
             device_overrides=overrides_config,
         ),
+        local_timezone=ZoneInfo(hass.config.time_zone),
     )
 
 

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -21,7 +21,7 @@
     "zha",
     "universal_silabs_flasher"
   ],
-  "requirements": ["universal-silabs-flasher==0.0.22", "zha==0.0.28"],
+  "requirements": ["universal-silabs-flasher==0.0.22", "zha==0.0.29"],
   "usb": [
     {
       "vid": "10C4",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2989,7 +2989,7 @@ zeroconf==0.132.2
 zeversolar==0.3.1
 
 # homeassistant.components.zha
-zha==0.0.28
+zha==0.0.29
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2366,7 +2366,7 @@ zeroconf==0.132.2
 zeversolar==0.3.1
 
 # homeassistant.components.zha
-zha==0.0.28
+zha==0.0.29
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.57.0

--- a/tests/components/zha/test_init.py
+++ b/tests/components/zha/test_init.py
@@ -3,6 +3,7 @@
 import asyncio
 import typing
 from unittest.mock import AsyncMock, Mock, patch
+import zoneinfo
 
 import pytest
 from zigpy.application import ControllerApplication
@@ -16,7 +17,7 @@ from homeassistant.components.zha.const import (
     CONF_USB_PATH,
     DOMAIN,
 )
-from homeassistant.components.zha.helpers import get_zha_data
+from homeassistant.components.zha.helpers import get_zha_data, get_zha_gateway
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
     MAJOR_VERSION,
@@ -288,3 +289,23 @@ async def test_shutdown_on_ha_stop(
         await hass.async_block_till_done()
 
     assert len(mock_shutdown.mock_calls) == 1
+
+
+async def test_timezone_update(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_zigpy_connect: ControllerApplication,
+) -> None:
+    """Test that the ZHA gateway timezone is updated when HA timezone changes."""
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    gateway = get_zha_gateway(hass)
+
+    assert hass.config.time_zone == "US/Pacific"
+    assert gateway.config.local_timezone == zoneinfo.ZoneInfo("US/Pacific")
+
+    await hass.config.async_update(time_zone="America/New_York")
+
+    assert hass.config.time_zone == "America/New_York"
+    assert gateway.config.local_timezone == zoneinfo.ZoneInfo("America/New_York")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump ZHA library to [0.0.29](https://github.com/zigpy/zha/releases/tag/0.0.29). This fixes a few minor issues found during the .0 Core release related to device unavailability and translations for group entities. This PR also incorporates code to pass the Home Assistant timezone to ZHA to fix an issue related to user-configured timezones not passing through to ZHA.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #123373, fixes #123425
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
