### PR TITLE
Improve type hints in homematicip_cloud tests

### DIFF
--- a/tests/components/homematicip_cloud/conftest.py
+++ b/tests/components/homematicip_cloud/conftest.py
@@ -8,7 +8,6 @@ from homematicip.aio.home import AsyncHome
 from homematicip.base.enums import WeatherCondition, WeatherDayTime
 import pytest
 
-from homeassistant import config_entries
 from homeassistant.components.homematicip_cloud import (
     DOMAIN as HMIPC_DOMAIN,
     async_setup as hmip_async_setup,
@@ -46,7 +45,7 @@ def mock_connection_fixture() -> AsyncConnection:
 
 
 @pytest.fixture(name="hmip_config_entry")
-def hmip_config_entry_fixture() -> config_entries.ConfigEntry:
+def hmip_config_entry_fixture() -> MockConfigEntry:
     """Create a mock config entry for homematic ip cloud."""
     entry_data = {
         HMIPC_HAPID: HAPID,
@@ -66,8 +65,8 @@ def hmip_config_entry_fixture() -> config_entries.ConfigEntry:
 
 @pytest.fixture(name="default_mock_hap_factory")
 async def default_mock_hap_factory_fixture(
-    hass: HomeAssistant, mock_connection, hmip_config_entry
-) -> HomematicipHAP:
+    hass: HomeAssistant, mock_connection, hmip_config_entry: MockConfigEntry
+) -> HomeFactory:
     """Create a mocked homematic access point."""
     return HomeFactory(hass, mock_connection, hmip_config_entry)
 
@@ -94,7 +93,7 @@ def dummy_config_fixture() -> ConfigType:
 
 @pytest.fixture(name="mock_hap_with_service")
 async def mock_hap_with_service_fixture(
-    hass: HomeAssistant, default_mock_hap_factory, dummy_config
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory, dummy_config
 ) -> HomematicipHAP:
     """Create a fake homematic access point with hass services."""
     mock_hap = await default_mock_hap_factory.async_get_mock_hap()

--- a/tests/components/homematicip_cloud/helper.py
+++ b/tests/components/homematicip_cloud/helper.py
@@ -1,6 +1,7 @@
 """Helper for HomematicIP Cloud Tests."""
 
 import json
+from typing import Any
 from unittest.mock import Mock, patch
 
 from homematicip.aio.class_maps import (
@@ -11,19 +12,19 @@ from homematicip.aio.class_maps import (
 from homematicip.aio.device import AsyncDevice
 from homematicip.aio.group import AsyncGroup
 from homematicip.aio.home import AsyncHome
+from homematicip.base.homematicip_object import HomeMaticIPObject
 from homematicip.home import Home
 
-from homeassistant import config_entries
 from homeassistant.components.homematicip_cloud import DOMAIN as HMIPC_DOMAIN
 from homeassistant.components.homematicip_cloud.generic_entity import (
     ATTR_IS_GROUP,
     ATTR_MODEL_TYPE,
 )
 from homeassistant.components.homematicip_cloud.hap import HomematicipHAP
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
 
-from tests.common import load_fixture
+from tests.common import MockConfigEntry, load_fixture
 
 HAPID = "3014F7110000000000000001"
 HAPPIN = "5678"
@@ -31,7 +32,13 @@ AUTH_TOKEN = "1234"
 FIXTURE_DATA = load_fixture("homematicip_cloud.json", "homematicip_cloud")
 
 
-def get_and_check_entity_basics(hass, mock_hap, entity_id, entity_name, device_model):
+def get_and_check_entity_basics(
+    hass: HomeAssistant,
+    mock_hap: HomematicipHAP,
+    entity_id: str,
+    entity_name: str,
+    device_model: str | None,
+) -> tuple[State, HomeMaticIPObject | None]:
     """Get and test basic device."""
     ha_state = hass.states.get(entity_id)
     assert ha_state is not None
@@ -50,7 +57,12 @@ def get_and_check_entity_basics(hass, mock_hap, entity_id, entity_name, device_m
 
 
 async def async_manipulate_test_data(
-    hass, hmip_device, attribute, new_value, channel=1, fire_device=None
+    hass: HomeAssistant,
+    hmip_device: HomeMaticIPObject,
+    attribute: str,
+    new_value: Any,
+    channel: int = 1,
+    fire_device: HomeMaticIPObject | None = None,
 ):
     """Set new value on hmip device."""
     if channel == 1:
@@ -76,7 +88,7 @@ class HomeFactory:
         self,
         hass: HomeAssistant,
         mock_connection,
-        hmip_config_entry: config_entries.ConfigEntry,
+        hmip_config_entry: MockConfigEntry,
     ) -> None:
         """Initialize the Factory."""
         self.hass = hass

--- a/tests/components/homematicip_cloud/test_alarm_control_panel.py
+++ b/tests/components/homematicip_cloud/test_alarm_control_panel.py
@@ -1,5 +1,7 @@
 """Tests for HomematicIP Cloud alarm control panel."""
 
+from homematicip.aio.home import AsyncHome
+
 from homeassistant.components.alarm_control_panel import (
     DOMAIN as ALARM_CONTROL_PANEL_DOMAIN,
 )
@@ -13,12 +15,16 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from .helper import get_and_check_entity_basics
+from .helper import HomeFactory, get_and_check_entity_basics
 
 
 async def _async_manipulate_security_zones(
-    hass, home, internal_active=False, external_active=False, alarm_triggered=False
-):
+    hass: HomeAssistant,
+    home: AsyncHome,
+    internal_active: bool = False,
+    external_active: bool = False,
+    alarm_triggered: bool = False,
+) -> None:
     """Set new values on hmip security zones."""
     json = home._rawJSONData
     json["functionalHomes"]["SECURITY_AND_ALARM"]["alarmActive"] = alarm_triggered
@@ -50,7 +56,7 @@ async def test_manually_configured_platform(hass: HomeAssistant) -> None:
 
 
 async def test_hmip_alarm_control_panel(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipAlarmControlPanel."""
     entity_id = "alarm_control_panel.hmip_alarm_control_panel"

--- a/tests/components/homematicip_cloud/test_binary_sensor.py
+++ b/tests/components/homematicip_cloud/test_binary_sensor.py
@@ -27,7 +27,7 @@ from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from .helper import async_manipulate_test_data, get_and_check_entity_basics
+from .helper import HomeFactory, async_manipulate_test_data, get_and_check_entity_basics
 
 
 async def test_manually_configured_platform(hass: HomeAssistant) -> None:
@@ -41,7 +41,7 @@ async def test_manually_configured_platform(hass: HomeAssistant) -> None:
 
 
 async def test_hmip_home_cloud_connection_sensor(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipCloudConnectionSensor."""
     entity_id = "binary_sensor.cloud_connection"
@@ -64,7 +64,7 @@ async def test_hmip_home_cloud_connection_sensor(
 
 
 async def test_hmip_acceleration_sensor(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipAccelerationSensor."""
     entity_id = "binary_sensor.garagentor"
@@ -103,7 +103,7 @@ async def test_hmip_acceleration_sensor(
 
 
 async def test_hmip_tilt_vibration_sensor(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipTiltVibrationSensor."""
     entity_id = "binary_sensor.garage_neigungs_und_erschutterungssensor"
@@ -141,7 +141,7 @@ async def test_hmip_tilt_vibration_sensor(
 
 
 async def test_hmip_contact_interface(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipContactInterface."""
     entity_id = "binary_sensor.kontakt_schnittstelle_unterputz_1_fach"
@@ -166,7 +166,7 @@ async def test_hmip_contact_interface(
 
 
 async def test_hmip_shutter_contact(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipShutterContact."""
     entity_id = "binary_sensor.fenstergriffsensor"
@@ -208,7 +208,7 @@ async def test_hmip_shutter_contact(
 
 
 async def test_hmip_shutter_contact_optical(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipShutterContact."""
     entity_id = "binary_sensor.sitzplatzture"
@@ -240,7 +240,7 @@ async def test_hmip_shutter_contact_optical(
 
 
 async def test_hmip_motion_detector(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipMotionDetector."""
     entity_id = "binary_sensor.bewegungsmelder_fur_55er_rahmen_innen"
@@ -261,7 +261,7 @@ async def test_hmip_motion_detector(
 
 
 async def test_hmip_presence_detector(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipPresenceDetector."""
     entity_id = "binary_sensor.spi_1"
@@ -287,7 +287,7 @@ async def test_hmip_presence_detector(
 
 
 async def test_hmip_pluggable_mains_failure_surveillance_sensor(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipPresenceDetector."""
     entity_id = "binary_sensor.netzausfalluberwachung"
@@ -308,7 +308,7 @@ async def test_hmip_pluggable_mains_failure_surveillance_sensor(
 
 
 async def test_hmip_smoke_detector(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipSmokeDetector."""
     entity_id = "binary_sensor.rauchwarnmelder"
@@ -342,7 +342,7 @@ async def test_hmip_smoke_detector(
 
 
 async def test_hmip_water_detector(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipWaterDetector."""
     entity_id = "binary_sensor.wassersensor"
@@ -378,7 +378,9 @@ async def test_hmip_water_detector(
     assert ha_state.state == STATE_OFF
 
 
-async def test_hmip_storm_sensor(hass: HomeAssistant, default_mock_hap_factory) -> None:
+async def test_hmip_storm_sensor(
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
+) -> None:
     """Test HomematicipStormSensor."""
     entity_id = "binary_sensor.weather_sensor_plus_storm"
     entity_name = "Weather Sensor – plus Storm"
@@ -397,7 +399,9 @@ async def test_hmip_storm_sensor(hass: HomeAssistant, default_mock_hap_factory) 
     assert ha_state.state == STATE_ON
 
 
-async def test_hmip_rain_sensor(hass: HomeAssistant, default_mock_hap_factory) -> None:
+async def test_hmip_rain_sensor(
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
+) -> None:
     """Test HomematicipRainSensor."""
     entity_id = "binary_sensor.wettersensor_pro_raining"
     entity_name = "Wettersensor - pro Raining"
@@ -417,7 +421,7 @@ async def test_hmip_rain_sensor(hass: HomeAssistant, default_mock_hap_factory) -
 
 
 async def test_hmip_sunshine_sensor(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipSunshineSensor."""
     entity_id = "binary_sensor.wettersensor_pro_sunshine"
@@ -439,7 +443,7 @@ async def test_hmip_sunshine_sensor(
 
 
 async def test_hmip_battery_sensor(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipSunshineSensor."""
     entity_id = "binary_sensor.wohnungsture_battery"
@@ -460,7 +464,7 @@ async def test_hmip_battery_sensor(
 
 
 async def test_hmip_security_zone_sensor_group(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipSecurityZoneSensorGroup."""
     entity_id = "binary_sensor.internal_securityzone"
@@ -497,7 +501,7 @@ async def test_hmip_security_zone_sensor_group(
 
 
 async def test_hmip_security_sensor_group(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipSecuritySensorGroup."""
     entity_id = "binary_sensor.buro_sensors"
@@ -571,7 +575,7 @@ async def test_hmip_security_sensor_group(
 
 
 async def test_hmip_multi_contact_interface(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipMultiContactInterface."""
     entity_id = "binary_sensor.wired_eingangsmodul_32_fach_channel5"

--- a/tests/components/homematicip_cloud/test_button.py
+++ b/tests/components/homematicip_cloud/test_button.py
@@ -7,11 +7,13 @@ from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
-from .helper import get_and_check_entity_basics
+from .helper import HomeFactory, get_and_check_entity_basics
 
 
 async def test_hmip_garage_door_controller_button(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, default_mock_hap_factory
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    default_mock_hap_factory: HomeFactory,
 ) -> None:
     """Test HomematicipGarageDoorControllerButton."""
     entity_id = "button.garagentor"

--- a/tests/components/homematicip_cloud/test_climate.py
+++ b/tests/components/homematicip_cloud/test_climate.py
@@ -28,7 +28,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.setup import async_setup_component
 
-from .helper import HAPID, async_manipulate_test_data, get_and_check_entity_basics
+from .helper import (
+    HAPID,
+    HomeFactory,
+    async_manipulate_test_data,
+    get_and_check_entity_basics,
+)
 
 
 async def test_manually_configured_platform(hass: HomeAssistant) -> None:
@@ -40,7 +45,7 @@ async def test_manually_configured_platform(hass: HomeAssistant) -> None:
 
 
 async def test_hmip_heating_group_heat(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipHeatingGroup."""
     entity_id = "climate.badezimmer"
@@ -257,7 +262,7 @@ async def test_hmip_heating_group_heat(
 
 
 async def test_hmip_heating_group_cool(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipHeatingGroup."""
     entity_id = "climate.badezimmer"
@@ -380,7 +385,7 @@ async def test_hmip_heating_group_cool(
 
 
 async def test_hmip_heating_group_heat_with_switch(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipHeatingGroup."""
     entity_id = "climate.schlafzimmer"
@@ -411,7 +416,7 @@ async def test_hmip_heating_group_heat_with_switch(
 
 
 async def test_hmip_heating_group_heat_with_radiator(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipHeatingGroup."""
     entity_id = "climate.vorzimmer"
@@ -440,7 +445,7 @@ async def test_hmip_heating_group_heat_with_radiator(
 
 
 async def test_hmip_heating_profile_default_name(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test visible profile 1 without a name should be displayed as 'Default'."""
     entity_id = "climate.vorzimmer3"
@@ -465,7 +470,7 @@ async def test_hmip_heating_profile_default_name(
 
 
 async def test_hmip_heating_profile_naming(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test Heating Profile Naming."""
     entity_id = "climate.vorzimmer2"
@@ -490,7 +495,7 @@ async def test_hmip_heating_profile_naming(
 
 
 async def test_hmip_heating_profile_name_not_in_list(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test set profile when profile is not in available profiles."""
     expected_profile = "Testprofile"
@@ -684,7 +689,7 @@ async def test_hmip_set_home_cooling_mode(
 
 
 async def test_hmip_heating_group_services(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipHeatingGroup services."""
     entity_id = "climate.badezimmer"

--- a/tests/components/homematicip_cloud/test_cover.py
+++ b/tests/components/homematicip_cloud/test_cover.py
@@ -12,7 +12,7 @@ from homeassistant.const import STATE_CLOSED, STATE_OPEN, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from .helper import async_manipulate_test_data, get_and_check_entity_basics
+from .helper import HomeFactory, async_manipulate_test_data, get_and_check_entity_basics
 
 
 async def test_manually_configured_platform(hass: HomeAssistant) -> None:
@@ -24,7 +24,7 @@ async def test_manually_configured_platform(hass: HomeAssistant) -> None:
 
 
 async def test_hmip_cover_shutter(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipCoverShutte."""
     entity_id = "cover.broll_1"
@@ -90,7 +90,9 @@ async def test_hmip_cover_shutter(
     assert ha_state.state == STATE_UNKNOWN
 
 
-async def test_hmip_cover_slats(hass: HomeAssistant, default_mock_hap_factory) -> None:
+async def test_hmip_cover_slats(
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
+) -> None:
     """Test HomematicipCoverSlats."""
     entity_id = "cover.sofa_links"
     entity_name = "Sofa links"
@@ -165,7 +167,7 @@ async def test_hmip_cover_slats(hass: HomeAssistant, default_mock_hap_factory) -
 
 
 async def test_hmip_multi_cover_slats(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipCoverSlats."""
     entity_id = "cover.wohnzimmer_fenster"
@@ -244,7 +246,9 @@ async def test_hmip_multi_cover_slats(
     assert ha_state.state == STATE_UNKNOWN
 
 
-async def test_hmip_blind_module(hass: HomeAssistant, default_mock_hap_factory) -> None:
+async def test_hmip_blind_module(
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
+) -> None:
     """Test HomematicipBlindModule."""
     entity_id = "cover.sonnenschutz_balkontur"
     entity_name = "Sonnenschutz Balkontür"
@@ -355,7 +359,7 @@ async def test_hmip_blind_module(hass: HomeAssistant, default_mock_hap_factory) 
 
 
 async def test_hmip_garage_door_tormatic(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipCoverShutte."""
     entity_id = "cover.garage_door_module"
@@ -404,7 +408,7 @@ async def test_hmip_garage_door_tormatic(
 
 
 async def test_hmip_garage_door_hoermann(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipCoverShutte."""
     entity_id = "cover.garage_door"
@@ -453,7 +457,7 @@ async def test_hmip_garage_door_hoermann(
 
 
 async def test_hmip_cover_shutter_group(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipCoverShutteGroup."""
     entity_id = "cover.rollos_shuttergroup"
@@ -518,7 +522,7 @@ async def test_hmip_cover_shutter_group(
 
 
 async def test_hmip_cover_slats_group(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test slats with HomematicipCoverShutteGroup."""
     entity_id = "cover.rollos_shuttergroup"

--- a/tests/components/homematicip_cloud/test_device.py
+++ b/tests/components/homematicip_cloud/test_device.py
@@ -17,9 +17,11 @@ from .helper import (
     get_and_check_entity_basics,
 )
 
+from tests.common import MockConfigEntry
+
 
 async def test_hmip_load_all_supported_devices(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Ensure that all supported devices could be loaded."""
     mock_hap = await default_mock_hap_factory.async_get_mock_hap(
@@ -33,7 +35,7 @@ async def test_hmip_remove_device(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     device_registry: dr.DeviceRegistry,
-    default_mock_hap_factory,
+    default_mock_hap_factory: HomeFactory,
 ) -> None:
     """Test Remove of hmip device."""
     entity_id = "light.treppe_ch"
@@ -67,8 +69,8 @@ async def test_hmip_add_device(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     device_registry: dr.DeviceRegistry,
-    default_mock_hap_factory,
-    hmip_config_entry,
+    default_mock_hap_factory: HomeFactory,
+    hmip_config_entry: MockConfigEntry,
 ) -> None:
     """Test Remove of hmip device."""
     entity_id = "light.treppe_ch"
@@ -121,7 +123,7 @@ async def test_hmip_remove_group(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     device_registry: dr.DeviceRegistry,
-    default_mock_hap_factory,
+    default_mock_hap_factory: HomeFactory,
 ) -> None:
     """Test Remove of hmip group."""
     entity_id = "switch.strom_group"
@@ -149,7 +151,7 @@ async def test_hmip_remove_group(
 
 
 async def test_all_devices_unavailable_when_hap_not_connected(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test make all devices unavaulable when hap is not connected."""
     entity_id = "light.treppe_ch"
@@ -174,7 +176,9 @@ async def test_all_devices_unavailable_when_hap_not_connected(
     assert ha_state.state == STATE_UNAVAILABLE
 
 
-async def test_hap_reconnected(hass: HomeAssistant, default_mock_hap_factory) -> None:
+async def test_hap_reconnected(
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
+) -> None:
     """Test reconnect hap."""
     entity_id = "light.treppe_ch"
     entity_name = "Treppe CH"
@@ -205,7 +209,7 @@ async def test_hap_reconnected(hass: HomeAssistant, default_mock_hap_factory) ->
 
 
 async def test_hap_with_name(
-    hass: HomeAssistant, mock_connection, hmip_config_entry
+    hass: HomeAssistant, mock_connection, hmip_config_entry: MockConfigEntry
 ) -> None:
     """Test hap with name."""
     home_name = "TestName"
@@ -232,7 +236,7 @@ async def test_hap_with_name(
 
 
 async def test_hmip_reset_energy_counter_services(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test reset_energy_counter service."""
     entity_id = "switch.pc"
@@ -267,7 +271,7 @@ async def test_hmip_multi_area_device(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     device_registry: dr.DeviceRegistry,
-    default_mock_hap_factory,
+    default_mock_hap_factory: HomeFactory,
 ) -> None:
     """Test multi area device. Check if devices are created and referenced."""
     entity_id = "binary_sensor.wired_eingangsmodul_32_fach_channel5"

--- a/tests/components/homematicip_cloud/test_hap.py
+++ b/tests/components/homematicip_cloud/test_hap.py
@@ -22,7 +22,7 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .helper import HAPID, HAPPIN
+from .helper import HAPID, HAPPIN, HomeFactory
 
 from tests.common import MockConfigEntry
 
@@ -114,7 +114,7 @@ async def test_hap_setup_connection_error() -> None:
 
 
 async def test_hap_reset_unloads_entry_if_setup(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test calling reset while the entry has been setup."""
     mock_hap = await default_mock_hap_factory.async_get_mock_hap()
@@ -129,7 +129,7 @@ async def test_hap_reset_unloads_entry_if_setup(
 
 
 async def test_hap_create(
-    hass: HomeAssistant, hmip_config_entry, simple_mock_home
+    hass: HomeAssistant, hmip_config_entry: MockConfigEntry, simple_mock_home
 ) -> None:
     """Mock AsyncHome to execute get_hap."""
     hass.config.components.add(HMIPC_DOMAIN)
@@ -141,7 +141,7 @@ async def test_hap_create(
 
 
 async def test_hap_create_exception(
-    hass: HomeAssistant, hmip_config_entry, mock_connection_init
+    hass: HomeAssistant, hmip_config_entry: MockConfigEntry, mock_connection_init
 ) -> None:
     """Mock AsyncHome to execute get_hap."""
     hass.config.components.add(HMIPC_DOMAIN)

--- a/tests/components/homematicip_cloud/test_init.py
+++ b/tests/components/homematicip_cloud/test_init.py
@@ -100,7 +100,7 @@ async def test_config_already_registered_not_passed_to_config_entry(
 
 
 async def test_load_entry_fails_due_to_connection_error(
-    hass: HomeAssistant, hmip_config_entry, mock_connection_init
+    hass: HomeAssistant, hmip_config_entry: MockConfigEntry, mock_connection_init
 ) -> None:
     """Test load entry fails due to connection error."""
     hmip_config_entry.add_to_hass(hass)
@@ -116,7 +116,7 @@ async def test_load_entry_fails_due_to_connection_error(
 
 
 async def test_load_entry_fails_due_to_generic_exception(
-    hass: HomeAssistant, hmip_config_entry
+    hass: HomeAssistant, hmip_config_entry: MockConfigEntry
 ) -> None:
     """Test load entry fails due to generic exception."""
     hmip_config_entry.add_to_hass(hass)

--- a/tests/components/homematicip_cloud/test_light.py
+++ b/tests/components/homematicip_cloud/test_light.py
@@ -16,7 +16,7 @@ from homeassistant.const import ATTR_SUPPORTED_FEATURES, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from .helper import async_manipulate_test_data, get_and_check_entity_basics
+from .helper import HomeFactory, async_manipulate_test_data, get_and_check_entity_basics
 
 
 async def test_manually_configured_platform(hass: HomeAssistant) -> None:
@@ -27,7 +27,9 @@ async def test_manually_configured_platform(hass: HomeAssistant) -> None:
     assert not hass.data.get(HMIPC_DOMAIN)
 
 
-async def test_hmip_light(hass: HomeAssistant, default_mock_hap_factory) -> None:
+async def test_hmip_light(
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
+) -> None:
     """Test HomematicipLight."""
     entity_id = "light.treppe_ch"
     entity_name = "Treppe CH"
@@ -73,7 +75,7 @@ async def test_hmip_light(hass: HomeAssistant, default_mock_hap_factory) -> None
 
 
 async def test_hmip_notification_light(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipNotificationLight."""
     entity_id = "light.alarm_status"
@@ -171,7 +173,9 @@ async def test_hmip_notification_light(
     assert not ha_state.attributes.get(ATTR_BRIGHTNESS)
 
 
-async def test_hmip_dimmer(hass: HomeAssistant, default_mock_hap_factory) -> None:
+async def test_hmip_dimmer(
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
+) -> None:
     """Test HomematicipDimmer."""
     entity_id = "light.schlafzimmerlicht"
     entity_name = "Schlafzimmerlicht"
@@ -230,7 +234,7 @@ async def test_hmip_dimmer(hass: HomeAssistant, default_mock_hap_factory) -> Non
 
 
 async def test_hmip_light_measuring(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipLightMeasuring."""
     entity_id = "light.flur_oben"
@@ -276,7 +280,7 @@ async def test_hmip_light_measuring(
 
 
 async def test_hmip_wired_multi_dimmer(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipMultiDimmer."""
     entity_id = "light.raumlich_kuche"
@@ -336,7 +340,7 @@ async def test_hmip_wired_multi_dimmer(
 
 
 async def test_hmip_din_rail_dimmer_3_channel1(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicIP DinRailDimmer3 Channel 1."""
     entity_id = "light.3_dimmer_channel1"
@@ -395,7 +399,7 @@ async def test_hmip_din_rail_dimmer_3_channel1(
 
 
 async def test_hmip_din_rail_dimmer_3_channel2(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicIP DinRailDimmer3 Channel 2."""
     entity_id = "light.3_dimmer_channel2"
@@ -454,7 +458,7 @@ async def test_hmip_din_rail_dimmer_3_channel2(
 
 
 async def test_hmip_din_rail_dimmer_3_channel3(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicIP DinRailDimmer3 Channel 3."""
     entity_id = "light.esstisch"

--- a/tests/components/homematicip_cloud/test_lock.py
+++ b/tests/components/homematicip_cloud/test_lock.py
@@ -17,7 +17,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
-from .helper import async_manipulate_test_data, get_and_check_entity_basics
+from .helper import HomeFactory, async_manipulate_test_data, get_and_check_entity_basics
 
 
 async def test_manually_configured_platform(hass: HomeAssistant) -> None:
@@ -29,7 +29,7 @@ async def test_manually_configured_platform(hass: HomeAssistant) -> None:
 
 
 async def test_hmip_doorlockdrive(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipDoorLockDrive."""
     entity_id = "lock.haustuer"
@@ -87,7 +87,7 @@ async def test_hmip_doorlockdrive(
 
 
 async def test_hmip_doorlockdrive_handle_errors(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipDoorLockDrive."""
     entity_id = "lock.haustuer"

--- a/tests/components/homematicip_cloud/test_sensor.py
+++ b/tests/components/homematicip_cloud/test_sensor.py
@@ -36,7 +36,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from .helper import async_manipulate_test_data, get_and_check_entity_basics
+from .helper import HomeFactory, async_manipulate_test_data, get_and_check_entity_basics
 
 
 async def test_manually_configured_platform(hass: HomeAssistant) -> None:
@@ -48,7 +48,7 @@ async def test_manually_configured_platform(hass: HomeAssistant) -> None:
 
 
 async def test_hmip_accesspoint_status(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipSwitch."""
     entity_id = "sensor.home_control_access_point_duty_cycle"
@@ -67,7 +67,7 @@ async def test_hmip_accesspoint_status(
 
 
 async def test_hmip_heating_thermostat(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipHeatingThermostat."""
     entity_id = "sensor.heizkorperthermostat_heating"
@@ -103,7 +103,7 @@ async def test_hmip_heating_thermostat(
 
 
 async def test_hmip_humidity_sensor(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipHumiditySensor."""
     entity_id = "sensor.bwth_1_humidity"
@@ -128,7 +128,7 @@ async def test_hmip_humidity_sensor(
 
 
 async def test_hmip_temperature_sensor1(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipTemperatureSensor."""
     entity_id = "sensor.bwth_1_temperature"
@@ -155,7 +155,7 @@ async def test_hmip_temperature_sensor1(
 
 
 async def test_hmip_temperature_sensor2(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipTemperatureSensor."""
     entity_id = "sensor.heizkorperthermostat_temperature"
@@ -182,7 +182,7 @@ async def test_hmip_temperature_sensor2(
 
 
 async def test_hmip_temperature_sensor3(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipTemperatureSensor."""
     entity_id = "sensor.raumbediengerat_analog_temperature"
@@ -209,7 +209,7 @@ async def test_hmip_temperature_sensor3(
 
 
 async def test_hmip_thermostat_evo_heating(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipHeatingThermostat for HmIP-eTRV-E."""
     entity_id = "sensor.thermostat_evo_heating"
@@ -231,7 +231,7 @@ async def test_hmip_thermostat_evo_heating(
 
 
 async def test_hmip_thermostat_evo_temperature(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipTemperatureSensor."""
     entity_id = "sensor.thermostat_evo_temperature"
@@ -256,7 +256,9 @@ async def test_hmip_thermostat_evo_temperature(
     assert ha_state.attributes[ATTR_TEMPERATURE_OFFSET] == 0.7
 
 
-async def test_hmip_power_sensor(hass: HomeAssistant, default_mock_hap_factory) -> None:
+async def test_hmip_power_sensor(
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
+) -> None:
     """Test HomematicipPowerSensor."""
     entity_id = "sensor.flur_oben_power"
     entity_name = "Flur oben Power"
@@ -294,7 +296,7 @@ async def test_hmip_power_sensor(hass: HomeAssistant, default_mock_hap_factory) 
 
 
 async def test_hmip_illuminance_sensor1(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipIlluminanceSensor."""
     entity_id = "sensor.wettersensor_illuminance"
@@ -316,7 +318,7 @@ async def test_hmip_illuminance_sensor1(
 
 
 async def test_hmip_illuminance_sensor2(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipIlluminanceSensor."""
     entity_id = "sensor.lichtsensor_nord_illuminance"
@@ -341,7 +343,7 @@ async def test_hmip_illuminance_sensor2(
 
 
 async def test_hmip_windspeed_sensor(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipWindspeedSensor."""
     entity_id = "sensor.wettersensor_pro_windspeed"
@@ -392,7 +394,7 @@ async def test_hmip_windspeed_sensor(
 
 
 async def test_hmip_today_rain_sensor(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipTodayRainSensor."""
     entity_id = "sensor.weather_sensor_plus_today_rain"
@@ -414,7 +416,7 @@ async def test_hmip_today_rain_sensor(
 
 
 async def test_hmip_temperature_external_sensor_channel_1(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipTemperatureDifferenceSensor Channel 1 HmIP-STE2-PCB."""
     entity_id = "sensor.ste2_channel_1_temperature"
@@ -439,7 +441,7 @@ async def test_hmip_temperature_external_sensor_channel_1(
 
 
 async def test_hmip_temperature_external_sensor_channel_2(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipTemperatureDifferenceSensor Channel 2 HmIP-STE2-PCB."""
     entity_id = "sensor.ste2_channel_2_temperature"
@@ -464,7 +466,7 @@ async def test_hmip_temperature_external_sensor_channel_2(
 
 
 async def test_hmip_temperature_external_sensor_delta(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipTemperatureDifferenceSensor Delta HmIP-STE2-PCB."""
     entity_id = "sensor.ste2_delta_temperature"
@@ -491,7 +493,7 @@ async def test_hmip_temperature_external_sensor_delta(
 
 
 async def test_hmip_passage_detector_delta_counter(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipPassageDetectorDeltaCounter."""
     entity_id = "sensor.spdr_1"
@@ -514,7 +516,7 @@ async def test_hmip_passage_detector_delta_counter(
 
 
 async def test_hmip_esi_iec_current_power_consumption(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test ESI-IEC currentPowerConsumption Sensor."""
     entity_id = "sensor.esi_iec_currentPowerConsumption"
@@ -532,7 +534,7 @@ async def test_hmip_esi_iec_current_power_consumption(
 
 
 async def test_hmip_esi_iec_energy_counter_usage_high_tariff(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test ESI-IEC ENERGY_COUNTER_USAGE_HIGH_TARIFF."""
     entity_id = "sensor.esi_iec_energy_counter_usage_high_tariff"
@@ -550,7 +552,7 @@ async def test_hmip_esi_iec_energy_counter_usage_high_tariff(
 
 
 async def test_hmip_esi_iec_energy_counter_usage_low_tariff(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test ESI-IEC ENERGY_COUNTER_USAGE_LOW_TARIFF."""
     entity_id = "sensor.esi_iec_energy_counter_usage_low_tariff"
@@ -568,7 +570,7 @@ async def test_hmip_esi_iec_energy_counter_usage_low_tariff(
 
 
 async def test_hmip_esi_iec_energy_counter_input_single_tariff(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test ESI-IEC ENERGY_COUNTER_INPUT_SINGLE_TARIFF."""
     entity_id = "sensor.esi_iec_energy_counter_input_single_tariff"
@@ -586,7 +588,7 @@ async def test_hmip_esi_iec_energy_counter_input_single_tariff(
 
 
 async def test_hmip_esi_iec_unknown_channel(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test devices are loaded partially."""
     not_existing_entity_id = "sensor.esi_iec2_energy_counter_input_single_tariff"
@@ -601,7 +603,7 @@ async def test_hmip_esi_iec_unknown_channel(
 
 
 async def test_hmip_esi_gas_current_gas_flow(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test ESI-IEC CurrentGasFlow."""
     entity_id = "sensor.esi_gas_currentgasflow"
@@ -619,7 +621,7 @@ async def test_hmip_esi_gas_current_gas_flow(
 
 
 async def test_hmip_esi_gas_gas_volume(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test ESI-IEC GasVolume."""
     entity_id = "sensor.esi_gas_gasvolume"
@@ -637,7 +639,7 @@ async def test_hmip_esi_gas_gas_volume(
 
 
 async def test_hmip_esi_led_current_power_consumption(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test ESI-IEC currentPowerConsumption Sensor."""
     entity_id = "sensor.esi_led_currentPowerConsumption"
@@ -655,7 +657,7 @@ async def test_hmip_esi_led_current_power_consumption(
 
 
 async def test_hmip_esi_led_energy_counter_usage_high_tariff(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test ESI-IEC ENERGY_COUNTER_USAGE_HIGH_TARIFF."""
     entity_id = "sensor.esi_led_energy_counter_usage_high_tariff"

--- a/tests/components/homematicip_cloud/test_switch.py
+++ b/tests/components/homematicip_cloud/test_switch.py
@@ -9,7 +9,7 @@ from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from .helper import async_manipulate_test_data, get_and_check_entity_basics
+from .helper import HomeFactory, async_manipulate_test_data, get_and_check_entity_basics
 
 
 async def test_manually_configured_platform(hass: HomeAssistant) -> None:
@@ -20,7 +20,9 @@ async def test_manually_configured_platform(hass: HomeAssistant) -> None:
     assert not hass.data.get(HMIPC_DOMAIN)
 
 
-async def test_hmip_switch(hass: HomeAssistant, default_mock_hap_factory) -> None:
+async def test_hmip_switch(
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
+) -> None:
     """Test HomematicipSwitch."""
     entity_id = "switch.schrank"
     entity_name = "Schrank"
@@ -57,7 +59,9 @@ async def test_hmip_switch(hass: HomeAssistant, default_mock_hap_factory) -> Non
     assert ha_state.state == STATE_ON
 
 
-async def test_hmip_switch_input(hass: HomeAssistant, default_mock_hap_factory) -> None:
+async def test_hmip_switch_input(
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
+) -> None:
     """Test HomematicipSwitch."""
     entity_id = "switch.wohnzimmer_beleuchtung"
     entity_name = "Wohnzimmer Beleuchtung"
@@ -95,7 +99,7 @@ async def test_hmip_switch_input(hass: HomeAssistant, default_mock_hap_factory) 
 
 
 async def test_hmip_switch_measuring(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipSwitchMeasuring."""
     entity_id = "switch.pc"
@@ -134,7 +138,9 @@ async def test_hmip_switch_measuring(
     assert ha_state.state == STATE_ON
 
 
-async def test_hmip_group_switch(hass: HomeAssistant, default_mock_hap_factory) -> None:
+async def test_hmip_group_switch(
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
+) -> None:
     """Test HomematicipGroupSwitch."""
     entity_id = "switch.strom_group"
     entity_name = "Strom Group"
@@ -174,7 +180,9 @@ async def test_hmip_group_switch(hass: HomeAssistant, default_mock_hap_factory) 
     assert ha_state.attributes[ATTR_GROUP_MEMBER_UNREACHABLE]
 
 
-async def test_hmip_multi_switch(hass: HomeAssistant, default_mock_hap_factory) -> None:
+async def test_hmip_multi_switch(
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
+) -> None:
     """Test HomematicipMultiSwitch."""
     entity_id = "switch.jalousien_1_kizi_2_schlazi_channel1"
     entity_name = "Jalousien - 1 KiZi, 2 SchlaZi Channel1"
@@ -228,7 +236,7 @@ async def test_hmip_multi_switch(hass: HomeAssistant, default_mock_hap_factory) 
 
 
 async def test_hmip_wired_multi_switch(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipMultiSwitch."""
     entity_id = "switch.fernseher_wohnzimmer"

--- a/tests/components/homematicip_cloud/test_weather.py
+++ b/tests/components/homematicip_cloud/test_weather.py
@@ -12,7 +12,7 @@ from homeassistant.const import ATTR_ATTRIBUTION
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from .helper import async_manipulate_test_data, get_and_check_entity_basics
+from .helper import HomeFactory, async_manipulate_test_data, get_and_check_entity_basics
 
 
 async def test_manually_configured_platform(hass: HomeAssistant) -> None:
@@ -24,7 +24,7 @@ async def test_manually_configured_platform(hass: HomeAssistant) -> None:
 
 
 async def test_hmip_weather_sensor(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipWeatherSensor."""
     entity_id = "weather.weather_sensor_plus"
@@ -50,7 +50,7 @@ async def test_hmip_weather_sensor(
 
 
 async def test_hmip_weather_sensor_pro(
-    hass: HomeAssistant, default_mock_hap_factory
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
 ) -> None:
     """Test HomematicipWeatherSensorPro."""
     entity_id = "weather.wettersensor_pro"
@@ -76,7 +76,9 @@ async def test_hmip_weather_sensor_pro(
     assert ha_state.attributes[ATTR_WEATHER_TEMPERATURE] == 12.1
 
 
-async def test_hmip_home_weather(hass: HomeAssistant, default_mock_hap_factory) -> None:
+async def test_hmip_home_weather(
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
+) -> None:
     """Test HomematicipHomeWeather."""
     entity_id = "weather.weather_1010_wien_osterreich"
     entity_name = "Weather 1010  Wien, Österreich"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
