### PR TITLE
Add Sonos Test for plex media player enqueue options

### DIFF
--- a/tests/components/sonos/test_plex_playback.py
+++ b/tests/components/sonos/test_plex_playback.py
@@ -8,17 +8,24 @@ import pytest
 from homeassistant.components.media_player import (
     ATTR_MEDIA_CONTENT_ID,
     ATTR_MEDIA_CONTENT_TYPE,
+    ATTR_MEDIA_ENQUEUE,
     DOMAIN as MP_DOMAIN,
     SERVICE_PLAY_MEDIA,
+    MediaPlayerEnqueue,
     MediaType,
 )
 from homeassistant.components.plex import DOMAIN as PLEX_DOMAIN, PLEX_URI_SCHEME
+from homeassistant.components.sonos.media_player import LONG_SERVICE_TIMEOUT
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
+from .conftest import MockSoCo
 
-async def test_plex_play_media(hass: HomeAssistant, async_autosetup_sonos) -> None:
+
+async def test_plex_play_media(
+    hass: HomeAssistant, soco: MockSoCo, async_autosetup_sonos
+) -> None:
     """Test playing media via the Plex integration."""
     mock_plex_server = Mock()
     mock_lookup = mock_plex_server.lookup_media
@@ -55,6 +62,9 @@ async def test_plex_play_media(hass: HomeAssistant, async_autosetup_sonos) -> No
         assert not mock_shuffle.called
         assert mock_lookup.mock_calls[0][1][0] == MediaType.MUSIC
         assert mock_lookup.mock_calls[0][2] == json.loads(media_content_id)
+        assert soco.clear_queue.call_count == 1
+        assert soco.play_from_queue.call_count == 1
+        soco.play_from_queue.assert_called_with(0)
 
         # Test handling shuffle in payload
         mock_lookup.reset_mock()
@@ -130,3 +140,41 @@ async def test_plex_play_media(hass: HomeAssistant, async_autosetup_sonos) -> No
         assert mock_shuffle.called
         assert mock_lookup.mock_calls[0][1][0] == PLEX_DOMAIN
         assert mock_lookup.mock_calls[0][2] == {"plex_key": plex_item_key}
+
+        mock_add_to_queue.reset_mock()
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_PLAY_MEDIA,
+            {
+                ATTR_ENTITY_ID: media_player,
+                ATTR_MEDIA_CONTENT_TYPE: MediaType.MUSIC,
+                ATTR_MEDIA_CONTENT_ID: f"{PLEX_URI_SCHEME}{media_content_id}",
+                ATTR_MEDIA_ENQUEUE: MediaPlayerEnqueue.ADD,
+            },
+            blocking=True,
+        )
+        assert mock_add_to_queue.call_count == 1
+        mock_add_to_queue.assert_called_with(
+            mock_lookup(), timeout=LONG_SERVICE_TIMEOUT
+        )
+
+        soco.play_from_queue.reset_mock()
+        mock_add_to_queue.reset_mock()
+        mock_add_to_queue.return_value = 9
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_PLAY_MEDIA,
+            {
+                ATTR_ENTITY_ID: media_player,
+                ATTR_MEDIA_CONTENT_TYPE: MediaType.MUSIC,
+                ATTR_MEDIA_CONTENT_ID: f"{PLEX_URI_SCHEME}{media_content_id}",
+                ATTR_MEDIA_ENQUEUE: MediaPlayerEnqueue.PLAY,
+            },
+            blocking=True,
+        )
+        assert mock_add_to_queue.call_count == 1
+        mock_add_to_queue.assert_called_with(
+            mock_lookup(), position=1, timeout=LONG_SERVICE_TIMEOUT
+        )
+        assert soco.play_from_queue.call_count == 1
+        soco.play_from_queue.assert_called_with(mock_add_to_queue.return_value - 1)


### PR DESCRIPTION
## Proposed change
Add tests to improve test coverage of playing plex media from Sonos Media Player

Targets this set of code

https://github.com/home-assistant/core/blob/7efd8089c88466a6c24c83f8eff2f3cbf431fabc/homeassistant/components/sonos/media_player.py#L572-L595


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
