### PR TITLE
Add missing hass type hint in component tests (o)

### DIFF
--- a/tests/components/onvif/__init__.py
+++ b/tests/components/onvif/__init__.py
@@ -151,7 +151,9 @@ def setup_mock_device(mock_device, capabilities=None):
         pullpoint_manager=MagicMock(state=PullPointManagerState.PAUSED),
     )
 
-    def mock_constructor(hass, config):
+    def mock_constructor(
+        hass: HomeAssistant, config: config_entries.ConfigEntry
+    ) -> MagicMock:
         """Fake the controller constructor."""
         return mock_device
 

--- a/tests/components/otbr/test_config_flow.py
+++ b/tests/components/otbr/test_config_flow.py
@@ -347,7 +347,7 @@ async def test_hassio_discovery_flow_2x_addons(
     aioclient_mock.get(f"{url1}/node/dataset/active", text="aa")
     aioclient_mock.get(f"{url2}/node/dataset/active", text="bb")
 
-    async def _addon_info(hass, slug):
+    async def _addon_info(hass: HomeAssistant, slug: str) -> dict[str, Any]:
         await asyncio.sleep(0)
         if slug == "otbr":
             return {

--- a/tests/components/owntracks/test_config_flow.py
+++ b/tests/components/owntracks/test_config_flow.py
@@ -51,7 +51,7 @@ def mock_not_supports_encryption():
         yield
 
 
-async def init_config_flow(hass):
+async def init_config_flow(hass: HomeAssistant) -> config_flow.OwnTracksFlow:
     """Init a configuration flow."""
     await async_process_ha_core_config(
         hass,

--- a/tests/components/owntracks/test_device_tracker.py
+++ b/tests/components/owntracks/test_device_tracker.py
@@ -4,6 +4,7 @@ import base64
 from collections.abc import Callable, Generator
 import json
 import pickle
+from typing import Any
 from unittest.mock import patch
 
 from nacl.encoding import Base64Encoder
@@ -305,7 +306,9 @@ def setup_comp(
     hass.states.async_set("zone.outer", "zoning", OUTER_ZONE)
 
 
-async def setup_owntracks(hass, config, ctx_cls=owntracks.OwnTracksContext):
+async def setup_owntracks(
+    hass: HomeAssistant, config: dict[str, Any], ctx_cls=owntracks.OwnTracksContext
+) -> None:
     """Set up OwnTracks."""
     MockConfigEntry(
         domain="owntracks", data={"webhook_id": "owntracks_test", "secret": "abcd"}
@@ -347,7 +350,9 @@ def context(hass: HomeAssistant, setup_comp: None) -> OwnTracksContextFactory:
     return get_context
 
 
-async def send_message(hass, topic, message, corrupt=False):
+async def send_message(
+    hass: HomeAssistant, topic: str, message: dict[str, Any], corrupt: bool = False
+) -> None:
     """Test the sending of a message."""
     str_message = json.dumps(message)
     if corrupt:
@@ -359,51 +364,57 @@ async def send_message(hass, topic, message, corrupt=False):
     await hass.async_block_till_done()
 
 
-def assert_location_state(hass, location):
+def assert_location_state(hass: HomeAssistant, location: str) -> None:
     """Test the assertion of a location state."""
     state = hass.states.get(DEVICE_TRACKER_STATE)
     assert state.state == location
 
 
-def assert_location_latitude(hass, latitude):
+def assert_location_latitude(hass: HomeAssistant, latitude: float) -> None:
     """Test the assertion of a location latitude."""
     state = hass.states.get(DEVICE_TRACKER_STATE)
     assert state.attributes.get("latitude") == latitude
 
 
-def assert_location_longitude(hass, longitude):
+def assert_location_longitude(hass: HomeAssistant, longitude: float) -> None:
     """Test the assertion of a location longitude."""
     state = hass.states.get(DEVICE_TRACKER_STATE)
     assert state.attributes.get("longitude") == longitude
 
 
-def assert_location_accuracy(hass, accuracy):
+def assert_location_accuracy(hass: HomeAssistant, accuracy: int) -> None:
     """Test the assertion of a location accuracy."""
     state = hass.states.get(DEVICE_TRACKER_STATE)
     assert state.attributes.get("gps_accuracy") == accuracy
 
 
-def assert_location_source_type(hass, source_type):
+def assert_location_source_type(hass: HomeAssistant, source_type: str) -> None:
     """Test the assertion of source_type."""
     state = hass.states.get(DEVICE_TRACKER_STATE)
     assert state.attributes.get("source_type") == source_type
 
 
-def assert_mobile_tracker_state(hass, location, beacon=IBEACON_DEVICE):
+def assert_mobile_tracker_state(
+    hass: HomeAssistant, location: str, beacon: str = IBEACON_DEVICE
+) -> None:
     """Test the assertion of a mobile beacon tracker state."""
     dev_id = MOBILE_BEACON_FMT.format(beacon)
     state = hass.states.get(dev_id)
     assert state.state == location
 
 
-def assert_mobile_tracker_latitude(hass, latitude, beacon=IBEACON_DEVICE):
+def assert_mobile_tracker_latitude(
+    hass: HomeAssistant, latitude: float, beacon: str = IBEACON_DEVICE
+) -> None:
     """Test the assertion of a mobile beacon tracker latitude."""
     dev_id = MOBILE_BEACON_FMT.format(beacon)
     state = hass.states.get(dev_id)
     assert state.attributes.get("latitude") == latitude
 
 
-def assert_mobile_tracker_accuracy(hass, accuracy, beacon=IBEACON_DEVICE):
+def assert_mobile_tracker_accuracy(
+    hass: HomeAssistant, accuracy: int, beacon: str = IBEACON_DEVICE
+) -> None:
     """Test the assertion of a mobile beacon tracker accuracy."""
     dev_id = MOBILE_BEACON_FMT.format(beacon)
     state = hass.states.get(dev_id)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
