### PR TITLE
Migrate back from `pysnmp-lextudio` to `pysnmp`

### DIFF
--- a/homeassistant/components/brother/manifest.json
+++ b/homeassistant/components/brother/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_polling",
   "loggers": ["brother", "pyasn1", "pysmi", "pysnmp"],
   "quality_scale": "platinum",
-  "requirements": ["brother==4.2.0"],
+  "requirements": ["brother==4.3.0"],
   "zeroconf": [
     {
       "type": "_printer._tcp.local.",

--- a/homeassistant/components/snmp/manifest.json
+++ b/homeassistant/components/snmp/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/snmp",
   "iot_class": "local_polling",
   "loggers": ["pyasn1", "pysmi", "pysnmp"],
-  "requirements": ["pysnmp==6.2.4"]
+  "requirements": ["pysnmp==6.2.5"]
 }

--- a/homeassistant/components/snmp/manifest.json
+++ b/homeassistant/components/snmp/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/snmp",
   "iot_class": "local_polling",
   "loggers": ["pyasn1", "pysmi", "pysnmp"],
-  "requirements": ["pysnmp-lextudio==6.0.11"]
+  "requirements": ["pysnmp==6.2.4"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -166,9 +166,6 @@ websockets>=11.0.1
 # pysnmplib is no longer maintained and does not work with newer
 # python
 pysnmplib==1000000000.0.0
-# pysnmp is no longer maintained and does not work with newer
-# python
-pysnmp==1000000000.0.0
 
 # The get-mac package has been replaced with getmac. Installing get-mac alongside getmac
 # breaks getmac due to them both sharing the same python package name inside 'getmac'.

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2205,7 +2205,7 @@ pysmartthings==0.7.8
 pysml==0.0.12
 
 # homeassistant.components.snmp
-pysnmp==6.2.4
+pysnmp==6.2.5
 
 # homeassistant.components.snooz
 pysnooz==0.8.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -622,7 +622,7 @@ bring-api==0.8.1
 broadlink==0.19.0
 
 # homeassistant.components.brother
-brother==4.2.0
+brother==4.3.0
 
 # homeassistant.components.brottsplatskartan
 brottsplatskartan==1.0.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2205,7 +2205,7 @@ pysmartthings==0.7.8
 pysml==0.0.12
 
 # homeassistant.components.snmp
-pysnmp-lextudio==6.0.11
+pysnmp==6.2.4
 
 # homeassistant.components.snooz
 pysnooz==0.8.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1762,7 +1762,7 @@ pysmartthings==0.7.8
 pysml==0.0.12
 
 # homeassistant.components.snmp
-pysnmp==6.2.4
+pysnmp==6.2.5
 
 # homeassistant.components.snooz
 pysnooz==0.8.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -542,7 +542,7 @@ bring-api==0.8.1
 broadlink==0.19.0
 
 # homeassistant.components.brother
-brother==4.2.0
+brother==4.3.0
 
 # homeassistant.components.brottsplatskartan
 brottsplatskartan==1.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1762,7 +1762,7 @@ pysmartthings==0.7.8
 pysml==0.0.12
 
 # homeassistant.components.snmp
-pysnmp-lextudio==6.0.11
+pysnmp==6.2.4
 
 # homeassistant.components.snooz
 pysnooz==0.8.6

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -188,9 +188,6 @@ websockets>=11.0.1
 # pysnmplib is no longer maintained and does not work with newer
 # python
 pysnmplib==1000000000.0.0
-# pysnmp is no longer maintained and does not work with newer
-# python
-pysnmp==1000000000.0.0
 
 # The get-mac package has been replaced with getmac. Installing get-mac alongside getmac
 # breaks getmac due to them both sharing the same python package name inside 'getmac'.

--- a/tests/components/snmp/test_integer_sensor.py
+++ b/tests/components/snmp/test_integer_sensor.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch
 
-from pysnmp.hlapi import Integer32
+from pysnmp.proto.rfc1902 import Integer32
 import pytest
 
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN

--- a/tests/components/snmp/test_negative_sensor.py
+++ b/tests/components/snmp/test_negative_sensor.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch
 
-from pysnmp.hlapi import Integer32
+from pysnmp.proto.rfc1902 import Integer32
 import pytest
 
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN

--- a/tests/components/snmp/test_switch.py
+++ b/tests/components/snmp/test_switch.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch
 
-from pysnmp.hlapi import Integer32
+from pysnmp.proto.rfc1902 import Integer32
 import pytest
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
[LeXtudio Inc. has taken over the entire PySNMP package](https://github.com/etingof/pysnmp/issues/429), so we can use `pysnmp` instead of `pysnmp-lextudio`.
I'm also bumping the version `brother` because it uses `pysnmp`.

`pysnmp` changelog: https://github.com/lextudio/pysnmp/compare/v6.0.11...v6.2.5
`brother` changelog: https://github.com/bieniu/brother/compare/4.2.0...4.3.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #119616
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
