### PR TITLE
Bump pyseventeentrack to 1.0.1

### DIFF
--- a/homeassistant/components/seventeentrack/manifest.json
+++ b/homeassistant/components/seventeentrack/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "loggers": ["pyseventeentrack"],
-  "requirements": ["pyseventeentrack==1.0.0"]
+  "requirements": ["pyseventeentrack==1.0.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2184,7 +2184,7 @@ pyserial==3.5
 pysesame2==1.0.1
 
 # homeassistant.components.seventeentrack
-pyseventeentrack==1.0.0
+pyseventeentrack==1.0.1
 
 # homeassistant.components.sia
 pysiaalarm==3.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1741,7 +1741,7 @@ pysensibo==1.1.0
 pyserial==3.5
 
 # homeassistant.components.seventeentrack
-pyseventeentrack==1.0.0
+pyseventeentrack==1.0.1
 
 # homeassistant.components.sia
 pysiaalarm==3.1.1


### PR DESCRIPTION
## Proposed change
Bump pyseventeentrack version to 1.0.1

https://pypi.org/project/pyseventeentrack/#history

Release: https://github.com/shaiu/pyseventeentrack/releases/tag/v1.0.1

## Type of change
- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.




