### PR TITLE
Improve Roborock error handling

### DIFF
--- a/homeassistant/components/roborock/number.py
+++ b/homeassistant/components/roborock/number.py
@@ -13,9 +13,10 @@ from roborock.version_1_apis.roborock_client_v1 import AttributeCache
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.const import PERCENTAGE, EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import RoborockConfigEntry
+from . import DOMAIN, RoborockConfigEntry
 from .coordinator import RoborockDataUpdateCoordinator
 from .entity import RoborockEntityV1
 
@@ -107,6 +108,12 @@ class RoborockNumberEntity(RoborockEntityV1, NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Set number value."""
-        await self.entity_description.update_value(
-            self.get_cache(self.entity_description.cache_key), value
-        )
+        try:
+            await self.entity_description.update_value(
+                self.get_cache(self.entity_description.cache_key), value
+            )
+        except RoborockException as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="update_options_failed",
+            ) from err

--- a/homeassistant/components/roborock/strings.json
+++ b/homeassistant/components/roborock/strings.json
@@ -419,6 +419,9 @@
     },
     "no_coordinators": {
       "message": "No devices were able to successfully setup"
+    },
+    "update_options_failed": {
+      "message": "Failed to update Roborock options"
     }
   },
   "services": {

--- a/homeassistant/components/roborock/switch.py
+++ b/homeassistant/components/roborock/switch.py
@@ -9,14 +9,16 @@ import logging
 from typing import Any
 
 from roborock.command_cache import CacheableAttribute
+from roborock.exceptions import RoborockException
 from roborock.version_1_apis.roborock_client_v1 import AttributeCache
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import RoborockConfigEntry
+from . import DOMAIN, RoborockConfigEntry
 from .coordinator import RoborockDataUpdateCoordinator
 from .entity import RoborockEntityV1
 
@@ -149,15 +151,27 @@ class RoborockSwitch(RoborockEntityV1, SwitchEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
-        await self.entity_description.update_value(
-            self.get_cache(self.entity_description.cache_key), False
-        )
+        try:
+            await self.entity_description.update_value(
+                self.get_cache(self.entity_description.cache_key), False
+            )
+        except RoborockException as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="update_options_failed",
+            ) from err
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
-        await self.entity_description.update_value(
-            self.get_cache(self.entity_description.cache_key), True
-        )
+        try:
+            await self.entity_description.update_value(
+                self.get_cache(self.entity_description.cache_key), True
+            )
+        except RoborockException as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="update_options_failed",
+            ) from err
 
     @property
     def is_on(self) -> bool | None:

--- a/homeassistant/components/roborock/time.py
+++ b/homeassistant/components/roborock/time.py
@@ -15,9 +15,10 @@ from roborock.version_1_apis.roborock_client_v1 import AttributeCache
 from homeassistant.components.time import TimeEntity, TimeEntityDescription
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import RoborockConfigEntry
+from . import DOMAIN, RoborockConfigEntry
 from .coordinator import RoborockDataUpdateCoordinator
 from .entity import RoborockEntityV1
 
@@ -172,6 +173,12 @@ class RoborockTimeEntity(RoborockEntityV1, TimeEntity):
 
     async def async_set_value(self, value: time) -> None:
         """Set the time."""
-        await self.entity_description.update_value(
-            self.get_cache(self.entity_description.cache_key), value
-        )
+        try:
+            await self.entity_description.update_value(
+                self.get_cache(self.entity_description.cache_key), value
+            )
+        except RoborockException as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="update_options_failed",
+            ) from err

--- a/tests/components/roborock/test_button.py
+++ b/tests/components/roborock/test_button.py
@@ -3,9 +3,11 @@
 from unittest.mock import patch
 
 import pytest
+import roborock
 
 from homeassistant.components.button import SERVICE_PRESS
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 
 from tests.common import MockConfigEntry
 
@@ -16,7 +18,7 @@ from tests.common import MockConfigEntry
         ("button.roborock_s7_maxv_reset_sensor_consumable"),
         ("button.roborock_s7_maxv_reset_air_filter_consumable"),
         ("button.roborock_s7_maxv_reset_side_brush_consumable"),
-        "button.roborock_s7_maxv_reset_main_brush_consumable",
+        ("button.roborock_s7_maxv_reset_main_brush_consumable"),
     ],
 )
 @pytest.mark.freeze_time("2023-10-30 08:50:00")
@@ -33,6 +35,40 @@ async def test_update_success(
     with patch(
         "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_message"
     ) as mock_send_message:
+        await hass.services.async_call(
+            "button",
+            SERVICE_PRESS,
+            blocking=True,
+            target={"entity_id": entity_id},
+        )
+    assert mock_send_message.assert_called_once
+    assert hass.states.get(entity_id).state == "2023-10-30T08:50:00+00:00"
+
+
+@pytest.mark.parametrize(
+    ("entity_id"),
+    [
+        ("button.roborock_s7_maxv_reset_air_filter_consumable"),
+    ],
+)
+@pytest.mark.freeze_time("2023-10-30 08:50:00")
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_update_failure(
+    hass: HomeAssistant,
+    bypass_api_fixture,
+    setup_entry: MockConfigEntry,
+    entity_id: str,
+) -> None:
+    """Test failure while pressing the button entity."""
+    # Ensure that the entity exist, as these test can pass even if there is no entity.
+    assert hass.states.get(entity_id).state == "unknown"
+    with (
+        patch(
+            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_message",
+            side_effect=roborock.exceptions.RoborockTimeout,
+        ) as mock_send_message,
+        pytest.raises(HomeAssistantError, match="Error while calling RESET_CONSUMABLE"),
+    ):
         await hass.services.async_call(
             "button",
             SERVICE_PRESS,

--- a/tests/components/roborock/test_number.py
+++ b/tests/components/roborock/test_number.py
@@ -3,9 +3,11 @@
 from unittest.mock import patch
 
 import pytest
+import roborock
 
 from homeassistant.components.number import ATTR_VALUE, SERVICE_SET_VALUE
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 
 from tests.common import MockConfigEntry
 
@@ -29,6 +31,39 @@ async def test_update_success(
     with patch(
         "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_message"
     ) as mock_send_message:
+        await hass.services.async_call(
+            "number",
+            SERVICE_SET_VALUE,
+            service_data={ATTR_VALUE: value},
+            blocking=True,
+            target={"entity_id": entity_id},
+        )
+    assert mock_send_message.assert_called_once
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "value"),
+    [
+        ("number.roborock_s7_maxv_volume", 3.0),
+    ],
+)
+async def test_update_failed(
+    hass: HomeAssistant,
+    bypass_api_fixture,
+    setup_entry: MockConfigEntry,
+    entity_id: str,
+    value: float,
+) -> None:
+    """Test allowed changing values for number entities."""
+    # Ensure that the entity exist, as these test can pass even if there is no entity.
+    assert hass.states.get(entity_id) is not None
+    with (
+        patch(
+            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_message",
+            side_effect=roborock.exceptions.RoborockTimeout,
+        ) as mock_send_message,
+        pytest.raises(HomeAssistantError, match="Failed to update Roborock options"),
+    ):
         await hass.services.async_call(
             "number",
             SERVICE_SET_VALUE,

--- a/tests/components/roborock/test_select.py
+++ b/tests/components/roborock/test_select.py
@@ -59,7 +59,7 @@ async def test_update_failure(
             "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_message",
             side_effect=RoborockException(),
         ),
-        pytest.raises(HomeAssistantError),
+        pytest.raises(HomeAssistantError, match="Error while calling SET_MOP_MOD"),
     ):
         await hass.services.async_call(
             "select",

--- a/tests/components/roborock/test_switch.py
+++ b/tests/components/roborock/test_switch.py
@@ -3,9 +3,11 @@
 from unittest.mock import patch
 
 import pytest
+import roborock
 
 from homeassistant.components.switch import SERVICE_TURN_OFF, SERVICE_TURN_ON
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 
 from tests.common import MockConfigEntry
 
@@ -44,6 +46,40 @@ async def test_update_success(
         await hass.services.async_call(
             "switch",
             SERVICE_TURN_OFF,
+            service_data=None,
+            blocking=True,
+            target={"entity_id": entity_id},
+        )
+    assert mock_send_message.assert_called_once
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "service"),
+    [
+        ("switch.roborock_s7_maxv_status_indicator_light", SERVICE_TURN_ON),
+        ("switch.roborock_s7_maxv_status_indicator_light", SERVICE_TURN_OFF),
+    ],
+)
+async def test_update_failed(
+    hass: HomeAssistant,
+    bypass_api_fixture,
+    setup_entry: MockConfigEntry,
+    entity_id: str,
+    service: str,
+) -> None:
+    """Test a failure while updating a switch."""
+    # Ensure that the entity exist, as these test can pass even if there is no entity.
+    assert hass.states.get(entity_id) is not None
+    with (
+        patch(
+            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1._send_command",
+            side_effect=roborock.exceptions.RoborockTimeout,
+        ) as mock_send_message,
+        pytest.raises(HomeAssistantError, match="Failed to update Roborock options"),
+    ):
+        await hass.services.async_call(
+            "switch",
+            service,
             service_data=None,
             blocking=True,
             target={"entity_id": entity_id},

--- a/tests/components/roborock/test_time.py
+++ b/tests/components/roborock/test_time.py
@@ -4,9 +4,11 @@ from datetime import time
 from unittest.mock import patch
 
 import pytest
+import roborock
 
 from homeassistant.components.time import SERVICE_SET_VALUE
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 
 from tests.common import MockConfigEntry
 
@@ -30,6 +32,38 @@ async def test_update_success(
     with patch(
         "homeassistant.components.roborock.coordinator.RoborockLocalClientV1._send_command"
     ) as mock_send_message:
+        await hass.services.async_call(
+            "time",
+            SERVICE_SET_VALUE,
+            service_data={"time": time(hour=1, minute=1)},
+            blocking=True,
+            target={"entity_id": entity_id},
+        )
+    assert mock_send_message.assert_called_once
+
+
+@pytest.mark.parametrize(
+    ("entity_id"),
+    [
+        ("time.roborock_s7_maxv_do_not_disturb_begin"),
+    ],
+)
+async def test_update_failure(
+    hass: HomeAssistant,
+    bypass_api_fixture,
+    setup_entry: MockConfigEntry,
+    entity_id: str,
+) -> None:
+    """Test turning switch entities on and off."""
+    # Ensure that the entity exist, as these test can pass even if there is no entity.
+    assert hass.states.get(entity_id) is not None
+    with (
+        patch(
+            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1._send_command",
+            side_effect=roborock.exceptions.RoborockTimeout,
+        ) as mock_send_message,
+        pytest.raises(HomeAssistantError, match="Failed to update Roborock options"),
+    ):
         await hass.services.async_call(
             "time",
             SERVICE_SET_VALUE,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve error handling in roborock. This improves a few entity types/service calls to match behavior in other parts of the integration for error handling to wrap exceptions as a HomeAssistantError so they can be properly handled/propagated.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #124193
- This PR is related to issue:  
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
