### PR TITLE
Cleanup unneeded assignment of hass property on MQTT Template objects

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -303,8 +303,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             # has been deprecated with HA Core 2024.8.0
             # and will be removed with HA Core 2025.2.0
             rendered_topic: Any = MqttCommandTemplate(
-                template.Template(msg_topic_template),
-                hass=hass,
+                template.Template(msg_topic_template, hass),
             ).async_render()
             ir.async_create_issue(
                 hass,
@@ -353,7 +352,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 },
             )
             payload = MqttCommandTemplate(
-                template.Template(payload_template), hass=hass
+                template.Template(payload_template, hass)
             ).async_render()
 
         if TYPE_CHECKING:

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -159,7 +159,6 @@ class MqttCommandTemplate:
         self,
         command_template: template.Template | None,
         *,
-        hass: HomeAssistant | None = None,
         entity: Entity | None = None,
     ) -> None:
         """Instantiate a command template."""
@@ -169,11 +168,6 @@ class MqttCommandTemplate:
             return
 
         self._entity = entity
-
-        command_template.hass = hass
-
-        if entity:
-            command_template.hass = entity.hass
 
     @callback
     def async_render(
@@ -281,11 +275,11 @@ class MqttValueTemplate:
         if value_template is None:
             return
 
-        value_template.hass = hass
+        # value_template.hass = hass
         self._entity = entity
 
-        if entity:
-            value_template.hass = entity.hass
+        # if entity:
+        #    value_template.hass = entity.hass
 
     @callback
     def async_render_with_possible_json_value(

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -12,7 +12,7 @@ import logging
 from typing import TYPE_CHECKING, Any, TypedDict
 
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_NAME, Platform
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, callback
 from homeassistant.exceptions import ServiceValidationError, TemplateError
 from homeassistant.helpers import template
 from homeassistant.helpers.entity import Entity
@@ -261,7 +261,6 @@ class MqttValueTemplate:
         self,
         value_template: template.Template | None,
         *,
-        hass: HomeAssistant | None = None,
         entity: Entity | None = None,
         config_attributes: TemplateVarsType = None,
     ) -> None:

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -164,9 +164,6 @@ class MqttCommandTemplate:
         """Instantiate a command template."""
         self._template_state: template.TemplateStateFromEntityId | None = None
         self._command_template = command_template
-        if command_template is None:
-            return
-
         self._entity = entity
 
     @callback
@@ -272,14 +269,7 @@ class MqttValueTemplate:
         self._template_state: template.TemplateStateFromEntityId | None = None
         self._value_template = value_template
         self._config_attributes = config_attributes
-        if value_template is None:
-            return
-
-        # value_template.hass = hass
         self._entity = entity
-
-        # if entity:
-        #    value_template.hass = entity.hass
 
     @callback
     def async_render_with_possible_json_value(

--- a/homeassistant/components/mqtt/tag.py
+++ b/homeassistant/components/mqtt/tag.py
@@ -118,8 +118,7 @@ class MQTTTagScanner(MqttDiscoveryDeviceUpdateMixin):
         self.hass = hass
         self._sub_state: dict[str, EntitySubscription] | None = None
         self._value_template = MqttValueTemplate(
-            config.get(CONF_VALUE_TEMPLATE),
-            hass=self.hass,
+            config.get(CONF_VALUE_TEMPLATE)
         ).async_render_with_possible_json_value
 
         MqttDiscoveryDeviceUpdateMixin.__init__(
@@ -136,8 +135,7 @@ class MQTTTagScanner(MqttDiscoveryDeviceUpdateMixin):
             return
         self._config = config
         self._value_template = MqttValueTemplate(
-            config.get(CONF_VALUE_TEMPLATE),
-            hass=self.hass,
+            config.get(CONF_VALUE_TEMPLATE)
         ).async_render_with_possible_json_value
         update_device(self.hass, self._config_entry, config)
         await self.subscribe_topics()

--- a/homeassistant/components/mqtt/trigger.py
+++ b/homeassistant/components/mqtt/trigger.py
@@ -75,7 +75,6 @@ async def async_attach_trigger(
     wanted_payload = command_template(None, variables)
 
     topic_template: Template = config[CONF_TOPIC]
-    topic_template.hass = hass
     topic = topic_template.async_render(variables, limited=True, parse_result=False)
     mqtt.util.valid_subscribe_topic(topic)
 

--- a/homeassistant/components/mqtt/trigger.py
+++ b/homeassistant/components/mqtt/trigger.py
@@ -60,10 +60,10 @@ async def async_attach_trigger(
     trigger_data: TriggerData = trigger_info["trigger_data"]
     command_template: Callable[
         [PublishPayloadType, TemplateVarsType], PublishPayloadType
-    ] = MqttCommandTemplate(config.get(CONF_PAYLOAD), hass=hass).async_render
+    ] = MqttCommandTemplate(config.get(CONF_PAYLOAD)).async_render
     value_template: Callable[[ReceivePayloadType, str], ReceivePayloadType]
     value_template = MqttValueTemplate(
-        config.get(CONF_VALUE_TEMPLATE), hass=hass
+        config.get(CONF_VALUE_TEMPLATE)
     ).async_render_with_possible_json_value
     encoding: str | None = config[CONF_ENCODING] or None
     qos: int = config[CONF_QOS]

--- a/tests/components/mqtt/test_client.py
+++ b/tests/components/mqtt/test_client.py
@@ -225,7 +225,7 @@ async def test_publish(
 
 async def test_convert_outgoing_payload(hass: HomeAssistant) -> None:
     """Test the converting of outgoing MQTT payloads without template."""
-    command_template = mqtt.MqttCommandTemplate(None, hass=hass)
+    command_template = mqtt.MqttCommandTemplate(None)
     assert command_template.async_render(b"\xde\xad\xbe\xef") == b"\xde\xad\xbe\xef"
     assert (
         command_template.async_render("b'\\xde\\xad\\xbe\\xef'")

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -88,13 +88,13 @@ async def test_command_template_value(hass: HomeAssistant) -> None:
     variables = {"id": 1234, "some_var": "beer"}
 
     # test rendering value
-    tpl = template.Template("{{ value + 1 }}", hass=hass)
-    cmd_tpl = mqtt.MqttCommandTemplate(tpl, hass=hass)
+    tpl = template.Template("{{ value + 1 }}", hass)
+    cmd_tpl = mqtt.MqttCommandTemplate(tpl)
     assert cmd_tpl.async_render(4321) == "4322"
 
     # test variables at rendering
-    tpl = template.Template("{{ some_var }}", hass=hass)
-    cmd_tpl = mqtt.MqttCommandTemplate(tpl, hass=hass)
+    tpl = template.Template("{{ some_var }}", hass)
+    cmd_tpl = mqtt.MqttCommandTemplate(tpl)
     assert cmd_tpl.async_render(None, variables=variables) == "beer"
 
 
@@ -161,8 +161,8 @@ async def test_command_template_variables(
 
 async def test_command_template_fails(hass: HomeAssistant) -> None:
     """Test the exception handling of an MQTT command template."""
-    tpl = template.Template("{{ value * 2 }}")
-    cmd_tpl = mqtt.MqttCommandTemplate(tpl, hass=hass)
+    tpl = template.Template("{{ value * 2 }}", hass)
+    cmd_tpl = mqtt.MqttCommandTemplate(tpl)
     with pytest.raises(MqttCommandTemplateException) as exc:
         cmd_tpl.async_render(None)
     assert "unsupported operand type(s) for *: 'NoneType' and 'int'" in str(exc.value)
@@ -174,13 +174,13 @@ async def test_value_template_value(hass: HomeAssistant) -> None:
     variables = {"id": 1234, "some_var": "beer"}
 
     # test rendering value
-    tpl = template.Template("{{ value_json.id }}")
-    val_tpl = mqtt.MqttValueTemplate(tpl, hass=hass)
+    tpl = template.Template("{{ value_json.id }}", hass)
+    val_tpl = mqtt.MqttValueTemplate(tpl)
     assert val_tpl.async_render_with_possible_json_value('{"id": 4321}') == "4321"
 
     # test variables at rendering
-    tpl = template.Template("{{ value_json.id }} {{ some_var }} {{ code }}")
-    val_tpl = mqtt.MqttValueTemplate(tpl, hass=hass, config_attributes={"code": 1234})
+    tpl = template.Template("{{ value_json.id }} {{ some_var }} {{ code }}", hass)
+    val_tpl = mqtt.MqttValueTemplate(tpl, config_attributes={"code": 1234})
     assert (
         val_tpl.async_render_with_possible_json_value(
             '{"id": 4321}', variables=variables
@@ -189,8 +189,8 @@ async def test_value_template_value(hass: HomeAssistant) -> None:
     )
 
     # test with default value if an error occurs due to an invalid template
-    tpl = template.Template("{{ value_json.id | as_datetime }}")
-    val_tpl = mqtt.MqttValueTemplate(tpl, hass=hass)
+    tpl = template.Template("{{ value_json.id | as_datetime }}", hass)
+    val_tpl = mqtt.MqttValueTemplate(tpl)
     assert (
         val_tpl.async_render_with_possible_json_value('{"otherid": 4321}', "my default")
         == "my default"
@@ -200,19 +200,19 @@ async def test_value_template_value(hass: HomeAssistant) -> None:
     entity = Entity()
     entity.hass = hass
     entity.entity_id = "select.test"
-    tpl = template.Template("{{ value_json.id }}")
+    tpl = template.Template("{{ value_json.id }}", hass)
     val_tpl = mqtt.MqttValueTemplate(tpl, entity=entity)
     assert val_tpl.async_render_with_possible_json_value('{"id": 4321}') == "4321"
 
     # test this object in a template
-    tpl2 = template.Template("{{ this.entity_id }}")
+    tpl2 = template.Template("{{ this.entity_id }}", hass)
     val_tpl2 = mqtt.MqttValueTemplate(tpl2, entity=entity)
     assert val_tpl2.async_render_with_possible_json_value("bla") == "select.test"
 
     with patch(
         "homeassistant.helpers.template.TemplateStateFromEntityId", MagicMock()
     ) as template_state_calls:
-        tpl3 = template.Template("{{ this.entity_id }}")
+        tpl3 = template.Template("{{ this.entity_id }}", hass)
         val_tpl3 = mqtt.MqttValueTemplate(tpl3, entity=entity)
         val_tpl3.async_render_with_possible_json_value("call1")
         val_tpl3.async_render_with_possible_json_value("call2")
@@ -223,8 +223,8 @@ async def test_value_template_fails(hass: HomeAssistant) -> None:
     """Test the rendering of MQTT value template fails."""
     entity = MockEntity(entity_id="sensor.test")
     entity.hass = hass
-    tpl = template.Template("{{ value_json.some_var * 2 }}")
-    val_tpl = mqtt.MqttValueTemplate(tpl, hass=hass, entity=entity)
+    tpl = template.Template("{{ value_json.some_var * 2 }}", hass)
+    val_tpl = mqtt.MqttValueTemplate(tpl, entity=entity)
     with pytest.raises(MqttValueTemplateException) as exc:
         val_tpl.async_render_with_possible_json_value('{"some_var": null }')
     assert str(exc.value) == (

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -88,12 +88,12 @@ async def test_command_template_value(hass: HomeAssistant) -> None:
     variables = {"id": 1234, "some_var": "beer"}
 
     # test rendering value
-    tpl = template.Template("{{ value + 1 }}", hass)
+    tpl = template.Template("{{ value + 1 }}", hass=hass)
     cmd_tpl = mqtt.MqttCommandTemplate(tpl)
     assert cmd_tpl.async_render(4321) == "4322"
 
     # test variables at rendering
-    tpl = template.Template("{{ some_var }}", hass)
+    tpl = template.Template("{{ some_var }}", hass=hass)
     cmd_tpl = mqtt.MqttCommandTemplate(tpl)
     assert cmd_tpl.async_render(None, variables=variables) == "beer"
 
@@ -161,7 +161,7 @@ async def test_command_template_variables(
 
 async def test_command_template_fails(hass: HomeAssistant) -> None:
     """Test the exception handling of an MQTT command template."""
-    tpl = template.Template("{{ value * 2 }}", hass)
+    tpl = template.Template("{{ value * 2 }}", hass=hass)
     cmd_tpl = mqtt.MqttCommandTemplate(tpl)
     with pytest.raises(MqttCommandTemplateException) as exc:
         cmd_tpl.async_render(None)
@@ -174,12 +174,12 @@ async def test_value_template_value(hass: HomeAssistant) -> None:
     variables = {"id": 1234, "some_var": "beer"}
 
     # test rendering value
-    tpl = template.Template("{{ value_json.id }}", hass)
+    tpl = template.Template("{{ value_json.id }}", hass=hass)
     val_tpl = mqtt.MqttValueTemplate(tpl)
     assert val_tpl.async_render_with_possible_json_value('{"id": 4321}') == "4321"
 
     # test variables at rendering
-    tpl = template.Template("{{ value_json.id }} {{ some_var }} {{ code }}", hass)
+    tpl = template.Template("{{ value_json.id }} {{ some_var }} {{ code }}", hass=hass)
     val_tpl = mqtt.MqttValueTemplate(tpl, config_attributes={"code": 1234})
     assert (
         val_tpl.async_render_with_possible_json_value(
@@ -189,7 +189,7 @@ async def test_value_template_value(hass: HomeAssistant) -> None:
     )
 
     # test with default value if an error occurs due to an invalid template
-    tpl = template.Template("{{ value_json.id | as_datetime }}", hass)
+    tpl = template.Template("{{ value_json.id | as_datetime }}", hass=hass)
     val_tpl = mqtt.MqttValueTemplate(tpl)
     assert (
         val_tpl.async_render_with_possible_json_value('{"otherid": 4321}', "my default")
@@ -200,19 +200,19 @@ async def test_value_template_value(hass: HomeAssistant) -> None:
     entity = Entity()
     entity.hass = hass
     entity.entity_id = "select.test"
-    tpl = template.Template("{{ value_json.id }}", hass)
+    tpl = template.Template("{{ value_json.id }}", hass=hass)
     val_tpl = mqtt.MqttValueTemplate(tpl, entity=entity)
     assert val_tpl.async_render_with_possible_json_value('{"id": 4321}') == "4321"
 
     # test this object in a template
-    tpl2 = template.Template("{{ this.entity_id }}", hass)
+    tpl2 = template.Template("{{ this.entity_id }}", hass=hass)
     val_tpl2 = mqtt.MqttValueTemplate(tpl2, entity=entity)
     assert val_tpl2.async_render_with_possible_json_value("bla") == "select.test"
 
     with patch(
         "homeassistant.helpers.template.TemplateStateFromEntityId", MagicMock()
     ) as template_state_calls:
-        tpl3 = template.Template("{{ this.entity_id }}", hass)
+        tpl3 = template.Template("{{ this.entity_id }}", hass=hass)
         val_tpl3 = mqtt.MqttValueTemplate(tpl3, entity=entity)
         val_tpl3.async_render_with_possible_json_value("call1")
         val_tpl3.async_render_with_possible_json_value("call2")
@@ -223,7 +223,7 @@ async def test_value_template_fails(hass: HomeAssistant) -> None:
     """Test the rendering of MQTT value template fails."""
     entity = MockEntity(entity_id="sensor.test")
     entity.hass = hass
-    tpl = template.Template("{{ value_json.some_var * 2 }}", hass)
+    tpl = template.Template("{{ value_json.some_var * 2 }}", hass=hass)
     val_tpl = mqtt.MqttValueTemplate(tpl, entity=entity)
     with pytest.raises(MqttValueTemplateException) as exc:
         val_tpl.async_render_with_possible_json_value('{"some_var": null }')


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Templates used in MQTT configs are validated through the `template` config helper. It will already assign `hass` to the template. Therefor it is not needed to set it again.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
