### PR TITLE
Update xknx to 3.1.0 and fix climate read only mode

### DIFF
--- a/homeassistant/components/knx/manifest.json
+++ b/homeassistant/components/knx/manifest.json
@@ -11,7 +11,7 @@
   "loggers": ["xknx", "xknxproject"],
   "quality_scale": "platinum",
   "requirements": [
-    "xknx==3.0.0",
+    "xknx==3.1.0",
     "xknxproject==3.7.1",
     "knx-frontend==2024.8.6.211307"
   ],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2933,7 +2933,7 @@ xbox-webapi==2.0.11
 xiaomi-ble==0.30.2
 
 # homeassistant.components.knx
-xknx==3.0.0
+xknx==3.1.0
 
 # homeassistant.components.knx
 xknxproject==3.7.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2319,7 +2319,7 @@ xbox-webapi==2.0.11
 xiaomi-ble==0.30.2
 
 # homeassistant.components.knx
-xknx==3.0.0
+xknx==3.1.0
 
 # homeassistant.components.knx
 xknxproject==3.7.1

--- a/tests/components/knx/test_climate.py
+++ b/tests/components/knx/test_climate.py
@@ -231,6 +231,90 @@ async def test_climate_hvac_mode(
     assert hass.states.get("climate.test").state == "cool"
 
 
+async def test_climate_heat_cool_read_only(
+    hass: HomeAssistant, knx: KNXTestKit
+) -> None:
+    """Test KNX climate hvac mode."""
+    heat_cool_state_ga = "3/3/3"
+    await knx.setup_integration(
+        {
+            ClimateSchema.PLATFORM: {
+                CONF_NAME: "test",
+                ClimateSchema.CONF_TEMPERATURE_ADDRESS: "1/2/3",
+                ClimateSchema.CONF_TARGET_TEMPERATURE_ADDRESS: "1/2/4",
+                ClimateSchema.CONF_TARGET_TEMPERATURE_STATE_ADDRESS: "1/2/5",
+                ClimateSchema.CONF_HEAT_COOL_STATE_ADDRESS: heat_cool_state_ga,
+            }
+        }
+    )
+    # read states state updater
+    # StateUpdater semaphore allows 2 concurrent requests
+    await knx.assert_read("1/2/3")
+    await knx.assert_read("1/2/5")
+    # StateUpdater initialize state
+    await knx.receive_response("1/2/3", RAW_FLOAT_20_0)
+    await knx.receive_response("1/2/5", RAW_FLOAT_20_0)
+    await knx.assert_read(heat_cool_state_ga)
+    await knx.receive_response(heat_cool_state_ga, True)  # heat
+
+    state = hass.states.get("climate.test")
+    assert state.state == "heat"
+    assert state.attributes["hvac_modes"] == ["heat"]
+    assert state.attributes["hvac_action"] == "heating"
+
+    await knx.receive_write(heat_cool_state_ga, False)  # cool
+    state = hass.states.get("climate.test")
+    assert state.state == "cool"
+    assert state.attributes["hvac_modes"] == ["cool"]
+    assert state.attributes["hvac_action"] == "cooling"
+
+
+async def test_climate_heat_cool_read_only_on_off(
+    hass: HomeAssistant, knx: KNXTestKit
+) -> None:
+    """Test KNX climate hvac mode."""
+    on_off_ga = "2/2/2"
+    heat_cool_state_ga = "3/3/3"
+    await knx.setup_integration(
+        {
+            ClimateSchema.PLATFORM: {
+                CONF_NAME: "test",
+                ClimateSchema.CONF_TEMPERATURE_ADDRESS: "1/2/3",
+                ClimateSchema.CONF_TARGET_TEMPERATURE_ADDRESS: "1/2/4",
+                ClimateSchema.CONF_TARGET_TEMPERATURE_STATE_ADDRESS: "1/2/5",
+                ClimateSchema.CONF_ON_OFF_ADDRESS: on_off_ga,
+                ClimateSchema.CONF_HEAT_COOL_STATE_ADDRESS: heat_cool_state_ga,
+            }
+        }
+    )
+    # read states state updater
+    # StateUpdater semaphore allows 2 concurrent requests
+    await knx.assert_read("1/2/3")
+    await knx.assert_read("1/2/5")
+    # StateUpdater initialize state
+    await knx.receive_response("1/2/3", RAW_FLOAT_20_0)
+    await knx.receive_response("1/2/5", RAW_FLOAT_20_0)
+    await knx.assert_read(heat_cool_state_ga)
+    await knx.receive_response(heat_cool_state_ga, True)  # heat
+
+    state = hass.states.get("climate.test")
+    assert state.state == "off"
+    assert set(state.attributes["hvac_modes"]) == {"off", "heat"}
+    assert state.attributes["hvac_action"] == "off"
+
+    await knx.receive_write(heat_cool_state_ga, False)  # cool
+    state = hass.states.get("climate.test")
+    assert state.state == "off"
+    assert set(state.attributes["hvac_modes"]) == {"off", "cool"}
+    assert state.attributes["hvac_action"] == "off"
+
+    await knx.receive_write(on_off_ga, True)
+    state = hass.states.get("climate.test")
+    assert state.state == "cool"
+    assert set(state.attributes["hvac_modes"]) == {"off", "cool"}
+    assert state.attributes["hvac_action"] == "cooling"
+
+
 async def test_climate_preset_mode(
     hass: HomeAssistant, knx: KNXTestKit, entity_registry: er.EntityRegistry
 ) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update xknx to 3.1.0

https://github.com/XKNX/xknx/releases/tag/3.1.0

DPT 1 definitions are now available - this doesn't change or break any runtime behaviour, but they would be resolved in the GroupMonitor.

<hr>

The climate fix needed the update of the `xknx` library. In 3.0.0 (HA 2024.8.0) `ClimateMode` objects changed unintentionally for read-only climate modes.

- Pre 2024.8 the `hvac_modes` attribute would always be `["heat"]` where "heat" is the default mode. So when it was cooling, it still hat heat as its only available mode.
- In 2024.8 `hvac_modes` behaved the same, but `hvac_mode` ignored read-only modes resulting in always default mode "heat". So since it is cooling season right now, these entities show the wrong state.
- After this PR `hvac_modes` will be a list containing 1 element (when read-only): the current mode. So in heating mode `["heat"]`, in cooling mode `["cool"]`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #123733
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
