### PR TITLE
Improve type hints in purpleair tests

### DIFF
--- a/tests/components/purpleair/conftest.py
+++ b/tests/components/purpleair/conftest.py
@@ -1,5 +1,7 @@
 """Define fixtures for PurpleAir tests."""
 
+from collections.abc import Generator
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 from aiopurpleair.endpoints.sensors import NearbySensorResult
@@ -7,6 +9,7 @@ from aiopurpleair.models.sensors import GetSensorsResponse
 import pytest
 
 from homeassistant.components.purpleair import DOMAIN
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, load_fixture
 
@@ -16,7 +19,7 @@ TEST_SENSOR_INDEX2 = 567890
 
 
 @pytest.fixture(name="api")
-def api_fixture(get_sensors_response):
+def api_fixture(get_sensors_response: GetSensorsResponse) -> Mock:
     """Define a fixture to return a mocked aiopurple API object."""
     return Mock(
         async_check_api_key=AsyncMock(),
@@ -34,7 +37,11 @@ def api_fixture(get_sensors_response):
 
 
 @pytest.fixture(name="config_entry")
-def config_entry_fixture(hass, config_entry_data, config_entry_options):
+def config_entry_fixture(
+    hass: HomeAssistant,
+    config_entry_data: dict[str, Any],
+    config_entry_options: dict[str, Any],
+) -> MockConfigEntry:
     """Define a config entry fixture."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -48,7 +55,7 @@ def config_entry_fixture(hass, config_entry_data, config_entry_options):
 
 
 @pytest.fixture(name="config_entry_data")
-def config_entry_data_fixture():
+def config_entry_data_fixture() -> dict[str, Any]:
     """Define a config entry data fixture."""
     return {
         "api_key": TEST_API_KEY,
@@ -56,7 +63,7 @@ def config_entry_data_fixture():
 
 
 @pytest.fixture(name="config_entry_options")
-def config_entry_options_fixture():
+def config_entry_options_fixture() -> dict[str, Any]:
     """Define a config entry options fixture."""
     return {
         "sensor_indices": [TEST_SENSOR_INDEX1],
@@ -64,7 +71,7 @@ def config_entry_options_fixture():
 
 
 @pytest.fixture(name="get_sensors_response", scope="package")
-def get_sensors_response_fixture():
+def get_sensors_response_fixture() -> GetSensorsResponse:
     """Define a fixture to mock an aiopurpleair GetSensorsResponse object."""
     return GetSensorsResponse.parse_raw(
         load_fixture("get_sensors_response.json", "purpleair")
@@ -72,7 +79,7 @@ def get_sensors_response_fixture():
 
 
 @pytest.fixture(name="mock_aiopurpleair")
-async def mock_aiopurpleair_fixture(api):
+def mock_aiopurpleair_fixture(api: Mock) -> Generator[Mock]:
     """Define a fixture to patch aiopurpleair."""
     with (
         patch("homeassistant.components.purpleair.config_flow.API", return_value=api),
@@ -82,7 +89,9 @@ async def mock_aiopurpleair_fixture(api):
 
 
 @pytest.fixture(name="setup_config_entry")
-async def setup_config_entry_fixture(hass, config_entry, mock_aiopurpleair):
+async def setup_config_entry_fixture(
+    hass: HomeAssistant, config_entry: MockConfigEntry, mock_aiopurpleair: Mock
+) -> None:
     """Define a fixture to set up purpleair."""
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
