### PR TITLE
Revert "Exclude aiohappyeyeballs from license check"

### DIFF
--- a/script/licenses.py
+++ b/script/licenses.py
@@ -125,7 +125,6 @@ EXCEPTIONS = {
     "PyXiaomiGateway",  # https://github.com/Danielhiversen/PyXiaomiGateway/pull/201
     "aiocomelit",  # https://github.com/chemelli74/aiocomelit/pull/138
     "aioecowitt",  # https://github.com/home-assistant-libs/aioecowitt/pull/180
-    "aiohappyeyeballs",  # Python-2.0.1
     "aioopenexchangerates",  # https://github.com/MartinHjelmare/aioopenexchangerates/pull/94
     "aiooui",  # https://github.com/Bluetooth-Devices/aiooui/pull/8
     "aioruuvigateway",  # https://github.com/akx/aioruuvigateway/pull/6


### PR DESCRIPTION
Reverts home-assistant/core#124041

This should no longer be needed