### PR TITLE
Change Tibber get_prices action to return datetimes as str

### DIFF
--- a/homeassistant/components/tibber/services.py
+++ b/homeassistant/components/tibber/services.py
@@ -52,7 +52,7 @@ async def __get_prices(call: ServiceCall, *, hass: HomeAssistant) -> ServiceResp
         ]
         price_data = [
             {
-                "start_time": dt.datetime.fromisoformat(price["startsAt"]),
+                "start_time": price["startsAt"],
                 "price": price["total"],
                 "level": price["level"],
             }
@@ -61,7 +61,9 @@ async def __get_prices(call: ServiceCall, *, hass: HomeAssistant) -> ServiceResp
         ]
 
         selected_data = [
-            price for price in price_data if start <= price["start_time"] < end
+            price
+            for price in price_data
+            if start <= dt.datetime.fromisoformat(price["start_time"]) < end
         ]
         tibber_prices[home_nickname] = selected_data
 

--- a/tests/components/tibber/test_services.py
+++ b/tests/components/tibber/test_services.py
@@ -138,29 +138,24 @@ async def test_get_prices(
         "prices": {
             "first_home": [
                 {
-                    "start_time": dt.datetime.fromisoformat(START_TIME.isoformat()),
-                    # back and forth conversion to deal with HAFakeDatetime vs real datetime being different types
+                    "start_time": START_TIME.isoformat(),
                     "price": 0.36914,
                     "level": "VERY_EXPENSIVE",
                 },
                 {
-                    "start_time": dt.datetime.fromisoformat(
-                        (START_TIME + dt.timedelta(hours=1)).isoformat()
-                    ),
+                    "start_time": (START_TIME + dt.timedelta(hours=1)).isoformat(),
                     "price": 0.36914,
                     "level": "VERY_EXPENSIVE",
                 },
             ],
             "second_home": [
                 {
-                    "start_time": dt.datetime.fromisoformat(START_TIME.isoformat()),
+                    "start_time": START_TIME.isoformat(),
                     "price": 0.36914,
                     "level": "VERY_EXPENSIVE",
                 },
                 {
-                    "start_time": dt.datetime.fromisoformat(
-                        (START_TIME + dt.timedelta(hours=1)).isoformat()
-                    ),
+                    "start_time": (START_TIME + dt.timedelta(hours=1)).isoformat(),
                     "price": 0.36914,
                     "level": "VERY_EXPENSIVE",
                 },
@@ -193,24 +188,24 @@ async def test_get_prices_start_tomorrow(
         "prices": {
             "first_home": [
                 {
-                    "start_time": tomorrow,
+                    "start_time": tomorrow.isoformat(),
                     "price": 0.46914,
                     "level": "VERY_EXPENSIVE",
                 },
                 {
-                    "start_time": (tomorrow + dt.timedelta(hours=1)),
+                    "start_time": (tomorrow + dt.timedelta(hours=1)).isoformat(),
                     "price": 0.46914,
                     "level": "VERY_EXPENSIVE",
                 },
             ],
             "second_home": [
                 {
-                    "start_time": tomorrow,
+                    "start_time": tomorrow.isoformat(),
                     "price": 0.46914,
                     "level": "VERY_EXPENSIVE",
                 },
                 {
-                    "start_time": (tomorrow + dt.timedelta(hours=1)),
+                    "start_time": (tomorrow + dt.timedelta(hours=1)).isoformat(),
                     "price": 0.46914,
                     "level": "VERY_EXPENSIVE",
                 },
@@ -252,24 +247,24 @@ async def test_get_prices_with_timezones(
         "prices": {
             "first_home": [
                 {
-                    "start_time": START_TIME,
+                    "start_time": START_TIME.isoformat(),
                     "price": 0.36914,
                     "level": "VERY_EXPENSIVE",
                 },
                 {
-                    "start_time": START_TIME + dt.timedelta(hours=1),
+                    "start_time": (START_TIME + dt.timedelta(hours=1)).isoformat(),
                     "price": 0.36914,
                     "level": "VERY_EXPENSIVE",
                 },
             ],
             "second_home": [
                 {
-                    "start_time": START_TIME,
+                    "start_time": START_TIME.isoformat(),
                     "price": 0.36914,
                     "level": "VERY_EXPENSIVE",
                 },
                 {
-                    "start_time": START_TIME + dt.timedelta(hours=1),
+                    "start_time": (START_TIME + dt.timedelta(hours=1)).isoformat(),
                     "price": 0.36914,
                     "level": "VERY_EXPENSIVE",
                 },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Changes `tibber.get_prices` action (fka service) responses to include datetimes as string.

Previously it was raw datetime objects.

Automations or template sensors using this may need to be modified with an `as_datetime` filter.
More information: https://www.home-assistant.io/docs/configuration/templating/#time

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `get_prices` action returns a dict including datetime objects. However, actions (fka services) should be returning a `ServiceResponse`, which only allows `str`, `int`, `float`, `bool`, `None` as well as lists and dicts of them.

This really should have been caught by a type checker. It also presents issues when using the response with templates: https://github.com/home-assistant/core/issues/123293

This PR fixes the issue by returning the datetime objects as strings. They are verified to be compatible with `isoformat()`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #123293
- This PR is related to issue: 
- Link to documentation pull request: 

**Due to overlapping changes with datetime code, this PR should be merged first: https://github.com/home-assistant/core/pull/123289**

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
