### PR TITLE
Refactor websocket handler to reduce complexity

### DIFF
--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -343,7 +343,9 @@ class WebSocketHandler:
             logger.debug("%s: Connection cancelled", self.description)
             raise
         except Disconnect as ex:
-            disconnect_warn = str(ex)
+            if disconnect_msg := str(ex):
+                disconnect_warn = disconnect_msg
+
             logger.debug("%s: Connection closed by client: %s", self.description, ex)
         except Exception:
             logger.exception(

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -384,7 +384,7 @@ class WebSocketHandler:
         if msg.type in (WSMsgType.CLOSE, WSMsgType.CLOSED, WSMsgType.CLOSING):
             raise Disconnect("Received close message during auth phase")
 
-        if msg.type != WSMsgType.TEXT:
+        if msg.type is not WSMsgType.TEXT:
             raise Disconnect("Received non-Text message during auth phase")
 
         try:

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -301,6 +301,7 @@ class WebSocketHandler:
         request = self._request
         wsock = self._wsock
         logger = self._logger
+        hass = self._hass
 
         try:
             async with asyncio.timeout(10):
@@ -319,7 +320,7 @@ class WebSocketHandler:
         logger.debug("%s: Connected from %s", self.description, request.remote)
         self._handle_task = asyncio.current_task()
 
-        unsub_stop = self._hass.bus.async_listen(
+        unsub_stop = hass.bus.async_listen(
             EVENT_HOMEASSISTANT_STOP, self._async_handle_hass_stop
         )
 
@@ -329,12 +330,7 @@ class WebSocketHandler:
 
         send_bytes_text = partial(writer.send, binary=False)
         auth = AuthPhase(
-            logger,
-            self._hass,
-            self._send_message,
-            self._cancel,
-            request,
-            send_bytes_text,
+            logger, hass, self._send_message, self._cancel, request, send_bytes_text
         )
         disconnect_warn: str | None = None
         connection: ActiveConnection | None = None

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -307,7 +307,7 @@ class WebSocketHandler:
             async with asyncio.timeout(10):
                 await wsock.prepare(request)
         except TimeoutError:
-            self._logger.warning("Timeout preparing request from %s", request.remote)
+            logger.warning("Timeout preparing request from %s", request.remote)
             return wsock
 
         logger.debug("%s: Connected from %s", self.description, request.remote)

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -306,13 +306,6 @@ class WebSocketHandler:
         try:
             async with asyncio.timeout(10):
                 await wsock.prepare(request)
-        except ConnectionResetError:
-            # Likely the client disconnected before we prepared the websocket
-            logger.debug(
-                "%s: Connection reset by peer while preparing WebSocket",
-                self.description,
-            )
-            return wsock
         except TimeoutError:
             self._logger.warning("Timeout preparing request from %s", request.remote)
             return wsock

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -332,8 +332,9 @@ class WebSocketHandler:
         auth = AuthPhase(
             logger, hass, self._send_message, self._cancel, request, send_bytes_text
         )
-        disconnect_warn: str | None = None
         connection: ActiveConnection | None = None
+        disconnect_warn: str | None = None
+
         try:
             connection = await self._async_handle_auth_phase(auth, send_bytes_text)
             self._async_increase_writer_limit(writer)

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -11,6 +11,7 @@ import logging
 from typing import TYPE_CHECKING, Any, Final
 
 from aiohttp import WSMsgType, web
+from aiohttp.http_websocket import WebSocketWriter
 
 from homeassistant.components.http import KEY_HASS, HomeAssistantView
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
@@ -124,7 +125,9 @@ class WebSocketHandler:
         return "finished connection"
 
     async def _writer(
-        self, send_bytes_text: Callable[[bytes], Coroutine[Any, Any, None]]
+        self,
+        connection: ActiveConnection,
+        send_bytes_text: Callable[[bytes], Coroutine[Any, Any, None]],
     ) -> None:
         """Write outgoing messages."""
         # Variables are set locally to avoid lookups in the loop
@@ -134,7 +137,7 @@ class WebSocketHandler:
         loop = self._loop
         is_debug_log_enabled = partial(logger.isEnabledFor, logging.DEBUG)
         debug = logger.debug
-        can_coalesce = self._connection and self._connection.can_coalesce
+        can_coalesce = connection.can_coalesce
         ready_message_count = len(message_queue)
         # Exceptions if Socket disconnected or cancelled by connection handler
         try:
@@ -148,7 +151,7 @@ class WebSocketHandler:
 
                 if not can_coalesce:
                     # coalesce may be enabled later in the connection
-                    can_coalesce = self._connection and self._connection.can_coalesce
+                    can_coalesce = connection.can_coalesce
 
                 if not can_coalesce or ready_message_count == 1:
                     message = message_queue.popleft()
@@ -298,22 +301,25 @@ class WebSocketHandler:
         request = self._request
         wsock = self._wsock
         logger = self._logger
-        debug = logger.debug
-        hass = self._hass
-        is_enabled_for = logger.isEnabledFor
-        logging_debug = logging.DEBUG
 
         try:
             async with asyncio.timeout(10):
                 await wsock.prepare(request)
+        except ConnectionResetError:
+            # Likely the client disconnected before we prepared the websocket
+            logger.debug(
+                "%s: Connection reset by peer while preparing WebSocket",
+                self.description,
+            )
+            return wsock
         except TimeoutError:
             self._logger.warning("Timeout preparing request from %s", request.remote)
             return wsock
 
-        debug("%s: Connected from %s", self.description, request.remote)
+        logger.debug("%s: Connected from %s", self.description, request.remote)
         self._handle_task = asyncio.current_task()
 
-        unsub_stop = hass.bus.async_listen(
+        unsub_stop = self._hass.bus.async_listen(
             EVENT_HOMEASSISTANT_STOP, self._async_handle_hass_stop
         )
 
@@ -323,136 +329,29 @@ class WebSocketHandler:
 
         send_bytes_text = partial(writer.send, binary=False)
         auth = AuthPhase(
-            logger, hass, self._send_message, self._cancel, request, send_bytes_text
+            logger,
+            self._hass,
+            self._send_message,
+            self._cancel,
+            request,
+            send_bytes_text,
         )
-        connection = None
-        disconnect_warn = None
-
+        disconnect_warn: str | None = None
+        connection: ActiveConnection | None = None
         try:
-            await send_bytes_text(AUTH_REQUIRED_MESSAGE)
-
-            # Auth Phase
-            try:
-                msg = await wsock.receive(10)
-            except TimeoutError as err:
-                disconnect_warn = "Did not receive auth message within 10 seconds"
-                raise Disconnect from err
-
-            if msg.type in (WSMsgType.CLOSE, WSMsgType.CLOSED, WSMsgType.CLOSING):
-                raise Disconnect  # noqa: TRY301
-
-            if msg.type != WSMsgType.TEXT:
-                disconnect_warn = "Received non-Text message."
-                raise Disconnect  # noqa: TRY301
-
-            try:
-                auth_msg_data = json_loads(msg.data)
-            except ValueError as err:
-                disconnect_warn = "Received invalid JSON."
-                raise Disconnect from err
-
-            if is_enabled_for(logging_debug):
-                debug("%s: Received %s", self.description, auth_msg_data)
-            connection = await auth.async_handle(auth_msg_data)
-            # As the webserver is now started before the start
-            # event we do not want to block for websocket responses
-            #
-            # We only start the writer queue after the auth phase is completed
-            # since there is no need to queue messages before the auth phase
-            self._connection = connection
-            self._writer_task = create_eager_task(self._writer(send_bytes_text))
-            hass.data[DATA_CONNECTIONS] = hass.data.get(DATA_CONNECTIONS, 0) + 1
-            async_dispatcher_send(hass, SIGNAL_WEBSOCKET_CONNECTED)
-
-            self._authenticated = True
-            #
-            #
-            # Our websocket implementation is backed by a deque
-            #
-            # As back-pressure builds, the queue will back up and use more memory
-            # until we disconnect the client when the queue size reaches
-            # MAX_PENDING_MSG. When we are generating a high volume of websocket messages,
-            # we hit a bottleneck in aiohttp where it will wait for
-            # the buffer to drain before sending the next message and messages
-            # start backing up in the queue.
-            #
-            # https://github.com/aio-libs/aiohttp/issues/1367 added drains
-            # to the websocket writer to handle malicious clients and network issues.
-            # The drain causes multiple problems for us since the buffer cannot be
-            # drained fast enough when we deliver a high volume or large messages:
-            #
-            # - We end up disconnecting the client. The client will then reconnect,
-            # and the cycle repeats itself, which results in a significant amount of
-            # CPU usage.
-            #
-            # - Messages latency increases because messages cannot be moved into
-            # the TCP buffer because it is blocked waiting for the drain to happen because
-            # of the low default limit of 16KiB. By increasing the limit, we instead
-            # rely on the underlying TCP buffer and stack to deliver the messages which
-            # can typically happen much faster.
-            #
-            # After the auth phase is completed, and we are not concerned about
-            # the user being a malicious client, we set the limit to force a drain
-            # to 1MiB. 1MiB is the maximum expected size of the serialized entity
-            # registry, which is the largest message we usually send.
-            #
-            # https://github.com/aio-libs/aiohttp/commit/b3c80ee3f7d5d8f0b8bc27afe52e4d46621eaf99
-            # added a way to set the limit, but there is no way to actually
-            # reach the code to set the limit, so we have to set it directly.
-            #
-            writer._limit = 2**20  # noqa: SLF001
-            async_handle_str = connection.async_handle
-            async_handle_binary = connection.async_handle_binary
-
-            # Command phase
-            while not wsock.closed:
-                msg = await wsock.receive()
-
-                if msg.type in (WSMsgType.CLOSE, WSMsgType.CLOSED, WSMsgType.CLOSING):
-                    break
-
-                if msg.type is WSMsgType.BINARY:
-                    if len(msg.data) < 1:
-                        disconnect_warn = "Received invalid binary message."
-                        break
-                    handler = msg.data[0]
-                    payload = msg.data[1:]
-                    async_handle_binary(handler, payload)
-                    continue
-
-                if msg.type is not WSMsgType.TEXT:
-                    disconnect_warn = "Received non-Text message."
-                    break
-
-                try:
-                    command_msg_data = json_loads(msg.data)
-                except ValueError:
-                    disconnect_warn = "Received invalid JSON."
-                    break
-
-                if is_enabled_for(logging_debug):
-                    debug("%s: Received %s", self.description, command_msg_data)
-
-                # command_msg_data is always deserialized from JSON as a list
-                if type(command_msg_data) is not list:  # noqa: E721
-                    async_handle_str(command_msg_data)
-                    continue
-
-                for split_msg in command_msg_data:
-                    async_handle_str(split_msg)
-
+            connection = await self._async_handle_auth_phase(auth, send_bytes_text)
+            self._async_increase_writer_limit(writer)
+            await self._async_websocket_command_phase(connection, send_bytes_text)
         except asyncio.CancelledError:
-            debug("%s: Connection cancelled", self.description)
+            logger.debug("%s: Connection cancelled", self.description)
             raise
-
         except Disconnect as ex:
-            debug("%s: Connection closed by client: %s", self.description, ex)
-
+            disconnect_warn = str(ex)
+            logger.debug("%s: Connection closed by client: %s", self.description, ex)
         except Exception:
-            self._logger.exception(
+            logger.exception(
                 "%s: Unexpected error inside websocket API", self.description
             )
-
         finally:
             unsub_stop()
 
@@ -465,38 +364,175 @@ class WebSocketHandler:
             if self._ready_future and not self._ready_future.done():
                 self._ready_future.set_result(len(self._message_queue))
 
-            # If the writer gets canceled we still need to close the websocket
-            # so we have another finally block to make sure we close the websocket
-            # if the writer gets canceled.
-            try:
-                if self._writer_task:
-                    await self._writer_task
-            finally:
-                try:
-                    # Make sure all error messages are written before closing
-                    await wsock.close()
-                finally:
-                    if disconnect_warn is None:
-                        debug("%s: Disconnected", self.description)
-                    else:
-                        self._logger.warning(
-                            "%s: Disconnected: %s", self.description, disconnect_warn
-                        )
-
-                    if connection is not None:
-                        hass.data[DATA_CONNECTIONS] -= 1
-                        self._connection = None
-
-                    async_dispatcher_send(hass, SIGNAL_WEBSOCKET_DISCONNECTED)
-
-                    # Break reference cycles to make sure GC can happen sooner
-                    self._wsock = None  # type: ignore[assignment]
-                    self._request = None  # type: ignore[assignment]
-                    self._hass = None  # type: ignore[assignment]
-                    self._logger = None  # type: ignore[assignment]
-                    self._message_queue = None  # type: ignore[assignment]
-                    self._handle_task = None
-                    self._writer_task = None
-                    self._ready_future = None
+            await self._async_cleanup_writer_and_close(disconnect_warn, connection)
 
         return wsock
+
+    async def _async_handle_auth_phase(
+        self,
+        auth: AuthPhase,
+        send_bytes_text: Callable[[bytes], Coroutine[Any, Any, None]],
+    ) -> ActiveConnection:
+        """Handle the auth phase of the websocket connection."""
+        await send_bytes_text(AUTH_REQUIRED_MESSAGE)
+
+        # Auth Phase
+        try:
+            msg = await self._wsock.receive(10)
+        except TimeoutError as err:
+            raise Disconnect("Did not receive auth message within 10 seconds") from err
+
+        if msg.type in (WSMsgType.CLOSE, WSMsgType.CLOSED, WSMsgType.CLOSING):
+            raise Disconnect("Received close message during auth phase")
+
+        if msg.type != WSMsgType.TEXT:
+            raise Disconnect("Received non-Text message during auth phase")
+
+        try:
+            auth_msg_data = json_loads(msg.data)
+        except ValueError as err:
+            raise Disconnect("Received invalid JSON during auth phase") from err
+
+        if self._logger.isEnabledFor(logging.DEBUG):
+            self._logger.debug("%s: Received %s", self.description, auth_msg_data)
+        connection = await auth.async_handle(auth_msg_data)
+        # As the webserver is now started before the start
+        # event we do not want to block for websocket responses
+        #
+        # We only start the writer queue after the auth phase is completed
+        # since there is no need to queue messages before the auth phase
+        self._connection = connection
+        self._writer_task = create_eager_task(self._writer(connection, send_bytes_text))
+        self._hass.data[DATA_CONNECTIONS] = self._hass.data.get(DATA_CONNECTIONS, 0) + 1
+        async_dispatcher_send(self._hass, SIGNAL_WEBSOCKET_CONNECTED)
+
+        self._authenticated = True
+        return connection
+
+    @callback
+    def _async_increase_writer_limit(self, writer: WebSocketWriter) -> None:
+        #
+        #
+        # Our websocket implementation is backed by a deque
+        #
+        # As back-pressure builds, the queue will back up and use more memory
+        # until we disconnect the client when the queue size reaches
+        # MAX_PENDING_MSG. When we are generating a high volume of websocket messages,
+        # we hit a bottleneck in aiohttp where it will wait for
+        # the buffer to drain before sending the next message and messages
+        # start backing up in the queue.
+        #
+        # https://github.com/aio-libs/aiohttp/issues/1367 added drains
+        # to the websocket writer to handle malicious clients and network issues.
+        # The drain causes multiple problems for us since the buffer cannot be
+        # drained fast enough when we deliver a high volume or large messages:
+        #
+        # - We end up disconnecting the client. The client will then reconnect,
+        # and the cycle repeats itself, which results in a significant amount of
+        # CPU usage.
+        #
+        # - Messages latency increases because messages cannot be moved into
+        # the TCP buffer because it is blocked waiting for the drain to happen because
+        # of the low default limit of 16KiB. By increasing the limit, we instead
+        # rely on the underlying TCP buffer and stack to deliver the messages which
+        # can typically happen much faster.
+        #
+        # After the auth phase is completed, and we are not concerned about
+        # the user being a malicious client, we set the limit to force a drain
+        # to 1MiB. 1MiB is the maximum expected size of the serialized entity
+        # registry, which is the largest message we usually send.
+        #
+        # https://github.com/aio-libs/aiohttp/commit/b3c80ee3f7d5d8f0b8bc27afe52e4d46621eaf99
+        # added a way to set the limit, but there is no way to actually
+        # reach the code to set the limit, so we have to set it directly.
+        #
+        writer._limit = 2**20  # noqa: SLF001
+
+    async def _async_websocket_command_phase(
+        self,
+        connection: ActiveConnection,
+        send_bytes_text: Callable[[bytes], Coroutine[Any, Any, None]],
+    ) -> None:
+        """Handle the command phase of the websocket connection."""
+        wsock = self._wsock
+        async_handle_str = connection.async_handle
+        async_handle_binary = connection.async_handle_binary
+        _debug_enabled = partial(self._logger.isEnabledFor, logging.DEBUG)
+
+        # Command phase
+        while not wsock.closed:
+            msg = await wsock.receive()
+
+            if msg.type in (WSMsgType.CLOSE, WSMsgType.CLOSED, WSMsgType.CLOSING):
+                break
+
+            if msg.type is WSMsgType.BINARY:
+                if len(msg.data) < 1:
+                    raise Disconnect("Received invalid binary message.")
+
+                handler = msg.data[0]
+                payload = msg.data[1:]
+                async_handle_binary(handler, payload)
+                continue
+
+            if msg.type is not WSMsgType.TEXT:
+                raise Disconnect("Received non-Text message.")
+
+            try:
+                command_msg_data = json_loads(msg.data)
+            except ValueError as ex:
+                raise Disconnect("Received invalid JSON.") from ex
+
+            if _debug_enabled():
+                self._logger.debug(
+                    "%s: Received %s", self.description, command_msg_data
+                )
+
+            # command_msg_data is always deserialized from JSON as a list
+            if type(command_msg_data) is not list:  # noqa: E721
+                async_handle_str(command_msg_data)
+                continue
+
+            for split_msg in command_msg_data:
+                async_handle_str(split_msg)
+
+    async def _async_cleanup_writer_and_close(
+        self, disconnect_warn: str | None, connection: ActiveConnection | None
+    ) -> None:
+        """Cleanup the writer and close the websocket."""
+        # If the writer gets canceled we still need to close the websocket
+        # so we have another finally block to make sure we close the websocket
+        # if the writer gets canceled.
+        wsock = self._wsock
+        hass = self._hass
+        logger = self._logger
+        try:
+            if self._writer_task:
+                await self._writer_task
+        finally:
+            try:
+                # Make sure all error messages are written before closing
+                await wsock.close()
+            finally:
+                if disconnect_warn is None:
+                    logger.debug("%s: Disconnected", self.description)
+                else:
+                    logger.warning(
+                        "%s: Disconnected: %s", self.description, disconnect_warn
+                    )
+
+                if connection is not None:
+                    hass.data[DATA_CONNECTIONS] -= 1
+                    self._connection = None
+
+                async_dispatcher_send(hass, SIGNAL_WEBSOCKET_DISCONNECTED)
+
+                # Break reference cycles to make sure GC can happen sooner
+                self._wsock = None  # type: ignore[assignment]
+                self._request = None  # type: ignore[assignment]
+                self._hass = None  # type: ignore[assignment]
+                self._logger = None  # type: ignore[assignment]
+                self._message_queue = None  # type: ignore[assignment]
+                self._handle_task = None
+                self._writer_task = None
+                self._ready_future = None

--- a/tests/components/websocket_api/test_http.py
+++ b/tests/components/websocket_api/test_http.py
@@ -363,12 +363,12 @@ async def test_non_json_message(
     assert "bad=<object" in caplog.text
 
 
-async def test_prepare_fail(
+async def test_prepare_fail_timeout(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test failing to prepare."""
+    """Test failing to prepare due to timeout."""
     with (
         patch(
             "homeassistant.components.websocket_api.http.web.WebSocketResponse.prepare",
@@ -379,6 +379,24 @@ async def test_prepare_fail(
         await hass_ws_client(hass)
 
     assert "Timeout preparing request" in caplog.text
+
+
+async def test_prepare_fail_connection_reset(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test failing to prepare due to connection reset."""
+    with (
+        patch(
+            "homeassistant.components.websocket_api.http.web.WebSocketResponse.prepare",
+            side_effect=(ConnectionResetError, web.WebSocketResponse.prepare),
+        ),
+        pytest.raises(WSServerHandshakeError),
+    ):
+        await hass_ws_client(hass)
+
+    assert "Connection reset by peer while preparing WebSocket" in caplog.text
 
 
 async def test_enable_coalesce(

--- a/tests/components/websocket_api/test_http.py
+++ b/tests/components/websocket_api/test_http.py
@@ -363,12 +363,12 @@ async def test_non_json_message(
     assert "bad=<object" in caplog.text
 
 
-async def test_prepare_fail_timeout(
+async def test_prepare_fail(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test failing to prepare due to timeout."""
+    """Test failing to prepare."""
     with (
         patch(
             "homeassistant.components.websocket_api.http.web.WebSocketResponse.prepare",
@@ -379,24 +379,6 @@ async def test_prepare_fail_timeout(
         await hass_ws_client(hass)
 
     assert "Timeout preparing request" in caplog.text
-
-
-async def test_prepare_fail_connection_reset(
-    hass: HomeAssistant,
-    hass_ws_client: WebSocketGenerator,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test failing to prepare due to connection reset."""
-    with (
-        patch(
-            "homeassistant.components.websocket_api.http.web.WebSocketResponse.prepare",
-            side_effect=(ConnectionResetError, web.WebSocketResponse.prepare),
-        ),
-        pytest.raises(WSServerHandshakeError),
-    ):
-        await hass_ws_client(hass)
-
-    assert "Connection reset by peer while preparing WebSocket" in caplog.text
 
 
 async def test_enable_coalesce(


### PR DESCRIPTION
broken out from https://github.com/home-assistant/core/pull/124173

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


The linter started complaining about the complexity of `async_handle` in https://github.com/home-assistant/core/pull/124173 when I added the exception catch for `ConnectionResetError` so I broke out the code in the `try:` block into 

`_async_handle_auth_phase`, `_async_increase_writer_limit`, `_async_websocket_command_phase`, and `_async_cleanup_writer_and_close`

This PR is likely a lot easier to review with whitespace off


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
