### PR TITLE
Fix status update loop in bluesound integration

### DIFF
--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -312,20 +312,24 @@ class BluesoundPlayer(MediaPlayerEntity):
 
     async def _start_poll_command(self):
         """Loop which polls the status of the player."""
-        try:
-            while True:
+        while True:
+            try:
                 await self.async_update_status()
-
-        except (TimeoutError, ClientError):
-            _LOGGER.error("Node %s:%s is offline, retrying later", self.host, self.port)
-            await asyncio.sleep(NODE_OFFLINE_CHECK_TIMEOUT)
-            self.start_polling()
-
-        except CancelledError:
-            _LOGGER.debug("Stopping the polling of node %s:%s", self.host, self.port)
-        except Exception:
-            _LOGGER.exception("Unexpected error in %s:%s", self.host, self.port)
-            raise
+            except (TimeoutError, ClientError):
+                _LOGGER.error(
+                    "Node %s:%s is offline, retrying later", self.host, self.port
+                )
+                await asyncio.sleep(NODE_OFFLINE_CHECK_TIMEOUT)
+            except CancelledError:
+                _LOGGER.debug(
+                    "Stopping the polling of node %s:%s", self.host, self.port
+                )
+                return
+            except Exception:
+                _LOGGER.exception(
+                    "Unexpected error in %s:%s, retrying later", self.host, self.port
+                )
+                await asyncio.sleep(NODE_OFFLINE_CHECK_TIMEOUT)
 
     async def async_added_to_hass(self) -> None:
         """Start the polling task."""

--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -244,7 +244,6 @@ class BluesoundPlayer(MediaPlayerEntity):
         self._status: Status | None = None
         self._inputs: list[Input] = []
         self._presets: list[Preset] = []
-        self._is_online = False
         self._muted = False
         self._master: BluesoundPlayer | None = None
         self._is_master = False
@@ -352,7 +351,7 @@ class BluesoundPlayer(MediaPlayerEntity):
 
     async def async_update(self) -> None:
         """Update internal status of the entity."""
-        if not self._is_online:
+        if not self.available:
             return
 
         with suppress(TimeoutError):
@@ -369,7 +368,7 @@ class BluesoundPlayer(MediaPlayerEntity):
         try:
             status = await self._player.status(etag=etag, poll_timeout=120, timeout=125)
 
-            self._is_online = True
+            self._attr_available = True
             self._last_status_update = dt_util.utcnow()
             self._status = status
 
@@ -398,7 +397,7 @@ class BluesoundPlayer(MediaPlayerEntity):
 
             self.async_write_ha_state()
         except (TimeoutError, ClientError):
-            self._is_online = False
+            self._attr_available = False
             self._last_status_update = None
             self._status = None
             self.async_write_ha_state()

--- a/tests/components/bluesound/conftest.py
+++ b/tests/components/bluesound/conftest.py
@@ -3,7 +3,7 @@
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
-from pyblu import SyncStatus
+from pyblu import Status, SyncStatus
 import pytest
 
 from homeassistant.components.bluesound.const import DOMAIN
@@ -40,6 +40,35 @@ def sync_status() -> SyncStatus:
 
 
 @pytest.fixture
+def status() -> Status:
+    """Return a status object."""
+    return Status(
+        etag="etag",
+        input_id=None,
+        service=None,
+        state="playing",
+        shuffle=False,
+        album=None,
+        artist=None,
+        name=None,
+        image=None,
+        volume=10,
+        volume_db=22.3,
+        mute=False,
+        mute_volume=None,
+        mute_volume_db=None,
+        seconds=2,
+        total_seconds=123.1,
+        can_seek=False,
+        sleep=0,
+        group_name=None,
+        group_volume=None,
+        indexing=False,
+        stream_url=None,
+    )
+
+
+@pytest.fixture
 def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
@@ -65,7 +94,7 @@ def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_player() -> Generator[AsyncMock]:
+def mock_player(status: Status) -> Generator[AsyncMock]:
     """Mock the player."""
     with (
         patch(
@@ -78,7 +107,7 @@ def mock_player() -> Generator[AsyncMock]:
     ):
         player = mock_player.return_value
         player.__aenter__.return_value = player
-        player.status.return_value = None
+        player.status.return_value = status
         player.sync_status.return_value = SyncStatus(
             etag="etag",
             id="1.1.1.1:11000",

--- a/tests/components/bluesound/test_config_flow.py
+++ b/tests/components/bluesound/test_config_flow.py
@@ -41,7 +41,7 @@ async def test_user_flow_success(
 
 
 async def test_user_flow_cannot_connect(
-    hass: HomeAssistant, mock_player: AsyncMock
+    hass: HomeAssistant, mock_player: AsyncMock, mock_setup_entry: AsyncMock
 ) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
@@ -75,6 +75,8 @@ async def test_user_flow_cannot_connect(
         CONF_HOST: "1.1.1.1",
         CONF_PORT: 11000,
     }
+
+    mock_setup_entry.assert_called_once()
 
 
 async def test_user_flow_aleady_configured(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This integration has a loop which fetches the current status. There was a recursive call to `self.start_polling`, which i removed in a previous PR. This PR removes the recursion and uses the existing while loop for retries.

I also added `_attr_available` and removed the use of a custom attribute `_is_online`, which had the same purpose internally.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #123745
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
