### PR TITLE
Update Prosegur API domain to api-smart.prosegur.cloud

### DIFF
--- a/homeassistant/components/prosegur/alarm_control_panel.py
+++ b/homeassistant/components/prosegur/alarm_control_panel.py
@@ -69,7 +69,7 @@ class ProsegurAlarm(AlarmControlPanelEntity):
             manufacturer="Prosegur",
             model="smart",
             identifiers={(DOMAIN, contract)},
-            configuration_url="https://smart.prosegur.com",
+            configuration_url="https://https://api-smart.prosegur.cloud",
         )
 
     async def async_update(self) -> None:


### PR DESCRIPTION
## Proposed change
Prosegur updated their API domain, which caused the integration to stop working. The old domain (`smart.prosegur.com`) has been replaced with `api-smart.prosegur.cloud`. This PR updates the configuration URL in the `alarm_control_panel.py` file to reflect this change, restoring functionality.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #123858
- This PR is related to issue: None
- Link to documentation pull request: None needed.

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
