### PR TITLE
Fix blocking I/O of SSLContext.load_default_certs in Ecovacs

### DIFF
--- a/homeassistant/components/ecovacs/config_flow.py
+++ b/homeassistant/components/ecovacs/config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from functools import partial
 import logging
 import ssl
 from typing import Any
@@ -100,11 +101,14 @@ async def _validate_input(
     if not user_input.get(CONF_VERIFY_MQTT_CERTIFICATE, True) and mqtt_url:
         ssl_context = get_default_no_verify_context()
 
-    mqtt_config = create_mqtt_config(
-        device_id=device_id,
-        country=country,
-        override_mqtt_url=mqtt_url,
-        ssl_context=ssl_context,
+    mqtt_config = await hass.async_add_executor_job(
+        partial(
+            create_mqtt_config,
+            device_id=device_id,
+            country=country,
+            override_mqtt_url=mqtt_url,
+            ssl_context=ssl_context,
+        )
     )
 
     client = MqttClient(mqtt_config, authenticator)

--- a/homeassistant/components/ecovacs/controller.py
+++ b/homeassistant/components/ecovacs/controller.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from functools import partial
 import logging
 import ssl
 from typing import Any
@@ -64,32 +65,28 @@ class EcovacsController:
         if not config.get(CONF_VERIFY_MQTT_CERTIFICATE, True) and mqtt_url:
             ssl_context = get_default_no_verify_context()
 
-        self._mqtt = MqttClient(
-            create_mqtt_config(
-                device_id=self._device_id,
-                country=country,
-                override_mqtt_url=mqtt_url,
-                ssl_context=ssl_context,
-            ),
-            self._authenticator,
+        self._mqtt_config_fn = partial(
+            create_mqtt_config,
+            device_id=self._device_id,
+            country=country,
+            override_mqtt_url=mqtt_url,
+            ssl_context=ssl_context,
         )
+        self._mqtt_client: MqttClient | None = None
 
         self._added_legacy_entities: set[str] = set()
 
     async def initialize(self) -> None:
         """Init controller."""
-        mqtt_config_verfied = False
         try:
             devices = await self._api_client.get_devices()
             credentials = await self._authenticator.authenticate()
             for device_config in devices:
                 if isinstance(device_config, DeviceInfo):
                     # MQTT device
-                    if not mqtt_config_verfied:
-                        await self._mqtt.verify_config()
-                        mqtt_config_verfied = True
                     device = Device(device_config, self._authenticator)
-                    await device.initialize(self._mqtt)
+                    mqtt = await self._get_mqtt_client()
+                    await device.initialize(mqtt)
                     self._devices.append(device)
                 else:
                     # Legacy device
@@ -116,7 +113,8 @@ class EcovacsController:
             await device.teardown()
         for legacy_device in self._legacy_devices:
             await self._hass.async_add_executor_job(legacy_device.disconnect)
-        await self._mqtt.disconnect()
+        if self._mqtt_client is not None:
+            await self._mqtt_client.disconnect()
         await self._authenticator.teardown()
 
     def add_legacy_entity(self, device: VacBot, component: str) -> None:
@@ -126,6 +124,16 @@ class EcovacsController:
     def legacy_entity_is_added(self, device: VacBot, component: str) -> bool:
         """Check if legacy entity is added."""
         return f"{device.vacuum['did']}_{component}" in self._added_legacy_entities
+
+    async def _get_mqtt_client(self) -> MqttClient:
+        """Return validated MQTT client."""
+        if self._mqtt_client is None:
+            config = await self._hass.async_add_executor_job(self._mqtt_config_fn)
+            mqtt = MqttClient(config, self._authenticator)
+            await mqtt.verify_config()
+            self._mqtt_client = mqtt
+
+        return self._mqtt_client
 
     @property
     def devices(self) -> list[Device]:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix the following message:
![grafik](https://github.com/user-attachments/assets/79e3de25-52ac-4449-be37-c04212dcd7d5)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
