### PR TITLE
Assist satellite entity

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -143,6 +143,7 @@ build.json @home-assistant/supervisor
 /tests/components/aseko_pool_live/ @milanmeu
 /homeassistant/components/assist_pipeline/ @balloob @synesthesiam
 /tests/components/assist_pipeline/ @balloob @synesthesiam
+/homeassistant/components/assist_satellite/ @synesthesiam
 /homeassistant/components/asuswrt/ @kennedyshead @ollo69
 /tests/components/asuswrt/ @kennedyshead @ollo69
 /homeassistant/components/atag/ @MatsNL

--- a/homeassistant/components/assist_pipeline/__init__.py
+++ b/homeassistant/components/assist_pipeline/__init__.py
@@ -55,6 +55,7 @@ __all__ = (
     "PipelineEvent",
     "PipelineEventType",
     "PipelineNotFound",
+    "PipelineStage",
     "WakeWordSettings",
     "EVENT_RECORDING",
     "SAMPLES_PER_CHUNK",
@@ -100,6 +101,7 @@ async def async_pipeline_from_audio_stream(
     pipeline_id: str | None = None,
     conversation_id: str | None = None,
     tts_audio_output: str | None = None,
+    tts_input: str | None = None,
     wake_word_settings: WakeWordSettings | None = None,
     audio_settings: AudioSettings | None = None,
     device_id: str | None = None,
@@ -116,6 +118,7 @@ async def async_pipeline_from_audio_stream(
         stt_metadata=stt_metadata,
         stt_stream=stt_stream,
         wake_word_phrase=wake_word_phrase,
+        tts_input=tts_input,
         run=PipelineRun(
             hass,
             context=context,

--- a/homeassistant/components/assist_satellite/__init__.py
+++ b/homeassistant/components/assist_satellite/__init__.py
@@ -1,0 +1,201 @@
+"""Base class for assist satellite entities."""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from collections.abc import AsyncIterable
+from dataclasses import dataclass
+from enum import IntFlag, StrEnum, auto
+import logging
+
+from homeassistant.components import stt
+from homeassistant.components.assist_pipeline.pipeline import PipelineStage
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity
+from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.typing import ConfigType
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class SatelliteCapabilities:
+    """Capabilities of satellite"""
+
+    has_vad: bool
+    """True if on-device VAD is supported"""
+
+    wake_words: list[str]
+    """Available on-device wake words"""
+
+    max_active_wake_words: int | None
+    """Maximum number of active wake words"""
+
+    @property
+    def has_wake_word(self) -> bool:
+        """True when device can do on-device wake word detection"""
+        return bool(self.wake_words)
+
+
+@dataclass
+class SatelliteConfig:
+    """Configuration of satellite"""
+
+    active_wake_words: list[str]
+    """List of wake words that should be active (empty = streaming)"""
+
+    finished_speaking_seconds: float | None
+    """Seconds of silence before voice command is finished (on-device VAD only)"""
+
+
+@dataclass
+class PipelineRunConfig:
+    """Configuration for a satellite pipeline run"""
+
+    wake_word_names: list[str] | None
+    """Wake word names to listen for (start_stage = wake)."""
+
+    announce_text: str | None
+    """Text to announce using text-to-speech (start_stage = tts)"""
+
+    announce_url: str | None
+    """Media URL to announce (start_stage = tts)"""
+
+
+@dataclass
+class PipelineRunResult:
+    """Result of a pipeline run"""
+
+    detected_wake_word: str | None
+    """Name of detected wake word (None if timeout)"""
+
+    command_text: str | None
+    """Transcript of speech-to-text for voice command"""
+
+
+class AssistSatelliteEntityFeature(IntFlag):
+    """Supported features of the satellite entity."""
+
+    AUDIO_INPUT = auto()
+    """Satellite is capable of recording and streaming audio to Home Assistant."""
+
+    AUDIO_OUTPUT = auto()
+    """Satellite is capable of playing audio."""
+
+    WAKE_WORD = auto()
+    """Satellite is capable of on-device wake word detection."""
+
+    VOICE_ACTIVITY_DETECTION = auto()
+    """Satellite is capable of on-device VAD."""
+
+    TRIGGER = auto()
+    """Satellite supports remotely triggering pipelines."""
+
+
+class AssistSatelliteState(StrEnum):
+    """Valid states of an Assist satellite entity."""
+
+    IDLE = "idle"
+    """Device is waiting for the wake word."""
+
+    LISTENING = "listening"
+    """Device is streaming audio with the command to Home Assistant."""
+
+    PROCESSING = "processing"
+    """Device has stopped streaming audio and is waiting for Home Assistant to process the voice command."""
+
+    RESPONDING = "responding"
+    """Device is speaking the response."""
+
+    TIMER_RINGING = "timer_ringing"
+    """Device is notifying the user that a timer has elapsed."""
+
+    MUTED = "muted"
+    """Device is muted (in software or hardware)."""
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    component = hass.data[DOMAIN] = EntityComponent[AssistSatelliteEntity](
+        _LOGGER, DOMAIN, hass
+    )
+    await component.async_setup(config)
+
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up a config entry."""
+    component: EntityComponent[AssistSatelliteEntity] = hass.data[DOMAIN]
+    return await component.async_setup_entry(entry)
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    component: EntityComponent[AssistSatelliteEntity] = hass.data[DOMAIN]
+    return await component.async_unload_entry(entry)
+
+
+class AssistSatelliteEntity(entity.Entity):
+    _attr_state: AssistSatelliteState | None = None
+    _attr_supported_features: AssistSatelliteEntityFeature = (
+        AssistSatelliteEntityFeature(0)
+    )
+
+    async def async_run_pipeline_on_satellite(
+        self,
+        start_stage: PipelineStage,
+        end_stage: PipelineStage,
+        run_config: PipelineRunConfig,
+    ) -> PipelineRunResult | None:
+        """Runs a pipeline on the satellite from start to end stage.
+
+        Can be called from a service.
+
+        - announce when start/end = "tts"
+        - listen for wake word when start/end = "wake"
+        - listen for command when start/end = "stt" (no processing)
+        - listen for command when start = "stt", end = "tts" (with processing)
+        """
+        raise NotImplementedError
+
+    async def _async_accept_pipeline_from_satellite(
+        self, stt_stream: AsyncIterable[bytes], stt_metadata: stt.SpeechMetadata
+    ) -> PipelineRunResult | None:
+        """Called by the platform when the voice satellite detected a wake word and
+        wants to trigger an assist pipeline in Home Assistant.
+        """
+        raise NotImplementedError
+
+    @property
+    def satellite_capabilities(self) -> SatelliteCapabilities:
+        """Get satellite capabilitites"""
+        raise NotImplementedError
+
+    async def async_get_config(self) -> SatelliteConfig:
+        """Get satellite configuration"""
+        raise NotImplementedError
+
+    async def async_set_config(self, config: SatelliteConfig) -> None:
+        """Set satellite configuration"""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def _async_config_updated(self) -> None:
+        """Callback called when the device config is updated.
+
+        Platforms need to make sure that the device has this configuration.
+        """
+        raise NotImplementedError
+
+    @property
+    def is_muted(self) -> bool:
+        """Return if the satellite is muted."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def async_set_mute(self, mute: bool) -> None:
+        """Mute or unmute the satellite."""
+        raise NotImplementedError

--- a/homeassistant/components/assist_satellite/const.py
+++ b/homeassistant/components/assist_satellite/const.py
@@ -1,1 +1,3 @@
+"""Constants for assist satellite."""
+
 DOMAIN = "assist_satellite"

--- a/homeassistant/components/assist_satellite/const.py
+++ b/homeassistant/components/assist_satellite/const.py
@@ -1,0 +1,1 @@
+DOMAIN = "assist_satellite"

--- a/homeassistant/components/assist_satellite/entity.py
+++ b/homeassistant/components/assist_satellite/entity.py
@@ -1,0 +1,80 @@
+"""Assist satellite entity."""
+
+from abc import abstractmethod
+
+from homeassistant.components.assist_pipeline.pipeline import PipelineStage
+from homeassistant.const import EntityCategory
+from homeassistant.helpers import entity
+from homeassistant.helpers.entity import EntityDescription
+
+from .models import (
+    AssistSatelliteEntityFeature,
+    AssistSatelliteState,
+    PipelineRunConfig,
+    PipelineRunResult,
+    SatelliteCapabilities,
+    SatelliteConfig,
+)
+
+
+class AssistSatelliteEntity(entity.Entity):
+    """Entity encapsulating the state and functionality of a voice satellite."""
+
+    entity_description = EntityDescription(
+        key="assist_satellite",
+        translation_key="assist_satellite",
+        entity_category=EntityCategory.CONFIG,
+    )
+    _attr_should_poll = False
+    _attr_state: AssistSatelliteState | None = None
+    _attr_supported_features: AssistSatelliteEntityFeature = (
+        AssistSatelliteEntityFeature(0)
+    )
+
+    async def async_run_pipeline_on_satellite(
+        self,
+        start_stage: PipelineStage,
+        end_stage: PipelineStage,
+        run_config: PipelineRunConfig,
+    ) -> PipelineRunResult | None:
+        """Run a pipeline on the satellite from start to end stage.
+
+        Can be called from a service.
+
+        - announce when start/end = "tts"
+        - listen for wake word when start/end = "wake"
+        - listen for command when start/end = "stt" (no processing)
+        - listen for command when start = "stt", end = "tts" (with processing)
+        """
+        raise NotImplementedError
+
+    @property
+    def satellite_capabilities(self) -> SatelliteCapabilities:
+        """Get satellite capabilitites."""
+        raise NotImplementedError
+
+    async def async_get_config(self) -> SatelliteConfig:
+        """Get satellite configuration."""
+        raise NotImplementedError
+
+    async def async_set_config(self, config: SatelliteConfig) -> None:
+        """Set satellite configuration."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def _async_config_updated(self) -> None:
+        """Inform when the device config is updated.
+
+        Platforms need to make sure that the device has this configuration.
+        """
+        raise NotImplementedError
+
+    @property
+    def is_microphone_muted(self) -> bool:
+        """Return if the satellite's microphone is muted."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def async_set_microphone_mute(self, mute: bool) -> None:
+        """Mute or unmute the satellite's microphone."""
+        raise NotImplementedError

--- a/homeassistant/components/assist_satellite/icons.json
+++ b/homeassistant/components/assist_satellite/icons.json
@@ -1,0 +1,13 @@
+{
+  "entity_component": {
+    "_": {
+      "default": "mdi:comment-processing-outline"
+    }
+  },
+  "services": {
+    "wait_wake": "mdi:microphone-message",
+    "get_text": "mdi:comment-text-outline",
+    "say_text": "mdi:speaker-message",
+    "mute_microphone": "mdi:volume-mute"
+  }
+}

--- a/homeassistant/components/assist_satellite/manifest.json
+++ b/homeassistant/components/assist_satellite/manifest.json
@@ -1,0 +1,9 @@
+{
+  "domain": "assist_satellite",
+  "name": "Assist Satellite",
+  "codeowners": ["@synesthesiam"],
+  "config_flow": false,
+  "dependencies": ["assist_pipeline"],
+  "documentation": "https://www.home-assistant.io/integrations/assist_satellite",
+  "integration_type": "entity"
+}

--- a/homeassistant/components/assist_satellite/models.py
+++ b/homeassistant/components/assist_satellite/models.py
@@ -1,6 +1,6 @@
 """Models for assist satellite."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import IntFlag, StrEnum, auto
 
 from homeassistant.const import STATE_UNAVAILABLE
@@ -11,7 +11,7 @@ class SatelliteCapabilities:
     """Capabilities of satellite."""
 
     wake_words: list[str]
-    """Available on-device wake words."""
+    """Available wake words."""
 
     max_active_wake_words: int | None = None
     """Maximum number of active wake words."""
@@ -22,10 +22,22 @@ class SatelliteConfig:
     """Configuration of satellite."""
 
     active_wake_words: list[str]
-    """List of wake words that should be active (empty = streaming)."""
+    """List of wake words that are actively being listened for."""
 
-    finished_speaking_seconds: float | None = None
-    """Seconds of silence before voice command is finished (on-device VAD only)."""
+    wake_word_entity_id: str | None = None
+    """Entity id of streaming wake word provider (None = on-device)."""
+
+    default_pipeline: str | None = None
+    """Pipeline id to use by default (None = preferred)."""
+
+    wake_word_pipeline: dict[str, str] = field(default_factory=dict)
+    """Mapping between wake words and pipeline ids.
+
+    If a wake word is not present, then use default_pipeline_id.
+    """
+
+    finished_speaking_seconds: float = 1.0
+    """Seconds of silence before voice command is finished."""
 
 
 @dataclass
@@ -36,7 +48,7 @@ class PipelineRunConfig:
     """Wake word names to listen for (start_stage = wake)."""
 
     announce_text: str | None = None
-    """Text to announce using text-to-speech (start_stage = tts)."""
+    """Text to announce using text-to-speech (start_stage = wake, stt, or tts)."""
 
 
 @dataclass

--- a/homeassistant/components/assist_satellite/models.py
+++ b/homeassistant/components/assist_satellite/models.py
@@ -1,0 +1,92 @@
+"""Models for assist satellite."""
+
+from dataclasses import dataclass
+from enum import IntFlag, StrEnum, auto
+
+from homeassistant.const import STATE_UNAVAILABLE
+
+
+@dataclass
+class SatelliteCapabilities:
+    """Capabilities of satellite."""
+
+    wake_words: list[str]
+    """Available on-device wake words."""
+
+    max_active_wake_words: int | None = None
+    """Maximum number of active wake words."""
+
+
+@dataclass
+class SatelliteConfig:
+    """Configuration of satellite."""
+
+    active_wake_words: list[str]
+    """List of wake words that should be active (empty = streaming)."""
+
+    finished_speaking_seconds: float | None = None
+    """Seconds of silence before voice command is finished (on-device VAD only)."""
+
+
+@dataclass
+class PipelineRunConfig:
+    """Configuration for a satellite pipeline run."""
+
+    wake_word_names: list[str] | None = None
+    """Wake word names to listen for (start_stage = wake)."""
+
+    announce_text: str | None = None
+    """Text to announce using text-to-speech (start_stage = tts)."""
+
+
+@dataclass
+class PipelineRunResult:
+    """Result of a pipeline run."""
+
+    detected_wake_word: str | None = None
+    """Name of detected wake word (None if timeout)."""
+
+    command_text: str | None = None
+    """Transcript of speech-to-text for voice command."""
+
+
+class AssistSatelliteEntityFeature(IntFlag):
+    """Supported features of the satellite entity."""
+
+    AUDIO_INPUT = auto()
+    """Satellite is capable of recording and streaming audio to Home Assistant."""
+
+    AUDIO_OUTPUT = auto()
+    """Satellite is capable of playing audio."""
+
+    VOICE_ACTIVITY_DETECTION = auto()
+    """Satellite is capable of on-device VAD."""
+
+    WAKE_WORD = auto()
+    """Satellite is capable of on-device wake word detection."""
+
+    TRIGGER = auto()
+    """Satellite supports remotely triggering pipelines."""
+
+
+class AssistSatelliteState(StrEnum):
+    """Valid states of an Assist satellite entity."""
+
+    UNAVAILABLE = STATE_UNAVAILABLE
+    """Satellite is not connected."""
+
+    IDLE = "idle"
+    """Device is waiting for the wake word."""
+
+    LISTENING = "listening"
+    """Device is streaming audio with the command to Home Assistant."""
+
+    PROCESSING = "processing"
+    """Device has stopped streaming audio and is waiting for Home Assistant to
+    process the voice command."""
+
+    RESPONDING = "responding"
+    """Device is speaking the response."""
+
+    MUTED = "muted"
+    """Device is muted (in software or hardware)."""

--- a/homeassistant/components/assist_satellite/services.yaml
+++ b/homeassistant/components/assist_satellite/services.yaml
@@ -1,0 +1,58 @@
+wait_wake:
+  target:
+    entity:
+      domain: assist_satellite
+      supported_features:
+        - assist_satellite.AssistSatelliteEntityFeature.TRIGGER
+  fields:
+    wake_words:
+      required: true
+      example: "ok nabu"
+      selector:
+        text:
+          multiple: true
+    announce_text:
+      required: false
+      example: "Please say ok nabu."
+      selector:
+        text:
+get_text:
+  target:
+    entity:
+      domain: assist_satellite
+      supported_features:
+        - assist_satellite.AssistSatelliteEntityFeature.TRIGGER
+  fields:
+    process:
+      required: false
+      selector:
+        boolean:
+    announce_text:
+      required: false
+      example: "What would you like for dinner?"
+      selector:
+        text:
+say_text:
+  target:
+    entity:
+      domain: assist_satellite
+      supported_features:
+        - assist_satellite.AssistSatelliteEntityFeature.TRIGGER
+  fields:
+    announce_text:
+      required: true
+      example: "Dinner is ready!"
+      selector:
+        text:
+mute_microphone:
+  target:
+    entity:
+      domain: assist_satellite
+      supported_features:
+        - assist_satellite.AssistSatelliteEntityFeature.AUDIO_INPUT
+  fields:
+    is_muted:
+      required: true
+      default: true
+      selector:
+        boolean:

--- a/homeassistant/components/assist_satellite/strings.json
+++ b/homeassistant/components/assist_satellite/strings.json
@@ -1,0 +1,67 @@
+{
+  "entity": {
+    "assist_satellite": {
+      "assist_satellite": {
+        "name": "Assist satellite",
+        "state": {
+          "idle": "Idle",
+          "listening": "Listening",
+          "responding": "Responding",
+          "processing": "Processing",
+          "muted": "Muted",
+          "unavailable": "Unavailable"
+        }
+      }
+    }
+  },
+  "services": {
+    "wait_wake": {
+      "name": "Wait for wake words",
+      "description": "Wait for one or more wake words to be spoken",
+      "fields": {
+        "wake_words": {
+          "name": "Wake words",
+          "description": "Names of wake words to wait for"
+        },
+        "announce_text": {
+          "name": "Announce text",
+          "description": "Text to speak before waiting for wake words"
+        }
+      }
+    },
+    "get_text": {
+      "name": "Get text response from satellite",
+      "description": "Records and transcribes a user response from a voice satellite",
+      "fields": {
+        "process": {
+          "name": "Process command",
+          "description": "Process the text of the voice command in Home Assistant"
+        },
+        "announce_text": {
+          "name": "announce_text",
+          "description": "Text to speak before recording user response"
+        }
+      }
+    },
+    "say_text": {
+      "name": "Say text",
+      "description": "Speak text from a voice satellite",
+      "fields": {
+        "announce_text": {
+          "name": "Announce text",
+          "description": "Text to speak"
+        }
+      }
+    },
+    "mute_microphone": {
+      "name": "Mute microphone",
+      "description": "Mute the microphone on the satellite",
+      "fields": {
+        "is_muted": {
+          "name": "Is muted",
+          "description": "Microphone is muted or unmuted"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/wyoming/__init__.py
+++ b/homeassistant/components/wyoming/__init__.py
@@ -19,6 +19,7 @@ from .satellite import WyomingSatellite
 _LOGGER = logging.getLogger(__name__)
 
 SATELLITE_PLATFORMS = [
+    Platform.ASSIST_SATELLITE,
     Platform.BINARY_SENSOR,
     Platform.SELECT,
     Platform.SWITCH,

--- a/homeassistant/components/wyoming/assist_satellite.py
+++ b/homeassistant/components/wyoming/assist_satellite.py
@@ -1,0 +1,28 @@
+"""Wyoming assist satellite entity."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+
+if TYPE_CHECKING:
+    from .models import DomainDataItem
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up assist satellite entity."""
+    item: DomainDataItem = hass.data[DOMAIN][config_entry.entry_id]
+
+    # Setup is only forwarded for satellites
+    assert item.satellite is not None
+
+    async_add_entities([item.satellite])

--- a/homeassistant/components/wyoming/data.py
+++ b/homeassistant/components/wyoming/data.py
@@ -47,6 +47,18 @@ class WyomingService:
             or ((self.info.satellite is not None) and self.info.satellite.installed)
         )
 
+    def has_mic(self) -> bool:
+        """Return True if an audio input service is installed."""
+        return any(mic for mic in self.info.mic if mic.installed)
+
+    def has_snd(self) -> bool:
+        """Return True if an audio output service is installed."""
+        return any(snd for snd in self.info.snd if snd.installed)
+
+    def has_wake(self) -> bool:
+        """Return True if local wake word detection service is installed."""
+        return any(wake for wake in self.info.wake if wake.installed)
+
     def get_name(self) -> str | None:
         """Return name of first installed usable service."""
 

--- a/homeassistant/components/wyoming/devices.py
+++ b/homeassistant/components/wyoming/devices.py
@@ -84,8 +84,6 @@ class SatelliteDevice:
         """Set VAD sensitivity."""
         if vad_sensitivity != self.vad_sensitivity:
             self.vad_sensitivity = vad_sensitivity
-            if self._audio_settings_listener is not None:
-                self._audio_settings_listener()
 
     @callback
     def set_is_active_listener(self, is_active_listener: Callable[[], None]) -> None:

--- a/homeassistant/components/wyoming/manifest.json
+++ b/homeassistant/components/wyoming/manifest.json
@@ -3,7 +3,12 @@
   "name": "Wyoming Protocol",
   "codeowners": ["@balloob", "@synesthesiam"],
   "config_flow": true,
-  "dependencies": ["assist_pipeline", "intent", "conversation"],
+  "dependencies": [
+    "assist_pipeline",
+    "assist_satellite",
+    "intent",
+    "conversation"
+  ],
   "documentation": "https://www.home-assistant.io/integrations/wyoming",
   "integration_type": "service",
   "iot_class": "local_push",

--- a/homeassistant/components/wyoming/manifest.json
+++ b/homeassistant/components/wyoming/manifest.json
@@ -12,6 +12,6 @@
   "documentation": "https://www.home-assistant.io/integrations/wyoming",
   "integration_type": "service",
   "iot_class": "local_push",
-  "requirements": ["wyoming==1.5.4"],
+  "requirements": ["wyoming==1.6.0"],
   "zeroconf": ["_wyoming._tcp.local."]
 }

--- a/homeassistant/components/wyoming/satellite.py
+++ b/homeassistant/components/wyoming/satellite.py
@@ -182,6 +182,10 @@ class WyomingSatellite(assist_satellite.AssistSatelliteEntity):
         finally:
             unregister_timer_handler()
 
+            if self._tts_timeout_task is not None:
+                self._tts_timeout_task.cancel()
+                self._tts_timeout_task = None
+
             # Ensure sensor is off (before stop)
             self.device.set_is_active(False)
 
@@ -690,8 +694,8 @@ class WyomingSatellite(assist_satellite.AssistSatelliteEntity):
             # Time out half a second second after response should have finished
             # playing in case the satellite doesn't tell us when it's done.
             wav_seconds = wav_file.getnframes() / sample_rate
-            self._tts_timeout_task = asyncio.create_task(
-                self._tts_timeout(wav_seconds + 0.5)
+            self._tts_timeout_task = self.config_entry.async_create_background_task(
+                self.hass, self._tts_timeout(wav_seconds + 0.5), "wyoming tts timeout"
             )
 
             timestamp = 0

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -41,6 +41,7 @@ class Platform(StrEnum):
 
     AIR_QUALITY = "air_quality"
     ALARM_CONTROL_PANEL = "alarm_control_panel"
+    ASSIST_SATELLITE = "assist_satellite"
     BINARY_SENSOR = "binary_sensor"
     BUTTON = "button"
     CALENDAR = "calendar"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2927,7 +2927,7 @@ wled==0.20.1
 wolf-comm==0.0.9
 
 # homeassistant.components.wyoming
-wyoming==1.5.4
+wyoming==1.6.0
 
 # homeassistant.components.xbox
 xbox-webapi==2.0.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2313,7 +2313,7 @@ wled==0.20.1
 wolf-comm==0.0.9
 
 # homeassistant.components.wyoming
-wyoming==1.5.4
+wyoming==1.6.0
 
 # homeassistant.components.xbox
 xbox-webapi==2.0.11

--- a/tests/components/wyoming/__init__.py
+++ b/tests/components/wyoming/__init__.py
@@ -3,13 +3,16 @@
 import asyncio
 from unittest.mock import patch
 
+from wyoming.audio import AudioFormat
 from wyoming.event import Event
 from wyoming.info import (
     AsrModel,
     AsrProgram,
     Attribution,
     Info,
+    MicProgram,
     Satellite,
+    SndProgram,
     TtsProgram,
     TtsVoice,
     TtsVoiceSpeaker,
@@ -95,7 +98,58 @@ SATELLITE_INFO = Info(
         attribution=TEST_ATTR,
         area="Office",
         version=None,
-    )
+        has_vad=True,
+        active_wake_words=["ok nabu"],
+        supports_trigger=True,
+    ),
+    wake=[
+        WakeProgram(
+            name="Test Wake Word",
+            description="Test Wake Word",
+            installed=True,
+            attribution=TEST_ATTR,
+            models=[
+                WakeModel(
+                    name="ok nabu",
+                    description="ok nabu",
+                    phrase="ok nabu",
+                    installed=True,
+                    attribution=TEST_ATTR,
+                    languages=["en-US"],
+                    version=None,
+                )
+            ],
+            version=None,
+        )
+    ],
+    mic=[
+        MicProgram(
+            name="Test Microphone",
+            description="Test Microphone",
+            installed=True,
+            attribution=TEST_ATTR,
+            mic_format=AudioFormat(
+                rate=16000,
+                width=2,
+                channels=1,
+            ),
+            version=None,
+        )
+    ],
+    snd=[
+        SndProgram(
+            name="Test Speaker",
+            description="Test Speaker",
+            installed=True,
+            attribution=TEST_ATTR,
+            snd_format=AudioFormat(
+                rate=16000,
+                width=2,
+                channels=1,
+            ),
+            version=None,
+        )
+    ],
 )
 EMPTY_INFO = Info()
 

--- a/tests/components/wyoming/conftest.py
+++ b/tests/components/wyoming/conftest.py
@@ -9,6 +9,7 @@ import pytest
 from homeassistant.components import stt
 from homeassistant.components.wyoming import DOMAIN
 from homeassistant.components.wyoming.devices import SatelliteDevice
+from homeassistant.components.wyoming.satellite import WyomingSatellite
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -161,8 +162,17 @@ async def init_satellite(hass: HomeAssistant, satellite_config_entry: ConfigEntr
 
 
 @pytest.fixture
-async def satellite_device(
+async def satellite(
     hass: HomeAssistant, init_satellite, satellite_config_entry: ConfigEntry
 ) -> SatelliteDevice:
+    """Get a satellite fixture."""
+    return hass.data[DOMAIN][satellite_config_entry.entry_id].satellite
+
+
+@pytest.fixture
+async def satellite_device(
+    hass: HomeAssistant,
+    satellite: WyomingSatellite,
+) -> SatelliteDevice:
     """Get a satellite device fixture."""
-    return hass.data[DOMAIN][satellite_config_entry.entry_id].satellite.device
+    return satellite.device

--- a/tests/components/wyoming/test_switch.py
+++ b/tests/components/wyoming/test_switch.py
@@ -32,7 +32,7 @@ async def test_muted(
     state = hass.states.get(muted_id)
     assert state is not None
     assert state.state == STATE_ON
-    assert satellite.is_muted
+    assert satellite.is_microphone_muted
     assert satellite.device.is_muted
 
     # test restore
@@ -41,14 +41,14 @@ async def test_muted(
     state = hass.states.get(muted_id)
     assert state is not None
     assert state.state == STATE_ON
-    assert satellite.is_muted
+    assert satellite.is_microphone_muted
     assert satellite.device.is_muted
 
     # test mute from entity
-    await satellite.async_set_mute(False)
+    await satellite.async_set_microphone_mute(False)
 
     state = hass.states.get(muted_id)
     assert state is not None
     assert state.state == STATE_OFF
-    assert not satellite.is_muted
+    assert not satellite.is_microphone_muted
     assert not satellite.device.is_muted


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Draft implementation of: https://github.com/home-assistant/architecture/discussions/1114
More tests need to be added.

Adds an `assist_satellite` platform with an `AssistSatelliteEntity` base class. This encapsulates the state and functionality of voice satellites, and offers a uniform method for interacting with them. This includes actions for:

* Muting and unmuting the satellite's microphone (`mute_microphone`)
* Listening once for specific wake words, optionally announcing first (`wait_wake`)
* Getting a response from a user, optionally announcing first (`get_text`)
* Announcing text on the satellite (`announce_text`)

As a proof-of-concept, the Wyoming satellite has been extended to include most of the `AssistSatelliteEntity` functionality. And update to the Wyoming protocol and the `wyoming-satellite` project has been completed to support the changes. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
