### PR TITLE
Add missing return type in test __init__ method (part 2)

### DIFF
--- a/tests/components/alexa/test_common.py
+++ b/tests/components/alexa/test_common.py
@@ -213,7 +213,7 @@ async def reported_properties(hass, endpoint, return_full_response=False):
 class ReportedProperties:
     """Class to help assert reported properties."""
 
-    def __init__(self, properties):
+    def __init__(self, properties) -> None:
         """Initialize class."""
         self.properties = properties
 

--- a/tests/components/androidtv/test_config_flow.py
+++ b/tests/components/androidtv/test_config_flow.py
@@ -73,7 +73,7 @@ CONNECT_METHOD = (
 class MockConfigDevice:
     """Mock class to emulate Android device."""
 
-    def __init__(self, eth_mac=ETH_MAC, wifi_mac=None):
+    def __init__(self, eth_mac=ETH_MAC, wifi_mac=None) -> None:
         """Initialize a fake device to test config flow."""
         self.available = True
         self.device_properties = {PROP_ETHMAC: eth_mac, PROP_WIFIMAC: wifi_mac}

--- a/tests/components/application_credentials/test_init.py
+++ b/tests/components/application_credentials/test_init.py
@@ -184,7 +184,7 @@ async def oauth_fixture(
 class Client:
     """Test client with helper methods for application credentials websocket."""
 
-    def __init__(self, client):
+    def __init__(self, client) -> None:
         """Initialize Client."""
         self.client = client
         self.id = 0

--- a/tests/components/assist_pipeline/conftest.py
+++ b/tests/components/assist_pipeline/conftest.py
@@ -153,7 +153,7 @@ class MockTTSPlatform(MockPlatform):
 
     PLATFORM_SCHEMA = tts.PLATFORM_SCHEMA
 
-    def __init__(self, *, async_get_engine, **kwargs):
+    def __init__(self, *, async_get_engine, **kwargs: Any) -> None:
         """Initialize the tts platform."""
         super().__init__(**kwargs)
         self.async_get_engine = async_get_engine
@@ -180,7 +180,7 @@ def mock_stt_provider_entity() -> MockSttProviderEntity:
 class MockSttPlatform(MockPlatform):
     """Provide a fake STT platform."""
 
-    def __init__(self, *, async_get_engine, **kwargs):
+    def __init__(self, *, async_get_engine, **kwargs: Any) -> None:
         """Initialize the stt platform."""
         super().__init__(**kwargs)
         self.async_get_engine = async_get_engine

--- a/tests/components/baf/__init__.py
+++ b/tests/components/baf/__init__.py
@@ -12,7 +12,7 @@ class MockBAFDevice(Device):
     """A simple mock for a BAF Device."""
 
     # pylint: disable-next=super-init-not-called
-    def __init__(self, async_wait_available_side_effect=None):
+    def __init__(self, async_wait_available_side_effect=None) -> None:
         """Init simple mock."""
         self._async_wait_available_side_effect = async_wait_available_side_effect
 

--- a/tests/components/bluetooth/test_scanner.py
+++ b/tests/components/bluetooth/test_scanner.py
@@ -212,7 +212,7 @@ async def test_recovery_from_dbus_restart(hass: HomeAssistant) -> None:
     mock_discovered = []
 
     class MockBleakScanner:
-        def __init__(self, detection_callback, *args, **kwargs):
+        def __init__(self, detection_callback, *args: Any, **kwargs: Any) -> None:
             nonlocal _callback
             _callback = detection_callback
 

--- a/tests/components/coinbase/common.py
+++ b/tests/components/coinbase/common.py
@@ -21,7 +21,7 @@ from tests.common import MockConfigEntry
 class MockPagination:
     """Mock pagination result."""
 
-    def __init__(self, value=None):
+    def __init__(self, value=None) -> None:
         """Load simple pagination for tests."""
         self.next_starting_after = value
 
@@ -29,7 +29,7 @@ class MockPagination:
 class MockGetAccounts:
     """Mock accounts with pagination."""
 
-    def __init__(self, starting_after=0):
+    def __init__(self, starting_after=0) -> None:
         """Init mocked object, forced to return two at a time."""
         if (target_end := starting_after + 2) >= (
             max_end := len(MOCK_ACCOUNTS_RESPONSE)

--- a/tests/components/coinbase/common.py
+++ b/tests/components/coinbase/common.py
@@ -58,7 +58,7 @@ def mocked_get_accounts(_, **kwargs):
 class MockGetAccountsV3:
     """Mock accounts with pagination."""
 
-    def __init__(self, cursor=""):
+    def __init__(self, cursor="") -> None:
         """Init mocked object, forced to return two at a time."""
         ids = [account["uuid"] for account in MOCK_ACCOUNTS_RESPONSE_V3]
         start = ids.index(cursor) if cursor else 0

--- a/tests/components/fido/test_sensor.py
+++ b/tests/components/fido/test_sensor.py
@@ -18,7 +18,7 @@ CONTRACT = "123456789"
 class FidoClientMock:
     """Fake Fido client."""
 
-    def __init__(self, username, password, timeout=None, httpsession=None):
+    def __init__(self, username, password, timeout=None, httpsession=None) -> None:
         """Fake Fido client init."""
 
     def get_phone_numbers(self):

--- a/tests/components/flic/test_binary_sensor.py
+++ b/tests/components/flic/test_binary_sensor.py
@@ -8,7 +8,7 @@ from homeassistant.setup import async_setup_component
 
 
 class _MockFlicClient:
-    def __init__(self, button_addresses):
+    def __init__(self, button_addresses) -> None:
         self.addresses = button_addresses
         self.get_info_callback = None
         self.scan_wizard = None

--- a/tests/components/folder_watcher/test_init.py
+++ b/tests/components/folder_watcher/test_init.py
@@ -36,7 +36,7 @@ def test_event() -> None:
     class MockPatternMatchingEventHandler:
         """Mock base class for the pattern matcher event handler."""
 
-        def __init__(self, patterns):
+        def __init__(self, patterns) -> None:
             pass
 
     with patch(
@@ -66,7 +66,7 @@ def test_move_event() -> None:
     class MockPatternMatchingEventHandler:
         """Mock base class for the pattern matcher event handler."""
 
-        def __init__(self, patterns):
+        def __init__(self, patterns) -> None:
             pass
 
     with patch(

--- a/tests/components/fritz/conftest.py
+++ b/tests/components/fritz/conftest.py
@@ -30,7 +30,7 @@ class FritzServiceMock(Service):
 class FritzConnectionMock:
     """FritzConnection mocking."""
 
-    def __init__(self, services):
+    def __init__(self, services) -> None:
         """Init Mocking class."""
         self.modelname = MOCK_MODELNAME
         self.call_action = self._call_action

--- a/tests/components/google/test_calendar.py
+++ b/tests/components/google/test_calendar.py
@@ -74,7 +74,7 @@ def upcoming_event_url(entity: str = TEST_ENTITY) -> str:
 class Client:
     """Test client with helper methods for calendar websocket."""
 
-    def __init__(self, client):
+    def __init__(self, client) -> None:
         """Initialize Client."""
         self.client = client
         self.id = 0

--- a/tests/components/hddtemp/test_sensor.py
+++ b/tests/components/hddtemp/test_sensor.py
@@ -60,7 +60,7 @@ REFERENCE = {
 class TelnetMock:
     """Mock class for the telnetlib.Telnet object."""
 
-    def __init__(self, host, port, timeout=0):
+    def __init__(self, host, port, timeout=0) -> None:
         """Initialize Telnet object."""
         self.host = host
         self.port = port

--- a/tests/components/hdmi_cec/__init__.py
+++ b/tests/components/hdmi_cec/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.components.hdmi_cec import KeyPressCommand, KeyReleaseCommand
 class MockHDMIDevice:
     """Mock of a HDMIDevice."""
 
-    def __init__(self, *, logical_address, **values):
+    def __init__(self, *, logical_address, **values) -> None:
         """Mock of a HDMIDevice."""
         self.set_update_callback = Mock(side_effect=self._set_update_callback)
         self.logical_address = logical_address

--- a/tests/components/hlk_sw16/test_config_flow.py
+++ b/tests/components/hlk_sw16/test_config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.data_entry_flow import FlowResultType
 class MockSW16Client:
     """Class to mock the SW16Client client."""
 
-    def __init__(self, fail):
+    def __init__(self, fail) -> None:
         """Initialise client with failure modes."""
         self.fail = fail
         self.disconnect_callback = None

--- a/tests/components/homematicip_cloud/helper.py
+++ b/tests/components/homematicip_cloud/helper.py
@@ -132,7 +132,7 @@ class HomeTemplate(Home):
 
     def __init__(
         self, connection=None, home_name="", test_devices=None, test_groups=None
-    ):
+    ) -> None:
         """Init template with connection."""
         super().__init__(connection=connection)
         self.name = home_name

--- a/tests/components/http/test_cors.py
+++ b/tests/components/http/test_cors.py
@@ -119,7 +119,7 @@ async def test_cors_middleware_with_cors_allowed_view(hass: HomeAssistant) -> No
         requires_auth = False
         cors_allowed = True
 
-        def __init__(self, url, name):
+        def __init__(self, url, name) -> None:
             """Initialize test view."""
             self.url = url
             self.name = name

--- a/tests/components/insteon/mock_devices.py
+++ b/tests/components/insteon/mock_devices.py
@@ -30,7 +30,7 @@ class MockSwitchLinc(SwitchedLightingControl_SwitchLinc02):
 class MockDevices:
     """Mock devices class."""
 
-    def __init__(self, connected=True):
+    def __init__(self, connected=True) -> None:
         """Init the MockDevices class."""
         self._devices = {}
         self.modem = None

--- a/tests/components/keymitt_ble/__init__.py
+++ b/tests/components/keymitt_ble/__init__.py
@@ -53,7 +53,7 @@ SERVICE_INFO = BluetoothServiceInfoBleak(
 class MockMicroBotApiClient:
     """Mock MicroBotApiClient."""
 
-    def __init__(self, device, token):
+    def __init__(self, device, token) -> None:
         """Mock init."""
 
     async def connect(self, init):
@@ -70,7 +70,7 @@ class MockMicroBotApiClient:
 class MockMicroBotApiClientFail:
     """Mock MicroBotApiClient."""
 
-    def __init__(self, device, token):
+    def __init__(self, device, token) -> None:
         """Mock init."""
 
     async def connect(self, init):

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -126,7 +126,7 @@ def _gateway_descriptor(
 class GatewayScannerMock:
     """Mock GatewayScanner."""
 
-    def __init__(self, gateways=None):
+    def __init__(self, gateways=None) -> None:
         """Initialize GatewayScannerMock."""
         # Key is a HPAI instance in xknx, but not used in HA anyway.
         self.found_gateways = (

--- a/tests/components/kodi/util.py
+++ b/tests/components/kodi/util.py
@@ -63,7 +63,7 @@ def get_kodi_connection(
 class MockConnection:
     """A mock kodi connection."""
 
-    def __init__(self, connected=True):
+    def __init__(self, connected=True) -> None:
         """Mock the Kodi connection."""
         self._connected = connected
 
@@ -92,7 +92,7 @@ class MockConnection:
 class MockWSConnection:
     """A mock kodi websocket connection."""
 
-    def __init__(self, connected=True):
+    def __init__(self, connected=True) -> None:
         """Mock the websocket connection."""
         self._connected = connected
 

--- a/tests/components/lifx/__init__.py
+++ b/tests/components/lifx/__init__.py
@@ -26,7 +26,7 @@ DEFAULT_ENTRY_TITLE = LABEL
 class MockMessage:
     """Mock a lifx message."""
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any) -> None:
         """Init message."""
         self.target_addr = SERIAL
         self.count = 9
@@ -38,7 +38,7 @@ class MockMessage:
 class MockFailingLifxCommand:
     """Mock a lifx command that fails."""
 
-    def __init__(self, bulb, **kwargs):
+    def __init__(self, bulb, **kwargs: Any) -> None:
         """Init command."""
         self.bulb = bulb
         self.calls = []
@@ -61,7 +61,7 @@ class MockLifxCommand:
         """Return name."""
         return "mock_lifx_command"
 
-    def __init__(self, bulb, **kwargs):
+    def __init__(self, bulb, **kwargs: Any) -> None:
         """Init command."""
         self.bulb = bulb
         self.calls = []

--- a/tests/components/lifx/test_config_flow.py
+++ b/tests/components/lifx/test_config_flow.py
@@ -575,7 +575,7 @@ async def test_suggested_area(
     class MockLifxCommandGetGroup:
         """Mock the get_group method that gets the group name from the bulb."""
 
-        def __init__(self, bulb, **kwargs):
+        def __init__(self, bulb, **kwargs: Any) -> None:
             """Init command."""
             self.bulb = bulb
             self.lifx_group = kwargs.get("lifx_group")

--- a/tests/components/lifx/test_light.py
+++ b/tests/components/lifx/test_light.py
@@ -1,6 +1,7 @@
 """Tests for the lifx integration light platform."""
 
 from datetime import timedelta
+from typing import Any
 from unittest.mock import patch
 
 import aiolifx_effects
@@ -1299,7 +1300,7 @@ async def test_config_zoned_light_strip_fails(
     class MockFailingLifxCommand:
         """Mock a lifx command that fails on the 2nd try."""
 
-        def __init__(self, bulb, **kwargs):
+        def __init__(self, bulb, **kwargs: Any) -> None:
             """Init command."""
             self.bulb = bulb
             self.call_count = 0
@@ -1338,7 +1339,7 @@ async def test_legacy_zoned_light_strip(
     class MockPopulateLifxZonesCommand:
         """Mock populating the number of zones."""
 
-        def __init__(self, bulb, **kwargs):
+        def __init__(self, bulb, **kwargs: Any) -> None:
             """Init command."""
             self.bulb = bulb
             self.call_count = 0
@@ -1845,7 +1846,7 @@ async def test_color_bulb_is_actually_off(hass: HomeAssistant) -> None:
     class MockLifxCommandActuallyOff:
         """Mock a lifx command that will update our power level state."""
 
-        def __init__(self, bulb, **kwargs):
+        def __init__(self, bulb, **kwargs: Any) -> None:
             """Init command."""
             self.bulb = bulb
             self.calls = []

--- a/tests/components/lutron_caseta/__init__.py
+++ b/tests/components/lutron_caseta/__init__.py
@@ -101,7 +101,7 @@ async def async_setup_integration(hass: HomeAssistant, mock_bridge) -> MockConfi
 class MockBridge:
     """Mock Lutron bridge that emulates configured connected status."""
 
-    def __init__(self, can_connect=True):
+    def __init__(self, can_connect=True) -> None:
         """Initialize MockBridge instance with configured mock connectivity."""
         self.can_connect = can_connect
         self.is_currently_connected = False

--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -37,7 +37,7 @@ TEST_PORT_SERIAL = "usb01"
 class ReadResult:
     """Storage class for register read results."""
 
-    def __init__(self, register_words):
+    def __init__(self, register_words) -> None:
         """Init."""
         self.registers = register_words
         self.bits = register_words

--- a/tests/components/nsw_fuel_station/test_sensor.py
+++ b/tests/components/nsw_fuel_station/test_sensor.py
@@ -23,7 +23,9 @@ VALID_CONFIG_EXPECTED_ENTITY_IDS = ["my_fake_station_p95", "my_fake_station_e10"
 class MockPrice:
     """Mock Price implementation."""
 
-    def __init__(self, price, fuel_type, last_updated, price_unit, station_code):
+    def __init__(
+        self, price, fuel_type, last_updated, price_unit, station_code
+    ) -> None:
         """Initialize a mock price instance."""
         self.price = price
         self.fuel_type = fuel_type
@@ -35,7 +37,7 @@ class MockPrice:
 class MockStation:
     """Mock Station implementation."""
 
-    def __init__(self, name, code):
+    def __init__(self, name, code) -> None:
         """Initialize a mock Station instance."""
         self.name = name
         self.code = code
@@ -44,7 +46,7 @@ class MockStation:
 class MockGetFuelPricesResponse:
     """Mock GetFuelPricesResponse implementation."""
 
-    def __init__(self, prices, stations):
+    def __init__(self, prices, stations) -> None:
         """Initialize a mock GetFuelPricesResponse instance."""
         self.prices = prices
         self.stations = stations

--- a/tests/components/numato/numato_mock.py
+++ b/tests/components/numato/numato_mock.py
@@ -15,7 +15,7 @@ class NumatoModuleMock:
     class NumatoDeviceMock:
         """Mockup for the numato_gpio.NumatoUsbGpio class."""
 
-        def __init__(self, device):
+        def __init__(self, device) -> None:
             """Initialize numato device mockup."""
             self.device = device
             self.callbacks = {}

--- a/tests/components/pilight/test_init.py
+++ b/tests/components/pilight/test_init.py
@@ -40,7 +40,7 @@ class PilightDaemonSim:
         "message": {"id": 0, "unit": 0, "off": 1},
     }
 
-    def __init__(self, host, port):
+    def __init__(self, host, port) -> None:
         """Init pilight client, ignore parameters."""
 
     def send_code(self, call):

--- a/tests/components/plex/mock_classes.py
+++ b/tests/components/plex/mock_classes.py
@@ -67,7 +67,7 @@ GDM_CLIENT_PAYLOAD = [
 class MockGDM:
     """Mock a GDM instance."""
 
-    def __init__(self, disabled=False):
+    def __init__(self, disabled=False) -> None:
         """Initialize the object."""
         self.entries = []
         self.disabled = disabled

--- a/tests/components/plex/test_playback.py
+++ b/tests/components/plex/test_playback.py
@@ -28,7 +28,7 @@ class MockPlexMedia:
     viewOffset = 333
     _server = Mock(_baseurl=PLEX_DIRECT_URL)
 
-    def __init__(self, title, mediatype):
+    def __init__(self, title, mediatype) -> None:
         """Initialize the instance."""
         self.listType = mediatype
         self.title = title

--- a/tests/components/profiler/test_init.py
+++ b/tests/components/profiler/test_init.py
@@ -176,7 +176,7 @@ async def test_dump_log_object(
     await hass.async_block_till_done()
 
     class DumpLogDummy:
-        def __init__(self, fail):
+        def __init__(self, fail) -> None:
             self.fail = fail
 
         def __repr__(self):

--- a/tests/components/recorder/db_schema_16.py
+++ b/tests/components/recorder/db_schema_16.py
@@ -356,7 +356,7 @@ class LazyState(State):
         "_context",
     ]
 
-    def __init__(self, row):  # pylint: disable=super-init-not-called
+    def __init__(self, row) -> None:  # pylint: disable=super-init-not-called
         """Init the lazy state."""
         self._row = row
         self.entity_id = self._row.entity_id

--- a/tests/components/recorder/db_schema_18.py
+++ b/tests/components/recorder/db_schema_18.py
@@ -369,7 +369,7 @@ class LazyState(State):
         "_context",
     ]
 
-    def __init__(self, row):  # pylint: disable=super-init-not-called
+    def __init__(self, row) -> None:  # pylint: disable=super-init-not-called
         """Init the lazy state."""
         self._row = row
         self.entity_id = self._row.entity_id

--- a/tests/components/recorder/db_schema_22.py
+++ b/tests/components/recorder/db_schema_22.py
@@ -488,7 +488,7 @@ class LazyState(State):
         "_context",
     ]
 
-    def __init__(self, row):  # pylint: disable=super-init-not-called
+    def __init__(self, row) -> None:  # pylint: disable=super-init-not-called
         """Init the lazy state."""
         self._row = row
         self.entity_id = self._row.entity_id

--- a/tests/components/recorder/db_schema_23.py
+++ b/tests/components/recorder/db_schema_23.py
@@ -478,7 +478,7 @@ class LazyState(State):
         "_context",
     ]
 
-    def __init__(self, row):  # pylint: disable=super-init-not-called
+    def __init__(self, row) -> None:  # pylint: disable=super-init-not-called
         """Init the lazy state."""
         self._row = row
         self.entity_id = self._row.entity_id

--- a/tests/components/recorder/db_schema_23_with_newer_columns.py
+++ b/tests/components/recorder/db_schema_23_with_newer_columns.py
@@ -602,7 +602,7 @@ class LazyState(State):
         "_context",
     ]
 
-    def __init__(self, row):  # pylint: disable=super-init-not-called
+    def __init__(self, row) -> None:  # pylint: disable=super-init-not-called
         """Init the lazy state."""
         self._row = row
         self.entity_id = self._row.entity_id

--- a/tests/components/recorder/test_util.py
+++ b/tests/components/recorder/test_util.py
@@ -990,7 +990,7 @@ async def test_execute_stmt_lambda_element(
     all_calls = 0
 
     class MockExecutor:
-        def __init__(self, stmt):
+        def __init__(self, stmt) -> None:
             assert isinstance(stmt, StatementLambdaElement)
 
         def all(self):

--- a/tests/components/reddit/test_sensor.py
+++ b/tests/components/reddit/test_sensor.py
@@ -66,7 +66,7 @@ INVALID_SORT_BY_CONFIG = {
 class ObjectView:
     """Use dict properties as attributes."""
 
-    def __init__(self, d):
+    def __init__(self, d) -> None:
         """Set dict as internal dict."""
         self.__dict__ = d
 

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -179,7 +179,7 @@ def rest_api_fixture_non_ssl_only() -> Mock:
     class MockSamsungTVAsyncRest:
         """Mock for a MockSamsungTVAsyncRest."""
 
-        def __init__(self, host, session, port, timeout):
+        def __init__(self, host, session, port, timeout) -> None:
             """Mock a MockSamsungTVAsyncRest."""
             self.port = port
             self.host = host

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -80,7 +80,7 @@ class SonosMockService:
 class SonosMockEvent:
     """Mock a sonos Event used in callbacks."""
 
-    def __init__(self, soco, service, variables):
+    def __init__(self, soco, service, variables) -> None:
         """Initialize the instance."""
         self.sid = f"{soco.uid}_sub0000000001"
         self.seq = "0"

--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -54,7 +54,7 @@ async def setup_component(hass: HomeAssistant) -> None:
 class HlsClient:
     """Test fixture for fetching the hls stream."""
 
-    def __init__(self, http_client, parsed_url):
+    def __init__(self, http_client, parsed_url) -> None:
         """Initialize HlsClient."""
         self.http_client = http_client
         self.parsed_url = parsed_url

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -100,7 +100,7 @@ def mock_stream_settings(hass: HomeAssistant) -> None:
 class FakeAvInputStream:
     """A fake pyav Stream."""
 
-    def __init__(self, name, time_base):
+    def __init__(self, name, time_base) -> None:
         """Initialize the stream."""
         self.name = name
         self.time_base = time_base
@@ -142,7 +142,7 @@ class PacketSequence:
     exercise corner cases.
     """
 
-    def __init__(self, num_packets):
+    def __init__(self, num_packets) -> None:
         """Initialize the sequence with the number of packets it provides."""
         self.packet = 0
         self.num_packets = num_packets
@@ -181,7 +181,7 @@ class PacketSequence:
 class FakePyAvContainer:
     """A fake container returned by mock av.open for a stream."""
 
-    def __init__(self, video_stream, audio_stream):
+    def __init__(self, video_stream, audio_stream) -> None:
         """Initialize the fake container."""
         # Tests can override this to trigger different worker behavior
         self.packets = PacketSequence(0)
@@ -220,7 +220,7 @@ class FakePyAvBuffer:
         """Create an output buffer that captures packets for test to examine."""
 
         class FakeAvOutputStream:
-            def __init__(self, capture_packets):
+            def __init__(self, capture_packets) -> None:
                 self.capture_packets = capture_packets
                 self.type = "ignored-type"
 
@@ -266,7 +266,7 @@ class FakePyAvBuffer:
 class MockPyAv:
     """Mocks out av.open."""
 
-    def __init__(self, video=True, audio=False):
+    def __init__(self, video=True, audio=False) -> None:
         """Initialize the MockPyAv."""
         video_stream = VIDEO_STREAM if video else None
         audio_stream = AUDIO_STREAM if audio else None

--- a/tests/components/tomato/test_device_tracker.py
+++ b/tests/components/tomato/test_device_tracker.py
@@ -25,7 +25,7 @@ def mock_session_response(*args, **kwargs):
     """Mock data generation for session response."""
 
     class MockSessionResponse:
-        def __init__(self, text, status_code):
+        def __init__(self, text, status_code) -> None:
             self.text = text
             self.status_code = status_code
 

--- a/tests/components/venstar/__init__.py
+++ b/tests/components/venstar/__init__.py
@@ -15,7 +15,7 @@ class VenstarColorTouchMock:
         pin=None,
         proto="http",
         SSLCert=False,
-    ):
+    ) -> None:
         """Initialize the Venstar library."""
         self.status = {}
         self.model = "COLORTOUCH"

--- a/tests/components/vera/common.py
+++ b/tests/components/vera/common.py
@@ -83,7 +83,7 @@ def new_simple_controller_config(
 class ComponentFactory:
     """Factory class."""
 
-    def __init__(self, vera_controller_class_mock):
+    def __init__(self, vera_controller_class_mock) -> None:
         """Initialize the factory."""
         self.vera_controller_class_mock = vera_controller_class_mock
 

--- a/tests/components/vizio/conftest.py
+++ b/tests/components/vizio/conftest.py
@@ -30,7 +30,7 @@ from .const import (
 class MockInput:
     """Mock Vizio device input."""
 
-    def __init__(self, name):
+    def __init__(self, name) -> None:
         """Initialize mock Vizio device input."""
         self.meta_name = name
         self.name = name

--- a/tests/components/ws66i/test_media_player.py
+++ b/tests/components/ws66i/test_media_player.py
@@ -73,7 +73,7 @@ class AttrDict(dict):
 class MockWs66i:
     """Mock for pyws66i object."""
 
-    def __init__(self, fail_open=False, fail_zone_check=None):
+    def __init__(self, fail_open=False, fail_zone_check=None) -> None:
         """Init mock object."""
         self.zones = defaultdict(
             lambda: AttrDict(

--- a/tests/components/yamaha/test_media_player.py
+++ b/tests/components/yamaha/test_media_player.py
@@ -25,7 +25,7 @@ def _create_zone_mock(name, url):
 class FakeYamahaDevice:
     """A fake Yamaha device."""
 
-    def __init__(self, ctrl_url, name, zones=None):
+    def __init__(self, ctrl_url, name, zones=None) -> None:
         """Initialize the fake Yamaha device."""
         self.ctrl_url = ctrl_url
         self.name = name

--- a/tests/components/yeelight/__init__.py
+++ b/tests/components/yeelight/__init__.py
@@ -109,7 +109,7 @@ CONFIG_ENTRY_DATA = {CONF_ID: ID}
 class MockAsyncBulb:
     """A mock for yeelight.aio.AsyncBulb."""
 
-    def __init__(self, model, bulb_type, cannot_connect):
+    def __init__(self, model, bulb_type, cannot_connect) -> None:
         """Init the mock."""
         self.model = model
         self.bulb_type = bulb_type

--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -174,7 +174,7 @@ class AiohttpClientMockResponse:
         headers=None,
         side_effect=None,
         closing=None,
-    ):
+    ) -> None:
         """Initialize a fake response."""
         if json is not None:
             text = json_dumps(json)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
