### PR TITLE
Allow raw mqtt payload to be in mqtt publish action

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -116,6 +116,7 @@ SERVICE_DUMP = "dump"
 
 ATTR_TOPIC_TEMPLATE = "topic_template"
 ATTR_PAYLOAD_TEMPLATE = "payload_template"
+ATTR_EVALUATE_BYTES = "evaluate_bytes"
 
 MAX_RECONNECT_WAIT = 300  # seconds
 
@@ -167,6 +168,7 @@ MQTT_PUBLISH_SCHEMA = vol.All(
             vol.Exclusive(ATTR_TOPIC_TEMPLATE, CONF_TOPIC): cv.string,
             vol.Exclusive(ATTR_PAYLOAD, CONF_PAYLOAD): cv.string,
             vol.Exclusive(ATTR_PAYLOAD_TEMPLATE, CONF_PAYLOAD): cv.string,
+            vol.Optional(ATTR_EVALUATE_BYTES): cv.boolean,
             vol.Optional(ATTR_QOS, default=DEFAULT_QOS): valid_qos_schema,
             vol.Optional(ATTR_RETAIN, default=DEFAULT_RETAIN): cv.boolean,
         },
@@ -296,6 +298,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         msg_topic: str | None = call.data.get(ATTR_TOPIC)
         msg_topic_template: str | None = call.data.get(ATTR_TOPIC_TEMPLATE)
         payload: PublishPayloadType = call.data.get(ATTR_PAYLOAD)
+        evaluate_bytes: bool = call.data.get(ATTR_EVALUATE_BYTES, False)
         payload_template: str | None = call.data.get(ATTR_PAYLOAD_TEMPLATE)
         qos: int = call.data[ATTR_QOS]
         retain: bool = call.data[ATTR_RETAIN]
@@ -355,7 +358,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             payload = MqttCommandTemplate(
                 template.Template(payload_template, hass)
             ).async_render()
-        else:
+        elif evaluate_bytes:
             # Convert templated and quoted binary payload to binary with literal_eval
             payload = convert_outgoing_mqtt_payload(payload)
 

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -90,6 +90,7 @@ from .models import (  # noqa: F401
     PublishPayloadType,
     ReceiveMessage,
     ReceivePayloadType,
+    convert_outgoing_mqtt_payload,
 )
 from .subscription import (  # noqa: F401
     EntitySubscription,
@@ -354,6 +355,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             payload = MqttCommandTemplate(
                 template.Template(payload_template, hass)
             ).async_render()
+        else:
+            # Convert templated and quoted binary payload to binary with literal_eval
+            payload = convert_outgoing_mqtt_payload(payload)
 
         if TYPE_CHECKING:
             assert msg_topic is not None

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -116,7 +116,7 @@ SERVICE_DUMP = "dump"
 
 ATTR_TOPIC_TEMPLATE = "topic_template"
 ATTR_PAYLOAD_TEMPLATE = "payload_template"
-ATTR_EVALUATE_BYTES = "evaluate_bytes"
+ATTR_EVALUATE_PAYLOAD = "evaluate_payload"
 
 MAX_RECONNECT_WAIT = 300  # seconds
 
@@ -168,7 +168,7 @@ MQTT_PUBLISH_SCHEMA = vol.All(
             vol.Exclusive(ATTR_TOPIC_TEMPLATE, CONF_TOPIC): cv.string,
             vol.Exclusive(ATTR_PAYLOAD, CONF_PAYLOAD): cv.string,
             vol.Exclusive(ATTR_PAYLOAD_TEMPLATE, CONF_PAYLOAD): cv.string,
-            vol.Optional(ATTR_EVALUATE_BYTES): cv.boolean,
+            vol.Optional(ATTR_EVALUATE_PAYLOAD): cv.boolean,
             vol.Optional(ATTR_QOS, default=DEFAULT_QOS): valid_qos_schema,
             vol.Optional(ATTR_RETAIN, default=DEFAULT_RETAIN): cv.boolean,
         },
@@ -298,7 +298,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         msg_topic: str | None = call.data.get(ATTR_TOPIC)
         msg_topic_template: str | None = call.data.get(ATTR_TOPIC_TEMPLATE)
         payload: PublishPayloadType = call.data.get(ATTR_PAYLOAD)
-        evaluate_bytes: bool = call.data.get(ATTR_EVALUATE_BYTES, False)
+        evaluate_payload: bool = call.data.get(ATTR_EVALUATE_PAYLOAD, False)
         payload_template: str | None = call.data.get(ATTR_PAYLOAD_TEMPLATE)
         qos: int = call.data[ATTR_QOS]
         retain: bool = call.data[ATTR_RETAIN]
@@ -358,8 +358,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             payload = MqttCommandTemplate(
                 template.Template(payload_template, hass)
             ).async_render()
-        elif evaluate_bytes:
-            # Convert templated and quoted binary payload to binary with literal_eval
+        elif evaluate_payload:
+            # Convert quoted binary literal to raw data
             payload = convert_outgoing_mqtt_payload(payload)
 
         if TYPE_CHECKING:

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -58,11 +58,11 @@ def convert_outgoing_mqtt_payload(
     if isinstance(payload, str):
         try:
             native_object = literal_eval(payload)
-            if isinstance(native_object, bytes):
-                return native_object
-
         except (ValueError, TypeError, SyntaxError, MemoryError):
             pass
+        else:
+            if isinstance(native_object, bytes):
+                return native_object
 
     return payload
 

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -51,6 +51,22 @@ ATTR_THIS = "this"
 type PublishPayloadType = str | bytes | int | float | None
 
 
+def convert_outgoing_mqtt_payload(
+    payload: PublishPayloadType,
+) -> PublishPayloadType:
+    """Ensure correct raw MQTT payload is passed as bytes for publishing."""
+    if isinstance(payload, str):
+        try:
+            native_object = literal_eval(payload)
+            if isinstance(native_object, bytes):
+                return native_object
+
+        except (ValueError, TypeError, SyntaxError, MemoryError):
+            pass
+
+    return payload
+
+
 @dataclass
 class PublishMessage:
     """MQTT Message for publishing."""
@@ -173,22 +189,6 @@ class MqttCommandTemplate:
         variables: TemplateVarsType = None,
     ) -> PublishPayloadType:
         """Render or convert the command template with given value or variables."""
-
-        def _convert_outgoing_payload(
-            payload: PublishPayloadType,
-        ) -> PublishPayloadType:
-            """Ensure correct raw MQTT payload is passed as bytes for publishing."""
-            if isinstance(payload, str):
-                try:
-                    native_object = literal_eval(payload)
-                    if isinstance(native_object, bytes):
-                        return native_object
-
-                except (ValueError, TypeError, SyntaxError, MemoryError):
-                    pass
-
-            return payload
-
         if self._command_template is None:
             return value
 
@@ -210,7 +210,7 @@ class MqttCommandTemplate:
             self._command_template,
         )
         try:
-            return _convert_outgoing_payload(
+            return convert_outgoing_mqtt_payload(
                 self._command_template.async_render(values, parse_result=False)
             )
         except TemplateError as exc:

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -55,7 +55,7 @@ def convert_outgoing_mqtt_payload(
     payload: PublishPayloadType,
 ) -> PublishPayloadType:
     """Ensure correct raw MQTT payload is passed as bytes for publishing."""
-    if isinstance(payload, str):
+    if isinstance(payload, str) and payload.startswith(("b'", 'b"')):
         try:
             native_object = literal_eval(payload)
         except (ValueError, TypeError, SyntaxError, MemoryError):

--- a/homeassistant/components/mqtt/services.yaml
+++ b/homeassistant/components/mqtt/services.yaml
@@ -12,6 +12,11 @@ publish:
       example: "The temperature is {{ states('sensor.temperature') }}"
       selector:
         template:
+    evaluate_bytes:
+      advanced: true
+      default: false
+      selector:
+        boolean:
     qos:
       advanced: true
       default: 0

--- a/homeassistant/components/mqtt/services.yaml
+++ b/homeassistant/components/mqtt/services.yaml
@@ -12,7 +12,7 @@ publish:
       example: "The temperature is {{ states('sensor.temperature') }}"
       selector:
         template:
-    evaluate_bytes:
+    evaluate_payload:
       advanced: true
       default: false
       selector:

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -230,6 +230,10 @@
       "name": "Publish",
       "description": "Publishes a message to an MQTT topic.",
       "fields": {
+        "evaluate_bytes": {
+          "name": "Evaluate bytes",
+          "description": "When `payload` is a bytes literal, then evaluate the lieral and publish the raw data."
+        },
         "topic": {
           "name": "Topic",
           "description": "Topic to publish to."

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -230,9 +230,9 @@
       "name": "Publish",
       "description": "Publishes a message to an MQTT topic.",
       "fields": {
-        "evaluate_bytes": {
-          "name": "Evaluate bytes",
-          "description": "When `payload` is a bytes literal, then evaluate the lieral and publish the raw data."
+        "evaluate_payload": {
+          "name": "Evaluate payload",
+          "description": "When `payload` is a bytes literal, then evaluate the literal to publish the raw data."
         },
         "topic": {
           "name": "Topic",

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -232,7 +232,7 @@
       "fields": {
         "evaluate_payload": {
           "name": "Evaluate payload",
-          "description": "When `payload` is a bytes literal, then evaluate the literal to publish the raw data."
+          "description": "When `payload` is a Python bytes literal, evaluate the bytes literal and publish the raw data."
         },
         "topic": {
           "name": "Topic",

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -421,7 +421,7 @@ async def test_mqtt_publish_action_call_with_template_payload_renders_template(
 
 
 @pytest.mark.parametrize(
-    ("attr_payload", "payload", "evaluate_bytes"),
+    ("attr_payload", "payload", "evaluate_payload"),
     [
         ("b'\\xde\\xad\\xbe\\xef'", b"\xde\xad\xbe\xef", True),
         ("b'\\xde\\xad\\xbe\\xef'", "b'\\xde\\xad\\xbe\\xef'", False),
@@ -434,12 +434,12 @@ async def test_mqtt_publish_action_call_with_raw_data(
     mqtt_mock_entry: MqttMockHAClientGenerator,
     attr_payload: str,
     payload: str | bytes,
-    evaluate_bytes: bool,
+    evaluate_payload: bool,
 ) -> None:
     """Test the mqtt publish action call raw data.
 
     When `payload` represents a `bytes` object, it should be published
-    as raw data if `evaluate_bytes` is set.
+    as raw data if `evaluate_payload` is set.
     """
     mqtt_mock = await mqtt_mock_entry()
     await hass.services.async_call(
@@ -448,7 +448,7 @@ async def test_mqtt_publish_action_call_with_raw_data(
         {
             mqtt.ATTR_TOPIC: "test/topic",
             mqtt.ATTR_PAYLOAD: attr_payload,
-            mqtt.ATTR_EVALUATE_BYTES: evaluate_bytes,
+            mqtt.ATTR_EVALUATE_PAYLOAD: evaluate_payload,
         },
         blocking=True,
     )

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -430,9 +430,10 @@ async def test_mqtt_publish_action_call_with_raw_data(
     attr_payload: str,
     payload: str | bytes,
 ) -> None:
-    """Test the mqtt publish action call with a previous rendered template.
+    """Test the mqtt publish action call raw data.
 
-    When a template rendered to a binary we try literal_eval to obtain the raw value.
+    When `payload` represents a `bytes` object, it should be published
+    as raw data.
     """
     mqtt_mock = await mqtt_mock_entry()
     await hass.services.async_call(

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -421,12 +421,17 @@ async def test_mqtt_publish_action_call_with_template_payload_renders_template(
 
 
 @pytest.mark.parametrize(
-    ("attr_payload", "payload", "evaluate_payload"),
+    ("attr_payload", "payload", "evaluate_payload", "literal_eval_calls"),
     [
-        ("b'\\xde\\xad\\xbe\\xef'", b"\xde\xad\xbe\xef", True),
-        ("b'\\xde\\xad\\xbe\\xef'", "b'\\xde\\xad\\xbe\\xef'", False),
-        ("DEADBEEF", "DEADBEEF", False),
-        ("b'\\xde", "b'\\xde", True),  # Bytes literal is invalid, fall back to string
+        ("b'\\xde\\xad\\xbe\\xef'", b"\xde\xad\xbe\xef", True, 1),
+        ("b'\\xde\\xad\\xbe\\xef'", "b'\\xde\\xad\\xbe\\xef'", False, 0),
+        ("DEADBEEF", "DEADBEEF", False, 0),
+        (
+            "b'\\xde",
+            "b'\\xde",
+            True,
+            1,
+        ),  # Bytes literal is invalid, fall back to string
     ],
 )
 async def test_mqtt_publish_action_call_with_raw_data(
@@ -435,6 +440,7 @@ async def test_mqtt_publish_action_call_with_raw_data(
     attr_payload: str,
     payload: str | bytes,
     evaluate_payload: bool,
+    literal_eval_calls: int,
 ) -> None:
     """Test the mqtt publish action call raw data.
 
@@ -454,6 +460,32 @@ async def test_mqtt_publish_action_call_with_raw_data(
     )
     assert mqtt_mock.async_publish.called
     assert mqtt_mock.async_publish.call_args[0][1] == payload
+
+    with patch(
+        "homeassistant.components.mqtt.models.literal_eval"
+    ) as literal_eval_mock:
+        await hass.services.async_call(
+            mqtt.DOMAIN,
+            mqtt.SERVICE_PUBLISH,
+            {
+                mqtt.ATTR_TOPIC: "test/topic",
+                mqtt.ATTR_PAYLOAD: attr_payload,
+            },
+            blocking=True,
+        )
+        literal_eval_mock.assert_not_called()
+
+        await hass.services.async_call(
+            mqtt.DOMAIN,
+            mqtt.SERVICE_PUBLISH,
+            {
+                mqtt.ATTR_TOPIC: "test/topic",
+                mqtt.ATTR_PAYLOAD: attr_payload,
+                mqtt.ATTR_EVALUATE_PAYLOAD: evaluate_payload,
+            },
+            blocking=True,
+        )
+        assert len(literal_eval_mock.mock_calls) == literal_eval_calls
 
 
 # The use of a payload_template in an mqtt publish action call

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -421,25 +421,35 @@ async def test_mqtt_publish_action_call_with_template_payload_renders_template(
 
 
 @pytest.mark.parametrize(
-    ("attr_payload", "payload"),
-    [("b'\\xde\\xad\\xbe\\xef'", b"\xde\xad\xbe\xef"), ("DEADBEEF", "DEADBEEF")],
+    ("attr_payload", "payload", "evaluate_bytes"),
+    [
+        ("b'\\xde\\xad\\xbe\\xef'", b"\xde\xad\xbe\xef", True),
+        ("b'\\xde\\xad\\xbe\\xef'", "b'\\xde\\xad\\xbe\\xef'", False),
+        ("DEADBEEF", "DEADBEEF", False),
+        ("b'\\xde", "b'\\xde", True),  # Bytes literal is invalid, fall back to string
+    ],
 )
 async def test_mqtt_publish_action_call_with_raw_data(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
     attr_payload: str,
     payload: str | bytes,
+    evaluate_bytes: bool,
 ) -> None:
     """Test the mqtt publish action call raw data.
 
     When `payload` represents a `bytes` object, it should be published
-    as raw data.
+    as raw data if `evaluate_bytes` is set.
     """
     mqtt_mock = await mqtt_mock_entry()
     await hass.services.async_call(
         mqtt.DOMAIN,
         mqtt.SERVICE_PUBLISH,
-        {mqtt.ATTR_TOPIC: "test/topic", mqtt.ATTR_PAYLOAD: attr_payload},
+        {
+            mqtt.ATTR_TOPIC: "test/topic",
+            mqtt.ATTR_PAYLOAD: attr_payload,
+            mqtt.ATTR_EVALUATE_BYTES: evaluate_bytes,
+        },
         blocking=True,
     )
     assert mqtt_mock.async_publish.called


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With #122098 and #123706 we deprecated the use of the `payload_template` option for the mqtt `publish` action and we expected this to be functionally to be fully equal.
This was not the case though, a rendered template is not evaluated like the `payload_template`. This means that if a raw payload was intended, it will send the `utf-8` encode string representation instead of the raw data.

In the base, templates return strings (so always). So in case the template renders to `binary` or an object, it will render to the string representation. So if a template renders to a raw value like `b'\xde\xad\xbe\xef'` will be rendered to `"b'\xde\xad\xbe\xef'"`. The `MqttCommandTemplate` that is used for handling the `payload_template` also did a literal conversion to `binary` of the payload seemed to be a literal `binary` (so a raw payload). This check was never done for the `payload` option as it was not assumed to be able to process templates, which it is now with `payload_template`.

The linked issue will further demonstrate this.

This PR allows that the rendered template `payload` to be evaluated as raw data, it will publish it as raw data as we did for the deprecated `payload_template` option if a `bytes` literal is passed.

This PR introduces a new advanced option `evaluate_payload`, that needs to be set to `true` in order to allow this. Example:

![afbeelding](https://github.com/user-attachments/assets/9ac9a4aa-332f-4287-9932-ce9dbf32c574)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #123865
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/34312

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
