### PR TITLE
Skip NextBus update if integration is still loading

### DIFF
--- a/homeassistant/components/nextbus/__init__.py
+++ b/homeassistant/components/nextbus/__init__.py
@@ -3,7 +3,6 @@
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_STOP, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.start import async_at_started
 
 from .const import CONF_AGENCY, CONF_ROUTE, DOMAIN
 from .coordinator import NextBusDataUpdateCoordinator
@@ -24,12 +23,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     coordinator.add_stop_route(entry.data[CONF_STOP], entry.data[CONF_ROUTE])
 
-    async def _async_finish_startup(hass: HomeAssistant) -> None:
-        """Run this only when HA has finished its startup."""
-        await coordinator.async_config_entry_first_refresh()
-
-    # Don't call the NextBus API during startup
-    async_at_started(hass, _async_finish_startup)
+    await coordinator.async_config_entry_first_refresh()
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/nextbus/__init__.py
+++ b/homeassistant/components/nextbus/__init__.py
@@ -3,6 +3,7 @@
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_STOP, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.start import async_at_started
 
 from .const import CONF_AGENCY, CONF_ROUTE, DOMAIN
 from .coordinator import NextBusDataUpdateCoordinator
@@ -23,7 +24,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     coordinator.add_stop_route(entry.data[CONF_STOP], entry.data[CONF_ROUTE])
 
-    await coordinator.async_config_entry_first_refresh()
+    async def _async_finish_startup(hass: HomeAssistant) -> None:
+        """Run this only when HA has finished its startup."""
+        await coordinator.async_config_entry_first_refresh()
+
+    # Don't call the NextBus API during startup
+    async_at_started(hass, _async_finish_startup)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/nextbus/coordinator.py
+++ b/homeassistant/components/nextbus/coordinator.py
@@ -48,15 +48,17 @@ class NextBusDataUpdateCoordinator(DataUpdateCoordinator):
         """Check if this coordinator is tracking any routes."""
         return len(self._route_stops) > 0
 
-    async def _async_update_data(self) -> dict[str, Any]:
+    async def _async_update_data(self) -> dict:
         """Fetch data from NextBus."""
-        self.logger.debug("Updating data from API. Routes: %s", str(self._route_stops))
+
+        _route_stops = set(self._route_stops)
+        self.logger.debug("Updating data from API. Routes: %s", str(_route_stops))
 
         def _update_data() -> dict:
             """Fetch data from NextBus."""
             self.logger.debug("Updating data from API (executor)")
             predictions: dict[RouteStop, dict[str, Any]] = {}
-            for route_stop in self._route_stops:
+            for route_stop in _route_stops:
                 prediction_results: list[dict[str, Any]] = []
                 try:
                     prediction_results = self.client.predictions_for_stop(

--- a/homeassistant/components/nextbus/coordinator.py
+++ b/homeassistant/components/nextbus/coordinator.py
@@ -48,7 +48,7 @@ class NextBusDataUpdateCoordinator(DataUpdateCoordinator):
         """Check if this coordinator is tracking any routes."""
         return len(self._route_stops) > 0
 
-    async def _async_update_data(self) -> dict:
+    async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from NextBus."""
 
         _route_stops = set(self._route_stops)

--- a/homeassistant/components/nextbus/coordinator.py
+++ b/homeassistant/components/nextbus/coordinator.py
@@ -7,7 +7,7 @@ from typing import Any
 from py_nextbus import NextBusClient
 from py_nextbus.client import NextBusFormatError, NextBusHTTPError
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN
@@ -51,6 +51,10 @@ class NextBusDataUpdateCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from NextBus."""
         self.logger.debug("Updating data from API. Routes: %s", str(self._route_stops))
+
+        if self.hass.state is not CoreState.running:
+            self.logger.debug("hass.state is %s, skipping update", self.hass.state)
+            return {}
 
         def _update_data() -> dict:
             """Fetch data from NextBus."""

--- a/homeassistant/components/nextbus/coordinator.py
+++ b/homeassistant/components/nextbus/coordinator.py
@@ -7,7 +7,7 @@ from typing import Any
 from py_nextbus import NextBusClient
 from py_nextbus.client import NextBusFormatError, NextBusHTTPError
 
-from homeassistant.core import CoreState, HomeAssistant
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN
@@ -51,10 +51,6 @@ class NextBusDataUpdateCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from NextBus."""
         self.logger.debug("Updating data from API. Routes: %s", str(self._route_stops))
-
-        if self.hass.state is not CoreState.running:
-            self.logger.debug("hass.state is %s, skipping update", self.hass.state)
-            return {}
 
         def _update_data() -> dict:
             """Fetch data from NextBus."""


### PR DESCRIPTION
Fixes a race between the loading thread and
update thread leading to an unrecoverable error

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The NextBus integration has a race condition at HA instance start between the thread which sequentially loads configured entities and the update thread which iterates through the set of loaded entities and makes NextBus API calls. The integration never recovers from this error, and will never update again until the HA instance is restarted. The likelihood of encountering this race condition increases as you increase the number of entities.

My fix checks the `hass` object state and returns an empty dict if it is not yet running. I have confirmed that this fixes the issue and that all automated tests pass.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #123562
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
