### PR TITLE
hue: remove custom None effect in favor of no_effect

### DIFF
--- a/homeassistant/components/hue/v2/helpers.py
+++ b/homeassistant/components/hue/v2/helpers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from aiohue.v2.models.feature import EffectStatus, TimedEffectStatus
+
 
 def normalize_hue_brightness(brightness: float | None) -> float | None:
     """Return calculated brightness values."""
@@ -28,3 +30,21 @@ def normalize_hue_colortemp(colortemp: int | None) -> int | None:
         colortemp = min(colortemp, 500)
         colortemp = max(colortemp, 153)
     return colortemp
+
+
+def normalize_hue_effect(effect_str: str | None) -> EffectStatus | TimedEffectStatus:
+    """Convert a string representation of an effect or timed effect into and EffectStatus or TimedEffectStatus.
+
+    If there is no effect, EffectStatus.NO_EFFECT is returned.
+    """
+    # Backwards compatibility: "None" or "none" were used instead of "no_effect" previously
+    if effect_str in (None, "None", "none"):
+        return EffectStatus.NO_EFFECT
+
+    if (effect := EffectStatus(effect_str)) != EffectStatus.UNKNOWN:
+        return effect
+
+    if (timed_effect := TimedEffectStatus(effect_str)) != TimedEffectStatus.UNKNOWN:
+        return timed_effect
+
+    return EffectStatus.UNKNOWN

--- a/tests/components/hue/test_light_v2.py
+++ b/tests/components/hue/test_light_v2.py
@@ -42,8 +42,8 @@ async def test_lights(
     assert light_1.attributes["min_mireds"] == 153
     assert light_1.attributes["max_mireds"] == 500
     assert light_1.attributes["dynamics"] == "dynamic_palette"
-    assert light_1.attributes["effect_list"] == ["None", "candle", "fire"]
-    assert light_1.attributes["effect"] == "None"
+    assert set(light_1.attributes["effect_list"]) == {"no_effect", "candle", "fire"}
+    assert light_1.attributes["effect"] == "no_effect"
 
     # test light which supports color temperature only
     light_2 = hass.states.get("light.hue_light_with_color_temperature_only")
@@ -57,7 +57,7 @@ async def test_lights(
     assert light_2.attributes["min_mireds"] == 153
     assert light_2.attributes["max_mireds"] == 454
     assert light_2.attributes["dynamics"] == "none"
-    assert light_2.attributes["effect_list"] == ["None", "candle", "sunrise"]
+    assert set(light_2.attributes["effect_list"]) == {"no_effect", "candle", "sunrise"}
 
     # test light which supports color only
     light_3 = hass.states.get("light.hue_light_with_color_only")
@@ -189,7 +189,7 @@ async def test_light_turn_on_service(
     await hass.services.async_call(
         "light",
         "turn_on",
-        {"entity_id": test_light_id, "effect": "None"},
+        {"entity_id": test_light_id, "effect": "no_effect"},
         blocking=True,
     )
     assert len(mock_bridge_v2.mock_requests) == 8
@@ -229,6 +229,16 @@ async def test_light_turn_on_service(
     assert len(mock_bridge_v2.mock_requests) == 11
     assert mock_bridge_v2.mock_requests[10]["json"]["effects"]["effect"] == "candle"
     assert "xy_color" not in mock_bridge_v2.mock_requests[9]["json"]
+
+    # test disable effect with "None" as effect
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": test_light_id, "effect": "None"},
+        blocking=True,
+    )
+    assert len(mock_bridge_v2.mock_requests) == 12
+    assert mock_bridge_v2.mock_requests[11]["json"]["effects"]["effect"] == "no_effect"
 
 
 async def test_light_turn_off_service(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
The value `None` has been removed from the supported effects of Hue lights, and been replaced with `no_effect` as reported by the Hue lights themselves. `None` and `none` are still accepted as an input.

## Proposed change
Instead of using the custom value `"None"` to specify that a Hue light should not display an effect, use the value `"no_effect"` that is the value that the Hue API reports.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- The `"None"` magic value was introduced in https://github.com/home-assistant/core/pull/68567
- This PR is related to issue: #122165

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
