### PR TITLE
Add LawnMowerActivity.RETURNING to Lawn Mower

### DIFF
--- a/homeassistant/components/kitchen_sink/lawn_mower.py
+++ b/homeassistant/components/kitchen_sink/lawn_mower.py
@@ -100,7 +100,7 @@ class DemoLawnMower(LawnMowerEntity):
 
     async def async_dock(self) -> None:
         """Start docking."""
-        self._attr_activity = LawnMowerActivity.RETURNING
+        self._attr_activity = LawnMowerActivity.DOCKED
         self.async_write_ha_state()
 
     async def async_pause(self) -> None:

--- a/homeassistant/components/kitchen_sink/lawn_mower.py
+++ b/homeassistant/components/kitchen_sink/lawn_mower.py
@@ -30,18 +30,24 @@ async def async_setup_platform(
             ),
             DemoLawnMower(
                 "kitchen_sink_mower_002",
+                "Mower can return",
+                LawnMowerActivity.RETURNING,
+                LawnMowerEntityFeature.DOCK | LawnMowerEntityFeature.START_MOWING,
+            ),
+            DemoLawnMower(
+                "kitchen_sink_mower_003",
                 "Mower can dock",
                 LawnMowerActivity.MOWING,
                 LawnMowerEntityFeature.DOCK | LawnMowerEntityFeature.START_MOWING,
             ),
             DemoLawnMower(
-                "kitchen_sink_mower_003",
+                "kitchen_sink_mower_004",
                 "Mower can pause",
                 LawnMowerActivity.DOCKED,
                 LawnMowerEntityFeature.PAUSE | LawnMowerEntityFeature.START_MOWING,
             ),
             DemoLawnMower(
-                "kitchen_sink_mower_004",
+                "kitchen_sink_mower_005",
                 "Mower can do all",
                 LawnMowerActivity.DOCKED,
                 LawnMowerEntityFeature.DOCK

--- a/homeassistant/components/kitchen_sink/lawn_mower.py
+++ b/homeassistant/components/kitchen_sink/lawn_mower.py
@@ -31,7 +31,7 @@ async def async_setup_platform(
             DemoLawnMower(
                 "kitchen_sink_mower_002",
                 "Mower can return",
-                LawnMowerActivity.PAUSED,
+                LawnMowerActivity.RETURNING,
                 LawnMowerEntityFeature.DOCK
                 | LawnMowerEntityFeature.PAUSE
                 | LawnMowerEntityFeature.START_MOWING,

--- a/homeassistant/components/kitchen_sink/lawn_mower.py
+++ b/homeassistant/components/kitchen_sink/lawn_mower.py
@@ -31,8 +31,10 @@ async def async_setup_platform(
             DemoLawnMower(
                 "kitchen_sink_mower_002",
                 "Mower can return",
-                LawnMowerActivity.RETURNING,
-                LawnMowerEntityFeature.DOCK | LawnMowerEntityFeature.START_MOWING,
+                LawnMowerActivity.PAUSED,
+                LawnMowerEntityFeature.DOCK
+                | LawnMowerEntityFeature.PAUSE
+                | LawnMowerEntityFeature.START_MOWING,
             ),
             DemoLawnMower(
                 "kitchen_sink_mower_003",
@@ -55,7 +57,7 @@ async def async_setup_platform(
                 | LawnMowerEntityFeature.START_MOWING,
             ),
             DemoLawnMower(
-                "kitchen_sink_mower_005",
+                "kitchen_sink_mower_006",
                 "Mower is paused",
                 LawnMowerActivity.PAUSED,
                 LawnMowerEntityFeature.DOCK
@@ -98,7 +100,7 @@ class DemoLawnMower(LawnMowerEntity):
 
     async def async_dock(self) -> None:
         """Start docking."""
-        self._attr_activity = LawnMowerActivity.DOCKED
+        self._attr_activity = LawnMowerActivity.RETURNING
         self.async_write_ha_state()
 
     async def async_pause(self) -> None:

--- a/homeassistant/components/lawn_mower/const.py
+++ b/homeassistant/components/lawn_mower/const.py
@@ -18,6 +18,9 @@ class LawnMowerActivity(StrEnum):
     DOCKED = "docked"
     """Device is docked."""
 
+    RETURNING = "returning"
+    """Device is returning."""
+
 
 class LawnMowerEntityFeature(IntFlag):
     """Supported features of the lawn mower entity."""

--- a/homeassistant/components/lawn_mower/strings.json
+++ b/homeassistant/components/lawn_mower/strings.json
@@ -7,7 +7,8 @@
         "error": "Error",
         "paused": "[%key:common::state::paused%]",
         "mowing": "Mowing",
-        "docked": "Docked"
+        "docked": "Docked",
+        "returning": "Returning"
       }
     }
   },

--- a/homeassistant/components/mqtt/lawn_mower.py
+++ b/homeassistant/components/mqtt/lawn_mower.py
@@ -199,7 +199,7 @@ class MqttLawnMower(MqttEntity, LawnMowerEntity, RestoreEntity):
 
     async def async_dock(self) -> None:
         """Dock the mower."""
-        await self._async_operate("dock", LawnMowerActivity.DOCKED)
+        await self._async_operate("dock", LawnMowerActivity.RETURNING)
 
     async def async_pause(self) -> None:
         """Pause the lawn mower."""

--- a/homeassistant/components/mqtt/lawn_mower.py
+++ b/homeassistant/components/mqtt/lawn_mower.py
@@ -199,7 +199,7 @@ class MqttLawnMower(MqttEntity, LawnMowerEntity, RestoreEntity):
 
     async def async_dock(self) -> None:
         """Dock the mower."""
-        await self._async_operate("dock", LawnMowerActivity.RETURNING)
+        await self._async_operate("dock", LawnMowerActivity.DOCKED)
 
     async def async_pause(self) -> None:
         """Pause the lawn mower."""

--- a/tests/components/kitchen_sink/snapshots/test_lawn_mower.ambr
+++ b/tests/components/kitchen_sink/snapshots/test_lawn_mower.ambr
@@ -51,6 +51,18 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
+        'friendly_name': 'Mower can return',
+        'supported_features': <LawnMowerEntityFeature: 7>,
+      }),
+      'context': <ANY>,
+      'entity_id': 'lawn_mower.mower_can_return',
+      'last_changed': <ANY>,
+      'last_reported': <ANY>,
+      'last_updated': <ANY>,
+      'state': 'paused',
+    }),
+    StateSnapshot({
+      'attributes': ReadOnlyDict({
         'friendly_name': 'Mower is paused',
         'supported_features': <LawnMowerEntityFeature: 7>,
       }),

--- a/tests/components/kitchen_sink/snapshots/test_lawn_mower.ambr
+++ b/tests/components/kitchen_sink/snapshots/test_lawn_mower.ambr
@@ -59,7 +59,7 @@
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
-      'state': 'paused',
+      'state': 'returning',
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({

--- a/tests/components/kitchen_sink/test_lawn_mower.py
+++ b/tests/components/kitchen_sink/test_lawn_mower.py
@@ -72,6 +72,12 @@ async def test_states(hass: HomeAssistant, snapshot: SnapshotAssertion) -> None:
             LawnMowerActivity.MOWING,
             LawnMowerActivity.DOCKED,
         ),
+        (
+            "lawn_mower.mower_can_return",
+            SERVICE_DOCK,
+            LawnMowerActivity.MOWING,
+            LawnMowerActivity.RETURNING,
+        ),
     ],
 )
 async def test_mower(

--- a/tests/components/kitchen_sink/test_lawn_mower.py
+++ b/tests/components/kitchen_sink/test_lawn_mower.py
@@ -67,15 +67,9 @@ async def test_states(hass: HomeAssistant, snapshot: SnapshotAssertion) -> None:
             LawnMowerActivity.MOWING,
         ),
         (
-            "lawn_mower.mower_can_dock",
-            SERVICE_DOCK,
-            LawnMowerActivity.MOWING,
-            LawnMowerActivity.DOCKED,
-        ),
-        (
             "lawn_mower.mower_can_return",
             SERVICE_DOCK,
-            LawnMowerActivity.MOWING,
+            LawnMowerActivity.PAUSED,
             LawnMowerActivity.RETURNING,
         ),
     ],

--- a/tests/components/kitchen_sink/test_lawn_mower.py
+++ b/tests/components/kitchen_sink/test_lawn_mower.py
@@ -67,6 +67,12 @@ async def test_states(hass: HomeAssistant, snapshot: SnapshotAssertion) -> None:
             LawnMowerActivity.MOWING,
         ),
         (
+            "lawn_mower.mower_can_dock",
+            SERVICE_DOCK,
+            LawnMowerActivity.MOWING,
+            LawnMowerActivity.DOCKED,
+        ),
+        (
             "lawn_mower.mower_can_return",
             SERVICE_DOCK,
             LawnMowerActivity.RETURNING,

--- a/tests/components/kitchen_sink/test_lawn_mower.py
+++ b/tests/components/kitchen_sink/test_lawn_mower.py
@@ -69,8 +69,8 @@ async def test_states(hass: HomeAssistant, snapshot: SnapshotAssertion) -> None:
         (
             "lawn_mower.mower_can_return",
             SERVICE_DOCK,
-            LawnMowerActivity.PAUSED,
             LawnMowerActivity.RETURNING,
+            LawnMowerActivity.DOCKED,
         ),
     ],
 )

--- a/tests/components/mqtt/test_lawn_mower.py
+++ b/tests/components/mqtt/test_lawn_mower.py
@@ -276,7 +276,7 @@ async def test_run_lawn_mower_service_optimistic(
     mqtt_mock.async_publish.assert_called_once_with("dock-test-topic", "dock", 0, False)
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("lawn_mower.test")
-    assert state.state == "returning"
+    assert state.state == "docked"
 
 
 @pytest.mark.parametrize(
@@ -376,7 +376,7 @@ async def test_run_lawn_mower_service_optimistic_with_command_templates(
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("lawn_mower.test_lawn_mower")
-    assert state.state == "returning"
+    assert state.state == "docked"
 
 
 @pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
@@ -646,7 +646,7 @@ async def test_entity_id_update_discovery_update(
         (
             SERVICE_DOCK,
             "dock",
-            "returning",
+            "docked",
             "test/lawn_mower_stat",
             "dock-test-topic",
         ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add returning state to Lawn Mower

see -> https://github.com/home-assistant/architecture/discussions/1123

frontend: https://github.com/home-assistant/frontend/pull/21740
developers: https://github.com/home-assistant/developers.home-assistant/pull/2280

welcome feedback on whether or not we need to add an entity feature for returning so that
async_dock can conditionally return docked or returning, however this really is implementation detail for integrations

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
