### PR TITLE
Add missing hass type hint in component tests (r)

### DIFF
--- a/tests/components/repairs/test_websocket_api.py
+++ b/tests/components/repairs/test_websocket_api.py
@@ -18,7 +18,11 @@ from homeassistant.helpers import issue_registry as ir
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockUser, mock_platform
-from tests.typing import ClientSessionGenerator, WebSocketGenerator
+from tests.typing import (
+    ClientSessionGenerator,
+    MockHAClientWebSocket,
+    WebSocketGenerator,
+)
 
 DEFAULT_ISSUES = [
     {
@@ -34,7 +38,11 @@ DEFAULT_ISSUES = [
 ]
 
 
-async def create_issues(hass, ws_client, issues=None):
+async def create_issues(
+    hass: HomeAssistant,
+    ws_client: MockHAClientWebSocket,
+    issues: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
     """Create issues."""
 
     def api_issue(issue):
@@ -119,7 +127,11 @@ async def mock_repairs_integration(hass: HomeAssistant) -> None:
     """Mock a repairs integration."""
     hass.config.components.add("fake_integration")
 
-    def async_create_fix_flow(hass, issue_id, data):
+    def async_create_fix_flow(
+        hass: HomeAssistant,
+        issue_id: str,
+        data: dict[str, str | int | float | None] | None,
+    ) -> RepairsFlow:
         assert issue_id in EXPECTED_DATA
         assert data == EXPECTED_DATA[issue_id]
 

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -29,7 +29,9 @@ def com_port():
     return port
 
 
-async def start_options_flow(hass, entry):
+async def start_options_flow(
+    hass: HomeAssistant, entry: MockConfigEntry
+) -> config_entries.ConfigFlowResult:
     """Start the options flow with the entry under test."""
     entry.add_to_hass(hass)
 

--- a/tests/components/rfxtrx/test_device_action.py
+++ b/tests/components/rfxtrx/test_device_action.py
@@ -47,7 +47,7 @@ async def test_device_test_data(rfxtrx, device: DeviceTestData) -> None:
     }
 
 
-async def setup_entry(hass, devices):
+async def setup_entry(hass: HomeAssistant, devices: dict[str, Any]) -> None:
     """Construct a config setup."""
     entry_data = create_rfx_test_cfg(devices=devices)
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
@@ -79,7 +79,10 @@ def _get_expected_actions(data):
     ],
 )
 async def test_get_actions(
-    hass: HomeAssistant, device_registry: dr.DeviceRegistry, device, expected
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    device: DeviceTestData,
+    expected,
 ) -> None:
     """Test we get the expected actions from a rfxtrx."""
     await setup_entry(hass, {device.code: {}})
@@ -136,7 +139,7 @@ async def test_action(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     rfxtrx: RFXtrx.Connect,
-    device,
+    device: DeviceTestData,
     config,
     expected,
 ) -> None:

--- a/tests/components/rfxtrx/test_device_trigger.py
+++ b/tests/components/rfxtrx/test_device_trigger.py
@@ -46,7 +46,7 @@ EVENT_FIREALARM_1 = EventTestData(
 )
 
 
-async def setup_entry(hass, devices):
+async def setup_entry(hass: HomeAssistant, devices: dict[str, Any]) -> None:
     """Construct a config setup."""
     entry_data = create_rfx_test_cfg(devices=devices)
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)

--- a/tests/components/ring/common.py
+++ b/tests/components/ring/common.py
@@ -3,12 +3,14 @@
 from unittest.mock import patch
 
 from homeassistant.components.ring import DOMAIN
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
 
-async def setup_platform(hass, platform):
+async def setup_platform(hass: HomeAssistant, platform: Platform) -> None:
     """Set up the ring platform and prerequisites."""
     MockConfigEntry(domain=DOMAIN, data={"username": "foo", "token": {}}).add_to_hass(
         hass

--- a/tests/components/risco/test_alarm_control_panel.py
+++ b/tests/components/risco/test_alarm_control_panel.py
@@ -1,5 +1,7 @@
 """Tests for the Risco alarm control panel device."""
 
+from collections.abc import Callable
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
@@ -180,8 +182,13 @@ async def test_cloud_setup(
 
 
 async def _check_cloud_state(
-    hass, partitions, property, state, entity_id, partition_id
-):
+    hass: HomeAssistant,
+    partitions: dict[int, Any],
+    property: str,
+    state: str,
+    entity_id: str,
+    partition_id: int,
+) -> None:
     with patch.object(partitions[partition_id], property, return_value=True):
         await async_update_entity(hass, entity_id)
         await hass.async_block_till_done()
@@ -256,7 +263,9 @@ async def test_cloud_states(
             )
 
 
-async def _call_alarm_service(hass, service, entity_id, **kwargs):
+async def _call_alarm_service(
+    hass: HomeAssistant, service: str, entity_id: str, **kwargs: Any
+) -> None:
     data = {"entity_id": entity_id, **kwargs}
 
     await hass.services.async_call(
@@ -265,16 +274,27 @@ async def _call_alarm_service(hass, service, entity_id, **kwargs):
 
 
 async def _test_cloud_service_call(
-    hass, service, method, entity_id, partition_id, *args, **kwargs
-):
+    hass: HomeAssistant,
+    service: str,
+    method: str,
+    entity_id: str,
+    partition_id: int,
+    *args: Any,
+    **kwargs: Any,
+) -> None:
     with patch(f"homeassistant.components.risco.RiscoCloud.{method}") as set_mock:
         await _call_alarm_service(hass, service, entity_id, **kwargs)
         set_mock.assert_awaited_once_with(partition_id, *args)
 
 
 async def _test_cloud_no_service_call(
-    hass, service, method, entity_id, partition_id, **kwargs
-):
+    hass: HomeAssistant,
+    service: str,
+    method: str,
+    entity_id: str,
+    partition_id: int,
+    **kwargs: Any,
+) -> None:
     with patch(f"homeassistant.components.risco.RiscoCloud.{method}") as set_mock:
         await _call_alarm_service(hass, service, entity_id, **kwargs)
         set_mock.assert_not_awaited()
@@ -531,8 +551,14 @@ async def test_local_setup(
 
 
 async def _check_local_state(
-    hass, partitions, property, state, entity_id, partition_id, callback
-):
+    hass: HomeAssistant,
+    partitions: dict[int, Any],
+    property: str,
+    state: str,
+    entity_id: str,
+    partition_id: int,
+    callback: Callable,
+) -> None:
     with patch.object(partitions[partition_id], property, return_value=True):
         await callback(partition_id, partitions[partition_id])
 
@@ -629,16 +655,27 @@ async def test_local_states(
 
 
 async def _test_local_service_call(
-    hass, service, method, entity_id, partition, *args, **kwargs
-):
+    hass: HomeAssistant,
+    service: str,
+    method: str,
+    entity_id: str,
+    partition: int,
+    *args: Any,
+    **kwargs: Any,
+) -> None:
     with patch.object(partition, method, AsyncMock()) as set_mock:
         await _call_alarm_service(hass, service, entity_id, **kwargs)
         set_mock.assert_awaited_once_with(*args)
 
 
 async def _test_local_no_service_call(
-    hass, service, method, entity_id, partition, **kwargs
-):
+    hass: HomeAssistant,
+    service: str,
+    method: str,
+    entity_id: str,
+    partition: int,
+    **kwargs: Any,
+) -> None:
     with patch.object(partition, method, AsyncMock()) as set_mock:
         await _call_alarm_service(hass, service, entity_id, **kwargs)
         set_mock.assert_not_awaited()

--- a/tests/components/risco/test_binary_sensor.py
+++ b/tests/components/risco/test_binary_sensor.py
@@ -1,6 +1,8 @@
 """Tests for the Risco binary sensors."""
 
-from unittest.mock import PropertyMock, patch
+from collections.abc import Callable
+from typing import Any
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
@@ -59,7 +61,13 @@ async def test_cloud_setup(
     assert device.manufacturer == "Risco"
 
 
-async def _check_cloud_state(hass, zones, triggered, entity_id, zone_id):
+async def _check_cloud_state(
+    hass: HomeAssistant,
+    zones: dict[int, Any],
+    triggered: bool,
+    entity_id: str,
+    zone_id: int,
+) -> None:
     with patch.object(
         zones[zone_id],
         "triggered",
@@ -130,8 +138,14 @@ async def test_local_setup(
 
 
 async def _check_local_state(
-    hass, zones, entity_property, value, entity_id, zone_id, callback
-):
+    hass: HomeAssistant,
+    zones: dict[int, Any],
+    entity_property: str,
+    value: bool,
+    entity_id: str,
+    zone_id: int,
+    callback: Callable,
+) -> None:
     with patch.object(
         zones[zone_id],
         entity_property,
@@ -218,7 +232,13 @@ async def test_armed_local_states(
     )
 
 
-async def _check_system_state(hass, system, entity_property, value, callback):
+async def _check_system_state(
+    hass: HomeAssistant,
+    system: MagicMock,
+    entity_property: str,
+    value: bool,
+    callback: Callable,
+) -> None:
     with patch.object(
         system,
         entity_property,

--- a/tests/components/risco/test_sensor.py
+++ b/tests/components/risco/test_sensor.py
@@ -136,7 +136,7 @@ async def test_error_on_login(
         assert not entity_registry.async_is_registered(entity_id)
 
 
-def _check_state(hass, category, entity_id):
+def _check_state(hass: HomeAssistant, category: str, entity_id: str) -> None:
     event_index = CATEGORIES_TO_EVENTS[category]
     event = TEST_EVENTS[event_index]
     state = hass.states.get(entity_id)

--- a/tests/components/risco/test_switch.py
+++ b/tests/components/risco/test_switch.py
@@ -1,5 +1,7 @@
 """Tests for the Risco binary sensors."""
 
+from collections.abc import Callable
+from typing import Any
 from unittest.mock import PropertyMock, patch
 
 import pytest
@@ -40,7 +42,13 @@ async def test_cloud_setup(
     assert entity_registry.async_is_registered(SECOND_ENTITY_ID)
 
 
-async def _check_cloud_state(hass, zones, bypassed, entity_id, zone_id):
+async def _check_cloud_state(
+    hass: HomeAssistant,
+    zones: dict[int, Any],
+    bypassed: bool,
+    entity_id: str,
+    zone_id: int,
+) -> None:
     with patch.object(
         zones[zone_id],
         "bypassed",
@@ -117,7 +125,14 @@ async def test_local_setup(
     assert entity_registry.async_is_registered(SECOND_ENTITY_ID)
 
 
-async def _check_local_state(hass, zones, bypassed, entity_id, zone_id, callback):
+async def _check_local_state(
+    hass: HomeAssistant,
+    zones: dict[int, Any],
+    bypassed: bool,
+    entity_id: str,
+    zone_id: int,
+    callback: Callable,
+) -> None:
     with patch.object(
         zones[zone_id],
         "bypassed",

--- a/tests/components/rpi_power/test_binary_sensor.py
+++ b/tests/components/rpi_power/test_binary_sensor.py
@@ -24,7 +24,7 @@ ENTITY_ID = "binary_sensor.rpi_power_status"
 MODULE = "homeassistant.components.rpi_power.binary_sensor.new_under_voltage"
 
 
-async def _async_setup_component(hass, detected):
+async def _async_setup_component(hass: HomeAssistant, detected: bool) -> MagicMock:
     mocked_under_voltage = MagicMock()
     type(mocked_under_voltage).get = MagicMock(return_value=detected)
     entry = MockConfigEntry(domain=DOMAIN)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
