### PR TITLE
Add missing hass type hint in component tests (f)

### DIFF
--- a/tests/components/ffmpeg/test_init.py
+++ b/tests/components/ffmpeg/test_init.py
@@ -22,7 +22,7 @@ from tests.common import assert_setup_component, get_test_home_assistant
 
 
 @callback
-def async_start(hass, entity_id=None):
+def async_start(hass: HomeAssistant, entity_id: str | None = None) -> None:
     """Start a FFmpeg process on entity.
 
     This is a legacy helper method. Do not use it for new tests.
@@ -32,7 +32,7 @@ def async_start(hass, entity_id=None):
 
 
 @callback
-def async_stop(hass, entity_id=None):
+def async_stop(hass: HomeAssistant, entity_id: str | None = None) -> None:
     """Stop a FFmpeg process on entity.
 
     This is a legacy helper method. Do not use it for new tests.
@@ -42,7 +42,7 @@ def async_stop(hass, entity_id=None):
 
 
 @callback
-def async_restart(hass, entity_id=None):
+def async_restart(hass: HomeAssistant, entity_id: str | None = None) -> None:
     """Restart a FFmpeg process on entity.
 
     This is a legacy helper method. Do not use it for new tests.

--- a/tests/components/flick_electric/test_config_flow.py
+++ b/tests/components/flick_electric/test_config_flow.py
@@ -6,6 +6,7 @@ from pyflick.authentication import AuthException
 
 from homeassistant import config_entries
 from homeassistant.components.flick_electric.const import DOMAIN
+from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -15,7 +16,7 @@ from tests.common import MockConfigEntry
 CONF = {CONF_USERNAME: "test-username", CONF_PASSWORD: "test-password"}
 
 
-async def _flow_submit(hass):
+async def _flow_submit(hass: HomeAssistant) -> ConfigFlowResult:
     return await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_USER},

--- a/tests/components/fronius/__init__.py
+++ b/tests/components/fronius/__init__.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from datetime import timedelta
 import json
 from typing import Any
+
+from freezegun.api import FrozenDateTimeFactory
 
 from homeassistant.components.fronius.const import DOMAIN
 from homeassistant.config_entries import ConfigEntry
@@ -114,7 +117,12 @@ def mock_responses(
     )
 
 
-async def enable_all_entities(hass, freezer, config_entry_id, time_till_next_update):
+async def enable_all_entities(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    config_entry_id: str,
+    time_till_next_update: timedelta,
+) -> None:
     """Enable all entities for a config entry and fast forward time to receive data."""
     registry = er.async_get(hass)
     entities = er.async_entries_for_config_entry(registry, config_entry_id)

--- a/tests/components/fully_kiosk/test_number.py
+++ b/tests/components/fully_kiosk/test_number.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 from homeassistant.components import number
 from homeassistant.components.fully_kiosk.const import DOMAIN, UPDATE_INTERVAL
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceResponse
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util import dt as dt_util
 
@@ -81,9 +81,11 @@ async def test_numbers(
     assert device_entry.sw_version == "1.42.5"
 
 
-def set_value(hass, entity_id, value):
+async def set_value(
+    hass: HomeAssistant, entity_id: str, value: float
+) -> ServiceResponse:
     """Set the value of a number entity."""
-    return hass.services.async_call(
+    return await hass.services.async_call(
         number.DOMAIN,
         "set_value",
         {ATTR_ENTITY_ID: entity_id, number.ATTR_VALUE: value},

--- a/tests/components/fully_kiosk/test_switch.py
+++ b/tests/components/fully_kiosk/test_switch.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 from homeassistant.components import switch
 from homeassistant.components.fully_kiosk.const import DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceResponse
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.common import MockConfigEntry, async_fire_mqtt_message
@@ -149,8 +149,10 @@ def has_subscribed(mqtt_mock: MqttMockHAClient, topic: str) -> bool:
     return False
 
 
-def call_service(hass, service, entity_id):
+async def call_service(
+    hass: HomeAssistant, service: str, entity_id: str
+) -> ServiceResponse:
     """Call any service on entity."""
-    return hass.services.async_call(
+    return await hass.services.async_call(
         switch.DOMAIN, service, {ATTR_ENTITY_ID: entity_id}, blocking=True
     )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
