### PR TITLE
Fix Tuya Fahrenheit device temperature readings

### DIFF
--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -137,26 +137,26 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
 
         # If both temperature values for celsius and fahrenheit are present,
         # use whatever the device is set to, with a fallback to celsius.
-        prefered_temperature_unit = None
+        preferred_temperature_unit = None
         if all(
             dpcode in device.status
             for dpcode in (DPCode.TEMP_CURRENT, DPCode.TEMP_CURRENT_F)
         ) or all(
             dpcode in device.status for dpcode in (DPCode.TEMP_SET, DPCode.TEMP_SET_F)
         ):
-            prefered_temperature_unit = UnitOfTemperature.CELSIUS
+            preferred_temperature_unit = UnitOfTemperature.CELSIUS
             if any(
                 "f" in device.status[dpcode].lower()
                 for dpcode in (DPCode.C_F, DPCode.TEMP_UNIT_CONVERT)
                 if isinstance(device.status.get(dpcode), str)
             ):
-                prefered_temperature_unit = UnitOfTemperature.FAHRENHEIT
+                preferred_temperature_unit = UnitOfTemperature.FAHRENHEIT
         else:
             # Default to System Temperature Unit
-            prefered_temperature_unit = system_temperature_unit
+            preferred_temperature_unit = system_temperature_unit
 
         # Figure out current temperature, use preferred unit or what is available
-        # Note the TEMP_CURRENT property may be in celcius or fahrenheit
+        # Note the TEMP_CURRENT property may be in celsius or fahrenheit
         temperature_type = self.find_dpcode(
             (DPCode.TEMP_CURRENT, DPCode.UPPER_TEMP), dptype=DPType.INTEGER
         )
@@ -165,17 +165,17 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
             (DPCode.TEMP_CURRENT_F, DPCode.UPPER_TEMP_F), dptype=DPType.INTEGER
         )
         if temperature_type_fahrenheit and (
-            prefered_temperature_unit == UnitOfTemperature.FAHRENHEIT
+            preferred_temperature_unit == UnitOfTemperature.FAHRENHEIT
             or (
-                prefered_temperature_unit == UnitOfTemperature.CELSIUS
+                preferred_temperature_unit == UnitOfTemperature.CELSIUS
                 and not temperature_type
             )
         ):
             self._attr_temperature_unit = UnitOfTemperature.FAHRENHEIT
             self._current_temperature = temperature_type_fahrenheit
         elif temperature_type:
-            # We aren't explicitly FAHRENHEIT or CELCIUS. So Fallback to the prefered unit (Usually Celcius)
-            self._attr_temperature_unit = prefered_temperature_unit
+            # We aren't explicitly FAHRENHEIT or CELSIUS. So Fallback to the preferred unit (Usually Celsius)
+            self._attr_temperature_unit = preferred_temperature_unit
             self._current_temperature = temperature_type
 
         # Figure out setting temperature, use preferred unit or what is available
@@ -186,9 +186,9 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
             DPCode.TEMP_SET_F, dptype=DPType.INTEGER, prefer_function=True
         )
         if temperature_type_fahrenheit and (
-            prefered_temperature_unit == UnitOfTemperature.FAHRENHEIT
+            preferred_temperature_unit == UnitOfTemperature.FAHRENHEIT
             or (
-                prefered_temperature_unit == UnitOfTemperature.CELSIUS
+                preferred_temperature_unit == UnitOfTemperature.CELSIUS
                 and not temperature_type
             )
         ):


### PR DESCRIPTION
Attempt to re-implement preferred unit's effect on climate. I think Tuya recently changed how the device temperature is reported, as I now see a Unit property under `TEMP_CURRENT` that reports Fahrenheit, but this code needs modification to read that.

NOTE: These changes aren't validated. I am busy with getting married and other things, so I don't have time to setup a development environment to validate these changes. I've done my best to ensure that code changes are stable, and easy to read.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Modifying the code to better handle the implicit type of the Tuya temperature readings.
This is done by leveraging the existing preferred unit variables.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #124119
- This PR is related to issue: #124119
- Link to documentation pull request: NA

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:
NA, can I delete this section?
- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:
NA, can I delete this section?
- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
