### PR TITLE
Add missing hass type hint in component tests (n)

### DIFF
--- a/tests/components/nest/test_camera.py
+++ b/tests/components/nest/test_camera.py
@@ -165,7 +165,9 @@ async def mock_create_stream(hass: HomeAssistant) -> Generator[AsyncMock]:
         yield mock_stream
 
 
-async def async_get_image(hass, width=None, height=None):
+async def async_get_image(
+    hass: HomeAssistant, width: int | None = None, height: int | None = None
+) -> bytes:
     """Get the camera image."""
     image = await camera.async_get_image(
         hass, "camera.my_camera", width=width, height=height
@@ -174,7 +176,7 @@ async def async_get_image(hass, width=None, height=None):
     return image.content
 
 
-async def fire_alarm(hass, point_in_time):
+async def fire_alarm(hass: HomeAssistant, point_in_time: datetime.datetime) -> None:
     """Fire an alarm and wait for callbacks to run."""
     with freeze_time(point_in_time):
         async_fire_time_changed(hass, point_in_time)

--- a/tests/components/nest/test_device_trigger.py
+++ b/tests/components/nest/test_device_trigger.py
@@ -59,7 +59,9 @@ def make_camera(
     }
 
 
-async def setup_automation(hass, device_id, trigger_type):
+async def setup_automation(
+    hass: HomeAssistant, device_id: str, trigger_type: str
+) -> bool:
     """Set up an automation trigger for testing triggering."""
     return await async_setup_component(
         hass,

--- a/tests/components/notify/common.py
+++ b/tests/components/notify/common.py
@@ -4,6 +4,8 @@ All containing methods are legacy helpers that should not be used by new
 components. Instead call the service directly.
 """
 
+from typing import Any
+
 from homeassistant.components.notify import (
     ATTR_DATA,
     ATTR_MESSAGE,
@@ -11,11 +13,14 @@ from homeassistant.components.notify import (
     DOMAIN,
     SERVICE_NOTIFY,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.loader import bind_hass
 
 
 @bind_hass
-def send_message(hass, message, title=None, data=None):
+def send_message(
+    hass: HomeAssistant, message: str, title: str | None = None, data: Any = None
+) -> None:
     """Send a notification message."""
     info = {ATTR_MESSAGE: message}
 

--- a/tests/components/notify/test_legacy.py
+++ b/tests/components/notify/test_legacy.py
@@ -1,7 +1,7 @@
 """The tests for legacy notify services."""
 
 import asyncio
-from collections.abc import Mapping
+from collections.abc import Callable, Coroutine, Mapping
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, Mock, patch
@@ -63,8 +63,16 @@ def mock_notify_platform(
     hass: HomeAssistant,
     tmp_path: Path,
     integration: str = "notify",
-    async_get_service: Any = None,
-    get_service: Any = None,
+    async_get_service: Callable[
+        [HomeAssistant, ConfigType, DiscoveryInfoType | None],
+        Coroutine[Any, Any, notify.BaseNotificationService],
+    ]
+    | None = None,
+    get_service: Callable[
+        [HomeAssistant, ConfigType, DiscoveryInfoType | None],
+        notify.BaseNotificationService,
+    ]
+    | None = None,
 ):
     """Specialize the mock platform for legacy notify service."""
     loaded_platform = MockNotifyPlatform(async_get_service, get_service)
@@ -263,7 +271,11 @@ async def test_platform_setup_with_error(
 ) -> None:
     """Test service setup with an invalid setup."""
 
-    async def async_get_service(hass, config, discovery_info=None):
+    async def async_get_service(
+        hass: HomeAssistant,
+        config: ConfigType,
+        discovery_info: DiscoveryInfoType | None = None,
+    ) -> notify.BaseNotificationService | None:
         """Return None for an invalid notify service."""
         raise Exception("Setup error")  # noqa: TRY002
 
@@ -283,11 +295,15 @@ async def test_platform_setup_with_error(
 
 
 async def test_reload_with_notify_builtin_platform_reload(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, tmp_path: Path
+    hass: HomeAssistant, tmp_path: Path
 ) -> None:
     """Test reload using the legacy notify platform reload method."""
 
-    async def async_get_service(hass, config, discovery_info=None):
+    async def async_get_service(
+        hass: HomeAssistant,
+        config: ConfigType,
+        discovery_info: DiscoveryInfoType | None = None,
+    ) -> NotificationService:
         """Get notify service for mocked platform."""
         targetlist = {"a": 1, "b": 2}
         return NotificationService(hass, targetlist, "testnotify")
@@ -314,19 +330,25 @@ async def test_reload_with_notify_builtin_platform_reload(
     assert hass.services.has_service(notify.DOMAIN, "testnotify_b")
 
 
-async def test_setup_platform_and_reload(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, tmp_path: Path
-) -> None:
+async def test_setup_platform_and_reload(hass: HomeAssistant, tmp_path: Path) -> None:
     """Test service setup and reload."""
     get_service_called = Mock()
 
-    async def async_get_service(hass, config, discovery_info=None):
+    async def async_get_service(
+        hass: HomeAssistant,
+        config: ConfigType,
+        discovery_info: DiscoveryInfoType | None = None,
+    ) -> NotificationService:
         """Get notify service for mocked platform."""
         get_service_called(config, discovery_info)
         targetlist = {"a": 1, "b": 2}
         return NotificationService(hass, targetlist, "testnotify")
 
-    async def async_get_service2(hass, config, discovery_info=None):
+    async def async_get_service2(
+        hass: HomeAssistant,
+        config: ConfigType,
+        discovery_info: DiscoveryInfoType | None = None,
+    ) -> NotificationService:
         """Get legacy notify service for mocked platform."""
         get_service_called(config, discovery_info)
         targetlist = {"c": 3, "d": 4}
@@ -405,18 +427,26 @@ async def test_setup_platform_and_reload(
 
 
 async def test_setup_platform_before_notify_setup(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, tmp_path: Path
+    hass: HomeAssistant, tmp_path: Path
 ) -> None:
     """Test trying to setup a platform before legacy notify service is setup."""
     get_service_called = Mock()
 
-    async def async_get_service(hass, config, discovery_info=None):
+    async def async_get_service(
+        hass: HomeAssistant,
+        config: ConfigType,
+        discovery_info: DiscoveryInfoType | None = None,
+    ) -> NotificationService:
         """Get notify service for mocked platform."""
         get_service_called(config, discovery_info)
         targetlist = {"a": 1, "b": 2}
         return NotificationService(hass, targetlist, "testnotify")
 
-    async def async_get_service2(hass, config, discovery_info=None):
+    async def async_get_service2(
+        hass: HomeAssistant,
+        config: ConfigType,
+        discovery_info: DiscoveryInfoType | None = None,
+    ) -> NotificationService:
         """Get notify service for mocked platform."""
         get_service_called(config, discovery_info)
         targetlist = {"c": 3, "d": 4}
@@ -455,18 +485,26 @@ async def test_setup_platform_before_notify_setup(
 
 
 async def test_setup_platform_after_notify_setup(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, tmp_path: Path
+    hass: HomeAssistant, tmp_path: Path
 ) -> None:
     """Test trying to setup a platform after legacy notify service is set up."""
     get_service_called = Mock()
 
-    async def async_get_service(hass, config, discovery_info=None):
+    async def async_get_service(
+        hass: HomeAssistant,
+        config: ConfigType,
+        discovery_info: DiscoveryInfoType | None = None,
+    ) -> NotificationService:
         """Get notify service for mocked platform."""
         get_service_called(config, discovery_info)
         targetlist = {"a": 1, "b": 2}
         return NotificationService(hass, targetlist, "testnotify")
 
-    async def async_get_service2(hass, config, discovery_info=None):
+    async def async_get_service2(
+        hass: HomeAssistant,
+        config: ConfigType,
+        discovery_info: DiscoveryInfoType | None = None,
+    ) -> NotificationService:
         """Get notify service for mocked platform."""
         get_service_called(config, discovery_info)
         targetlist = {"c": 3, "d": 4}

--- a/tests/components/nx584/test_binary_sensor.py
+++ b/tests/components/nx584/test_binary_sensor.py
@@ -1,5 +1,6 @@
 """The tests for the nx584 sensor platform."""
 
+from typing import Any
 from unittest import mock
 
 from nx584 import client as nx584_client
@@ -99,7 +100,9 @@ def test_nx584_sensor_setup_full_config(
     assert mock_watcher.called
 
 
-async def _test_assert_graceful_fail(hass, config):
+async def _test_assert_graceful_fail(
+    hass: HomeAssistant, config: dict[str, Any]
+) -> None:
     """Test the failing."""
     assert not await async_setup_component(hass, "nx584", config)
 
@@ -114,7 +117,9 @@ async def _test_assert_graceful_fail(hass, config):
         ({"zone_types": {"notazone": "motion"}}),
     ],
 )
-async def test_nx584_sensor_setup_bad_config(hass: HomeAssistant, config) -> None:
+async def test_nx584_sensor_setup_bad_config(
+    hass: HomeAssistant, config: dict[str, Any]
+) -> None:
     """Test the setup with bad configuration."""
     await _test_assert_graceful_fail(hass, config)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
