### PR TITLE
Add 'select' to configure Schlage locks "Auto Lock Time"

### DIFF
--- a/homeassistant/components/schlage/__init__.py
+++ b/homeassistant/components/schlage/__init__.py
@@ -16,6 +16,7 @@ from .coordinator import SchlageDataUpdateCoordinator
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.LOCK,
+    Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
 ]

--- a/homeassistant/components/schlage/select.py
+++ b/homeassistant/components/schlage/select.py
@@ -1,0 +1,78 @@
+"""Platform for Schlage select integration."""
+
+from __future__ import annotations
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import LockData, SchlageDataUpdateCoordinator
+from .entity import SchlageEntity
+
+_DESCRIPTIONS = (
+    SelectEntityDescription(
+        key="auto_lock_time",
+        translation_key="auto_lock_time",
+        entity_category=EntityCategory.CONFIG,
+        # valid values are from Schlage UI and validated by pyschlage
+        options=[
+            "0",
+            "15",
+            "30",
+            "60",
+            "120",
+            "240",
+            "300",
+        ],
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up selects based on a config entry."""
+    coordinator: SchlageDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    def _add_new_locks(locks: dict[str, LockData]) -> None:
+        async_add_entities(
+            SchlageSelect(
+                coordinator=coordinator,
+                description=description,
+                device_id=device_id,
+            )
+            for device_id in locks
+            for description in _DESCRIPTIONS
+        )
+
+    _add_new_locks(coordinator.data.locks)
+    coordinator.new_locks_callbacks.append(_add_new_locks)
+
+
+class SchlageSelect(SchlageEntity, SelectEntity):
+    """Schlage select entity."""
+
+    def __init__(
+        self,
+        coordinator: SchlageDataUpdateCoordinator,
+        description: SelectEntityDescription,
+        device_id: str,
+    ) -> None:
+        """Initialize a SchlageSelect."""
+        super().__init__(coordinator, device_id)
+        self.entity_description = description
+        self._attr_unique_id = f"{device_id}_{self.entity_description.key}"
+
+    @property
+    def current_option(self) -> str:
+        """Return the current option."""
+        return str(self._lock_data.lock.auto_lock_time)
+
+    def select_option(self, option: str) -> None:
+        """Set the current option."""
+        self._lock.set_auto_lock_time(int(option))

--- a/homeassistant/components/schlage/strings.json
+++ b/homeassistant/components/schlage/strings.json
@@ -31,6 +31,20 @@
         "name": "Keypad disabled"
       }
     },
+    "select": {
+      "auto_lock_time": {
+        "name": "Auto-Lock time",
+        "state": {
+          "0": "Disabled",
+          "15": "15 seconds",
+          "30": "30 seconds",
+          "60": "1 minute",
+          "120": "2 minutes",
+          "240": "4 minutes",
+          "300": "5 minutes"
+        }
+      }
+    },
     "switch": {
       "beeper": {
         "name": "Keypress Beep"

--- a/tests/components/schlage/conftest.py
+++ b/tests/components/schlage/conftest.py
@@ -91,6 +91,7 @@ def mock_lock_attrs() -> dict[str, Any]:
         "is_locked": False,
         "is_jammed": False,
         "battery_level": 20,
+        "auto_lock_time": 15,
         "firmware_version": "1.0",
         "lock_and_leave_enabled": True,
         "beeper_enabled": True,

--- a/tests/components/schlage/test_select.py
+++ b/tests/components/schlage/test_select.py
@@ -1,0 +1,31 @@
+"""Test Schlage select."""
+
+from unittest.mock import Mock
+
+from homeassistant.components.select import (
+    ATTR_OPTION,
+    DOMAIN as SELECT_DOMAIN,
+    SERVICE_SELECT_OPTION,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+
+
+async def test_select(
+    hass: HomeAssistant, mock_lock: Mock, mock_added_config_entry: ConfigEntry
+) -> None:
+    """Test the auto-lock time select entity."""
+    entity_id = "select.vault_door_auto_lock_time"
+
+    select = hass.states.get(entity_id)
+    assert select is not None
+    assert select.state == "15"
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: entity_id, ATTR_OPTION: "30"},
+        blocking=True,
+    )
+    mock_lock.set_auto_lock_time.assert_called_once_with(30)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Various Schlage locks support automatically locking the deadbolt after some time has elapsed. This amount of time is the "auto lock time" and it's configurable by the user. This PR adds a 'select' to manage this feature. A 'select' is used because only discrete values are allowed.

Here are some screenshots:

| Initially Disabled (HA) | After Setting to 30s (HA) | After Setting to 30s (Schlage App) |
|--------|--------|--------|
| <img src="https://github.com/user-attachments/assets/537c91b1-4eb6-4371-891d-be2b5b3ba918"> | <img src="https://github.com/user-attachments/assets/a77176d8-0e82-4c4c-aa5a-82faa96dcde0"> | <img src="https://github.com/user-attachments/assets/512e643e-7be7-4aed-b816-4a219d696777"> | 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/34273

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
