### PR TITLE
Add missing hass type hint in component tests (l)

### DIFF
--- a/tests/components/lg_soundbar/test_config_flow.py
+++ b/tests/components/lg_soundbar/test_config_flow.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 import socket
 from typing import Any
-from unittest.mock import DEFAULT, patch
+from unittest.mock import DEFAULT, MagicMock, patch
 
 from homeassistant import config_entries
 from homeassistant.components.lg_soundbar.const import DEFAULT_PORT, DOMAIN
@@ -17,8 +17,12 @@ from tests.common import MockConfigEntry
 
 
 def setup_mock_temescal(
-    hass, mock_temescal, mac_info_dev=None, product_info=None, info=None
-):
+    hass: HomeAssistant,
+    mock_temescal: MagicMock,
+    mac_info_dev: dict[str, Any] | None = None,
+    product_info: dict[str, Any] | None = None,
+    info: dict[str, Any] | None = None,
+) -> None:
     """Set up a mock of the temescal object to craft our expected responses."""
     tmock = mock_temescal.temescal
     instance = tmock.return_value

--- a/tests/components/light/common.py
+++ b/tests/components/light/common.py
@@ -33,6 +33,7 @@ from homeassistant.const import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.loader import bind_hass
 
 from tests.common import MockToggleEntity
@@ -40,24 +41,24 @@ from tests.common import MockToggleEntity
 
 @bind_hass
 def turn_on(
-    hass,
-    entity_id=ENTITY_MATCH_ALL,
-    transition=None,
-    brightness=None,
-    brightness_pct=None,
-    rgb_color=None,
-    rgbw_color=None,
-    rgbww_color=None,
-    xy_color=None,
-    hs_color=None,
-    color_temp=None,
-    kelvin=None,
-    profile=None,
-    flash=None,
-    effect=None,
-    color_name=None,
-    white=None,
-):
+    hass: HomeAssistant,
+    entity_id: str = ENTITY_MATCH_ALL,
+    transition: float | None = None,
+    brightness: int | None = None,
+    brightness_pct: float | None = None,
+    rgb_color: tuple[int, int, int] | None = None,
+    rgbw_color: tuple[int, int, int, int] | None = None,
+    rgbww_color: tuple[int, int, int, int, int] | None = None,
+    xy_color: tuple[float, float] | None = None,
+    hs_color: tuple[float, float] | None = None,
+    color_temp: int | None = None,
+    kelvin: int | None = None,
+    profile: str | None = None,
+    flash: str | None = None,
+    effect: str | None = None,
+    color_name: str | None = None,
+    white: bool | None = None,
+) -> None:
     """Turn all or specified light on."""
     hass.add_job(
         async_turn_on,
@@ -82,24 +83,24 @@ def turn_on(
 
 
 async def async_turn_on(
-    hass,
-    entity_id=ENTITY_MATCH_ALL,
-    transition=None,
-    brightness=None,
-    brightness_pct=None,
-    rgb_color=None,
-    rgbw_color=None,
-    rgbww_color=None,
-    xy_color=None,
-    hs_color=None,
-    color_temp=None,
-    kelvin=None,
-    profile=None,
-    flash=None,
-    effect=None,
-    color_name=None,
-    white=None,
-):
+    hass: HomeAssistant,
+    entity_id: str = ENTITY_MATCH_ALL,
+    transition: float | None = None,
+    brightness: int | None = None,
+    brightness_pct: float | None = None,
+    rgb_color: tuple[int, int, int] | None = None,
+    rgbw_color: tuple[int, int, int, int] | None = None,
+    rgbww_color: tuple[int, int, int, int, int] | None = None,
+    xy_color: tuple[float, float] | None = None,
+    hs_color: tuple[float, float] | None = None,
+    color_temp: int | None = None,
+    kelvin: int | None = None,
+    profile: str | None = None,
+    flash: str | None = None,
+    effect: str | None = None,
+    color_name: str | None = None,
+    white: bool | None = None,
+) -> None:
     """Turn all or specified light on."""
     data = {
         key: value
@@ -128,12 +129,22 @@ async def async_turn_on(
 
 
 @bind_hass
-def turn_off(hass, entity_id=ENTITY_MATCH_ALL, transition=None, flash=None):
+def turn_off(
+    hass: HomeAssistant,
+    entity_id: str = ENTITY_MATCH_ALL,
+    transition: float | None = None,
+    flash: str | None = None,
+) -> None:
     """Turn all or specified light off."""
     hass.add_job(async_turn_off, hass, entity_id, transition, flash)
 
 
-async def async_turn_off(hass, entity_id=ENTITY_MATCH_ALL, transition=None, flash=None):
+async def async_turn_off(
+    hass: HomeAssistant,
+    entity_id: str = ENTITY_MATCH_ALL,
+    transition: float | None = None,
+    flash: str | None = None,
+) -> None:
     """Turn all or specified light off."""
     data = {
         key: value
@@ -150,21 +161,21 @@ async def async_turn_off(hass, entity_id=ENTITY_MATCH_ALL, transition=None, flas
 
 @bind_hass
 def toggle(
-    hass,
-    entity_id=ENTITY_MATCH_ALL,
-    transition=None,
-    brightness=None,
-    brightness_pct=None,
-    rgb_color=None,
-    xy_color=None,
-    hs_color=None,
-    color_temp=None,
-    kelvin=None,
-    profile=None,
-    flash=None,
-    effect=None,
-    color_name=None,
-):
+    hass: HomeAssistant,
+    entity_id: str = ENTITY_MATCH_ALL,
+    transition: float | None = None,
+    brightness: int | None = None,
+    brightness_pct: float | None = None,
+    rgb_color: tuple[int, int, int] | None = None,
+    xy_color: tuple[float, float] | None = None,
+    hs_color: tuple[float, float] | None = None,
+    color_temp: int | None = None,
+    kelvin: int | None = None,
+    profile: str | None = None,
+    flash: str | None = None,
+    effect: str | None = None,
+    color_name: str | None = None,
+) -> None:
     """Toggle all or specified light."""
     hass.add_job(
         async_toggle,
@@ -186,21 +197,21 @@ def toggle(
 
 
 async def async_toggle(
-    hass,
-    entity_id=ENTITY_MATCH_ALL,
-    transition=None,
-    brightness=None,
-    brightness_pct=None,
-    rgb_color=None,
-    xy_color=None,
-    hs_color=None,
-    color_temp=None,
-    kelvin=None,
-    profile=None,
-    flash=None,
-    effect=None,
-    color_name=None,
-):
+    hass: HomeAssistant,
+    entity_id: str = ENTITY_MATCH_ALL,
+    transition: float | None = None,
+    brightness: int | None = None,
+    brightness_pct: float | None = None,
+    rgb_color: tuple[int, int, int] | None = None,
+    xy_color: tuple[float, float] | None = None,
+    hs_color: tuple[float, float] | None = None,
+    color_temp: int | None = None,
+    kelvin: int | None = None,
+    profile: str | None = None,
+    flash: str | None = None,
+    effect: str | None = None,
+    color_name: str | None = None,
+) -> None:
     """Turn all or specified light on."""
     data = {
         key: value

--- a/tests/components/light/conftest.py
+++ b/tests/components/light/conftest.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from homeassistant.components.light import Profiles
+from homeassistant.core import HomeAssistant
 
 
 @pytest.fixture(autouse=True)
@@ -12,7 +13,7 @@ def mock_light_profiles():
     """Mock loading of profiles."""
     data = {}
 
-    def mock_profiles_class(hass):
+    def mock_profiles_class(hass: HomeAssistant) -> Profiles:
         profiles = Profiles(hass)
         profiles.data = data
         profiles.async_initialize = AsyncMock()

--- a/tests/components/litejet/test_trigger.py
+++ b/tests/components/litejet/test_trigger.py
@@ -2,8 +2,9 @@
 
 from datetime import timedelta
 import logging
+from typing import Any
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -30,7 +31,9 @@ ENTITY_OTHER_SWITCH = "switch.mock_switch_2"
 ENTITY_OTHER_SWITCH_NUMBER = 2
 
 
-async def simulate_press(hass, mock_litejet, number):
+async def simulate_press(
+    hass: HomeAssistant, mock_litejet: MagicMock, number: int
+) -> None:
     """Test to simulate a press."""
     _LOGGER.info("*** simulate press of %d", number)
     callback = mock_litejet.switch_pressed_callbacks.get(number)
@@ -43,7 +46,9 @@ async def simulate_press(hass, mock_litejet, number):
         await hass.async_block_till_done()
 
 
-async def simulate_release(hass, mock_litejet, number):
+async def simulate_release(
+    hass: HomeAssistant, mock_litejet: MagicMock, number: int
+) -> None:
     """Test to simulate releasing."""
     _LOGGER.info("*** simulate release of %d", number)
     callback = mock_litejet.switch_released_callbacks.get(number)
@@ -56,7 +61,9 @@ async def simulate_release(hass, mock_litejet, number):
         await hass.async_block_till_done()
 
 
-async def simulate_time(hass, mock_litejet, delta):
+async def simulate_time(
+    hass: HomeAssistant, mock_litejet: MagicMock, delta: timedelta
+) -> None:
     """Test to simulate time."""
     _LOGGER.info(
         "*** simulate time change by %s: %s", delta, mock_litejet.start_time + delta
@@ -72,7 +79,7 @@ async def simulate_time(hass, mock_litejet, delta):
         _LOGGER.info("*** done with now=%s", dt_util.utcnow())
 
 
-async def setup_automation(hass, trigger):
+async def setup_automation(hass: HomeAssistant, trigger: dict[str, Any]) -> None:
     """Test setting up the automation."""
     await async_init_integration(hass, use_switch=True)
     assert await setup.async_setup_component(
@@ -95,7 +102,7 @@ async def setup_automation(hass, trigger):
 
 
 async def test_simple(
-    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet
+    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet: MagicMock
 ) -> None:
     """Test the simplest form of a LiteJet trigger."""
     await setup_automation(
@@ -110,7 +117,7 @@ async def test_simple(
 
 
 async def test_only_release(
-    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet
+    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet: MagicMock
 ) -> None:
     """Test the simplest form of a LiteJet trigger."""
     await setup_automation(
@@ -123,7 +130,7 @@ async def test_only_release(
 
 
 async def test_held_more_than_short(
-    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet
+    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet: MagicMock
 ) -> None:
     """Test a too short hold."""
     await setup_automation(
@@ -142,7 +149,7 @@ async def test_held_more_than_short(
 
 
 async def test_held_more_than_long(
-    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet
+    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet: MagicMock
 ) -> None:
     """Test a hold that is long enough."""
     await setup_automation(
@@ -164,7 +171,7 @@ async def test_held_more_than_long(
 
 
 async def test_held_less_than_short(
-    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet
+    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet: MagicMock
 ) -> None:
     """Test a hold that is short enough."""
     await setup_automation(
@@ -185,7 +192,7 @@ async def test_held_less_than_short(
 
 
 async def test_held_less_than_long(
-    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet
+    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet: MagicMock
 ) -> None:
     """Test a hold that is too long."""
     await setup_automation(
@@ -206,7 +213,7 @@ async def test_held_less_than_long(
 
 
 async def test_held_in_range_short(
-    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet
+    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet: MagicMock
 ) -> None:
     """Test an in-range trigger with a too short hold."""
     await setup_automation(
@@ -226,7 +233,7 @@ async def test_held_in_range_short(
 
 
 async def test_held_in_range_just_right(
-    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet
+    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet: MagicMock
 ) -> None:
     """Test an in-range trigger with a just right hold."""
     await setup_automation(
@@ -249,7 +256,7 @@ async def test_held_in_range_just_right(
 
 
 async def test_held_in_range_long(
-    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet
+    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet: MagicMock
 ) -> None:
     """Test an in-range trigger with a too long hold."""
     await setup_automation(
@@ -271,7 +278,7 @@ async def test_held_in_range_long(
 
 
 async def test_reload(
-    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet
+    hass: HomeAssistant, service_calls: list[ServiceCall], mock_litejet: MagicMock
 ) -> None:
     """Test reloading automation."""
     await setup_automation(

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -524,7 +524,7 @@ async def test_exclude_described_event(
     entity_id2 = "automation.included_rule"
     entity_id3 = "sensor.excluded_domain"
 
-    def _describe(event):
+    def _describe(event: Event) -> dict[str, str]:
         """Describe an event."""
         return {
             "name": "Test Name",
@@ -532,7 +532,12 @@ async def test_exclude_described_event(
             "entity_id": event.data[ATTR_ENTITY_ID],
         }
 
-    def async_describe_events(hass, async_describe_event):
+    def async_describe_events(
+        hass: HomeAssistant,
+        async_describe_event: Callable[
+            [str, str, Callable[[Event], dict[str, str]]], None
+        ],
+    ) -> None:
         """Mock to describe events."""
         async_describe_event("automation", "some_automation_event", _describe)
         async_describe_event("sensor", "some_event", _describe)

--- a/tests/components/logger/test_init.py
+++ b/tests/components/logger/test_init.py
@@ -226,7 +226,7 @@ async def test_can_set_level_from_store(
     _reset_logging()
 
 
-async def _assert_log_levels(hass):
+async def _assert_log_levels(hass: HomeAssistant) -> None:
     assert logging.getLogger(UNCONFIG_NS).level == logging.NOTSET
     assert logging.getLogger(UNCONFIG_NS).isEnabledFor(logging.CRITICAL) is True
     assert (

--- a/tests/components/lutron_caseta/test_device_trigger.py
+++ b/tests/components/lutron_caseta/test_device_trigger.py
@@ -98,7 +98,7 @@ MOCK_BUTTON_DEVICES = [
 ]
 
 
-async def _async_setup_lutron_with_picos(hass):
+async def _async_setup_lutron_with_picos(hass: HomeAssistant) -> str:
     """Setups a lutron bridge with picos."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
