### PR TITLE
Add missing hass type hint in component tests (g)

### DIFF
--- a/tests/components/generic_hygrostat/test_humidifier.py
+++ b/tests/components/generic_hygrostat/test_humidifier.py
@@ -32,10 +32,12 @@ from homeassistant.core import (
     DOMAIN as HOMEASSISTANT_DOMAIN,
     CoreState,
     HomeAssistant,
+    ServiceCall,
     State,
     callback,
 )
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.typing import StateType
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -206,7 +208,7 @@ async def test_unique_id(
     assert entry.unique_id == unique_id
 
 
-def _setup_sensor(hass, humidity):
+def _setup_sensor(hass: HomeAssistant, humidity: StateType) -> None:
     """Set up the test sensor."""
     hass.states.async_set(ENT_SENSOR, humidity)
 
@@ -669,13 +671,13 @@ async def test_operation_mode_humidify(hass: HomeAssistant) -> None:
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-async def _setup_switch(hass, is_on):
+async def _setup_switch(hass: HomeAssistant, is_on: bool) -> list[ServiceCall]:
     """Set up the test switch."""
     hass.states.async_set(ENT_SWITCH, STATE_ON if is_on else STATE_OFF)
     calls = []
 
     @callback
-    def log_call(call):
+    def log_call(call: ServiceCall) -> None:
         """Log service calls."""
         calls.append(call)
 
@@ -1615,7 +1617,7 @@ async def test_restore_state_uncoherence_case(hass: HomeAssistant) -> None:
     assert state.state == STATE_OFF
 
 
-async def _setup_humidifier(hass):
+async def _setup_humidifier(hass: HomeAssistant) -> None:
     assert await async_setup_component(
         hass,
         DOMAIN,
@@ -1635,7 +1637,9 @@ async def _setup_humidifier(hass):
     await hass.async_block_till_done()
 
 
-def _mock_restore_cache(hass, humidity=40, state=STATE_OFF):
+def _mock_restore_cache(
+    hass: HomeAssistant, humidity: int = 40, state: str = STATE_OFF
+) -> None:
     mock_restore_cache(
         hass,
         (

--- a/tests/components/generic_thermostat/test_climate.py
+++ b/tests/components/generic_thermostat/test_climate.py
@@ -40,11 +40,13 @@ from homeassistant.core import (
     DOMAIN as HOMEASSISTANT_DOMAIN,
     CoreState,
     HomeAssistant,
+    ServiceCall,
     State,
     callback,
 )
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.typing import StateType
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 from homeassistant.util.unit_system import METRIC_SYSTEM, US_CUSTOMARY_SYSTEM
@@ -208,7 +210,7 @@ async def test_unique_id(
     assert entry.unique_id == unique_id
 
 
-def _setup_sensor(hass, temp):
+def _setup_sensor(hass: HomeAssistant, temp: StateType) -> None:
     """Set up the test sensor."""
     hass.states.async_set(ENT_SENSOR, temp)
 
@@ -594,13 +596,13 @@ async def test_hvac_mode_heat(hass: HomeAssistant) -> None:
     assert call.data["entity_id"] == ENT_SWITCH
 
 
-def _setup_switch(hass, is_on):
+def _setup_switch(hass: HomeAssistant, is_on: bool) -> list[ServiceCall]:
     """Set up the test switch."""
     hass.states.async_set(ENT_SWITCH, STATE_ON if is_on else STATE_OFF)
     calls = []
 
     @callback
-    def log_call(call):
+    def log_call(call: ServiceCall) -> None:
         """Log service calls."""
         calls.append(call)
 
@@ -1374,7 +1376,7 @@ async def test_restore_state_uncoherence_case(hass: HomeAssistant) -> None:
     assert state.state == HVACMode.OFF
 
 
-async def _setup_climate(hass):
+async def _setup_climate(hass: HomeAssistant) -> None:
     assert await async_setup_component(
         hass,
         DOMAIN,
@@ -1393,7 +1395,9 @@ async def _setup_climate(hass):
     )
 
 
-def _mock_restore_cache(hass, temperature=20, hvac_mode=HVACMode.OFF):
+def _mock_restore_cache(
+    hass: HomeAssistant, temperature: int = 20, hvac_mode: HVACMode = HVACMode.OFF
+) -> None:
     mock_restore_cache(
         hass,
         (

--- a/tests/components/google/test_config_flow.py
+++ b/tests/components/google/test_config_flow.py
@@ -130,7 +130,7 @@ async def primary_calendar(
     )
 
 
-async def fire_alarm(hass, point_in_time):
+async def fire_alarm(hass: HomeAssistant, point_in_time: datetime.datetime) -> None:
     """Fire an alarm and wait for callbacks to run."""
     with freeze_time(point_in_time):
         async_fire_time_changed(hass, point_in_time)

--- a/tests/components/google_generative_ai_conversation/test_conversation.py
+++ b/tests/components/google_generative_ai_conversation/test_conversation.py
@@ -1,5 +1,6 @@
 """Tests for the Google Generative AI Conversation integration conversation platform."""
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from freezegun import freeze_time
@@ -215,7 +216,9 @@ async def test_function_call(
             },
         )
 
-        def tool_call(hass, tool_input, tool_context):
+        def tool_call(
+            hass: HomeAssistant, tool_input: llm.ToolInput, tool_context: llm.LLMContext
+        ) -> dict[str, Any]:
             mock_part.function_call = None
             mock_part.text = "Hi there!"
             return {"result": "Test response"}
@@ -314,7 +317,9 @@ async def test_function_call_without_parameters(
         mock_part = MagicMock()
         mock_part.function_call = FunctionCall(name="test_tool", args={})
 
-        def tool_call(hass, tool_input, tool_context):
+        def tool_call(
+            hass: HomeAssistant, tool_input: llm.ToolInput, tool_context: llm.LLMContext
+        ) -> dict[str, Any]:
             mock_part.function_call = None
             mock_part.text = "Hi there!"
             return {"result": "Test response"}
@@ -400,7 +405,9 @@ async def test_function_exception(
         mock_part = MagicMock()
         mock_part.function_call = FunctionCall(name="test_tool", args={"param1": 1})
 
-        def tool_call(hass, tool_input, tool_context):
+        def tool_call(
+            hass: HomeAssistant, tool_input: llm.ToolInput, tool_context: llm.LLMContext
+        ) -> dict[str, Any]:
             mock_part.function_call = None
             mock_part.text = "Hi there!"
             raise HomeAssistantError("Test tool exception")

--- a/tests/components/google_pubsub/test_init.py
+++ b/tests/components/google_pubsub/test_init.py
@@ -4,6 +4,7 @@ from collections.abc import Generator
 from dataclasses import dataclass
 from datetime import datetime
 import os
+from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -111,7 +112,7 @@ async def test_full_config(hass: HomeAssistant, mock_client) -> None:
     )
 
 
-async def _setup(hass, filter_config):
+async def _setup(hass: HomeAssistant, filter_config: dict[str, Any]) -> None:
     """Shared set up for filtering tests."""
     config = {
         google_pubsub.DOMAIN: {

--- a/tests/components/google_wifi/test_sensor.py
+++ b/tests/components/google_wifi/test_sensor.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime, timedelta
 from http import HTTPStatus
+from typing import Any
 from unittest.mock import Mock, patch
 
 import requests_mock
@@ -78,7 +79,9 @@ async def test_setup_get(
     assert_setup_component(6, "sensor")
 
 
-def setup_api(hass, data, requests_mock):
+def setup_api(
+    hass: HomeAssistant | None, data: str | None, requests_mock: requests_mock.Mocker
+) -> tuple[google_wifi.GoogleWifiAPI, dict[str, Any]]:
     """Set up API with fake data."""
     resource = f"http://localhost{google_wifi.ENDPOINT}"
     now = datetime(1970, month=1, day=1)
@@ -101,7 +104,7 @@ def setup_api(hass, data, requests_mock):
     return api, sensor_dict
 
 
-def fake_delay(hass, ha_delay):
+def fake_delay(hass: HomeAssistant, ha_delay: int) -> None:
     """Fake delay to prevent update throttle."""
     hass_now = dt_util.utcnow()
     shifted_time = hass_now + timedelta(seconds=ha_delay)
@@ -220,7 +223,9 @@ def test_update_when_unavailable(
         assert sensor.state is None
 
 
-def update_side_effect(hass, requests_mock):
+def update_side_effect(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker
+) -> None:
     """Mock representation of update function."""
     api, sensor_dict = setup_api(hass, MOCK_DATA, requests_mock)
     api.data = None

--- a/tests/components/group/common.py
+++ b/tests/components/group/common.py
@@ -13,32 +13,32 @@ from homeassistant.components.group import (
     SERVICE_SET,
 )
 from homeassistant.const import ATTR_ICON, ATTR_NAME, SERVICE_RELOAD
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.loader import bind_hass
 
 
 @bind_hass
-def reload(hass):
+def reload(hass: HomeAssistant) -> None:
     """Reload the automation from config."""
     hass.add_job(async_reload, hass)
 
 
 @callback
 @bind_hass
-def async_reload(hass):
+def async_reload(hass: HomeAssistant) -> None:
     """Reload the automation from config."""
     hass.async_create_task(hass.services.async_call(DOMAIN, SERVICE_RELOAD))
 
 
 @bind_hass
 def set_group(
-    hass,
-    object_id,
-    name=None,
-    entity_ids=None,
-    icon=None,
-    add=None,
-):
+    hass: HomeAssistant,
+    object_id: str,
+    name: str | None = None,
+    entity_ids: list[str] | None = None,
+    icon: str | None = None,
+    add: list[str] | None = None,
+) -> None:
     """Create/Update a group."""
     hass.add_job(
         async_set_group,
@@ -54,13 +54,13 @@ def set_group(
 @callback
 @bind_hass
 def async_set_group(
-    hass,
-    object_id,
-    name=None,
-    entity_ids=None,
-    icon=None,
-    add=None,
-):
+    hass: HomeAssistant,
+    object_id: str,
+    name: str | None = None,
+    entity_ids: list[str] | None = None,
+    icon: str | None = None,
+    add: list[str] | None = None,
+) -> None:
     """Create/Update a group."""
     data = {
         key: value
@@ -79,7 +79,7 @@ def async_set_group(
 
 @callback
 @bind_hass
-def async_remove(hass, object_id):
+def async_remove(hass: HomeAssistant, object_id: str) -> None:
     """Remove a user group."""
     data = {ATTR_OBJECT_ID: object_id}
     hass.async_create_task(hass.services.async_call(DOMAIN, SERVICE_REMOVE, data))


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
