### PR TITLE
Use BIGINT SQL type for ID columns

### DIFF
--- a/homeassistant/components/recorder/db_schema.py
+++ b/homeassistant/components/recorder/db_schema.py
@@ -77,7 +77,7 @@ class LegacyBase(DeclarativeBase):
     """Base class for tables, used for schema migration."""
 
 
-SCHEMA_VERSION = 45
+SCHEMA_VERSION = 47
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -1120,7 +1120,7 @@ class _SchemaVersion16Migrator(_SchemaVersionMigrator, target_version=16):
             # Version 16 changes settings for the foreign key constraint on
             # states.old_state_id. Dropping the constraint is not really correct
             # we should have recreated it instead. Recreating the constraint now
-            # happens in the migration to schema version 45.
+            # happens in the migration to schema version 47.
             _drop_foreign_key_constraints(
                 self.session_maker, self.engine, TABLE_STATES, "old_state_id"
             )
@@ -1645,6 +1645,24 @@ class _SchemaVersion43Migrator(_SchemaVersionMigrator, target_version=43):
         )
 
 
+class _SchemaVersion44Migrator(_SchemaVersionMigrator, target_version=44):
+    def _apply_update(self) -> None:
+        """Version specific update method."""
+        # The changes in this version are identical to the changes in version
+        # 46. We apply the same changes again because the migration code previously
+        # swallowed errors which caused some users' databases to end up in an
+        # undefined state after the migration.
+
+
+class _SchemaVersion45Migrator(_SchemaVersionMigrator, target_version=45):
+    def _apply_update(self) -> None:
+        """Version specific update method."""
+        # The changes in this version are identical to the changes in version
+        # 47. We apply the same changes again because the migration code previously
+        # swallowed errors which caused some users' databases to end up in an
+        # undefined state after the migration.
+
+
 FOREIGN_COLUMNS = (
     (
         "events",
@@ -1677,7 +1695,7 @@ FOREIGN_COLUMNS = (
 )
 
 
-class _SchemaVersion44Migrator(_SchemaVersionMigrator, target_version=44):
+class _SchemaVersion46Migrator(_SchemaVersionMigrator, target_version=46):
     def _apply_update(self) -> None:
         """Version specific update method."""
         # We skip this step for SQLITE, it doesn't have differently sized integers
@@ -1728,14 +1746,14 @@ class _SchemaVersion44Migrator(_SchemaVersionMigrator, target_version=44):
             )
 
 
-class _SchemaVersion45Migrator(_SchemaVersionMigrator, target_version=45):
+class _SchemaVersion47Migrator(_SchemaVersionMigrator, target_version=47):
     def _apply_update(self) -> None:
         """Version specific update method."""
         # We skip this step for SQLITE, it doesn't have differently sized integers
         if self.engine.dialect.name == SupportedDialect.SQLITE:
             return
 
-        # Restore constraints dropped in migration to schema version 44
+        # Restore constraints dropped in migration to schema version 46
         _restore_foreign_key_constraints(
             self.session_maker,
             self.engine,

--- a/tests/components/recorder/test_migrate.py
+++ b/tests/components/recorder/test_migrate.py
@@ -213,7 +213,7 @@ async def test_database_migration_failed(
         # Test error handling in _modify_columns
         (12, "sqlalchemy.engine.base.Connection.execute", False, 1, 0),
         # Test error handling in _drop_foreign_key_constraints
-        (44, "homeassistant.components.recorder.migration.DropConstraint", False, 2, 1),
+        (46, "homeassistant.components.recorder.migration.DropConstraint", False, 2, 1),
     ],
 )
 @pytest.mark.skip_on_db_engine(["sqlite"])

--- a/tests/components/recorder/test_v32_migration.py
+++ b/tests/components/recorder/test_v32_migration.py
@@ -640,7 +640,7 @@ async def test_out_of_disk_space_while_removing_foreign_key(
     ix_states_event_id is removed from the states table.
 
     Note that the test is somewhat forced; the states.event_id foreign key constraint is
-    removed when migrating to schema version 44, inspecting the schema in
+    removed when migrating to schema version 46, inspecting the schema in
     cleanup_legacy_states_event_ids is not likely to fail.
     """
     importlib.import_module(SCHEMA_MODULE)
@@ -779,7 +779,7 @@ async def test_out_of_disk_space_while_removing_foreign_key(
                     states_index_names = {index["name"] for index in states_indexes}
                     assert instance.use_legacy_events_index is True
                     # The states.event_id foreign key constraint was removed when
-                    # migration to schema version 44
+                    # migration to schema version 46
                     assert (
                         await instance.async_add_executor_job(
                             _get_event_id_foreign_keys


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Redo recorder ID migration from INT to BIGINT which was added by https://github.com/home-assistant/core/pull/121025

#### Background
In HA Core 2024.8.0, we migrate all ID columns from INT to BIGINT. However, because the migration helpers previously swallowed errors, this meant we would in some cases mark an unsuccessful migration as successful with the users' databases in unknown states.

In a set of PRs, https://github.com/home-assistant/core/pull/123642, https://github.com/home-assistant/core/pull/123644, https://github.com/home-assistant/core/pull/123645, https://github.com/home-assistant/core/pull/123646, the migration code has been changed to instead fail.

With migration code now failing, we redo the migration of  ID columns from INT to BIGINT. If the migration was previously successful, the migration will be much faster than the migration to schema version 44, although there's still an integrity check when re-adding foreign key constraints which will take a considerable amount of time on big databases.

~~Set to draft waiting for PR https://github.com/home-assistant/core/pull/123642 to be merged.~~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
