### PR TITLE
Add missing hass type hint in component tests (h)

### DIFF
--- a/tests/components/harmony/test_remote.py
+++ b/tests/components/harmony/test_remote.py
@@ -1,6 +1,7 @@
 """Test the Logitech Harmony Hub remote."""
 
 from datetime import timedelta
+from typing import Any
 
 from aioharmony.const import SendCommandDevice
 
@@ -387,7 +388,9 @@ async def test_sync(
     mock_write_config.assert_called()
 
 
-async def _send_commands_and_wait(hass, service_data):
+async def _send_commands_and_wait(
+    hass: HomeAssistant, service_data: dict[str, Any]
+) -> None:
     await hass.services.async_call(
         REMOTE_DOMAIN,
         SERVICE_SEND_COMMAND,

--- a/tests/components/harmony/test_select.py
+++ b/tests/components/harmony/test_select.py
@@ -91,7 +91,9 @@ async def test_select_option(
     assert hass.states.is_state(ENTITY_SELECT, "power_off")
 
 
-async def _select_option_and_wait(hass, entity, option):
+async def _select_option_and_wait(
+    hass: HomeAssistant, entity: str, option: str
+) -> None:
     await hass.services.async_call(
         SELECT_DOMAIN,
         SERVICE_SELECT_OPTION,

--- a/tests/components/heos/test_media_player.py
+++ b/tests/components/heos/test_media_player.py
@@ -1,6 +1,7 @@
 """Tests for the Heos Media Player platform."""
 
 import asyncio
+from typing import Any
 
 from pyheos import CommandFailedError, const
 from pyheos.error import HeosError
@@ -58,8 +59,12 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.setup import async_setup_component
 
+from tests.common import MockConfigEntry
 
-async def setup_platform(hass, config_entry, config):
+
+async def setup_platform(
+    hass: HomeAssistant, config_entry: MockConfigEntry, config: dict[str, Any]
+) -> None:
     """Set up the media player platform for testing."""
     config_entry.add_to_hass(hass)
     assert await async_setup_component(hass, DOMAIN, config)

--- a/tests/components/heos/test_services.py
+++ b/tests/components/heos/test_services.py
@@ -13,8 +13,10 @@ from homeassistant.components.heos.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
+from tests.common import MockConfigEntry
 
-async def setup_component(hass, config_entry):
+
+async def setup_component(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
     """Set up the component for testing."""
     config_entry.add_to_hass(hass)
     assert await async_setup_component(hass, DOMAIN, {})

--- a/tests/components/homeassistant_hardware/conftest.py
+++ b/tests/components/homeassistant_hardware/conftest.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from homeassistant.core import HomeAssistant
+
 
 @pytest.fixture(autouse=True)
 def mock_zha_config_flow_setup() -> Generator[None]:
@@ -122,7 +124,7 @@ def set_addon_options_fixture():
 def install_addon_side_effect_fixture(addon_store_info, addon_info):
     """Return the install add-on side effect."""
 
-    async def install_addon(hass, slug):
+    async def install_addon(hass: HomeAssistant, slug: str) -> None:
         """Mock install add-on."""
         addon_store_info.return_value = {
             "installed": "1.0.0",

--- a/tests/components/homeassistant_sky_connect/conftest.py
+++ b/tests/components/homeassistant_sky_connect/conftest.py
@@ -5,6 +5,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from homeassistant.core import HomeAssistant
+
 
 @pytest.fixture(name="mock_usb_serial_by_id", autouse=True)
 def mock_usb_serial_by_id_fixture() -> Generator[MagicMock]:
@@ -122,7 +124,7 @@ def set_addon_options_fixture():
 def install_addon_side_effect_fixture(addon_store_info, addon_info):
     """Return the install add-on side effect."""
 
-    async def install_addon(hass, slug):
+    async def install_addon(hass: HomeAssistant, slug: str) -> None:
         """Mock install add-on."""
         addon_store_info.return_value = {
             "installed": "1.0.0",

--- a/tests/components/homeassistant_yellow/conftest.py
+++ b/tests/components/homeassistant_yellow/conftest.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from homeassistant.core import HomeAssistant
+
 
 @pytest.fixture(autouse=True)
 def mock_zha_config_flow_setup() -> Generator[None]:
@@ -122,7 +124,7 @@ def set_addon_options_fixture():
 def install_addon_side_effect_fixture(addon_store_info, addon_info):
     """Return the install add-on side effect."""
 
-    async def install_addon(hass, slug):
+    async def install_addon(hass: HomeAssistant, slug: str) -> None:
         """Mock install add-on."""
         addon_store_info.return_value = {
             "installed": "1.0.0",

--- a/tests/components/html5/test_notify.py
+++ b/tests/components/html5/test_notify.py
@@ -2,9 +2,11 @@
 
 from http import HTTPStatus
 import json
+from typing import Any
 from unittest.mock import mock_open, patch
 
 from aiohttp.hdrs import AUTHORIZATION
+from aiohttp.test_utils import TestClient
 
 import homeassistant.components.html5.notify as html5
 from homeassistant.core import HomeAssistant
@@ -69,7 +71,11 @@ REGISTER_URL = "/api/notify.html5"
 PUBLISH_URL = "/api/notify.html5/callback"
 
 
-async def mock_client(hass, hass_client, registrations=None):
+async def mock_client(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    registrations: dict[str, Any] | None = None,
+) -> TestClient:
     """Create a test client for HTML5 views."""
     if registrations is None:
         registrations = {}

--- a/tests/components/http/test_auth.py
+++ b/tests/components/http/test_auth.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from http import HTTPStatus
 from ipaddress import ip_network
 import logging
+from typing import Any
 from unittest.mock import Mock, patch
 
 from aiohttp import BasicAuth, web
@@ -476,7 +477,9 @@ async def test_auth_access_signed_path_via_websocket(
 
     @websocket_api.websocket_command({"type": "diagnostics/list"})
     @callback
-    def get_signed_path(hass, connection, msg):
+    def get_signed_path(
+        hass: HomeAssistant, connection: web.ActiveConnection, msg: dict[str, Any]
+    ) -> None:
         connection.send_result(
             msg["id"], {"path": async_sign_path(hass, "/", timedelta(seconds=5))}
         )

--- a/tests/components/http/test_auth.py
+++ b/tests/components/http/test_auth.py
@@ -478,7 +478,9 @@ async def test_auth_access_signed_path_via_websocket(
     @websocket_api.websocket_command({"type": "diagnostics/list"})
     @callback
     def get_signed_path(
-        hass: HomeAssistant, connection: web.ActiveConnection, msg: dict[str, Any]
+        hass: HomeAssistant,
+        connection: websocket_api.ActiveConnection,
+        msg: dict[str, Any],
     ) -> None:
         connection.send_result(
             msg["id"], {"path": async_sign_path(hass, "/", timedelta(seconds=5))}


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
