### PR TITLE
Improve type hints in rfxtrx tests

### DIFF
--- a/tests/components/rfxtrx/conftest.py
+++ b/tests/components/rfxtrx/conftest.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from unittest.mock import Mock, patch
+from collections.abc import Callable, Coroutine, Generator
+from typing import Any
+from unittest.mock import MagicMock, Mock, patch
 
 from freezegun import freeze_time
 import pytest
@@ -67,7 +69,7 @@ async def setup_rfx_test_cfg(
 
 
 @pytest.fixture(autouse=True)
-async def transport_mock(hass):
+def transport_mock() -> Generator[Mock]:
     """Fixture that make sure all transports are fake."""
     transport = Mock(spec=RFXtrxTransport)
     with (
@@ -78,14 +80,14 @@ async def transport_mock(hass):
 
 
 @pytest.fixture(autouse=True)
-async def connect_mock(hass):
+def connect_mock() -> Generator[MagicMock]:
     """Fixture that make sure connect class is mocked."""
     with patch("RFXtrx.Connect") as connect:
         yield connect
 
 
 @pytest.fixture(autouse=True, name="rfxtrx")
-def rfxtrx_fixture(hass, connect_mock):
+def rfxtrx_fixture(hass: HomeAssistant, connect_mock: MagicMock) -> Mock:
     """Fixture that cleans up threads from integration."""
 
     rfx = Mock(spec=Connect)
@@ -114,19 +116,21 @@ def rfxtrx_fixture(hass, connect_mock):
 
 
 @pytest.fixture(name="rfxtrx_automatic")
-async def rfxtrx_automatic_fixture(hass, rfxtrx):
+async def rfxtrx_automatic_fixture(hass: HomeAssistant, rfxtrx: Mock) -> Mock:
     """Fixture that starts up with automatic additions."""
     await setup_rfx_test_cfg(hass, automatic_add=True, devices={})
     return rfxtrx
 
 
 @pytest.fixture
-async def timestep(hass):
+def timestep(
+    hass: HomeAssistant,
+) -> Generator[Callable[[int], Coroutine[Any, Any, None]]]:
     """Step system time forward."""
 
     with freeze_time(utcnow()) as frozen_time:
 
-        async def delay(seconds):
+        async def delay(seconds: int) -> None:
             """Trigger delay in system."""
             frozen_time.tick(delta=seconds)
             async_fire_time_changed(hass)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
