### PR TITLE
Migrate Mastodon unique id

### DIFF
--- a/homeassistant/components/mastodon/__init__.py
+++ b/homeassistant/components/mastodon/__init__.py
@@ -17,10 +17,11 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import discovery
+from homeassistant.util import slugify
 
-from .const import CONF_BASE_URL, DOMAIN
+from .const import CONF_BASE_URL, DOMAIN, LOGGER
 from .coordinator import MastodonCoordinator
-from .utils import create_mastodon_client
+from .utils import construct_mastodon_username, create_mastodon_client
 
 PLATFORMS: list[Platform] = [Platform.NOTIFY, Platform.SENSOR]
 
@@ -78,6 +79,38 @@ async def async_unload_entry(hass: HomeAssistant, entry: MastodonConfigEntry) ->
     return await hass.config_entries.async_unload_platforms(
         entry, [platform for platform in PLATFORMS if platform != Platform.NOTIFY]
     )
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate old config."""
+
+    if entry.version == 1:
+        # Version 1 had the unique_id as client_id, this isn't necessarily unique
+        LOGGER.debug("Migrating config entry from version %s", entry.version)
+
+        try:
+            _, instance, account = await hass.async_add_executor_job(
+                setup_mastodon,
+                entry,
+            )
+        except MastodonError as ex:
+            LOGGER.error("Migration failed with error %s", ex)
+
+        entry.version = 2
+
+        hass.config_entries.async_update_entry(
+            entry,
+            title=entry.title,
+            unique_id=slugify(construct_mastodon_username(instance, account)),
+        )
+
+        LOGGER.info(
+            "Entry %s successfully migrated to version %s",
+            entry.entry_id,
+            entry.version,
+        )
+
+    return True
 
 
 def setup_mastodon(entry: ConfigEntry) -> tuple[Mastodon, dict, dict]:

--- a/homeassistant/components/mastodon/__init__.py
+++ b/homeassistant/components/mastodon/__init__.py
@@ -84,8 +84,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: MastodonConfigEntry) ->
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate old config."""
 
-    if entry.version == 1:
-        # Version 1 had the unique_id as client_id, this isn't necessarily unique
+    if entry.version == 1 and entry.minor_version == 1:
+        # Version 1.1 had the unique_id as client_id, this isn't necessarily unique
         LOGGER.debug("Migrating config entry from version %s", entry.version)
 
         try:
@@ -95,19 +95,20 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
         except MastodonError as ex:
             LOGGER.error("Migration failed with error %s", ex)
+            return False
 
-        entry.version = 2
+        entry.minor_version = 2
 
         hass.config_entries.async_update_entry(
             entry,
-            title=entry.title,
             unique_id=slugify(construct_mastodon_username(instance, account)),
         )
 
         LOGGER.info(
-            "Entry %s successfully migrated to version %s",
+            "Entry %s successfully migrated to version %s.%s",
             entry.entry_id,
             entry.version,
+            entry.minor_version,
         )
 
     return True

--- a/homeassistant/components/mastodon/config_flow.py
+++ b/homeassistant/components/mastodon/config_flow.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.selector import (
     TextSelectorType,
 )
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.util import slugify
 
 from .const import CONF_BASE_URL, DEFAULT_URL, DOMAIN, LOGGER
 from .utils import construct_mastodon_username, create_mastodon_client
@@ -46,7 +47,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 class MastodonConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow."""
 
-    VERSION = 1
+    VERSION = 2
     config_entry: ConfigEntry
 
     def check_connection(
@@ -119,7 +120,7 @@ class MastodonConfigFlow(ConfigFlow, domain=DOMAIN):
 
             if not errors:
                 name = construct_mastodon_username(instance, account)
-                await self.async_set_unique_id(user_input[CONF_CLIENT_ID])
+                await self.async_set_unique_id(slugify(name))
                 return self.async_create_entry(
                     title=name,
                     data=user_input,

--- a/homeassistant/components/mastodon/config_flow.py
+++ b/homeassistant/components/mastodon/config_flow.py
@@ -47,7 +47,8 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 class MastodonConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow."""
 
-    VERSION = 2
+    VERSION = 1
+    MINOR_VERSION = 2
     config_entry: ConfigEntry
 
     def check_connection(

--- a/homeassistant/components/mastodon/config_flow.py
+++ b/homeassistant/components/mastodon/config_flow.py
@@ -106,10 +106,6 @@ class MastodonConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle a flow initialized by the user."""
         errors: dict[str, str] | None = None
         if user_input:
-            self._async_abort_entries_match(
-                {CONF_CLIENT_ID: user_input[CONF_CLIENT_ID]}
-            )
-
             instance, account, errors = await self.hass.async_add_executor_job(
                 self.check_connection,
                 user_input[CONF_BASE_URL],
@@ -121,6 +117,7 @@ class MastodonConfigFlow(ConfigFlow, domain=DOMAIN):
             if not errors:
                 name = construct_mastodon_username(instance, account)
                 await self.async_set_unique_id(slugify(name))
+                self._abort_if_unique_id_configured()
                 return self.async_create_entry(
                     title=name,
                     data=user_input,
@@ -149,7 +146,8 @@ class MastodonConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
         if not errors:
-            await self.async_set_unique_id(client_id)
+            name = construct_mastodon_username(instance, account)
+            await self.async_set_unique_id(slugify(name))
             self._abort_if_unique_id_configured()
 
             if not name:

--- a/tests/components/mastodon/conftest.py
+++ b/tests/components/mastodon/conftest.py
@@ -53,5 +53,6 @@ def mock_config_entry() -> MockConfigEntry:
             CONF_ACCESS_TOKEN: "access_token",
         },
         entry_id="01J35M4AH9HYRC2V0G6RNVNWJH",
-        unique_id="client_id",
+        unique_id="trwnh_mastodon_social",
+        version=2,
     )

--- a/tests/components/mastodon/conftest.py
+++ b/tests/components/mastodon/conftest.py
@@ -54,5 +54,6 @@ def mock_config_entry() -> MockConfigEntry:
         },
         entry_id="01J35M4AH9HYRC2V0G6RNVNWJH",
         unique_id="trwnh_mastodon_social",
-        version=2,
+        version=1,
+        minor_version=2,
     )

--- a/tests/components/mastodon/snapshots/test_init.ambr
+++ b/tests/components/mastodon/snapshots/test_init.ambr
@@ -1,0 +1,33 @@
+# serializer version: 1
+# name: test_device_info
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': <DeviceEntryType.SERVICE: 'service'>,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'mastodon',
+        'trwnh_mastodon_social',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'Mastodon gGmbH',
+    'model': '@trwnh@mastodon.social',
+    'model_id': None,
+    'name': 'Mastodon @trwnh@mastodon.social',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': '4.0.0rc1',
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/mastodon/snapshots/test_sensor.ambr
+++ b/tests/components/mastodon/snapshots/test_sensor.ambr
@@ -30,7 +30,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'followers',
-    'unique_id': 'client_id_followers',
+    'unique_id': 'trwnh_mastodon_social_followers',
     'unit_of_measurement': 'accounts',
   })
 # ---
@@ -80,7 +80,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'following',
-    'unique_id': 'client_id_following',
+    'unique_id': 'trwnh_mastodon_social_following',
     'unit_of_measurement': 'accounts',
   })
 # ---
@@ -130,7 +130,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'posts',
-    'unique_id': 'client_id_posts',
+    'unique_id': 'trwnh_mastodon_social_posts',
     'unit_of_measurement': 'posts',
   })
 # ---

--- a/tests/components/mastodon/test_config_flow.py
+++ b/tests/components/mastodon/test_config_flow.py
@@ -44,7 +44,7 @@ async def test_full_flow(
         CONF_CLIENT_SECRET: "client_secret",
         CONF_ACCESS_TOKEN: "access_token",
     }
-    assert result["result"].unique_id == "client_id"
+    assert result["result"].unique_id == "trwnh_mastodon_social"
 
 
 @pytest.mark.parametrize(

--- a/tests/components/mastodon/test_init.py
+++ b/tests/components/mastodon/test_init.py
@@ -3,13 +3,34 @@
 from unittest.mock import AsyncMock
 
 from mastodon.Mastodon import MastodonError
+from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.mastodon.config_flow import MastodonConfigFlow
+from homeassistant.components.mastodon.const import CONF_BASE_URL, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_ACCESS_TOKEN, CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
 from . import setup_integration
 
 from tests.common import MockConfigEntry
+
+
+async def test_device_info(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_mastodon_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test device registry integration."""
+    await setup_integration(hass, mock_config_entry)
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, mock_config_entry.unique_id)}
+    )
+    assert device_entry is not None
+    assert device_entry == snapshot
 
 
 async def test_initialization_failure(
@@ -23,3 +44,36 @@ async def test_initialization_failure(
     await setup_integration(hass, mock_config_entry)
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_migrate(
+    hass: HomeAssistant,
+    mock_mastodon_client: AsyncMock,
+) -> None:
+    """Test migration."""
+    # Setup the config entry
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_BASE_URL: "https://mastodon.social",
+            CONF_CLIENT_ID: "client_id",
+            CONF_CLIENT_SECRET: "client_secret",
+            CONF_ACCESS_TOKEN: "access_token",
+        },
+        title="@trwnh@mastodon.social",
+        version=1,
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Check migration was successful
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert config_entry.data == {
+        CONF_BASE_URL: "https://mastodon.social",
+        CONF_CLIENT_ID: "client_id",
+        CONF_CLIENT_SECRET: "client_secret",
+        CONF_ACCESS_TOKEN: "access_token",
+    }
+    assert config_entry.version == MastodonConfigFlow.VERSION
+    assert config_entry.unique_id == "trwnh_mastodon_social"

--- a/tests/components/mastodon/test_init.py
+++ b/tests/components/mastodon/test_init.py
@@ -61,7 +61,9 @@ async def test_migrate(
             CONF_ACCESS_TOKEN: "access_token",
         },
         title="@trwnh@mastodon.social",
+        unique_id="client_id",
         version=1,
+        minor_version=1,
     )
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -76,4 +78,5 @@ async def test_migrate(
         CONF_ACCESS_TOKEN: "access_token",
     }
     assert config_entry.version == MastodonConfigFlow.VERSION
+    assert config_entry.minor_version == MastodonConfigFlow.MINOR_VERSION
     assert config_entry.unique_id == "trwnh_mastodon_social"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The current unique_id of Mastodon client_id has the potential to not be unique when we migrate to oAuth.
This PR migrates the unique_id to a sluggified username_instance which will be unique, we only want one per account.
As the 2024.8 release only has the Mastodon post service it does not create a device so no need to migrate the device entries if this goes in the 2024.9 release which will introduce entities/devices.
This does not change the current long lived token method of auth so no user re-auth will be required.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
