### PR TITLE
Add price sensor for energy without taxes to Tibber

### DIFF
--- a/homeassistant/components/tibber/icons.json
+++ b/homeassistant/components/tibber/icons.json
@@ -1,6 +1,9 @@
 {
   "entity": {
     "sensor": {
+      "electricity_price": {
+        "default": "mdi:currency-usd"
+      },
       "electricity_price_excl_tax": {
         "default": "mdi:currency-usd"
       }

--- a/homeassistant/components/tibber/icons.json
+++ b/homeassistant/components/tibber/icons.json
@@ -1,4 +1,11 @@
 {
+  "entity": {
+    "sensor": {
+      "electricity_price_excl_tax": {
+        "default": "mdi:currency-usd"
+      }
+    }
+  },
   "services": {
     "get_prices": {
       "service": "mdi:cash"

--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -453,8 +453,8 @@ class TibberSensorElPriceExclTax(TibberSensor):
 
         self._attr_available = False
         self._attr_icon = ICON
-        self._attr_unique_id = f"{self._tibber_home.home_id}_excl_tax"
-        self._model = "Price Sensor Excluding Tax"
+        self._attr_unique_id = f"{self._tibber_home.home_id}-excl_tax"
+        self._model = "Price Sensor excluding tax"
 
         self._device_name = self._home_name
 

--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -373,7 +373,6 @@ class TibberSensorElPrice(TibberSensor):
 
         self._attr_available = False
         self._attr_native_unit_of_measurement = self._tibber_home.price_unit
-        self._attr_icon = ICON
         self._attr_unique_id = self._tibber_home.home_id
         self._model = "Price Sensor"
 

--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -452,7 +452,6 @@ class TibberSensorElPriceExclTax(TibberSensor):
         self._spread_load_constant = randrange(TWENTY_MINUTES)
 
         self._attr_available = False
-        self._attr_icon = ICON
         self._attr_unique_id = f"{self._tibber_home.home_id}-excl_tax"
         self._model = "Price Sensor excluding tax"
 

--- a/homeassistant/components/tibber/strings.json
+++ b/homeassistant/components/tibber/strings.json
@@ -4,6 +4,9 @@
       "electricity_price": {
         "name": "Electricity price"
       },
+      "electricity_price_excl_tax": {
+        "name": "Electricity price excluding tax"
+      },
       "month_cost": {
         "name": "Monthly cost"
       },


### PR DESCRIPTION
## Proposed change
Expose additional information such as energy price (excluding tax) and the amount of tax. In my situation I would like to control/limit my solar inverter power based on the energy price excluding tax.

I added these values as state attribute to the energy price sensor (including tax) however I'm not sure what the best place is to implement this change (as state attribute or a separate sensor excluding tax). I would like to have your opinion, so I marked this PR as draft.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
