### PR TITLE
Improve type hints in watttime tests

### DIFF
--- a/tests/components/watttime/conftest.py
+++ b/tests/components/watttime/conftest.py
@@ -1,6 +1,7 @@
 """Define test fixtures for WattTime."""
 
-import json
+from collections.abc import AsyncGenerator
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -20,13 +21,17 @@ from homeassistant.const import (
     CONF_PASSWORD,
     CONF_USERNAME,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+from homeassistant.util.json import JsonObjectType
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, load_json_object_fixture
 
 
 @pytest.fixture(name="client")
-def client_fixture(get_grid_region, data_realtime_emissions):
+def client_fixture(
+    get_grid_region: AsyncMock, data_realtime_emissions: JsonObjectType
+) -> Mock:
     """Define an aiowatttime client."""
     client = Mock()
     client.emissions.async_get_grid_region = get_grid_region
@@ -37,7 +42,7 @@ def client_fixture(get_grid_region, data_realtime_emissions):
 
 
 @pytest.fixture(name="config_auth")
-def config_auth_fixture(hass):
+def config_auth_fixture() -> dict[str, Any]:
     """Define an auth config entry data fixture."""
     return {
         CONF_USERNAME: "user",
@@ -46,7 +51,7 @@ def config_auth_fixture(hass):
 
 
 @pytest.fixture(name="config_coordinates")
-def config_coordinates_fixture(hass):
+def config_coordinates_fixture() -> dict[str, Any]:
     """Define a coordinates config entry data fixture."""
     return {
         CONF_LATITUDE: 32.87336,
@@ -55,7 +60,7 @@ def config_coordinates_fixture(hass):
 
 
 @pytest.fixture(name="config_location_type")
-def config_location_type_fixture(hass):
+def config_location_type_fixture() -> dict[str, Any]:
     """Define a location type config entry data fixture."""
     return {
         CONF_LOCATION_TYPE: LOCATION_TYPE_COORDINATES,
@@ -63,7 +68,9 @@ def config_location_type_fixture(hass):
 
 
 @pytest.fixture(name="config_entry")
-def config_entry_fixture(hass, config_auth, config_coordinates):
+def config_entry_fixture(
+    hass: HomeAssistant, config_auth: dict[str, Any], config_coordinates: dict[str, Any]
+) -> MockConfigEntry:
     """Define a config entry fixture."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -82,25 +89,30 @@ def config_entry_fixture(hass, config_auth, config_coordinates):
 
 
 @pytest.fixture(name="data_grid_region", scope="package")
-def data_grid_region_fixture():
+def data_grid_region_fixture() -> JsonObjectType:
     """Define grid region data."""
-    return json.loads(load_fixture("grid_region_data.json", "watttime"))
+    return load_json_object_fixture("grid_region_data.json", "watttime")
 
 
 @pytest.fixture(name="data_realtime_emissions", scope="package")
-def data_realtime_emissions_fixture():
+def data_realtime_emissions_fixture() -> JsonObjectType:
     """Define realtime emissions data."""
-    return json.loads(load_fixture("realtime_emissions_data.json", "watttime"))
+    return load_json_object_fixture("realtime_emissions_data.json", "watttime")
 
 
 @pytest.fixture(name="get_grid_region")
-def get_grid_region_fixture(data_grid_region):
+def get_grid_region_fixture(data_grid_region: JsonObjectType) -> AsyncMock:
     """Define an aiowatttime method to get grid region data."""
     return AsyncMock(return_value=data_grid_region)
 
 
 @pytest.fixture(name="setup_watttime")
-async def setup_watttime_fixture(hass, client, config_auth, config_coordinates):
+async def setup_watttime_fixture(
+    hass: HomeAssistant,
+    client: Mock,
+    config_auth: dict[str, Any],
+    config_coordinates: dict[str, Any],
+) -> AsyncGenerator[None]:
     """Define a fixture to set up WattTime."""
     with (
         patch(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
