### PR TITLE
Improve type hints in owntracks tests

### DIFF
--- a/tests/components/owntracks/test_device_tracker.py
+++ b/tests/components/owntracks/test_device_tracker.py
@@ -1,6 +1,7 @@
 """The tests for the Owntracks device tracker."""
 
 import base64
+from collections.abc import Callable
 import json
 import pickle
 from unittest.mock import patch
@@ -17,6 +18,8 @@ from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, async_fire_mqtt_message
 from tests.typing import ClientSessionGenerator, MqttMockHAClient
+
+type OwnTracksContextFactory = Callable[[], owntracks.OwnTracksContext]
 
 USER = "greg"
 DEVICE = "phone"
@@ -314,7 +317,7 @@ async def setup_owntracks(hass, config, ctx_cls=owntracks.OwnTracksContext):
 
 
 @pytest.fixture
-def context(hass, setup_comp):
+def context(hass: HomeAssistant, setup_comp: None) -> OwnTracksContextFactory:
     """Set up the mocked context."""
     orig_context = owntracks.OwnTracksContext
     context = None
@@ -407,14 +410,16 @@ def assert_mobile_tracker_accuracy(hass, accuracy, beacon=IBEACON_DEVICE):
     assert state.attributes.get("gps_accuracy") == accuracy
 
 
-async def test_location_invalid_devid(hass: HomeAssistant, context) -> None:
+@pytest.mark.usefixtures("context")
+async def test_location_invalid_devid(hass: HomeAssistant) -> None:
     """Test the update of a location."""
     await send_message(hass, "owntracks/paulus/nexus-5x", LOCATION_MESSAGE)
     state = hass.states.get("device_tracker.paulus_nexus_5x")
     assert state.state == "outer"
 
 
-async def test_location_update(hass: HomeAssistant, context) -> None:
+@pytest.mark.usefixtures("context")
+async def test_location_update(hass: HomeAssistant) -> None:
     """Test the update of a location."""
     await send_message(hass, LOCATION_TOPIC, LOCATION_MESSAGE)
 
@@ -424,7 +429,8 @@ async def test_location_update(hass: HomeAssistant, context) -> None:
     assert_location_state(hass, "outer")
 
 
-async def test_location_update_no_t_key(hass: HomeAssistant, context) -> None:
+@pytest.mark.usefixtures("context")
+async def test_location_update_no_t_key(hass: HomeAssistant) -> None:
     """Test the update of a location when message does not contain 't'."""
     message = LOCATION_MESSAGE.copy()
     message.pop("t")
@@ -436,7 +442,8 @@ async def test_location_update_no_t_key(hass: HomeAssistant, context) -> None:
     assert_location_state(hass, "outer")
 
 
-async def test_location_inaccurate_gps(hass: HomeAssistant, context) -> None:
+@pytest.mark.usefixtures("context")
+async def test_location_inaccurate_gps(hass: HomeAssistant) -> None:
     """Test the location for inaccurate GPS information."""
     await send_message(hass, LOCATION_TOPIC, LOCATION_MESSAGE)
     await send_message(hass, LOCATION_TOPIC, LOCATION_MESSAGE_INACCURATE)
@@ -446,7 +453,8 @@ async def test_location_inaccurate_gps(hass: HomeAssistant, context) -> None:
     assert_location_longitude(hass, LOCATION_MESSAGE["lon"])
 
 
-async def test_location_zero_accuracy_gps(hass: HomeAssistant, context) -> None:
+@pytest.mark.usefixtures("context")
+async def test_location_zero_accuracy_gps(hass: HomeAssistant) -> None:
     """Ignore the location for zero accuracy GPS information."""
     await send_message(hass, LOCATION_TOPIC, LOCATION_MESSAGE)
     await send_message(hass, LOCATION_TOPIC, LOCATION_MESSAGE_ZERO_ACCURACY)
@@ -458,7 +466,9 @@ async def test_location_zero_accuracy_gps(hass: HomeAssistant, context) -> None:
 
 # ------------------------------------------------------------------------
 # GPS based event entry / exit testing
-async def test_event_gps_entry_exit(hass: HomeAssistant, context) -> None:
+async def test_event_gps_entry_exit(
+    hass: HomeAssistant, context: OwnTracksContextFactory
+) -> None:
     """Test the entry event."""
     # Entering the owntracks circular region named "inner"
     await send_message(hass, EVENT_TOPIC, REGION_GPS_ENTER_MESSAGE)
@@ -496,7 +506,9 @@ async def test_event_gps_entry_exit(hass: HomeAssistant, context) -> None:
     assert_location_accuracy(hass, LOCATION_MESSAGE["acc"])
 
 
-async def test_event_gps_with_spaces(hass: HomeAssistant, context) -> None:
+async def test_event_gps_with_spaces(
+    hass: HomeAssistant, context: OwnTracksContextFactory
+) -> None:
     """Test the entry event."""
     message = build_message({"desc": "inner 2"}, REGION_GPS_ENTER_MESSAGE)
     await send_message(hass, EVENT_TOPIC, message)
@@ -509,7 +521,8 @@ async def test_event_gps_with_spaces(hass: HomeAssistant, context) -> None:
     assert not context().regions_entered[USER]
 
 
-async def test_event_gps_entry_inaccurate(hass: HomeAssistant, context) -> None:
+@pytest.mark.usefixtures("context")
+async def test_event_gps_entry_inaccurate(hass: HomeAssistant) -> None:
     """Test the event for inaccurate entry."""
     # Set location to the outer zone.
     await send_message(hass, LOCATION_TOPIC, LOCATION_MESSAGE)
@@ -522,7 +535,9 @@ async def test_event_gps_entry_inaccurate(hass: HomeAssistant, context) -> None:
     assert_location_state(hass, "inner")
 
 
-async def test_event_gps_entry_exit_inaccurate(hass: HomeAssistant, context) -> None:
+async def test_event_gps_entry_exit_inaccurate(
+    hass: HomeAssistant, context: OwnTracksContextFactory
+) -> None:
     """Test the event for inaccurate exit."""
     await send_message(hass, EVENT_TOPIC, REGION_GPS_ENTER_MESSAGE)
 
@@ -542,7 +557,9 @@ async def test_event_gps_entry_exit_inaccurate(hass: HomeAssistant, context) -> 
     assert not context().regions_entered[USER]
 
 
-async def test_event_gps_entry_exit_zero_accuracy(hass: HomeAssistant, context) -> None:
+async def test_event_gps_entry_exit_zero_accuracy(
+    hass: HomeAssistant, context: OwnTracksContextFactory
+) -> None:
     """Test entry/exit events with accuracy zero."""
     await send_message(hass, EVENT_TOPIC, REGION_GPS_ENTER_MESSAGE_ZERO)
 
@@ -562,9 +579,8 @@ async def test_event_gps_entry_exit_zero_accuracy(hass: HomeAssistant, context) 
     assert not context().regions_entered[USER]
 
 
-async def test_event_gps_exit_outside_zone_sets_away(
-    hass: HomeAssistant, context
-) -> None:
+@pytest.mark.usefixtures("context")
+async def test_event_gps_exit_outside_zone_sets_away(hass: HomeAssistant) -> None:
     """Test the event for exit zone."""
     await send_message(hass, EVENT_TOPIC, REGION_GPS_ENTER_MESSAGE)
     assert_location_state(hass, "inner")
@@ -577,7 +593,8 @@ async def test_event_gps_exit_outside_zone_sets_away(
     assert_location_state(hass, STATE_NOT_HOME)
 
 
-async def test_event_gps_entry_exit_right_order(hass: HomeAssistant, context) -> None:
+@pytest.mark.usefixtures("context")
+async def test_event_gps_entry_exit_right_order(hass: HomeAssistant) -> None:
     """Test the event for ordering."""
     # Enter inner zone
     # Set location to the outer zone.
@@ -602,7 +619,8 @@ async def test_event_gps_entry_exit_right_order(hass: HomeAssistant, context) ->
     assert_location_state(hass, "outer")
 
 
-async def test_event_gps_entry_exit_wrong_order(hass: HomeAssistant, context) -> None:
+@pytest.mark.usefixtures("context")
+async def test_event_gps_entry_exit_wrong_order(hass: HomeAssistant) -> None:
     """Test the event for wrong order."""
     # Enter inner zone
     await send_message(hass, EVENT_TOPIC, REGION_GPS_ENTER_MESSAGE)
@@ -625,7 +643,8 @@ async def test_event_gps_entry_exit_wrong_order(hass: HomeAssistant, context) ->
     assert_location_state(hass, "outer")
 
 
-async def test_event_gps_entry_unknown_zone(hass: HomeAssistant, context) -> None:
+@pytest.mark.usefixtures("context")
+async def test_event_gps_entry_unknown_zone(hass: HomeAssistant) -> None:
     """Test the event for unknown zone."""
     # Just treat as location update
     message = build_message({"desc": "unknown"}, REGION_GPS_ENTER_MESSAGE)
@@ -634,7 +653,8 @@ async def test_event_gps_entry_unknown_zone(hass: HomeAssistant, context) -> Non
     assert_location_state(hass, "inner")
 
 
-async def test_event_gps_exit_unknown_zone(hass: HomeAssistant, context) -> None:
+@pytest.mark.usefixtures("context")
+async def test_event_gps_exit_unknown_zone(hass: HomeAssistant) -> None:
     """Test the event for unknown zone."""
     # Just treat as location update
     message = build_message({"desc": "unknown"}, REGION_GPS_LEAVE_MESSAGE)
@@ -643,7 +663,8 @@ async def test_event_gps_exit_unknown_zone(hass: HomeAssistant, context) -> None
     assert_location_state(hass, "outer")
 
 
-async def test_event_entry_zone_loading_dash(hass: HomeAssistant, context) -> None:
+@pytest.mark.usefixtures("context")
+async def test_event_entry_zone_loading_dash(hass: HomeAssistant) -> None:
     """Test the event for zone landing."""
     # Make sure the leading - is ignored
     # Owntracks uses this to switch on hold
@@ -652,7 +673,9 @@ async def test_event_entry_zone_loading_dash(hass: HomeAssistant, context) -> No
     assert_location_state(hass, "inner")
 
 
-async def test_events_only_on(hass: HomeAssistant, context) -> None:
+async def test_events_only_on(
+    hass: HomeAssistant, context: OwnTracksContextFactory
+) -> None:
     """Test events_only config suppresses location updates."""
     # Sending a location message that is not home
     await send_message(hass, LOCATION_TOPIC, LOCATION_MESSAGE_NOT_HOME)
@@ -673,7 +696,9 @@ async def test_events_only_on(hass: HomeAssistant, context) -> None:
     assert_location_state(hass, STATE_NOT_HOME)
 
 
-async def test_events_only_off(hass: HomeAssistant, context) -> None:
+async def test_events_only_off(
+    hass: HomeAssistant, context: OwnTracksContextFactory
+) -> None:
     """Test when events_only is False."""
     # Sending a location message that is not home
     await send_message(hass, LOCATION_TOPIC, LOCATION_MESSAGE_NOT_HOME)
@@ -694,7 +719,8 @@ async def test_events_only_off(hass: HomeAssistant, context) -> None:
     assert_location_state(hass, "outer")
 
 
-async def test_event_source_type_entry_exit(hass: HomeAssistant, context) -> None:
+@pytest.mark.usefixtures("context")
+async def test_event_source_type_entry_exit(hass: HomeAssistant) -> None:
     """Test the entry and exit events of source type."""
     # Entering the owntracks circular region named "inner"
     await send_message(hass, EVENT_TOPIC, REGION_GPS_ENTER_MESSAGE)
@@ -724,7 +750,9 @@ async def test_event_source_type_entry_exit(hass: HomeAssistant, context) -> Non
 
 
 # Region Beacon based event entry / exit testing
-async def test_event_region_entry_exit(hass: HomeAssistant, context) -> None:
+async def test_event_region_entry_exit(
+    hass: HomeAssistant, context: OwnTracksContextFactory
+) -> None:
     """Test the entry event."""
     # Seeing a beacon named "inner"
     await send_message(hass, EVENT_TOPIC, REGION_BEACON_ENTER_MESSAGE)
@@ -763,7 +791,9 @@ async def test_event_region_entry_exit(hass: HomeAssistant, context) -> None:
     assert_location_accuracy(hass, LOCATION_MESSAGE["acc"])
 
 
-async def test_event_region_with_spaces(hass: HomeAssistant, context) -> None:
+async def test_event_region_with_spaces(
+    hass: HomeAssistant, context: OwnTracksContextFactory
+) -> None:
     """Test the entry event."""
     message = build_message({"desc": "inner 2"}, REGION_BEACON_ENTER_MESSAGE)
     await send_message(hass, EVENT_TOPIC, message)
@@ -776,9 +806,8 @@ async def test_event_region_with_spaces(hass: HomeAssistant, context) -> None:
     assert not context().regions_entered[USER]
 
 
-async def test_event_region_entry_exit_right_order(
-    hass: HomeAssistant, context
-) -> None:
+@pytest.mark.usefixtures("context")
+async def test_event_region_entry_exit_right_order(hass: HomeAssistant) -> None:
     """Test the event for ordering."""
     # Enter inner zone
     # Set location to the outer zone.
@@ -809,9 +838,8 @@ async def test_event_region_entry_exit_right_order(
     assert_location_state(hass, "inner")
 
 
-async def test_event_region_entry_exit_wrong_order(
-    hass: HomeAssistant, context
-) -> None:
+@pytest.mark.usefixtures("context")
+async def test_event_region_entry_exit_wrong_order(hass: HomeAssistant) -> None:
     """Test the event for wrong order."""
     # Enter inner zone
     await send_message(hass, EVENT_TOPIC, REGION_BEACON_ENTER_MESSAGE)
@@ -838,9 +866,8 @@ async def test_event_region_entry_exit_wrong_order(
     assert_location_state(hass, "inner_2")
 
 
-async def test_event_beacon_unknown_zone_no_location(
-    hass: HomeAssistant, context
-) -> None:
+@pytest.mark.usefixtures("context")
+async def test_event_beacon_unknown_zone_no_location(hass: HomeAssistant) -> None:
     """Test the event for unknown zone."""
     # A beacon which does not match a HA zone is the
     # definition of a mobile beacon. In this case, "unknown"
@@ -865,7 +892,8 @@ async def test_event_beacon_unknown_zone_no_location(
     assert_mobile_tracker_state(hass, "unknown", "unknown")
 
 
-async def test_event_beacon_unknown_zone(hass: HomeAssistant, context) -> None:
+@pytest.mark.usefixtures("context")
+async def test_event_beacon_unknown_zone(hass: HomeAssistant) -> None:
     """Test the event for unknown zone."""
     # A beacon which does not match a HA zone is the
     # definition of a mobile beacon. In this case, "unknown"
@@ -885,9 +913,8 @@ async def test_event_beacon_unknown_zone(hass: HomeAssistant, context) -> None:
     assert_mobile_tracker_state(hass, "outer", "unknown")
 
 
-async def test_event_beacon_entry_zone_loading_dash(
-    hass: HomeAssistant, context
-) -> None:
+@pytest.mark.usefixtures("context")
+async def test_event_beacon_entry_zone_loading_dash(hass: HomeAssistant) -> None:
     """Test the event for beacon zone landing."""
     # Make sure the leading - is ignored
     # Owntracks uses this to switch on hold
@@ -899,7 +926,8 @@ async def test_event_beacon_entry_zone_loading_dash(
 
 # ------------------------------------------------------------------------
 # Mobile Beacon based event entry / exit testing
-async def test_mobile_enter_move_beacon(hass: HomeAssistant, context) -> None:
+@pytest.mark.usefixtures("context")
+async def test_mobile_enter_move_beacon(hass: HomeAssistant) -> None:
     """Test the movement of a beacon."""
     # I am in the outer zone.
     await send_message(hass, LOCATION_TOPIC, LOCATION_MESSAGE)
@@ -923,7 +951,8 @@ async def test_mobile_enter_move_beacon(hass: HomeAssistant, context) -> None:
     assert_mobile_tracker_latitude(hass, not_home_lat)
 
 
-async def test_mobile_enter_exit_region_beacon(hass: HomeAssistant, context) -> None:
+@pytest.mark.usefixtures("context")
+async def test_mobile_enter_exit_region_beacon(hass: HomeAssistant) -> None:
     """Test the enter and the exit of a mobile beacon."""
     # I am in the outer zone.
     await send_message(hass, LOCATION_TOPIC, LOCATION_MESSAGE)
@@ -946,7 +975,8 @@ async def test_mobile_enter_exit_region_beacon(hass: HomeAssistant, context) -> 
     assert_mobile_tracker_state(hass, "outer")
 
 
-async def test_mobile_exit_move_beacon(hass: HomeAssistant, context) -> None:
+@pytest.mark.usefixtures("context")
+async def test_mobile_exit_move_beacon(hass: HomeAssistant) -> None:
     """Test the exit move of a beacon."""
     # I am in the outer zone.
     await send_message(hass, LOCATION_TOPIC, LOCATION_MESSAGE)
@@ -968,7 +998,9 @@ async def test_mobile_exit_move_beacon(hass: HomeAssistant, context) -> None:
     assert_mobile_tracker_state(hass, "outer")
 
 
-async def test_mobile_multiple_async_enter_exit(hass: HomeAssistant, context) -> None:
+async def test_mobile_multiple_async_enter_exit(
+    hass: HomeAssistant, context: OwnTracksContextFactory
+) -> None:
     """Test the multiple entering."""
     # Test race condition
     for _ in range(20):
@@ -988,7 +1020,9 @@ async def test_mobile_multiple_async_enter_exit(hass: HomeAssistant, context) ->
     assert len(context().mobile_beacons_active["greg_phone"]) == 0
 
 
-async def test_mobile_multiple_enter_exit(hass: HomeAssistant, context) -> None:
+async def test_mobile_multiple_enter_exit(
+    hass: HomeAssistant, context: OwnTracksContextFactory
+) -> None:
     """Test the multiple entering."""
     await send_message(hass, EVENT_TOPIC, MOBILE_BEACON_ENTER_EVENT_MESSAGE)
     await send_message(hass, EVENT_TOPIC, MOBILE_BEACON_ENTER_EVENT_MESSAGE)
@@ -997,7 +1031,8 @@ async def test_mobile_multiple_enter_exit(hass: HomeAssistant, context) -> None:
     assert len(context().mobile_beacons_active["greg_phone"]) == 0
 
 
-async def test_complex_movement(hass: HomeAssistant, context) -> None:
+@pytest.mark.usefixtures("context")
+async def test_complex_movement(hass: HomeAssistant) -> None:
     """Test a complex sequence representative of real-world use."""
     # I am in the outer zone.
     await send_message(hass, LOCATION_TOPIC, LOCATION_MESSAGE)
@@ -1119,9 +1154,8 @@ async def test_complex_movement(hass: HomeAssistant, context) -> None:
     assert_mobile_tracker_state(hass, "outer")
 
 
-async def test_complex_movement_sticky_keys_beacon(
-    hass: HomeAssistant, context
-) -> None:
+@pytest.mark.usefixtures("context")
+async def test_complex_movement_sticky_keys_beacon(hass: HomeAssistant) -> None:
     """Test a complex sequence which was previously broken."""
     # I am not_home
     await send_message(hass, LOCATION_TOPIC, LOCATION_MESSAGE)
@@ -1233,7 +1267,8 @@ async def test_complex_movement_sticky_keys_beacon(
     assert_mobile_tracker_latitude(hass, INNER_ZONE["latitude"])
 
 
-async def test_waypoint_import_simple(hass: HomeAssistant, context) -> None:
+@pytest.mark.usefixtures("context")
+async def test_waypoint_import_simple(hass: HomeAssistant) -> None:
     """Test a simple import of list of waypoints."""
     waypoints_message = WAYPOINTS_EXPORTED_MESSAGE.copy()
     await send_message(hass, WAYPOINTS_TOPIC, waypoints_message)
@@ -1244,7 +1279,8 @@ async def test_waypoint_import_simple(hass: HomeAssistant, context) -> None:
     assert wayp is not None
 
 
-async def test_waypoint_import_block(hass: HomeAssistant, context) -> None:
+@pytest.mark.usefixtures("context")
+async def test_waypoint_import_block(hass: HomeAssistant) -> None:
     """Test import of list of waypoints for blocked user."""
     waypoints_message = WAYPOINTS_EXPORTED_MESSAGE.copy()
     await send_message(hass, WAYPOINTS_TOPIC_BLOCKED, waypoints_message)
@@ -1275,7 +1311,8 @@ async def test_waypoint_import_no_whitelist(hass: HomeAssistant, setup_comp) -> 
     assert wayp is not None
 
 
-async def test_waypoint_import_bad_json(hass: HomeAssistant, context) -> None:
+@pytest.mark.usefixtures("context")
+async def test_waypoint_import_bad_json(hass: HomeAssistant) -> None:
     """Test importing a bad JSON payload."""
     waypoints_message = WAYPOINTS_EXPORTED_MESSAGE.copy()
     await send_message(hass, WAYPOINTS_TOPIC, waypoints_message, True)
@@ -1286,7 +1323,8 @@ async def test_waypoint_import_bad_json(hass: HomeAssistant, context) -> None:
     assert wayp is None
 
 
-async def test_waypoint_import_existing(hass: HomeAssistant, context) -> None:
+@pytest.mark.usefixtures("context")
+async def test_waypoint_import_existing(hass: HomeAssistant) -> None:
     """Test importing a zone that exists."""
     waypoints_message = WAYPOINTS_EXPORTED_MESSAGE.copy()
     await send_message(hass, WAYPOINTS_TOPIC, waypoints_message)
@@ -1299,7 +1337,8 @@ async def test_waypoint_import_existing(hass: HomeAssistant, context) -> None:
     assert wayp == new_wayp
 
 
-async def test_single_waypoint_import(hass: HomeAssistant, context) -> None:
+@pytest.mark.usefixtures("context")
+async def test_single_waypoint_import(hass: HomeAssistant) -> None:
     """Test single waypoint message."""
     waypoint_message = WAYPOINT_MESSAGE.copy()
     await send_message(hass, WAYPOINT_TOPIC, waypoint_message)
@@ -1307,7 +1346,8 @@ async def test_single_waypoint_import(hass: HomeAssistant, context) -> None:
     assert wayp is not None
 
 
-async def test_not_implemented_message(hass: HomeAssistant, context) -> None:
+@pytest.mark.usefixtures("context")
+async def test_not_implemented_message(hass: HomeAssistant) -> None:
     """Handle not implemented message type."""
     patch_handler = patch(
         "homeassistant.components.owntracks.messages.async_handle_not_impl_msg",
@@ -1318,7 +1358,8 @@ async def test_not_implemented_message(hass: HomeAssistant, context) -> None:
     patch_handler.stop()
 
 
-async def test_unsupported_message(hass: HomeAssistant, context) -> None:
+@pytest.mark.usefixtures("context")
+async def test_unsupported_message(hass: HomeAssistant) -> None:
     """Handle not implemented message type."""
     patch_handler = patch(
         "homeassistant.components.owntracks.messages.async_handle_unsupported_msg",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
