### PR TITLE
Add missing hass type hint in component tests (p)

### DIFF
--- a/tests/components/panasonic_viera/test_remote.py
+++ b/tests/components/panasonic_viera/test_remote.py
@@ -18,7 +18,7 @@ from .conftest import MOCK_CONFIG_DATA, MOCK_DEVICE_INFO, MOCK_ENCRYPTION_DATA
 from tests.common import MockConfigEntry
 
 
-async def setup_panasonic_viera(hass):
+async def setup_panasonic_viera(hass: HomeAssistant) -> None:
     """Initialize integration for tests."""
     mock_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/pilight/test_sensor.py
+++ b/tests/components/pilight/test_sensor.py
@@ -1,6 +1,7 @@
 """The tests for the Pilight sensor platform."""
 
 import logging
+from typing import Any
 
 import pytest
 
@@ -17,7 +18,9 @@ def setup_comp(hass: HomeAssistant) -> None:
     mock_component(hass, "pilight")
 
 
-def fire_pilight_message(hass, protocol, data):
+def fire_pilight_message(
+    hass: HomeAssistant, protocol: str, data: dict[str, Any]
+) -> None:
     """Fire the fake Pilight message."""
     message = {pilight.CONF_PROTOCOL: protocol}
     message.update(data)

--- a/tests/components/plex/helpers.py
+++ b/tests/components/plex/helpers.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from plexwebsocket import SIGNAL_CONNECTION_STATE, STATE_CONNECTED
 
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import UNDEFINED, UndefinedType
 import homeassistant.util.dt as dt_util
 
@@ -39,7 +40,7 @@ def trigger_plex_update(
     callback(msgtype, UPDATE_PAYLOAD if payload is UNDEFINED else payload, None)
 
 
-async def wait_for_debouncer(hass):
+async def wait_for_debouncer(hass: HomeAssistant) -> None:
     """Move time forward to wait for sensor debouncer."""
     next_update = dt_util.utcnow() + timedelta(seconds=3)
     async_fire_time_changed(hass, next_update)

--- a/tests/components/point/test_config_flow.py
+++ b/tests/components/point/test_config_flow.py
@@ -10,7 +10,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 
-def init_config_flow(hass, side_effect=None):
+def init_config_flow(
+    hass: HomeAssistant, side_effect: type[Exception] | None = None
+) -> config_flow.PointFlowHandler:
     """Init a configuration flow."""
     config_flow.register_flow_implementation(hass, DOMAIN, "id", "secret")
     flow = config_flow.PointFlowHandler()
@@ -22,7 +24,7 @@ def init_config_flow(hass, side_effect=None):
 
 
 @pytest.fixture
-def is_authorized():
+def is_authorized() -> bool:
     """Set PointSession authorized."""
     return True
 

--- a/tests/components/powerwall/mocks.py
+++ b/tests/components/powerwall/mocks.py
@@ -17,6 +17,7 @@ from tesla_powerwall import (
 )
 
 from homeassistant.core import HomeAssistant
+from homeassistant.util.json import JsonValueType
 
 from tests.common import load_fixture
 
@@ -87,7 +88,7 @@ async def _mock_powerwall_return_value(
     return powerwall_mock
 
 
-async def _mock_powerwall_site_name(hass, site_name):
+async def _mock_powerwall_site_name(hass: HomeAssistant, site_name: str) -> MagicMock:
     powerwall_mock = MagicMock(Powerwall)
     powerwall_mock.__aenter__.return_value = powerwall_mock
 
@@ -110,7 +111,7 @@ async def _mock_powerwall_side_effect(site_info=None):
     return powerwall_mock
 
 
-async def _async_load_json_fixture(hass, path):
+async def _async_load_json_fixture(hass: HomeAssistant, path: str) -> JsonValueType:
     fixture = await hass.async_add_executor_job(
         load_fixture, os.path.join("powerwall", path)
     )

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -199,7 +199,7 @@ async def test_media_player_is_setup(hass: HomeAssistant) -> None:
     assert len(hass.data[PS4_DATA].devices) == 1
 
 
-async def setup_mock_component(hass):
+async def setup_mock_component(hass: HomeAssistant) -> None:
     """Set up Mock Media Player."""
     entry = MockConfigEntry(domain=ps4.DOMAIN, data=MOCK_DATA, version=VERSION)
     entry.add_to_manager(hass.config_entries)

--- a/tests/components/ps4/test_media_player.py
+++ b/tests/components/ps4/test_media_player.py
@@ -1,5 +1,6 @@
 """Tests for the PS4 media player platform."""
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from pyps4_2ndscreen.credential import get_ddp_message
@@ -130,7 +131,9 @@ MOCK_CONFIG = MockConfigEntry(domain=DOMAIN, data=MOCK_DATA, entry_id=MOCK_ENTRY
 MOCK_LOAD = "homeassistant.components.ps4.media_player.load_games"
 
 
-async def setup_mock_component(hass, entry=None):
+async def setup_mock_component(
+    hass: HomeAssistant, entry: MockConfigEntry | None = None
+) -> str:
     """Set up Mock Media Player."""
     if entry is None:
         mock_entry = MockConfigEntry(
@@ -150,7 +153,9 @@ async def setup_mock_component(hass, entry=None):
     return mock_entities[0]
 
 
-async def mock_ddp_response(hass, mock_status_data):
+async def mock_ddp_response(
+    hass: HomeAssistant, mock_status_data: dict[str, Any]
+) -> None:
     """Mock raw UDP response from device."""
     mock_protocol = hass.data[PS4_DATA].protocol
     assert mock_protocol.local_port == DEFAULT_UDP_PORT


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
