### PR TITLE
Add handling for `RoborockTooFrequentCodeRequests` for roborock integration

### DIFF
--- a/homeassistant/components/roborock/config_flow.py
+++ b/homeassistant/components/roborock/config_flow.py
@@ -12,6 +12,7 @@ from roborock.exceptions import (
     RoborockException,
     RoborockInvalidCode,
     RoborockInvalidEmail,
+    RoborockTooFrequentCodeRequests,
     RoborockUrlException,
 )
 from roborock.web_api import RoborockApiClient
@@ -83,6 +84,8 @@ class RoborockFlowHandler(ConfigFlow, domain=DOMAIN):
             errors["base"] = "unknown_url"
         except RoborockInvalidEmail:
             errors["base"] = "invalid_email_format"
+        except RoborockTooFrequentCodeRequests:
+            errors["base"] = "too_frequent_code_requests"
         except RoborockException:
             _LOGGER.exception("Unexpected exception")
             errors["base"] = "unknown_roborock"

--- a/homeassistant/components/roborock/strings.json
+++ b/homeassistant/components/roborock/strings.json
@@ -22,6 +22,7 @@
       "invalid_code": "The code you entered was incorrect, please check it and try again.",
       "invalid_email": "There is no account associated with the email you entered, please try again.",
       "invalid_email_format": "There is an issue with the formatting of your email - please try again.",
+      "too_frequent_code_requests": "You have attempted to request too many codes. Try again later.",
       "unknown_roborock": "There was an unknown roborock exception - please check your logs.",
       "unknown_url": "There was an issue determining the correct url for your roborock account - please check your logs.",
       "unknown": "[%key:common::config_flow::error::unknown%]"

--- a/tests/components/roborock/test_config_flow.py
+++ b/tests/components/roborock/test_config_flow.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from unittest.mock import patch
 
 import pytest
+from roborock import RoborockTooFrequentCodeRequests
 from roborock.exceptions import (
     RoborockAccountDoesNotExist,
     RoborockException,
@@ -71,6 +72,7 @@ async def test_config_flow_success(
         (RoborockException(), {"base": "unknown_roborock"}),
         (RoborockAccountDoesNotExist(), {"base": "invalid_email"}),
         (RoborockInvalidEmail(), {"base": "invalid_email_format"}),
+        (RoborockTooFrequentCodeRequests(), {"base": "too_frequent_code_requests"}),
         (RoborockUrlException(), {"base": "unknown_url"}),
         (Exception(), {"base": "unknown"}),
     ],


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds handling for `RoborockTooFrequentCodeRequests` when requesting code in config flow. This exception happens when user sends too many requests in a short period of time. We should properly display a help message to instruct users to try again later.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
