### PR TITLE
Fix Pure AQI value sensor in Sensibo

### DIFF
--- a/homeassistant/components/sensibo/manifest.json
+++ b/homeassistant/components/sensibo/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["pysensibo"],
   "quality_scale": "platinum",
-  "requirements": ["pysensibo==1.0.36"]
+  "requirements": ["pysensibo==1.1.0"]
 }

--- a/homeassistant/components/sensibo/sensor.py
+++ b/homeassistant/components/sensibo/sensor.py
@@ -97,10 +97,8 @@ MOTION_SENSOR_TYPES: tuple[SensiboMotionSensorEntityDescription, ...] = (
 PURE_SENSOR_TYPES: tuple[SensiboDeviceSensorEntityDescription, ...] = (
     SensiboDeviceSensorEntityDescription(
         key="pm25",
-        device_class=SensorDeviceClass.PM25,
-        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-        state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: data.pm25,
+        translation_key="pm25_pure",
+        value_fn=lambda data: data.pm25_pure.name.lower() if data.pm25_pure else None,
         extra_fn=None,
     ),
     SensiboDeviceSensorEntityDescription(

--- a/homeassistant/components/sensibo/sensor.py
+++ b/homeassistant/components/sensibo/sensor.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from pysensibo.model import MotionSensor, SensiboDevice
+from pysensibo.model import MotionSensor, PureAQI, SensiboDevice
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -98,8 +98,10 @@ PURE_SENSOR_TYPES: tuple[SensiboDeviceSensorEntityDescription, ...] = (
     SensiboDeviceSensorEntityDescription(
         key="pm25",
         translation_key="pm25_pure",
+        device_class=SensorDeviceClass.ENUM,
         value_fn=lambda data: data.pm25_pure.name.lower() if data.pm25_pure else None,
         extra_fn=None,
+        options=[aqi.name.lower() for aqi in PureAQI],
     ),
     SensiboDeviceSensorEntityDescription(
         key="pure_sensitivity",

--- a/homeassistant/components/sensibo/strings.json
+++ b/homeassistant/components/sensibo/strings.json
@@ -110,6 +110,14 @@
           "s": "Sensitive"
         }
       },
+      "pm25_pure": {
+        "name": "Pure AQI",
+        "state": {
+          "good": "Good",
+          "moderate": "Moderate",
+          "bad": "Bad"
+        }
+      },
       "timer_time": {
         "name": "Timer end time"
       },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2166,7 +2166,7 @@ pysaj==0.0.16
 pyschlage==2024.8.0
 
 # homeassistant.components.sensibo
-pysensibo==1.0.36
+pysensibo==1.1.0
 
 # homeassistant.components.serial
 pyserial-asyncio-fast==0.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1729,7 +1729,7 @@ pysabnzbd==1.1.1
 pyschlage==2024.8.0
 
 # homeassistant.components.sensibo
-pysensibo==1.0.36
+pysensibo==1.1.0
 
 # homeassistant.components.acer_projector
 # homeassistant.components.crownstone

--- a/tests/components/sensibo/snapshots/test_diagnostics.ambr
+++ b/tests/components/sensibo/snapshots/test_diagnostics.ambr
@@ -91,7 +91,8 @@
       'motion_sensors': dict({
       }),
       'name': 'Kitchen',
-      'pm25': 1,
+      'pm25': None,
+      'pm25_pure': 1,
       'pure_ac_integration': False,
       'pure_boost_enabled': False,
       'pure_conf': dict({
@@ -424,6 +425,7 @@
       }),
       'name': 'Hallway',
       'pm25': None,
+      'pm25_pure': None,
       'pure_ac_integration': None,
       'pure_boost_enabled': None,
       'pure_conf': dict({
@@ -550,7 +552,8 @@
       'motion_sensors': dict({
       }),
       'name': 'Bedroom',
-      'pm25': 1,
+      'pm25': None,
+      'pm25_pure': 1,
       'pure_ac_integration': False,
       'pure_boost_enabled': False,
       'pure_conf': dict({

--- a/tests/components/sensibo/snapshots/test_sensor.ambr
+++ b/tests/components/sensibo/snapshots/test_sensor.ambr
@@ -1,10 +1,7 @@
 # serializer version: 1
 # name: test_sensor
   ReadOnlyDict({
-    'device_class': 'pm25',
-    'friendly_name': 'Kitchen PM2.5',
-    'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    'unit_of_measurement': 'µg/m³',
+    'friendly_name': 'Kitchen Pure AQI',
   })
 # ---
 # name: test_sensor.1

--- a/tests/components/sensibo/snapshots/test_sensor.ambr
+++ b/tests/components/sensibo/snapshots/test_sensor.ambr
@@ -1,7 +1,13 @@
 # serializer version: 1
 # name: test_sensor
   ReadOnlyDict({
+    'device_class': 'enum',
     'friendly_name': 'Kitchen Pure AQI',
+    'options': list([
+      'good',
+      'moderate',
+      'bad',
+    ]),
   })
 # ---
 # name: test_sensor.1

--- a/tests/components/sensibo/test_sensor.py
+++ b/tests/components/sensibo/test_sensor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import timedelta
 from unittest.mock import patch
 
-from pysensibo.model import SensiboData
+from pysensibo.model import PureAQI, SensiboData
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -27,17 +27,17 @@ async def test_sensor(
     """Test the Sensibo sensor."""
 
     state1 = hass.states.get("sensor.hallway_motion_sensor_battery_voltage")
-    state2 = hass.states.get("sensor.kitchen_pm2_5")
+    state2 = hass.states.get("sensor.kitchen_pure_aqi")
     state3 = hass.states.get("sensor.kitchen_pure_sensitivity")
     state4 = hass.states.get("sensor.hallway_climate_react_low_temperature_threshold")
     assert state1.state == "3000"
-    assert state2.state == "1"
+    assert state2.state == "good"
     assert state3.state == "n"
     assert state4.state == "0.0"
     assert state2.attributes == snapshot
     assert state4.attributes == snapshot
 
-    monkeypatch.setattr(get_data.parsed["AAZZAAZZ"], "pm25", 2)
+    monkeypatch.setattr(get_data.parsed["AAZZAAZZ"], "pm25_pure", PureAQI(2))
 
     with patch(
         "homeassistant.components.sensibo.coordinator.SensiboClient.async_get_devices_data",
@@ -49,5 +49,5 @@ async def test_sensor(
         )
         await hass.async_block_till_done()
 
-    state1 = hass.states.get("sensor.kitchen_pm2_5")
-    assert state1.state == "2"
+    state1 = hass.states.get("sensor.kitchen_pure_aqi")
+    assert state1.state == "moderate"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The previous PM2.5 sensor for Pure devices was incorrectly reporting a PM2.5 value but it's actually a number representing an AQI level. This PR modifies the sensor to provide the new states of `good`, `moderate` and `bad`.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
See breaking change.

Bump pysensibo to 1.1.0
https://github.com/andrey-git/pysensibo/releases/tag/v1.1.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #117705
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
