### PR TITLE
Bump aiolifx to 1.0.8 to support LIFX B10 and T10 Candles

### DIFF
--- a/homeassistant/components/lifx/manifest.json
+++ b/homeassistant/components/lifx/manifest.json
@@ -17,6 +17,7 @@
     "models": [
       "LIFX A19",
       "LIFX A21",
+      "LIFX B10",
       "LIFX Beam",
       "LIFX BR30",
       "LIFX Candle",
@@ -40,6 +41,7 @@
       "LIFX Round",
       "LIFX Square",
       "LIFX String",
+      "LIFX T10",
       "LIFX Tile",
       "LIFX White",
       "LIFX Z"
@@ -48,7 +50,7 @@
   "iot_class": "local_polling",
   "loggers": ["aiolifx", "aiolifx_effects", "bitstring"],
   "requirements": [
-    "aiolifx==1.0.6",
+    "aiolifx==1.0.8",
     "aiolifx-effects==0.3.2",
     "aiolifx-themes==0.5.0"
   ]

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -68,6 +68,10 @@ HOMEKIT = {
         "always_discover": True,
         "domain": "lifx",
     },
+    "LIFX B10": {
+        "always_discover": True,
+        "domain": "lifx",
+    },
     "LIFX BR30": {
         "always_discover": True,
         "domain": "lifx",
@@ -157,6 +161,10 @@ HOMEKIT = {
         "domain": "lifx",
     },
     "LIFX String": {
+        "always_discover": True,
+        "domain": "lifx",
+    },
+    "LIFX T10": {
         "always_discover": True,
         "domain": "lifx",
     },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -276,7 +276,7 @@ aiolifx-effects==0.3.2
 aiolifx-themes==0.5.0
 
 # homeassistant.components.lifx
-aiolifx==1.0.6
+aiolifx==1.0.8
 
 # homeassistant.components.livisi
 aiolivisi==0.0.19

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -258,7 +258,7 @@ aiolifx-effects==0.3.2
 aiolifx-themes==0.5.0
 
 # homeassistant.components.lifx
-aiolifx==1.0.6
+aiolifx==1.0.8
 
 # homeassistant.components.livisi
 aiolivisi==0.0.19


### PR DESCRIPTION
## Proposed change

Bump `aiolifx` to 1.0.8 to enable support for LIFX B10 Candle and
LIFX T10 Candle devices.

Release: https://github.com/aiolifx/aiolifx/releases/tag/1.0.8
Changelog: https://github.com/aiolifx/aiolifx/compare/1.0.6...1.0.8

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
