### PR TITLE
Rename KNX Climate preset modes according to specification

### DIFF
--- a/homeassistant/components/knx/const.py
+++ b/homeassistant/components/knx/const.py
@@ -6,18 +6,10 @@ from collections.abc import Awaitable, Callable
 from enum import Enum
 from typing import Final, TypedDict
 
-from xknx.dpt.dpt_20 import HVACControllerMode, HVACOperationMode
+from xknx.dpt.dpt_20 import HVACControllerMode
 from xknx.telegram import Telegram
 
-from homeassistant.components.climate import (
-    PRESET_AWAY,
-    PRESET_COMFORT,
-    PRESET_ECO,
-    PRESET_NONE,
-    PRESET_SLEEP,
-    HVACAction,
-    HVACMode,
-)
+from homeassistant.components.climate import HVACAction, HVACMode
 from homeassistant.const import Platform
 
 DOMAIN: Final = "knx"
@@ -173,13 +165,4 @@ CURRENT_HVAC_ACTIONS: Final = {
     HVACMode.OFF: HVACAction.OFF,
     HVACMode.FAN_ONLY: HVACAction.FAN,
     HVACMode.DRY: HVACAction.DRYING,
-}
-
-PRESET_MODES: Final = {
-    # Map DPT 20.102 HVAC operating modes to HA presets
-    HVACOperationMode.AUTO: PRESET_NONE,
-    HVACOperationMode.BUILDING_PROTECTION: PRESET_ECO,
-    HVACOperationMode.ECONOMY: PRESET_SLEEP,
-    HVACOperationMode.STANDBY: PRESET_AWAY,
-    HVACOperationMode.COMFORT: PRESET_COMFORT,
 }

--- a/homeassistant/components/knx/icons.json
+++ b/homeassistant/components/knx/icons.json
@@ -1,5 +1,19 @@
 {
   "entity": {
+    "climate": {
+      "knx_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "comfort": "mdi:sofa",
+              "standby": "mdi:account-arrow-right",
+              "economy": "mdi:leaf",
+              "building_protection": "mdi:sun-snowflake-variant"
+            }
+          }
+        }
+      }
+    },
     "sensor": {
       "individual_address": {
         "default": "mdi:router-network"

--- a/homeassistant/components/knx/icons.json
+++ b/homeassistant/components/knx/icons.json
@@ -6,7 +6,7 @@
           "preset_mode": {
             "state": {
               "comfort": "mdi:sofa",
-              "standby": "mdi:account-arrow-right",
+              "standby": "mdi:home-export-outline",
               "economy": "mdi:leaf",
               "building_protection": "mdi:sun-snowflake-variant"
             }

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -267,6 +267,22 @@
     }
   },
   "entity": {
+    "climate": {
+      "knx_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "name": "[%key:component::climate::entity_component::_::state_attributes::preset_mode::name%]",
+            "state": {
+              "auto": "Auto",
+              "comfort": "[%key:component::climate::entity_component::_::state_attributes::preset_mode::state::comfort%]",
+              "standby": "Standby",
+              "economy": "[%key:component::climate::entity_component::_::state_attributes::preset_mode::state::eco%]",
+              "building_protection": "Building protection"
+            }
+          }
+        }
+      }
+    },
     "sensor": {
       "individual_address": {
         "name": "[%key:component::knx::config::step::routing::data::individual_address%]"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Removes the previous mapping to HA-pre-defined preset names that didn't really fit KNX mode names.

### Mode names
| KNX specifications | previous | now |
|--------|--------|--------|
| Auto | none | auto |
| Comfort | comfort | comfort |
| Standby | away | standby |
| Economy | sleep | economy |
| Building protection | eco | building_protection | 

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/34305

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
