### PR TITLE
Improve type hints in homekit and homekit_controller tests

### DIFF
--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -73,6 +73,7 @@ from homeassistant.helpers.entityfilter import (
     CONF_INCLUDE_DOMAINS,
     CONF_INCLUDE_ENTITIES,
     CONF_INCLUDE_ENTITY_GLOBS,
+    EntityFilter,
     convert_filter,
 )
 from homeassistant.setup import async_setup_component
@@ -119,7 +120,13 @@ def patch_source_ip():
         yield
 
 
-def _mock_homekit(hass, entry, homekit_mode, entity_filter=None, devices=None):
+def _mock_homekit(
+    hass: HomeAssistant,
+    entry: MockConfigEntry,
+    homekit_mode: str,
+    entity_filter: EntityFilter | None = None,
+    devices: list[str] | None = None,
+) -> HomeKit:
     return HomeKit(
         hass=hass,
         name=BRIDGE_NAME,
@@ -136,7 +143,7 @@ def _mock_homekit(hass, entry, homekit_mode, entity_filter=None, devices=None):
     )
 
 
-def _mock_homekit_bridge(hass, entry):
+def _mock_homekit_bridge(hass: HomeAssistant, entry: MockConfigEntry) -> HomeKit:
     homekit = _mock_homekit(hass, entry, HOMEKIT_MODE_BRIDGE)
     homekit.driver = MagicMock()
     homekit.iid_storage = MagicMock()

--- a/tests/components/homekit/test_type_cameras.py
+++ b/tests/components/homekit/test_type_cameras.py
@@ -1,6 +1,7 @@
 """Test different accessory types: Camera."""
 
 import asyncio
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 from uuid import UUID
 
@@ -53,12 +54,12 @@ PID_THAT_WILL_NEVER_BE_ALIVE = 2147483647
 
 
 @pytest.fixture(autouse=True)
-async def setup_homeassistant(hass: HomeAssistant):
+async def setup_homeassistant(hass: HomeAssistant) -> None:
     """Set up the homeassistant integration."""
     await async_setup_component(hass, "homeassistant", {})
 
 
-async def _async_start_streaming(hass, acc):
+async def _async_start_streaming(hass: HomeAssistant, acc: Camera) -> None:
     """Start streaming a camera."""
     acc.set_selected_stream_configuration(MOCK_START_STREAM_TLV)
     await hass.async_block_till_done()
@@ -66,28 +67,35 @@ async def _async_start_streaming(hass, acc):
     await hass.async_block_till_done()
 
 
-async def _async_setup_endpoints(hass, acc):
+async def _async_setup_endpoints(hass: HomeAssistant, acc: Camera) -> None:
     """Set camera endpoints."""
     acc.set_endpoints(MOCK_END_POINTS_TLV)
     acc.run()
     await hass.async_block_till_done()
 
 
-async def _async_reconfigure_stream(hass, acc, session_info, stream_config):
+async def _async_reconfigure_stream(
+    hass: HomeAssistant,
+    acc: Camera,
+    session_info: dict[str, Any],
+    stream_config: dict[str, Any],
+) -> None:
     """Reconfigure the stream."""
     await acc.reconfigure_stream(session_info, stream_config)
     acc.run()
     await hass.async_block_till_done()
 
 
-async def _async_stop_all_streams(hass, acc):
+async def _async_stop_all_streams(hass: HomeAssistant, acc: Camera) -> None:
     """Stop all camera streams."""
     await acc.stop()
     acc.run()
     await hass.async_block_till_done()
 
 
-async def _async_stop_stream(hass, acc, session_info):
+async def _async_stop_stream(
+    hass: HomeAssistant, acc: Camera, session_info: dict[str, Any]
+) -> None:
     """Stop a camera stream."""
     await acc.stop_stream(session_info)
     acc.run()

--- a/tests/components/homekit/test_type_lights.py
+++ b/tests/components/homekit/test_type_lights.py
@@ -46,7 +46,7 @@ import homeassistant.util.dt as dt_util
 from tests.common import async_fire_time_changed, async_mock_service
 
 
-async def _wait_for_light_coalesce(hass):
+async def _wait_for_light_coalesce(hass: HomeAssistant) -> None:
     async_fire_time_changed(
         hass, dt_util.utcnow() + timedelta(seconds=CHANGE_COALESCE_TIME_WINDOW)
     )

--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
@@ -12,6 +13,7 @@ from unittest import mock
 from aiohomekit.controller.abstract import AbstractDescription, AbstractPairing
 from aiohomekit.hkjson import loads as hkloads
 from aiohomekit.model import Accessories, AccessoriesState, Accessory
+from aiohomekit.model.services import Service
 from aiohomekit.testing import FakeController, FakePairing
 
 from homeassistant.components.device_automation import DeviceAutomationType
@@ -177,7 +179,7 @@ class Helper:
         return state
 
 
-async def time_changed(hass, seconds):
+async def time_changed(hass: HomeAssistant, seconds: int) -> None:
     """Trigger time changed."""
     next_update = dt_util.utcnow() + timedelta(seconds)
     async_fire_time_changed(hass, next_update)
@@ -193,7 +195,7 @@ async def setup_accessories_from_file(hass: HomeAssistant, path: str) -> Accesso
     return Accessories.from_list(accessories_json)
 
 
-async def setup_platform(hass):
+async def setup_platform(hass: HomeAssistant) -> FakeController:
     """Load the platform but with a fake Controller API."""
     config = {"discovery": {}}
 
@@ -205,7 +207,9 @@ async def setup_platform(hass):
     return await async_get_controller(hass)
 
 
-async def setup_test_accessories(hass, accessories, connection=None):
+async def setup_test_accessories(
+    hass: HomeAssistant, accessories: list[Accessory], connection: str | None = None
+) -> tuple[MockConfigEntry, AbstractPairing]:
     """Load a fake homekit device based on captured JSON profile."""
     fake_controller = await setup_platform(hass)
     return await setup_test_accessories_with_controller(
@@ -214,8 +218,11 @@ async def setup_test_accessories(hass, accessories, connection=None):
 
 
 async def setup_test_accessories_with_controller(
-    hass, accessories, fake_controller, connection=None
-):
+    hass: HomeAssistant,
+    accessories: list[Accessory],
+    fake_controller: FakeController,
+    connection: str | None = None,
+) -> tuple[MockConfigEntry, AbstractPairing]:
     """Load a fake homekit device based on captured JSON profile."""
 
     pairing_id = "00:00:00:00:00:00"
@@ -277,8 +284,13 @@ async def device_config_changed(hass: HomeAssistant, accessories: Accessories):
 
 
 async def setup_test_component(
-    hass, aid, setup_accessory, capitalize=False, suffix=None, connection=None
-):
+    hass: HomeAssistant,
+    aid: int,
+    setup_accessory: Callable[[Accessory], Service | None],
+    capitalize: bool = False,
+    suffix: str | None = None,
+    connection: str | None = None,
+) -> Helper:
     """Load a fake homekit accessory based on a homekit accessory model.
 
     If capitalize is True, property names will be in upper case.

--- a/tests/components/homekit_controller/test_alarm_control_panel.py
+++ b/tests/components/homekit_controller/test_alarm_control_panel.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 
+from aiohomekit.model import Accessory
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import ServicesTypes
 
@@ -11,7 +12,7 @@ from homeassistant.helpers import entity_registry as er
 from .common import setup_test_component
 
 
-def create_security_system_service(accessory):
+def create_security_system_service(accessory: Accessory) -> None:
     """Define a security-system characteristics as per page 219 of HAP spec."""
     service = accessory.add_service(ServicesTypes.SECURITY_SYSTEM)
 

--- a/tests/components/homekit_controller/test_binary_sensor.py
+++ b/tests/components/homekit_controller/test_binary_sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 
+from aiohomekit.model import Accessory
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import ServicesTypes
 
@@ -12,7 +13,7 @@ from homeassistant.helpers import entity_registry as er
 from .common import setup_test_component
 
 
-def create_motion_sensor_service(accessory):
+def create_motion_sensor_service(accessory: Accessory) -> None:
     """Define motion characteristics as per page 225 of HAP spec."""
     service = accessory.add_service(ServicesTypes.MOTION_SENSOR)
 
@@ -43,7 +44,7 @@ async def test_motion_sensor_read_state(
     assert state.attributes["device_class"] == BinarySensorDeviceClass.MOTION
 
 
-def create_contact_sensor_service(accessory):
+def create_contact_sensor_service(accessory: Accessory) -> None:
     """Define contact characteristics."""
     service = accessory.add_service(ServicesTypes.CONTACT_SENSOR)
 
@@ -74,7 +75,7 @@ async def test_contact_sensor_read_state(
     assert state.attributes["device_class"] == BinarySensorDeviceClass.OPENING
 
 
-def create_smoke_sensor_service(accessory):
+def create_smoke_sensor_service(accessory: Accessory) -> None:
     """Define smoke sensor characteristics."""
     service = accessory.add_service(ServicesTypes.SMOKE_SENSOR)
 
@@ -105,7 +106,7 @@ async def test_smoke_sensor_read_state(
     assert state.attributes["device_class"] == BinarySensorDeviceClass.SMOKE
 
 
-def create_carbon_monoxide_sensor_service(accessory):
+def create_carbon_monoxide_sensor_service(accessory: Accessory) -> None:
     """Define carbon monoxide sensor characteristics."""
     service = accessory.add_service(ServicesTypes.CARBON_MONOXIDE_SENSOR)
 
@@ -138,7 +139,7 @@ async def test_carbon_monoxide_sensor_read_state(
     assert state.attributes["device_class"] == BinarySensorDeviceClass.CO
 
 
-def create_occupancy_sensor_service(accessory):
+def create_occupancy_sensor_service(accessory: Accessory) -> None:
     """Define occupancy characteristics."""
     service = accessory.add_service(ServicesTypes.OCCUPANCY_SENSOR)
 
@@ -169,7 +170,7 @@ async def test_occupancy_sensor_read_state(
     assert state.attributes["device_class"] == BinarySensorDeviceClass.OCCUPANCY
 
 
-def create_leak_sensor_service(accessory):
+def create_leak_sensor_service(accessory: Accessory) -> None:
     """Define leak characteristics."""
     service = accessory.add_service(ServicesTypes.LEAK_SENSOR)
 

--- a/tests/components/homekit_controller/test_button.py
+++ b/tests/components/homekit_controller/test_button.py
@@ -2,8 +2,9 @@
 
 from collections.abc import Callable
 
+from aiohomekit.model import Accessory
 from aiohomekit.model.characteristics import CharacteristicsTypes
-from aiohomekit.model.services import ServicesTypes
+from aiohomekit.model.services import Service, ServicesTypes
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -11,7 +12,7 @@ from homeassistant.helpers import entity_registry as er
 from .common import Helper, setup_test_component
 
 
-def create_switch_with_setup_button(accessory):
+def create_switch_with_setup_button(accessory: Accessory) -> Service:
     """Define setup button characteristics."""
     service = accessory.add_service(ServicesTypes.OUTLET)
 
@@ -26,7 +27,7 @@ def create_switch_with_setup_button(accessory):
     return service
 
 
-def create_switch_with_ecobee_clear_hold_button(accessory):
+def create_switch_with_ecobee_clear_hold_button(accessory: Accessory) -> Service:
     """Define setup button characteristics."""
     service = accessory.add_service(ServicesTypes.OUTLET)
 

--- a/tests/components/homekit_controller/test_camera.py
+++ b/tests/components/homekit_controller/test_camera.py
@@ -3,6 +3,7 @@
 import base64
 from collections.abc import Callable
 
+from aiohomekit.model import Accessory
 from aiohomekit.model.services import ServicesTypes
 from aiohomekit.testing import FAKE_CAMERA_IMAGE
 
@@ -13,7 +14,7 @@ from homeassistant.helpers import entity_registry as er
 from .common import setup_test_component
 
 
-def create_camera(accessory):
+def create_camera(accessory: Accessory) -> None:
     """Define camera characteristics."""
     accessory.add_service(ServicesTypes.CAMERA_RTP_STREAM_MANAGEMENT)
 

--- a/tests/components/homekit_controller/test_climate.py
+++ b/tests/components/homekit_controller/test_climate.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 
+from aiohomekit.model import Accessory
 from aiohomekit.model.characteristics import (
     ActivationStateValues,
     CharacteristicsTypes,
@@ -28,7 +29,7 @@ from .common import setup_test_component
 # Test thermostat devices
 
 
-def create_thermostat_service(accessory):
+def create_thermostat_service(accessory: Accessory) -> None:
     """Define thermostat characteristics."""
     service = accessory.add_service(ServicesTypes.THERMOSTAT)
 
@@ -66,7 +67,7 @@ def create_thermostat_service(accessory):
     char.value = 0
 
 
-def create_thermostat_service_min_max(accessory):
+def create_thermostat_service_min_max(accessory: Accessory) -> None:
     """Define thermostat characteristics."""
     service = accessory.add_service(ServicesTypes.THERMOSTAT)
     char = service.add_char(CharacteristicsTypes.HEATING_COOLING_TARGET)
@@ -86,7 +87,7 @@ async def test_climate_respect_supported_op_modes_1(
     assert state.attributes["hvac_modes"] == ["off", "heat"]
 
 
-def create_thermostat_service_valid_vals(accessory):
+def create_thermostat_service_valid_vals(accessory: Accessory) -> None:
     """Define thermostat characteristics."""
     service = accessory.add_service(ServicesTypes.THERMOSTAT)
     char = service.add_char(CharacteristicsTypes.HEATING_COOLING_TARGET)
@@ -364,7 +365,7 @@ async def test_climate_cannot_set_thermostat_temp_range_in_wrong_mode(
     )
 
 
-def create_thermostat_single_set_point_auto(accessory):
+def create_thermostat_single_set_point_auto(accessory: Accessory) -> None:
     """Define thermostat characteristics with a single set point in auto."""
     service = accessory.add_service(ServicesTypes.THERMOSTAT)
 
@@ -685,7 +686,7 @@ async def test_hvac_mode_vs_hvac_action_current_mode_wrong(
     assert state.attributes["hvac_action"] == "idle"
 
 
-def create_heater_cooler_service(accessory):
+def create_heater_cooler_service(accessory: Accessory) -> None:
     """Define thermostat characteristics."""
     service = accessory.add_service(ServicesTypes.HEATER_COOLER)
 
@@ -719,7 +720,7 @@ def create_heater_cooler_service(accessory):
 
 
 # Test heater-cooler devices
-def create_heater_cooler_service_min_max(accessory):
+def create_heater_cooler_service_min_max(accessory: Accessory) -> None:
     """Define thermostat characteristics."""
     service = accessory.add_service(ServicesTypes.HEATER_COOLER)
     char = service.add_char(CharacteristicsTypes.TARGET_HEATER_COOLER_STATE)
@@ -739,7 +740,7 @@ async def test_heater_cooler_respect_supported_op_modes_1(
     assert state.attributes["hvac_modes"] == ["heat", "cool", "off"]
 
 
-def create_theater_cooler_service_valid_vals(accessory):
+def create_theater_cooler_service_valid_vals(accessory: Accessory) -> None:
     """Define heater-cooler characteristics."""
     service = accessory.add_service(ServicesTypes.HEATER_COOLER)
     char = service.add_char(CharacteristicsTypes.TARGET_HEATER_COOLER_STATE)

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from ipaddress import ip_address
+from typing import Any
 import unittest.mock
 from unittest.mock import AsyncMock, patch
 
@@ -160,7 +161,9 @@ def test_valid_pairing_codes(pairing_code) -> None:
     assert len(valid_pin[2]) == 3
 
 
-def get_flow_context(hass, result):
+def get_flow_context(
+    hass: HomeAssistant, result: config_flow.ConfigFlowResult
+) -> dict[str, Any]:
     """Get the flow context from the result of async_init or async_configure."""
     flow = next(
         flow

--- a/tests/components/homekit_controller/test_connection.py
+++ b/tests/components/homekit_controller/test_connection.py
@@ -5,8 +5,9 @@ import dataclasses
 from unittest import mock
 
 from aiohomekit.controller import TransportType
+from aiohomekit.model import Accessory
 from aiohomekit.model.characteristics import CharacteristicsTypes
-from aiohomekit.model.services import ServicesTypes
+from aiohomekit.model.services import Service, ServicesTypes
 from aiohomekit.testing import FakeController
 import pytest
 
@@ -349,7 +350,7 @@ async def test_poll_firmware_version_only_all_watchable_accessory_mode(
 ) -> None:
     """Test that we only poll firmware if available and all chars are watchable accessory mode."""
 
-    def _create_accessory(accessory):
+    def _create_accessory(accessory: Accessory) -> Service:
         service = accessory.add_service(ServicesTypes.LIGHTBULB, name="TestDevice")
 
         on_char = service.add_char(CharacteristicsTypes.ON)

--- a/tests/components/homekit_controller/test_cover.py
+++ b/tests/components/homekit_controller/test_cover.py
@@ -2,8 +2,9 @@
 
 from collections.abc import Callable
 
+from aiohomekit.model import Accessory
 from aiohomekit.model.characteristics import CharacteristicsTypes
-from aiohomekit.model.services import ServicesTypes
+from aiohomekit.model.services import Service, ServicesTypes
 
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
@@ -12,7 +13,7 @@ from homeassistant.helpers import entity_registry as er
 from .common import setup_test_component
 
 
-def create_window_covering_service(accessory):
+def create_window_covering_service(accessory: Accessory) -> Service:
     """Define a window-covering characteristics as per page 219 of HAP spec."""
     service = accessory.add_service(ServicesTypes.WINDOW_COVERING)
 
@@ -37,7 +38,7 @@ def create_window_covering_service(accessory):
     return service
 
 
-def create_window_covering_service_with_h_tilt(accessory):
+def create_window_covering_service_with_h_tilt(accessory: Accessory) -> None:
     """Define a window-covering characteristics as per page 219 of HAP spec."""
     service = create_window_covering_service(accessory)
 
@@ -52,7 +53,7 @@ def create_window_covering_service_with_h_tilt(accessory):
     tilt_target.maxValue = 90
 
 
-def create_window_covering_service_with_h_tilt_2(accessory):
+def create_window_covering_service_with_h_tilt_2(accessory: Accessory) -> None:
     """Define a window-covering characteristics as per page 219 of HAP spec."""
     service = create_window_covering_service(accessory)
 
@@ -67,7 +68,7 @@ def create_window_covering_service_with_h_tilt_2(accessory):
     tilt_target.maxValue = 0
 
 
-def create_window_covering_service_with_v_tilt(accessory):
+def create_window_covering_service_with_v_tilt(accessory: Accessory) -> None:
     """Define a window-covering characteristics as per page 219 of HAP spec."""
     service = create_window_covering_service(accessory)
 
@@ -82,7 +83,7 @@ def create_window_covering_service_with_v_tilt(accessory):
     tilt_target.maxValue = 90
 
 
-def create_window_covering_service_with_v_tilt_2(accessory):
+def create_window_covering_service_with_v_tilt_2(accessory: Accessory) -> None:
     """Define a window-covering characteristics as per page 219 of HAP spec."""
     service = create_window_covering_service(accessory)
 
@@ -97,7 +98,7 @@ def create_window_covering_service_with_v_tilt_2(accessory):
     tilt_target.maxValue = 0
 
 
-def create_window_covering_service_with_none_tilt(accessory):
+def create_window_covering_service_with_none_tilt(accessory: Accessory) -> None:
     """Define a window-covering characteristics as per page 219 of HAP spec.
 
     This accessory uses None for the tilt value unexpectedly.
@@ -377,7 +378,7 @@ async def test_window_cover_stop(
     )
 
 
-def create_garage_door_opener_service(accessory):
+def create_garage_door_opener_service(accessory: Accessory) -> None:
     """Define a garage-door-opener chars as per page 217 of HAP spec."""
     service = accessory.add_service(ServicesTypes.GARAGE_DOOR_OPENER)
 

--- a/tests/components/homekit_controller/test_device_trigger.py
+++ b/tests/components/homekit_controller/test_device_trigger.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 
+from aiohomekit.model import Accessory
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import ServicesTypes
 import pytest
@@ -25,7 +26,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
     """Stub copying the blueprints to the config folder."""
 
 
-def create_remote(accessory):
+def create_remote(accessory: Accessory) -> None:
     """Define characteristics for a button (that is inn a group)."""
     service_label = accessory.add_service(ServicesTypes.SERVICE_LABEL)
 
@@ -50,7 +51,7 @@ def create_remote(accessory):
     battery.add_char(CharacteristicsTypes.BATTERY_LEVEL)
 
 
-def create_button(accessory):
+def create_button(accessory: Accessory) -> None:
     """Define a button (that is not in a group)."""
     button = accessory.add_service(ServicesTypes.STATELESS_PROGRAMMABLE_SWITCH)
 
@@ -65,7 +66,7 @@ def create_button(accessory):
     battery.add_char(CharacteristicsTypes.BATTERY_LEVEL)
 
 
-def create_doorbell(accessory):
+def create_doorbell(accessory: Accessory) -> None:
     """Define a button (that is not in a group)."""
     button = accessory.add_service(ServicesTypes.DOORBELL)
 

--- a/tests/components/homekit_controller/test_event.py
+++ b/tests/components/homekit_controller/test_event.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 
+from aiohomekit.model import Accessory
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import ServicesTypes
 
@@ -12,7 +13,7 @@ from homeassistant.helpers import entity_registry as er
 from .common import setup_test_component
 
 
-def create_remote(accessory):
+def create_remote(accessory: Accessory) -> None:
     """Define characteristics for a button (that is inn a group)."""
     service_label = accessory.add_service(ServicesTypes.SERVICE_LABEL)
 
@@ -37,7 +38,7 @@ def create_remote(accessory):
     battery.add_char(CharacteristicsTypes.BATTERY_LEVEL)
 
 
-def create_button(accessory):
+def create_button(accessory: Accessory) -> None:
     """Define a button (that is not in a group)."""
     button = accessory.add_service(ServicesTypes.STATELESS_PROGRAMMABLE_SWITCH)
 
@@ -52,7 +53,7 @@ def create_button(accessory):
     battery.add_char(CharacteristicsTypes.BATTERY_LEVEL)
 
 
-def create_doorbell(accessory):
+def create_doorbell(accessory: Accessory) -> None:
     """Define a button (that is not in a group)."""
     button = accessory.add_service(ServicesTypes.DOORBELL)
 

--- a/tests/components/homekit_controller/test_fan.py
+++ b/tests/components/homekit_controller/test_fan.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 
+from aiohomekit.model import Accessory
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import ServicesTypes
 
@@ -11,7 +12,7 @@ from homeassistant.helpers import entity_registry as er
 from .common import setup_test_component
 
 
-def create_fan_service(accessory):
+def create_fan_service(accessory: Accessory) -> None:
     """Define fan v1 characteristics as per HAP spec.
 
     This service is no longer documented in R2 of the public HAP spec but existing
@@ -29,7 +30,7 @@ def create_fan_service(accessory):
     speed.value = 0
 
 
-def create_fanv2_service(accessory):
+def create_fanv2_service(accessory: Accessory) -> None:
     """Define fan v2 characteristics as per HAP spec."""
     service = accessory.add_service(ServicesTypes.FAN_V2)
 
@@ -46,7 +47,7 @@ def create_fanv2_service(accessory):
     swing_mode.value = 0
 
 
-def create_fanv2_service_non_standard_rotation_range(accessory):
+def create_fanv2_service_non_standard_rotation_range(accessory: Accessory) -> None:
     """Define fan v2 with a non-standard rotation range."""
     service = accessory.add_service(ServicesTypes.FAN_V2)
 
@@ -60,7 +61,7 @@ def create_fanv2_service_non_standard_rotation_range(accessory):
     speed.minStep = 1
 
 
-def create_fanv2_service_with_min_step(accessory):
+def create_fanv2_service_with_min_step(accessory: Accessory) -> None:
     """Define fan v2 characteristics as per HAP spec."""
     service = accessory.add_service(ServicesTypes.FAN_V2)
 
@@ -78,7 +79,7 @@ def create_fanv2_service_with_min_step(accessory):
     swing_mode.value = 0
 
 
-def create_fanv2_service_without_rotation_speed(accessory):
+def create_fanv2_service_without_rotation_speed(accessory: Accessory) -> None:
     """Define fan v2 characteristics as per HAP spec."""
     service = accessory.add_service(ServicesTypes.FAN_V2)
 

--- a/tests/components/homekit_controller/test_humidifier.py
+++ b/tests/components/homekit_controller/test_humidifier.py
@@ -2,8 +2,9 @@
 
 from collections.abc import Callable
 
+from aiohomekit.model import Accessory
 from aiohomekit.model.characteristics import CharacteristicsTypes
-from aiohomekit.model.services import ServicesTypes
+from aiohomekit.model.services import Service, ServicesTypes
 
 from homeassistant.components.humidifier import DOMAIN, MODE_AUTO, MODE_NORMAL
 from homeassistant.core import HomeAssistant
@@ -12,7 +13,7 @@ from homeassistant.helpers import entity_registry as er
 from .common import setup_test_component
 
 
-def create_humidifier_service(accessory):
+def create_humidifier_service(accessory: Accessory) -> Service:
     """Define a humidifier characteristics as per page 219 of HAP spec."""
     service = accessory.add_service(ServicesTypes.HUMIDIFIER_DEHUMIDIFIER)
 
@@ -39,7 +40,7 @@ def create_humidifier_service(accessory):
     return service
 
 
-def create_dehumidifier_service(accessory):
+def create_dehumidifier_service(accessory: Accessory) -> Service:
     """Define a dehumidifier characteristics as per page 219 of HAP spec."""
     service = accessory.add_service(ServicesTypes.HUMIDIFIER_DEHUMIDIFIER)
 

--- a/tests/components/homekit_controller/test_init.py
+++ b/tests/components/homekit_controller/test_init.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 from aiohomekit import AccessoryNotFoundError
 from aiohomekit.model import Accessory, Transport
 from aiohomekit.model.characteristics import CharacteristicsTypes
-from aiohomekit.model.services import ServicesTypes
+from aiohomekit.model.services import Service, ServicesTypes
 from aiohomekit.testing import FakePairing
 from attr import asdict
 import pytest
@@ -40,7 +40,7 @@ ALIVE_DEVICE_NAME = "testdevice"
 ALIVE_DEVICE_ENTITY_ID = "light.testdevice"
 
 
-def create_motion_sensor_service(accessory):
+def create_motion_sensor_service(accessory: Accessory) -> None:
     """Define motion characteristics as per page 225 of HAP spec."""
     service = accessory.add_service(ServicesTypes.MOTION_SENSOR)
     cur_state = service.add_char(CharacteristicsTypes.MOTION_DETECTED)
@@ -83,7 +83,7 @@ async def test_async_remove_entry(
     assert hkid not in hass.data[ENTITY_MAP].storage_data
 
 
-def create_alive_service(accessory):
+def create_alive_service(accessory: Accessory) -> Service:
     """Create a service to validate we can only remove dead devices."""
     service = accessory.add_service(ServicesTypes.LIGHTBULB, name=ALIVE_DEVICE_NAME)
     service.add_char(CharacteristicsTypes.ON)

--- a/tests/components/homekit_controller/test_light.py
+++ b/tests/components/homekit_controller/test_light.py
@@ -3,8 +3,9 @@
 from collections.abc import Callable
 from unittest import mock
 
+from aiohomekit.model import Accessory
 from aiohomekit.model.characteristics import CharacteristicsTypes
-from aiohomekit.model.services import ServicesTypes
+from aiohomekit.model.services import Service, ServicesTypes
 from aiohomekit.testing import FakeController
 
 from homeassistant.components.homekit_controller.const import KNOWN_DEVICES
@@ -23,7 +24,7 @@ LIGHT_BULB_NAME = "TestDevice"
 LIGHT_BULB_ENTITY_ID = "light.testdevice"
 
 
-def create_lightbulb_service(accessory):
+def create_lightbulb_service(accessory: Accessory) -> Service:
     """Define lightbulb characteristics."""
     service = accessory.add_service(ServicesTypes.LIGHTBULB, name=LIGHT_BULB_NAME)
 
@@ -36,7 +37,7 @@ def create_lightbulb_service(accessory):
     return service
 
 
-def create_lightbulb_service_with_hs(accessory):
+def create_lightbulb_service_with_hs(accessory: Accessory) -> Service:
     """Define a lightbulb service with hue + saturation."""
     service = create_lightbulb_service(accessory)
 
@@ -49,7 +50,7 @@ def create_lightbulb_service_with_hs(accessory):
     return service
 
 
-def create_lightbulb_service_with_color_temp(accessory):
+def create_lightbulb_service_with_color_temp(accessory: Accessory) -> Service:
     """Define a lightbulb service with color temp."""
     service = create_lightbulb_service(accessory)
 

--- a/tests/components/homekit_controller/test_lock.py
+++ b/tests/components/homekit_controller/test_lock.py
@@ -2,8 +2,9 @@
 
 from collections.abc import Callable
 
+from aiohomekit.model import Accessory
 from aiohomekit.model.characteristics import CharacteristicsTypes
-from aiohomekit.model.services import ServicesTypes
+from aiohomekit.model.services import Service, ServicesTypes
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -11,7 +12,7 @@ from homeassistant.helpers import entity_registry as er
 from .common import setup_test_component
 
 
-def create_lock_service(accessory):
+def create_lock_service(accessory: Accessory) -> Service:
     """Define a lock characteristics as per page 219 of HAP spec."""
     service = accessory.add_service(ServicesTypes.LOCK_MECHANISM)
 

--- a/tests/components/homekit_controller/test_media_player.py
+++ b/tests/components/homekit_controller/test_media_player.py
@@ -2,11 +2,12 @@
 
 from collections.abc import Callable
 
+from aiohomekit.model import Accessory
 from aiohomekit.model.characteristics import (
     CharacteristicPermissions,
     CharacteristicsTypes,
 )
-from aiohomekit.model.services import ServicesTypes
+from aiohomekit.model.services import Service, ServicesTypes
 import pytest
 
 from homeassistant.core import HomeAssistant
@@ -15,7 +16,7 @@ from homeassistant.helpers import entity_registry as er
 from .common import setup_test_component
 
 
-def create_tv_service(accessory):
+def create_tv_service(accessory: Accessory) -> Service:
     """Define tv characteristics.
 
     The TV is not currently documented publicly - this is based on observing really TV's that have HomeKit support.
@@ -53,7 +54,7 @@ def create_tv_service(accessory):
     return tv_service
 
 
-def create_tv_service_with_target_media_state(accessory):
+def create_tv_service_with_target_media_state(accessory: Accessory) -> Service:
     """Define a TV service that can play/pause/stop without generate remote events."""
     service = create_tv_service(accessory)
 

--- a/tests/components/homekit_controller/test_number.py
+++ b/tests/components/homekit_controller/test_number.py
@@ -2,8 +2,9 @@
 
 from collections.abc import Callable
 
+from aiohomekit.model import Accessory
 from aiohomekit.model.characteristics import CharacteristicsTypes
-from aiohomekit.model.services import ServicesTypes
+from aiohomekit.model.services import Service, ServicesTypes
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -11,7 +12,7 @@ from homeassistant.helpers import entity_registry as er
 from .common import Helper, setup_test_component
 
 
-def create_switch_with_spray_level(accessory):
+def create_switch_with_spray_level(accessory: Accessory) -> Service:
     """Define battery level characteristics."""
     service = accessory.add_service(ServicesTypes.OUTLET)
 

--- a/tests/components/homekit_controller/test_sensor.py
+++ b/tests/components/homekit_controller/test_sensor.py
@@ -3,10 +3,10 @@
 from collections.abc import Callable
 from unittest.mock import patch
 
-from aiohomekit.model import Transport
+from aiohomekit.model import Accessory, Transport
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.characteristics.const import ThreadNodeCapabilities, ThreadStatus
-from aiohomekit.model.services import ServicesTypes
+from aiohomekit.model.services import Service, ServicesTypes
 from aiohomekit.protocol.statuscodes import HapStatusCode
 from aiohomekit.testing import FakePairing
 import pytest
@@ -24,7 +24,7 @@ from .common import TEST_DEVICE_SERVICE_INFO, Helper, setup_test_component
 from tests.components.bluetooth import inject_bluetooth_service_info
 
 
-def create_temperature_sensor_service(accessory):
+def create_temperature_sensor_service(accessory: Accessory) -> None:
     """Define temperature characteristics."""
     service = accessory.add_service(ServicesTypes.TEMPERATURE_SENSOR)
 
@@ -32,7 +32,7 @@ def create_temperature_sensor_service(accessory):
     cur_state.value = 0
 
 
-def create_humidity_sensor_service(accessory):
+def create_humidity_sensor_service(accessory: Accessory) -> None:
     """Define humidity characteristics."""
     service = accessory.add_service(ServicesTypes.HUMIDITY_SENSOR)
 
@@ -40,7 +40,7 @@ def create_humidity_sensor_service(accessory):
     cur_state.value = 0
 
 
-def create_light_level_sensor_service(accessory):
+def create_light_level_sensor_service(accessory: Accessory) -> None:
     """Define light level characteristics."""
     service = accessory.add_service(ServicesTypes.LIGHT_SENSOR)
 
@@ -48,7 +48,7 @@ def create_light_level_sensor_service(accessory):
     cur_state.value = 0
 
 
-def create_carbon_dioxide_level_sensor_service(accessory):
+def create_carbon_dioxide_level_sensor_service(accessory: Accessory) -> None:
     """Define carbon dioxide level characteristics."""
     service = accessory.add_service(ServicesTypes.CARBON_DIOXIDE_SENSOR)
 
@@ -56,7 +56,7 @@ def create_carbon_dioxide_level_sensor_service(accessory):
     cur_state.value = 0
 
 
-def create_battery_level_sensor(accessory):
+def create_battery_level_sensor(accessory: Accessory) -> Service:
     """Define battery level characteristics."""
     service = accessory.add_service(ServicesTypes.BATTERY_SERVICE)
 
@@ -280,7 +280,7 @@ async def test_battery_low(
     assert state.attributes["icon"] == "mdi:battery-alert"
 
 
-def create_switch_with_sensor(accessory):
+def create_switch_with_sensor(accessory: Accessory) -> Service:
     """Define battery level characteristics."""
     service = accessory.add_service(ServicesTypes.OUTLET)
 

--- a/tests/components/homekit_controller/test_storage.py
+++ b/tests/components/homekit_controller/test_storage.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from typing import Any
 
+from aiohomekit.model import Accessory
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import ServicesTypes
 
@@ -65,7 +66,7 @@ async def test_storage_is_removed_idempotent(hass: HomeAssistant) -> None:
     assert hkid not in entity_map.storage_data
 
 
-def create_lightbulb_service(accessory):
+def create_lightbulb_service(accessory: Accessory) -> None:
     """Define lightbulb characteristics."""
     service = accessory.add_service(ServicesTypes.LIGHTBULB)
     on_char = service.add_char(CharacteristicsTypes.ON)

--- a/tests/components/homekit_controller/test_switch.py
+++ b/tests/components/homekit_controller/test_switch.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 
+from aiohomekit.model import Accessory
 from aiohomekit.model.characteristics import (
     CharacteristicsTypes,
     InUseValues,
@@ -15,7 +16,7 @@ from homeassistant.helpers import entity_registry as er
 from .common import setup_test_component
 
 
-def create_switch_service(accessory):
+def create_switch_service(accessory: Accessory) -> None:
     """Define outlet characteristics."""
     service = accessory.add_service(ServicesTypes.OUTLET)
 
@@ -26,7 +27,7 @@ def create_switch_service(accessory):
     outlet_in_use.value = False
 
 
-def create_valve_service(accessory):
+def create_valve_service(accessory: Accessory) -> None:
     """Define valve characteristics."""
     service = accessory.add_service(ServicesTypes.VALVE)
 
@@ -43,7 +44,7 @@ def create_valve_service(accessory):
     remaining.value = 99
 
 
-def create_char_switch_service(accessory):
+def create_char_switch_service(accessory: Accessory) -> None:
     """Define swtch characteristics."""
     service = accessory.add_service(ServicesTypes.OUTLET)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
