### PR TITLE
Add missing hass type hint in component tests (d)

### DIFF
--- a/tests/components/denonavr/test_media_player.py
+++ b/tests/components/denonavr/test_media_player.py
@@ -60,7 +60,7 @@ def client_fixture():
         yield mock_client_class.return_value
 
 
-async def setup_denonavr(hass):
+async def setup_denonavr(hass: HomeAssistant) -> None:
     """Initialize media_player for tests."""
     entry_data = {
         CONF_HOST: TEST_HOST,

--- a/tests/components/derivative/test_sensor.py
+++ b/tests/components/derivative/test_sensor.py
@@ -3,12 +3,13 @@
 from datetime import timedelta
 from math import sin
 import random
+from typing import Any
 
 from freezegun import freeze_time
 
 from homeassistant.components.derivative.const import DOMAIN
 from homeassistant.const import UnitOfPower, UnitOfTime
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -49,7 +50,9 @@ async def test_state(hass: HomeAssistant) -> None:
     assert state.attributes.get("unit_of_measurement") == "kW"
 
 
-async def _setup_sensor(hass, config):
+async def _setup_sensor(
+    hass: HomeAssistant, config: dict[str, Any]
+) -> tuple[dict[str, Any], str]:
     default_config = {
         "platform": "derivative",
         "name": "power",
@@ -67,7 +70,13 @@ async def _setup_sensor(hass, config):
     return config, entity_id
 
 
-async def setup_tests(hass, config, times, values, expected_state):
+async def setup_tests(
+    hass: HomeAssistant,
+    config: dict[str, Any],
+    times: list[int],
+    values: list[float],
+    expected_state: float,
+) -> State:
     """Test derivative sensor state."""
     config, entity_id = await _setup_sensor(hass, config)
 

--- a/tests/components/duckdns/test_init.py
+++ b/tests/components/duckdns/test_init.py
@@ -8,7 +8,6 @@ import pytest
 from homeassistant.components import duckdns
 from homeassistant.components.duckdns import async_track_time_interval_backoff
 from homeassistant.core import HomeAssistant
-from homeassistant.loader import bind_hass
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
@@ -21,8 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 INTERVAL = duckdns.INTERVAL
 
 
-@bind_hass
-async def async_set_txt(hass, txt):
+async def async_set_txt(hass: HomeAssistant, txt: str | None) -> None:
     """Set the txt record. Pass in None to remove it.
 
     This is a legacy helper method. Do not use it for new tests.

--- a/tests/components/dynalite/common.py
+++ b/tests/components/dynalite/common.py
@@ -2,8 +2,11 @@
 
 from unittest.mock import AsyncMock, Mock, call, patch
 
+from dynalite_devices_lib.dynalitebase import DynaliteBaseDevice
+
 from homeassistant.components import dynalite
 from homeassistant.const import ATTR_SERVICE
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -21,14 +24,14 @@ def create_mock_device(platform, spec):
     return device
 
 
-async def get_entry_id_from_hass(hass):
+async def get_entry_id_from_hass(hass: HomeAssistant) -> str:
     """Get the config entry id from hass."""
     conf_entries = hass.config_entries.async_entries(dynalite.DOMAIN)
     assert len(conf_entries) == 1
     return conf_entries[0].entry_id
 
 
-async def create_entity_from_device(hass, device):
+async def create_entity_from_device(hass: HomeAssistant, device: DynaliteBaseDevice):
     """Set up the component and platform and create a light based on the device provided."""
     host = "1.2.3.4"
     entry = MockConfigEntry(domain=dynalite.DOMAIN, data={dynalite.CONF_HOST: host})
@@ -45,7 +48,7 @@ async def create_entity_from_device(hass, device):
     return mock_dyn_dev.mock_calls[1][2]["update_device_func"]
 
 
-async def run_service_tests(hass, device, platform, services):
+async def run_service_tests(hass: HomeAssistant, device, platform, services):
     """Run a series of service calls and check that the entity and device behave correctly."""
     for cur_item in services:
         service = cur_item[ATTR_SERVICE]

--- a/tests/components/dynalite/test_cover.py
+++ b/tests/components/dynalite/test_cover.py
@@ -1,8 +1,10 @@
 """Test Dynalite cover."""
 
+from collections.abc import Callable
 from unittest.mock import Mock
 
 from dynalite_devices_lib.cover import DynaliteTimeCoverWithTiltDevice
+from dynalite_devices_lib.dynalitebase import DynaliteBaseDevice
 import pytest
 
 from homeassistant.components.cover import (
@@ -36,7 +38,7 @@ from tests.common import mock_restore_cache
 
 
 @pytest.fixture
-def mock_device():
+def mock_device() -> Mock:
     """Mock a Dynalite device."""
     mock_dev = create_mock_device("cover", DynaliteTimeCoverWithTiltDevice)
     mock_dev.device_class = CoverDeviceClass.BLIND.value
@@ -54,7 +56,7 @@ def mock_device():
     return mock_dev
 
 
-async def test_cover_setup(hass: HomeAssistant, mock_device) -> None:
+async def test_cover_setup(hass: HomeAssistant, mock_device: Mock) -> None:
     """Test a successful setup."""
     await create_entity_from_device(hass, mock_device)
     entity_state = hass.states.get("cover.name")
@@ -93,7 +95,7 @@ async def test_cover_setup(hass: HomeAssistant, mock_device) -> None:
     )
 
 
-async def test_cover_without_tilt(hass: HomeAssistant, mock_device) -> None:
+async def test_cover_without_tilt(hass: HomeAssistant, mock_device: Mock) -> None:
     """Test a cover with no tilt."""
     mock_device.has_tilt = False
     await create_entity_from_device(hass, mock_device)
@@ -106,8 +108,14 @@ async def test_cover_without_tilt(hass: HomeAssistant, mock_device) -> None:
 
 
 async def check_cover_position(
-    hass, update_func, device, closing, opening, closed, expected
-):
+    hass: HomeAssistant,
+    update_func: Callable[[DynaliteBaseDevice | None], None],
+    device: Mock,
+    closing: bool,
+    opening: bool,
+    closed: bool,
+    expected: str,
+) -> None:
     """Check that a given position behaves correctly."""
     device.is_closing = closing
     device.is_opening = opening
@@ -118,7 +126,7 @@ async def check_cover_position(
     assert entity_state.state == expected
 
 
-async def test_cover_positions(hass: HomeAssistant, mock_device) -> None:
+async def test_cover_positions(hass: HomeAssistant, mock_device: Mock) -> None:
     """Test that the state updates in the various positions."""
     update_func = await create_entity_from_device(hass, mock_device)
     await check_cover_position(
@@ -135,7 +143,7 @@ async def test_cover_positions(hass: HomeAssistant, mock_device) -> None:
     )
 
 
-async def test_cover_restore_state(hass: HomeAssistant, mock_device) -> None:
+async def test_cover_restore_state(hass: HomeAssistant, mock_device: Mock) -> None:
     """Test restore from cache."""
     mock_restore_cache(
         hass,
@@ -147,7 +155,9 @@ async def test_cover_restore_state(hass: HomeAssistant, mock_device) -> None:
     assert entity_state.state == STATE_OPEN
 
 
-async def test_cover_restore_state_bad_cache(hass: HomeAssistant, mock_device) -> None:
+async def test_cover_restore_state_bad_cache(
+    hass: HomeAssistant, mock_device: Mock
+) -> None:
     """Test restore from a cache without the attribute."""
     mock_restore_cache(
         hass,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
