### PR TITLE
Set available property in russound base entity

### DIFF
--- a/homeassistant/components/russound_rio/__init__.py
+++ b/homeassistant/components/russound_rio/__init__.py
@@ -29,7 +29,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: RussoundConfigEntry) -> 
     @callback
     def is_connected_updated(connected: bool) -> None:
         if connected:
-            _LOGGER.debug("Reconnected to controller at %s:%s", host, port)
+            _LOGGER.warning("Reconnected to controller at %s:%s", host, port)
         else:
             _LOGGER.warning(
                 "Disconnected from controller at %s:%s",

--- a/homeassistant/components/russound_rio/__init__.py
+++ b/homeassistant/components/russound_rio/__init__.py
@@ -29,7 +29,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: RussoundConfigEntry) -> 
     @callback
     def is_connected_updated(connected: bool) -> None:
         if connected:
-            _LOGGER.info("Reconnected to controller at %s:%s", host, port)
+            _LOGGER.debug("Reconnected to controller at %s:%s", host, port)
         else:
             _LOGGER.warning(
                 "Disconnected from controller at %s:%s",

--- a/homeassistant/components/russound_rio/entity.py
+++ b/homeassistant/components/russound_rio/entity.py
@@ -6,6 +6,7 @@ from typing import Any, Concatenate
 
 from aiorussound import Controller
 
+from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.entity import Entity
@@ -68,3 +69,17 @@ class RussoundBaseEntity(Entity):
             self._attr_device_info["connections"] = {
                 (CONNECTION_NETWORK_MAC, controller.mac_address)
             }
+
+    @callback
+    def _is_connected_updated(self, connected: bool) -> None:
+        """Update the state when the device is ready to receive commands or is unavailable."""
+        self._attr_available = connected
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks."""
+        self._instance.add_connection_callback(self._is_connected_updated)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove callbacks."""
+        self._instance.remove_connection_callback(self._is_connected_updated)

--- a/homeassistant/components/russound_rio/media_player.py
+++ b/homeassistant/components/russound_rio/media_player.py
@@ -140,7 +140,12 @@ class RussoundZoneDevice(RussoundBaseEntity, MediaPlayerEntity):
 
     async def async_added_to_hass(self) -> None:
         """Register callback handlers."""
+        await super().async_added_to_hass()
         self._zone.add_callback(self._callback_handler)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove callbacks."""
+        await super().async_will_remove_from_hass()
 
     def _current_source(self) -> Source:
         return self._zone.fetch_current_source()

--- a/homeassistant/components/russound_rio/media_player.py
+++ b/homeassistant/components/russound_rio/media_player.py
@@ -146,6 +146,7 @@ class RussoundZoneDevice(RussoundBaseEntity, MediaPlayerEntity):
     async def async_will_remove_from_hass(self) -> None:
         """Remove callbacks."""
         await super().async_will_remove_from_hass()
+        self._zone.remove_callback(self._callback_handler)
 
     def _current_source(self) -> Source:
         return self._zone.fetch_current_source()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR implements a callback to set the availability property based upon whether a controller is connected or not. Additionally, logs were implemented whenever the connection status changes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
