### PR TITLE
Handle InvalidRegion in Tesla Fleet

### DIFF
--- a/homeassistant/components/tesla_fleet/__init__.py
+++ b/homeassistant/components/tesla_fleet/__init__.py
@@ -89,6 +89,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -
         try:
             LOGGER.info("Region is invalid, trying to find the correct region")
             await tesla.find_server()
+            try:
+                products = (await tesla.products())["response"]
+            except TeslaFleetError as e:
+                raise ConfigEntryNotReady from e
         except LibraryError as e:
             raise ConfigEntryAuthFailed from e
     except TeslaFleetError as e:

--- a/homeassistant/components/tesla_fleet/__init__.py
+++ b/homeassistant/components/tesla_fleet/__init__.py
@@ -7,7 +7,9 @@ import jwt
 from tesla_fleet_api import EnergySpecific, TeslaFleetApi, VehicleSpecific
 from tesla_fleet_api.const import Scope
 from tesla_fleet_api.exceptions import (
+    InvalidRegion,
     InvalidToken,
+    LibraryError,
     LoginRequired,
     OAuthExpired,
     TeslaFleetError,
@@ -75,7 +77,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -
         region=region,
         charging_scope=False,
         partner_scope=False,
-        user_scope=False,
         energy_scope=Scope.ENERGY_DEVICE_DATA in scopes,
         vehicle_scope=Scope.VEHICLE_DEVICE_DATA in scopes,
         refresh_hook=_refresh_token,
@@ -84,6 +85,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -
         products = (await tesla.products())["response"]
     except (InvalidToken, OAuthExpired, LoginRequired) as e:
         raise ConfigEntryAuthFailed from e
+    except InvalidRegion:
+        try:
+            LOGGER.info("Region is invalid, trying to find the correct region")
+            await tesla.find_server()
+        except LibraryError as e:
+            raise ConfigEntryAuthFailed from e
     except TeslaFleetError as e:
         raise ConfigEntryNotReady from e
 

--- a/tests/components/tesla_fleet/conftest.py
+++ b/tests/components/tesla_fleet/conftest.py
@@ -122,3 +122,12 @@ def mock_site_info() -> Generator[AsyncMock]:
         side_effect=lambda: deepcopy(SITE_INFO),
     ) as mock_live_status:
         yield mock_live_status
+
+
+@pytest.fixture(autouse=True)
+def mock_find_server() -> Generator[AsyncMock]:
+    """Mock Tesla Fleet find server method."""
+    with patch(
+        "homeassistant.components.tesla_fleet.find_server",
+    ) as mock_find_server:
+        yield mock_find_server

--- a/tests/components/tesla_fleet/conftest.py
+++ b/tests/components/tesla_fleet/conftest.py
@@ -128,6 +128,6 @@ def mock_site_info() -> Generator[AsyncMock]:
 def mock_find_server() -> Generator[AsyncMock]:
     """Mock Tesla Fleet find server method."""
     with patch(
-        "homeassistant.components.tesla_fleet.find_server",
+        "homeassistant.components.tesla_fleet.TeslaFleetApi.find_server",
     ) as mock_find_server:
         yield mock_find_server

--- a/tests/components/tesla_fleet/test_init.py
+++ b/tests/components/tesla_fleet/test_init.py
@@ -341,7 +341,7 @@ async def test_init_region_issue(
     mock_products.side_effect = InvalidRegion
     await setup_platform(hass, normal_config_entry)
     mock_find_server.assert_called_once()
-    assert normal_config_entry.state is ConfigEntryState.LOADED
+    assert normal_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_init_region_issue_failed(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds an error handler for InvalidRegion that attempts to correct the issue by finding the right user region.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #https://github.com/home-assistant/core/issues/123796
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
