### PR TITLE
Raise on database error in recorder.migration._drop_foreign_key_constraints

### DIFF
--- a/tests/components/recorder/test_migrate.py
+++ b/tests/components/recorder/test_migrate.py
@@ -611,7 +611,7 @@ async def test_schema_migrate(
         assert recorder.util.async_migration_is_live(hass) == live
         instrument_migration.migration_stall.set()
         await hass.async_block_till_done()
-        await hass.async_add_executor_job(instrument_migration.migration_done.wait)
+        await hass.async_add_executor_job(instrument_migration.live_migration_done.wait)
         await async_wait_recording_done(hass)
         assert instrument_migration.migration_version == db_schema.SCHEMA_VERSION
         assert setup_run.called

--- a/tests/components/recorder/test_migrate.py
+++ b/tests/components/recorder/test_migrate.py
@@ -963,7 +963,7 @@ def test_drop_restore_foreign_key_constraints(recorder_db_url: str) -> None:
             for table, column, _, _ in constraints_to_recreate
             for dropped_constraint in migration._drop_foreign_key_constraints(
                 session_maker, engine, table, column
-            )[1]
+            )
         ]
     assert dropped_constraints_1 == expected_dropped_constraints[db_engine]
 
@@ -975,7 +975,7 @@ def test_drop_restore_foreign_key_constraints(recorder_db_url: str) -> None:
             for table, column, _, _ in constraints_to_recreate
             for dropped_constraint in migration._drop_foreign_key_constraints(
                 session_maker, engine, table, column
-            )[1]
+            )
         ]
     assert dropped_constraints_2 == []
 
@@ -994,7 +994,7 @@ def test_drop_restore_foreign_key_constraints(recorder_db_url: str) -> None:
             for table, column, _, _ in constraints_to_recreate
             for dropped_constraint in migration._drop_foreign_key_constraints(
                 session_maker, engine, table, column
-            )[1]
+            )
         ]
     assert dropped_constraints_3 == expected_dropped_constraints[db_engine]
 

--- a/tests/components/recorder/test_migrate.py
+++ b/tests/components/recorder/test_migrate.py
@@ -268,6 +268,8 @@ async def test_database_migration_failed_step_11(
         ("DropConstraint", False, 2, 1),  # This makes migration to step 44 fail
     ],
 )
+@pytest.mark.skip_on_db_engine(["sqlite"])
+@pytest.mark.usefixtures("skip_by_db_engine")
 async def test_database_migration_failed_step_44(
     hass: HomeAssistant,
     async_setup_recorder_instance: RecorderInstanceGenerator,

--- a/tests/components/recorder/test_v32_migration.py
+++ b/tests/components/recorder/test_v32_migration.py
@@ -9,7 +9,6 @@ import pytest
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.exc import OperationalError, SQLAlchemyError
 from sqlalchemy.orm import Session
-from sqlalchemy.pool import StaticPool
 
 from homeassistant.components import recorder
 from homeassistant.components.recorder import core, migration, statistics
@@ -670,13 +669,10 @@ async def test_out_of_disk_space_while_removing_foreign_key(
 
     def _get_event_id_foreign_keys():
         assert instance.engine is not None
-        return _get_event_id_foreign_keys_impl(instance.engine)
-
-    def _get_event_id_foreign_keys_impl(engine):
         return next(
             (
                 fk  # type: ignore[misc]
-                for fk in inspect(engine).get_foreign_keys("states")
+                for fk in inspect(instance.engine).get_foreign_keys("states")
                 if fk["constrained_columns"] == ["event_id"]
             ),
             None,
@@ -684,10 +680,7 @@ async def test_out_of_disk_space_while_removing_foreign_key(
 
     def _get_states_index_names():
         with session_scope(hass=hass) as session:
-            return _get_states_index_names_impl(session)
-
-    def _get_states_index_names_impl(session):
-        return inspect(session.connection()).get_indexes("states")
+            return inspect(session.connection()).get_indexes("states")
 
     with (
         patch.object(recorder, "db_schema", old_db_schema),
@@ -756,22 +749,24 @@ async def test_out_of_disk_space_while_removing_foreign_key(
     ):
         async with (
             async_test_home_assistant() as hass,
-            async_test_recorder(hass, wait_recorder=False) as instance,
+            async_test_recorder(hass) as instance,
         ):
             await hass.async_block_till_done()
-            # Wait for recorder thread to finish
-            instance.join()
+
+            # We need to wait for all the migration tasks to complete
+            # before we can check the database.
+            for _ in range(number_of_migrations):
+                await instance.async_block_till_done()
+                await async_wait_recording_done(hass)
+
+            states_indexes = await instance.async_add_executor_job(
+                _get_states_index_names
+            )
+            states_index_names = {index["name"] for index in states_indexes}
+            assert instance.use_legacy_events_index is True
+            assert await instance.async_add_executor_job(_get_event_id_foreign_keys)
 
             await hass.async_stop()
-
-    engine = create_engine(recorder_db_url, poolclass=StaticPool)
-    with Session(engine) as session:
-        states_indexes = _get_states_index_names_impl(session)
-        states_index_names = {index["name"] for index in states_indexes}
-        assert instance.use_legacy_events_index is True
-        assert _get_event_id_foreign_keys_impl(engine)
-
-    engine.dispose()
 
     # Now run it again to verify the table rebuild tries again
     caplog.clear()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Raise on database error in `recorder.migration._drop_foreign_key_constraints`

Rationale:
Without the changes in this PR, errors are swallowed and the migration is marked as successful even when it isn't. 
By swallowing the error and continuing on, the user's database ends up in an undefined state where the database schema is not aligned with the schema assumed by the recorder. This makes the behavior unpredictable and debugging difficult.

~~Note:~~
~~Set to draft waiting for https://github.com/home-assistant/core/pull/123454 to be merged~~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
