### PR TITLE
Automatically remove unregistered TP-Link Omada devices at start up

### DIFF
--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from tplink_omada_client import OmadaSite
+from tplink_omada_client.devices import OmadaListDevice
 from tplink_omada_client.exceptions import (
     ConnectionFailed,
     LoginFailed,
@@ -14,6 +15,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
 
 from .config_flow import CONF_SITE, create_omada_client
 from .const import DOMAIN
@@ -56,6 +58,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data[DOMAIN][entry.entry_id] = controller
 
+    _remove_old_devices(hass, entry, controller.devices_coordinator.data)
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
@@ -67,3 +71,20 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
+
+
+def _remove_old_devices(
+    hass: HomeAssistant, entry: ConfigEntry, omada_devices: dict[str, OmadaListDevice]
+) -> None:
+    device_registry = dr.async_get(hass)
+
+    for registered_device in device_registry.devices.get_devices_for_config_entry_id(
+        entry.entry_id
+    ):
+        mac = next(
+            (i[1] for i in registered_device.identifiers if i[0] == DOMAIN), None
+        )
+        if mac and mac not in omada_devices:
+            device_registry.async_update_device(
+                registered_device.id, remove_config_entry_id=entry.entry_id
+            )

--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -51,11 +51,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         ) from ex
 
     site_client = await client.get_site_client(OmadaSite("", entry.data[CONF_SITE]))
-    controller = OmadaSiteController(hass, site_client)
-    gateway_coordinator = await controller.get_gateway_coordinator()
-    if gateway_coordinator:
-        await gateway_coordinator.async_config_entry_first_refresh()
-    await controller.get_clients_coordinator().async_config_entry_first_refresh()
+    controller = OmadaSiteController(hass, entry, site_client)
+    await controller.initialize_first_refresh()
 
     hass.data[DOMAIN][entry.entry_id] = controller
 

--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -53,7 +53,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         ) from ex
 
     site_client = await client.get_site_client(OmadaSite("", entry.data[CONF_SITE]))
-    controller = OmadaSiteController(hass, entry, site_client)
+    controller = OmadaSiteController(hass, site_client)
     await controller.initialize_first_refresh()
 
     hass.data[DOMAIN][entry.entry_id] = controller

--- a/homeassistant/components/tplink_omada/binary_sensor.py
+++ b/homeassistant/components/tplink_omada/binary_sensor.py
@@ -34,7 +34,7 @@ async def async_setup_entry(
     """Set up binary sensors."""
     controller: OmadaSiteController = hass.data[DOMAIN][config_entry.entry_id]
 
-    gateway_coordinator = await controller.get_gateway_coordinator()
+    gateway_coordinator = controller.gateway_coordinator
     if not gateway_coordinator:
         return
 

--- a/homeassistant/components/tplink_omada/controller.py
+++ b/homeassistant/components/tplink_omada/controller.py
@@ -29,10 +29,10 @@ class OmadaSiteController:
 
         self._switch_port_coordinators: dict[str, OmadaSwitchPortCoordinator] = {}
         self._devices_coordinator = OmadaDevicesCoordinator(
-            self._hass, self._omada_client
+            hass, omada_client
         )
         self._clients_coordinator = OmadaClientsCoordinator(
-            self._hass, self._omada_client
+            hass, omada_client
         )
 
     async def initialize_first_refresh(self) -> None:

--- a/homeassistant/components/tplink_omada/controller.py
+++ b/homeassistant/components/tplink_omada/controller.py
@@ -3,7 +3,6 @@
 from tplink_omada_client import OmadaSiteClient
 from tplink_omada_client.devices import OmadaSwitch
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .coordinator import (
@@ -17,17 +16,11 @@ from .coordinator import (
 class OmadaSiteController:
     """Controller for the Omada SDN site."""
 
-    devices_coordinator: OmadaDevicesCoordinator
-    """Coordinator for site's devices."""
-    clients_coordinator: OmadaClientsCoordinator
-    """Coordinator for site's clients."""
-    gateway_coordinator: OmadaGatewayCoordinator | None = None
-    """Coordinator for site's gateway, or None if there is no gateway."""
+    _gateway_coordinator: OmadaGatewayCoordinator | None = None
 
     def __init__(
         self,
         hass: HomeAssistant,
-        config_entry: ConfigEntry,
         omada_client: OmadaSiteClient,
     ) -> None:
         """Create the controller."""
@@ -35,24 +28,24 @@ class OmadaSiteController:
         self._omada_client = omada_client
 
         self._switch_port_coordinators: dict[str, OmadaSwitchPortCoordinator] = {}
-        self.devices_coordinator = OmadaDevicesCoordinator(
+        self._devices_coordinator = OmadaDevicesCoordinator(
             self._hass, self._omada_client
         )
-        self.clients_coordinator = OmadaClientsCoordinator(
+        self._clients_coordinator = OmadaClientsCoordinator(
             self._hass, self._omada_client
         )
 
     async def initialize_first_refresh(self) -> None:
         """Initialize the all coordinators, and perform first refresh."""
-        await self.devices_coordinator.async_config_entry_first_refresh()
+        await self._devices_coordinator.async_config_entry_first_refresh()
 
         devices = self.devices_coordinator.data.values()
         gateway = next((d for d in devices if d.type == "gateway"), None)
         if gateway:
-            self.gateway_coordinator = OmadaGatewayCoordinator(
+            self._gateway_coordinator = OmadaGatewayCoordinator(
                 self._hass, self._omada_client, gateway.mac
             )
-            await self.gateway_coordinator.async_config_entry_first_refresh()
+            await self._gateway_coordinator.async_config_entry_first_refresh()
 
         await self.clients_coordinator.async_config_entry_first_refresh()
 
@@ -71,3 +64,18 @@ class OmadaSiteController:
             )
 
         return self._switch_port_coordinators[switch.mac]
+
+    @property
+    def gateway_coordinator(self) -> OmadaGatewayCoordinator | None:
+        """Gets the coordinator for site's gateway, or None if there is no gateway."""
+        return self._gateway_coordinator
+
+    @property
+    def devices_coordinator(self) -> OmadaDevicesCoordinator:
+        """Gets the coordinator for site's devices."""
+        return self._devices_coordinator
+
+    @property
+    def clients_coordinator(self) -> OmadaClientsCoordinator:
+        """Gets the coordinator for site's clients."""
+        return self._clients_coordinator

--- a/homeassistant/components/tplink_omada/controller.py
+++ b/homeassistant/components/tplink_omada/controller.py
@@ -39,7 +39,7 @@ class OmadaSiteController:
         """Initialize the all coordinators, and perform first refresh."""
         await self._devices_coordinator.async_config_entry_first_refresh()
 
-        devices = self.devices_coordinator.data.values()
+        devices = self._devices_coordinator.data.values()
         gateway = next((d for d in devices if d.type == "gateway"), None)
         if gateway:
             self._gateway_coordinator = OmadaGatewayCoordinator(

--- a/homeassistant/components/tplink_omada/controller.py
+++ b/homeassistant/components/tplink_omada/controller.py
@@ -28,12 +28,8 @@ class OmadaSiteController:
         self._omada_client = omada_client
 
         self._switch_port_coordinators: dict[str, OmadaSwitchPortCoordinator] = {}
-        self._devices_coordinator = OmadaDevicesCoordinator(
-            hass, omada_client
-        )
-        self._clients_coordinator = OmadaClientsCoordinator(
-            hass, omada_client
-        )
+        self._devices_coordinator = OmadaDevicesCoordinator(hass, omada_client)
+        self._clients_coordinator = OmadaClientsCoordinator(hass, omada_client)
 
     async def initialize_first_refresh(self) -> None:
         """Initialize the all coordinators, and perform first refresh."""

--- a/homeassistant/components/tplink_omada/coordinator.py
+++ b/homeassistant/components/tplink_omada/coordinator.py
@@ -6,17 +6,22 @@ import logging
 
 from tplink_omada_client import OmadaSiteClient, OmadaSwitchPortDetails
 from tplink_omada_client.clients import OmadaWirelessClient
-from tplink_omada_client.devices import OmadaGateway, OmadaSwitch
+from tplink_omada_client.devices import OmadaGateway, OmadaListDevice, OmadaSwitch
 from tplink_omada_client.exceptions import OmadaClientException
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 POLL_SWITCH_PORT = 300
 POLL_GATEWAY = 300
 POLL_CLIENTS = 300
+POLL_DEVICES = 900
 
 
 class OmadaCoordinator[_T](DataUpdateCoordinator[dict[str, _T]]):
@@ -27,14 +32,14 @@ class OmadaCoordinator[_T](DataUpdateCoordinator[dict[str, _T]]):
         hass: HomeAssistant,
         omada_client: OmadaSiteClient,
         name: str,
-        poll_delay: int = 300,
+        poll_delay: int | None = 300,
     ) -> None:
         """Initialize my coordinator."""
         super().__init__(
             hass,
             _LOGGER,
             name=f"Omada API Data - {name}",
-            update_interval=timedelta(seconds=poll_delay),
+            update_interval=timedelta(seconds=poll_delay) if poll_delay else None,
         )
         self.omada_client = omada_client
 
@@ -89,6 +94,57 @@ class OmadaGatewayCoordinator(OmadaCoordinator[OmadaGateway]):
         """Poll a the gateway's current state."""
         gateway = await self.omada_client.get_gateway(self.mac)
         return {self.mac: gateway}
+
+
+class OmadaDevicesCoordinator(OmadaCoordinator[OmadaListDevice]):
+    """Coordinator for generic device lists from the controller."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        omada_client: OmadaSiteClient,
+    ) -> None:
+        """Initialize my coordinator."""
+        super().__init__(hass, omada_client, "DeviceList", POLL_CLIENTS)
+        self._config_entry = config_entry
+
+    async def poll_update(self) -> dict[str, OmadaListDevice]:
+        """Poll the site's current registered Omada devices."""
+        devices = {d.mac: d for d in await self.omada_client.get_devices()}
+
+        self._update_device_registry(devices)
+
+        return devices
+
+    def _update_device_registry(self, devices: dict[str, OmadaListDevice]) -> None:
+        device_registry = dr.async_get(self.hass)
+        # Remove any devices that are no longer present
+        for (
+            registered_device
+        ) in device_registry.devices.get_devices_for_config_entry_id(
+            self._config_entry.entry_id
+        ):
+            if all(i[1] not in devices for i in registered_device.identifiers):
+                entity_registry = er.async_get(self.hass)
+                dev_entities = er.async_entries_for_device(
+                    entity_registry,
+                    registered_device.id,
+                    include_disabled_entities=True,
+                )
+                if not dev_entities:
+                    dr.async_remove_device(registered_device.id)
+
+        # Add or update all connected devices
+        for device in devices.values():
+            dr.async_get_or_create(
+                config_entry_id=self._config_entry.entry_id,
+                connections={(dr.CONNECTION_NETWORK_MAC, device.mac)},
+                identifiers={(DOMAIN, device.mac)},
+                manufacturer="TP-Link",
+                model=device.model_display_name,
+                name=device.name,
+            )
 
 
 class OmadaClientsCoordinator(OmadaCoordinator[OmadaWirelessClient]):

--- a/homeassistant/components/tplink_omada/coordinator.py
+++ b/homeassistant/components/tplink_omada/coordinator.py
@@ -9,7 +9,6 @@ from tplink_omada_client.clients import OmadaWirelessClient
 from tplink_omada_client.devices import OmadaGateway, OmadaListDevice, OmadaSwitch
 from tplink_omada_client.exceptions import OmadaClientException
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -99,12 +98,10 @@ class OmadaDevicesCoordinator(OmadaCoordinator[OmadaListDevice]):
     def __init__(
         self,
         hass: HomeAssistant,
-        config_entry: ConfigEntry,
         omada_client: OmadaSiteClient,
     ) -> None:
         """Initialize my coordinator."""
         super().__init__(hass, omada_client, "DeviceList", POLL_CLIENTS)
-        self._config_entry = config_entry
 
     async def poll_update(self) -> dict[str, OmadaListDevice]:
         """Poll the site's current registered Omada devices."""

--- a/homeassistant/components/tplink_omada/device_tracker.py
+++ b/homeassistant/components/tplink_omada/device_tracker.py
@@ -26,7 +26,6 @@ async def async_setup_entry(
 
     controller: OmadaSiteController = hass.data[DOMAIN][config_entry.entry_id]
 
-    clients_coordinator = controller.get_clients_coordinator()
     site_id = config_entry.data[CONF_SITE]
 
     # Add all known WiFi devices as potentially tracked devices. They will only be
@@ -34,7 +33,7 @@ async def async_setup_entry(
     async_add_entities(
         [
             OmadaClientScannerEntity(
-                site_id, client.mac, client.name, clients_coordinator
+                site_id, client.mac, client.name, controller.clients_coordinator
             )
             async for client in controller.omada_client.get_known_clients()
             if isinstance(client, OmadaWirelessClient)

--- a/homeassistant/components/tplink_omada/entity.py
+++ b/homeassistant/components/tplink_omada/entity.py
@@ -4,7 +4,6 @@ from typing import Any
 
 from tplink_omada_client.devices import OmadaDevice
 
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -20,9 +19,5 @@ class OmadaDeviceEntity[_T: OmadaCoordinator[Any]](CoordinatorEntity[_T]):
         super().__init__(coordinator)
         self.device = device
         self._attr_device_info = DeviceInfo(
-            connections={(dr.CONNECTION_NETWORK_MAC, device.mac)},
             identifiers={(DOMAIN, device.mac)},
-            manufacturer="TP-Link",
-            model=device.model_display_name,
-            name=device.name,
         )

--- a/homeassistant/components/tplink_omada/entity.py
+++ b/homeassistant/components/tplink_omada/entity.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from tplink_omada_client.devices import OmadaDevice
 
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
@@ -18,6 +18,10 @@ class OmadaDeviceEntity[_T: OmadaCoordinator[Any]](CoordinatorEntity[_T]):
         """Initialize the device."""
         super().__init__(coordinator)
         self.device = device
-        self._attr_device_info = DeviceInfo(
+        self._attr_device_info = dr.DeviceInfo(
+            connections={(dr.CONNECTION_NETWORK_MAC, device.mac)},
             identifiers={(DOMAIN, device.mac)},
+            manufacturer="TP-Link",
+            model=device.model_display_name,
+            name=device.name,
         )

--- a/homeassistant/components/tplink_omada/switch.py
+++ b/homeassistant/components/tplink_omada/switch.py
@@ -74,7 +74,7 @@ async def async_setup_entry(
             if desc.exists_func(switch, port)
         )
 
-    gateway_coordinator = await controller.get_gateway_coordinator()
+    gateway_coordinator = controller.gateway_coordinator
     if gateway_coordinator:
         for gateway in gateway_coordinator.data.values():
             entities.extend(

--- a/homeassistant/components/tplink_omada/update.py
+++ b/homeassistant/components/tplink_omada/update.py
@@ -21,10 +21,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
 from .controller import OmadaSiteController
-from .coordinator import OmadaCoordinator
+from .coordinator import POLL_DEVICES, OmadaCoordinator, OmadaDevicesCoordinator
 from .entity import OmadaDeviceEntity
 
-POLL_DELAY_IDLE = 6 * 60 * 60
 POLL_DELAY_UPGRADE = 60
 
 
@@ -35,15 +34,28 @@ class FirmwareUpdateStatus(NamedTuple):
     firmware: OmadaFirmwareUpdate | None
 
 
-class OmadaFirmwareUpdateCoodinator(OmadaCoordinator[FirmwareUpdateStatus]):  # pylint: disable=hass-enforce-class-module
-    """Coordinator for getting details about ports on a switch."""
+class OmadaFirmwareUpdateCoordinator(OmadaCoordinator[FirmwareUpdateStatus]):  # pylint: disable=hass-enforce-class-module
+    """Coordinator for getting details about available firmware updates for Omada devices."""
 
-    def __init__(self, hass: HomeAssistant, omada_client: OmadaSiteClient) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        omada_client: OmadaSiteClient,
+        devices_coordinator: OmadaDevicesCoordinator,
+    ) -> None:
         """Initialize my coordinator."""
-        super().__init__(hass, omada_client, "Firmware Updates", POLL_DELAY_IDLE)
+        super().__init__(hass, omada_client, "Firmware Updates", poll_delay=None)
+
+        self._devices_coordinator = devices_coordinator
+        self._config_entry = config_entry
+
+        config_entry.async_on_unload(
+            devices_coordinator.async_add_listener(self._handle_devices_update)
+        )
 
     async def _get_firmware_updates(self) -> list[FirmwareUpdateStatus]:
-        devices = await self.omada_client.get_devices()
+        devices = self._devices_coordinator.data.values()
 
         updates = [
             FirmwareUpdateStatus(
@@ -55,12 +67,12 @@ class OmadaFirmwareUpdateCoodinator(OmadaCoordinator[FirmwareUpdateStatus]):  # 
             for d in devices
         ]
 
-        # During a firmware upgrade, poll more frequently
-        self.update_interval = timedelta(
+        # During a firmware upgrade, poll device list more frequently
+        self._devices_coordinator.update_interval = timedelta(
             seconds=(
                 POLL_DELAY_UPGRADE
                 if any(u.device.fw_download for u in updates)
-                else POLL_DELAY_IDLE
+                else POLL_DEVICES
             )
         )
         return updates
@@ -68,6 +80,14 @@ class OmadaFirmwareUpdateCoodinator(OmadaCoordinator[FirmwareUpdateStatus]):  # 
     async def poll_update(self) -> dict[str, FirmwareUpdateStatus]:
         """Poll the state of Omada Devices firmware update availability."""
         return {d.device.mac: d for d in await self._get_firmware_updates()}
+
+    @callback
+    def _handle_devices_update(self) -> None:
+        """Handle updated data from the devices coordinator."""
+        # Trigger a refresh of our data, based on the updated device list
+        self._config_entry.async_create_background_task(
+            self.hass, self.async_request_refresh(), "Omada Firmware Update Refresh"
+        )
 
 
 async def async_setup_entry(
@@ -77,18 +97,21 @@ async def async_setup_entry(
 ) -> None:
     """Set up switches."""
     controller: OmadaSiteController = hass.data[DOMAIN][config_entry.entry_id]
-    omada_client = controller.omada_client
 
-    devices = await omada_client.get_devices()
+    devices = controller.devices_coordinator.data
 
-    coordinator = OmadaFirmwareUpdateCoodinator(hass, omada_client)
+    coordinator = OmadaFirmwareUpdateCoordinator(
+        hass, config_entry, controller.omada_client, controller.devices_coordinator
+    )
 
-    async_add_entities(OmadaDeviceUpdate(coordinator, device) for device in devices)
+    async_add_entities(
+        OmadaDeviceUpdate(coordinator, device) for device in devices.values()
+    )
     await coordinator.async_request_refresh()
 
 
 class OmadaDeviceUpdate(
-    OmadaDeviceEntity[OmadaFirmwareUpdateCoodinator],
+    OmadaDeviceEntity[OmadaFirmwareUpdateCoordinator],
     UpdateEntity,
 ):
     """Firmware update status for Omada SDN devices."""
@@ -103,7 +126,7 @@ class OmadaDeviceUpdate(
 
     def __init__(
         self,
-        coordinator: OmadaFirmwareUpdateCoodinator,
+        coordinator: OmadaFirmwareUpdateCoordinator,
         device: OmadaListDevice,
     ) -> None:
         """Initialize the update entity."""

--- a/tests/components/tplink_omada/test_init.py
+++ b/tests/components/tplink_omada/test_init.py
@@ -1,0 +1,52 @@
+"""Tests for TP-Link Omada integration init."""
+
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+from homeassistant.components.tplink_omada.const import DOMAIN
+from homeassistant.components.tplink_omada.coordinator import POLL_CLIENTS
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from tests.common import MockConfigEntry
+
+UPDATE_INTERVAL = timedelta(seconds=10)
+POLL_INTERVAL = timedelta(seconds=POLL_CLIENTS + 10)
+
+MOCK_ENTRY_DATA = {
+    "host": "https://fake.omada.host",
+    "verify_ssl": True,
+    "site": "SiteId",
+    "username": "test-username",
+    "password": "test-password",
+}
+
+
+async def test_missing_devices_removed_at_startup(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_omada_client: MagicMock,
+) -> None:
+    """Test missing devices are removed at startup."""
+    mock_config_entry = MockConfigEntry(
+        title="Test Omada Controller",
+        domain=DOMAIN,
+        data=dict(MOCK_ENTRY_DATA),
+        unique_id="12345",
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, "AA:BB:CC:DD:EE:FF")},
+        manufacturer="TPLink",
+        name="Old Device",
+        model="Some old model",
+    )
+
+    assert device_registry.async_get(device_entry.id) == device_entry
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert device_registry.async_get(device_entry.id) is None

--- a/tests/components/tplink_omada/test_init.py
+++ b/tests/components/tplink_omada/test_init.py
@@ -1,17 +1,12 @@
 """Tests for TP-Link Omada integration init."""
 
-from datetime import timedelta
 from unittest.mock import MagicMock
 
 from homeassistant.components.tplink_omada.const import DOMAIN
-from homeassistant.components.tplink_omada.coordinator import POLL_CLIENTS
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 from tests.common import MockConfigEntry
-
-UPDATE_INTERVAL = timedelta(seconds=10)
-POLL_INTERVAL = timedelta(seconds=POLL_CLIENTS + 10)
 
 MOCK_ENTRY_DATA = {
     "host": "https://fake.omada.host",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Second attempt at this PR.

Remove devices that no longer exist when the integration loads.

As part of this, I added a new coordinator that tracks the list of devices. If this fails
to load at integration startup, we'll get a `ConfigNotReady` exception, so the devices
won't get removed by accident.

I could have just made a call during startup to get the current device list, but the
coordinator is going to be used in an upcoming PR to add sensor entities that track
the state of Omada devices, so it seemed more sensible to add this now. 

However, as there was already an existing coordinator that called the same API as part
of it's work for tracking Firmware updates, I needed to do a bit of work to make the
Firmware update coordinator dependent on the new Device List coordinator. This will
prevent the integration from spamming the controller with extra poll requests.

The firmware update coordinator will now only make API calls to Omada if there are
firmware updates pending according to the Omada Device List coordinator.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #123130
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
