### PR TITLE
Add missing hass type hint in component tests (t)

### DIFF
--- a/tests/components/tasmota/conftest.py
+++ b/tests/components/tasmota/conftest.py
@@ -37,7 +37,7 @@ def disable_status_sensor(status_sensor_disabled):
         yield
 
 
-async def setup_tasmota_helper(hass):
+async def setup_tasmota_helper(hass: HomeAssistant) -> None:
     """Set up Tasmota."""
     hass.config.components.add("tasmota")
 

--- a/tests/components/tasmota/test_common.py
+++ b/tests/components/tasmota/test_common.py
@@ -2,7 +2,8 @@
 
 import copy
 import json
-from unittest.mock import ANY
+from typing import Any
+from unittest.mock import ANY, AsyncMock
 
 from hatasmota.const import (
     CONF_DEEP_SLEEP,
@@ -19,6 +20,7 @@ from hatasmota.utils import (
     get_topic_tele_state,
     get_topic_tele_will,
 )
+import pytest
 
 from homeassistant.components.tasmota.const import DEFAULT_PREFIX, DOMAIN
 from homeassistant.const import STATE_UNAVAILABLE
@@ -26,7 +28,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.common import async_fire_mqtt_message
-from tests.typing import WebSocketGenerator
+from tests.typing import MqttMockHAClient, MqttMockPahoClient, WebSocketGenerator
 
 DEFAULT_CONFIG = {
     "ip": "192.168.15.10",
@@ -125,14 +127,14 @@ async def remove_device(
 
 
 async def help_test_availability_when_connection_lost(
-    hass,
-    mqtt_client_mock,
-    mqtt_mock,
-    domain,
-    config,
-    sensor_config=None,
-    object_id="tasmota_test",
-):
+    hass: HomeAssistant,
+    mqtt_client_mock: MqttMockPahoClient,
+    mqtt_mock: MqttMockHAClient,
+    domain: str,
+    config: dict[str, Any],
+    sensor_config: dict[str, Any] | None = None,
+    object_id: str = "tasmota_test",
+) -> None:
     """Test availability after MQTT disconnection.
 
     This is a test helper for the TasmotaAvailability mixin.
@@ -191,14 +193,14 @@ async def help_test_availability_when_connection_lost(
 
 
 async def help_test_deep_sleep_availability_when_connection_lost(
-    hass,
-    mqtt_client_mock,
-    mqtt_mock,
-    domain,
-    config,
-    sensor_config=None,
-    object_id="tasmota_test",
-):
+    hass: HomeAssistant,
+    mqtt_client_mock: MqttMockPahoClient,
+    mqtt_mock: MqttMockHAClient,
+    domain: str,
+    config: dict[str, Any],
+    sensor_config: dict[str, Any] | None = None,
+    object_id: str = "tasmota_test",
+) -> None:
     """Test availability after MQTT disconnection when deep sleep is enabled.
 
     This is a test helper for the TasmotaAvailability mixin.
@@ -261,13 +263,13 @@ async def help_test_deep_sleep_availability_when_connection_lost(
 
 
 async def help_test_availability(
-    hass,
-    mqtt_mock,
-    domain,
-    config,
-    sensor_config=None,
-    object_id="tasmota_test",
-):
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    domain: str,
+    config: dict[str, Any],
+    sensor_config: dict[str, Any] | None = None,
+    object_id: str = "tasmota_test",
+) -> None:
     """Test availability.
 
     This is a test helper for the TasmotaAvailability mixin.
@@ -309,13 +311,13 @@ async def help_test_availability(
 
 
 async def help_test_deep_sleep_availability(
-    hass,
-    mqtt_mock,
-    domain,
-    config,
-    sensor_config=None,
-    object_id="tasmota_test",
-):
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    domain: str,
+    config: dict[str, Any],
+    sensor_config: dict[str, Any] | None = None,
+    object_id: str = "tasmota_test",
+) -> None:
     """Test availability when deep sleep is enabled.
 
     This is a test helper for the TasmotaAvailability mixin.
@@ -358,13 +360,13 @@ async def help_test_deep_sleep_availability(
 
 
 async def help_test_availability_discovery_update(
-    hass,
-    mqtt_mock,
-    domain,
-    config,
-    sensor_config=None,
-    object_id="tasmota_test",
-):
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    domain: str,
+    config: dict[str, Any],
+    sensor_config: dict[str, Any] | None = None,
+    object_id: str = "tasmota_test",
+) -> None:
     """Test update of discovered TasmotaAvailability.
 
     This is a test helper for the TasmotaAvailability mixin.
@@ -434,15 +436,15 @@ async def help_test_availability_discovery_update(
 
 
 async def help_test_availability_poll_state(
-    hass,
-    mqtt_client_mock,
-    mqtt_mock,
-    domain,
-    config,
-    poll_topic,
-    poll_payload,
-    sensor_config=None,
-):
+    hass: HomeAssistant,
+    mqtt_client_mock: MqttMockPahoClient,
+    mqtt_mock: MqttMockHAClient,
+    domain: str,
+    config: dict[str, Any],
+    poll_topic: str,
+    poll_payload: str,
+    sensor_config: dict[str, Any] | None = None,
+) -> None:
     """Test polling of state when device is available.
 
     This is a test helper for the TasmotaAvailability mixin.
@@ -503,17 +505,17 @@ async def help_test_availability_poll_state(
 
 
 async def help_test_discovery_removal(
-    hass,
-    mqtt_mock,
-    caplog,
-    domain,
-    config1,
-    config2,
-    sensor_config1=None,
-    sensor_config2=None,
-    object_id="tasmota_test",
-    name="Tasmota Test",
-):
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    domain: str,
+    config1: dict[str, Any],
+    config2: dict[str, Any],
+    sensor_config1: dict[str, Any] | None = None,
+    sensor_config2: dict[str, Any] | None = None,
+    object_id: str = "tasmota_test",
+    name: str = "Tasmota Test",
+) -> None:
     """Test removal of discovered entity."""
     device_reg = dr.async_get(hass)
     entity_reg = er.async_get(hass)
@@ -569,16 +571,16 @@ async def help_test_discovery_removal(
 
 
 async def help_test_discovery_update_unchanged(
-    hass,
-    mqtt_mock,
-    caplog,
-    domain,
-    config,
-    discovery_update,
-    sensor_config=None,
-    object_id="tasmota_test",
-    name="Tasmota Test",
-):
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    caplog: pytest.LogCaptureFixture,
+    domain: str,
+    config: dict[str, Any],
+    discovery_update: AsyncMock,
+    sensor_config: dict[str, Any] | None = None,
+    object_id: str = "tasmota_test",
+    name: str = "Tasmota Test",
+) -> None:
     """Test update of discovered component with and without changes.
 
     This is a test helper for the MqttDiscoveryUpdate mixin.
@@ -623,8 +625,13 @@ async def help_test_discovery_update_unchanged(
 
 
 async def help_test_discovery_device_remove(
-    hass, mqtt_mock, domain, unique_id, config, sensor_config=None
-):
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    domain: str,
+    unique_id: str,
+    config: dict[str, Any],
+    sensor_config: dict[str, Any] | None = None,
+) -> None:
     """Test domain entity is removed when device is removed."""
     device_reg = dr.async_get(hass)
     entity_reg = er.async_get(hass)
@@ -659,14 +666,14 @@ async def help_test_discovery_device_remove(
 
 
 async def help_test_entity_id_update_subscriptions(
-    hass,
-    mqtt_mock,
-    domain,
-    config,
-    topics=None,
-    sensor_config=None,
-    object_id="tasmota_test",
-):
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    domain: str,
+    config: dict[str, Any],
+    topics: list[str] | None = None,
+    sensor_config: dict[str, Any] | None = None,
+    object_id: str = "tasmota_test",
+) -> None:
     """Test MQTT subscriptions are managed when entity_id is updated."""
     entity_reg = er.async_get(hass)
 
@@ -711,8 +718,13 @@ async def help_test_entity_id_update_subscriptions(
 
 
 async def help_test_entity_id_update_discovery_update(
-    hass, mqtt_mock, domain, config, sensor_config=None, object_id="tasmota_test"
-):
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    domain: str,
+    config: dict[str, Any],
+    sensor_config: dict[str, Any] | None = None,
+    object_id: str = "tasmota_test",
+) -> None:
     """Test MQTT discovery update after entity_id is updated."""
     entity_reg = er.async_get(hass)
 

--- a/tests/components/tasmota/test_cover.py
+++ b/tests/components/tasmota/test_cover.py
@@ -2,6 +2,7 @@
 
 import copy
 import json
+from typing import Any
 from unittest.mock import patch
 
 from hatasmota.utils import (
@@ -464,7 +465,9 @@ async def test_controlling_state_via_mqtt_inverted(
     assert state.attributes["current_position"] == 0
 
 
-async def call_service(hass, entity_id, service, **kwargs):
+async def call_service(
+    hass: HomeAssistant, entity_id: str, service: str, **kwargs: Any
+) -> None:
     """Call a fan service."""
     await hass.services.async_call(
         cover.DOMAIN,

--- a/tests/components/tasmota/test_init.py
+++ b/tests/components/tasmota/test_init.py
@@ -5,6 +5,7 @@ import json
 from unittest.mock import call
 
 from homeassistant.components.tasmota.const import DEFAULT_PREFIX, DOMAIN
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
@@ -74,7 +75,9 @@ async def test_device_remove_non_tasmota_device(
     """Test removing a non Tasmota device through device registry."""
     assert await async_setup_component(hass, "config", {})
 
-    async def async_remove_config_entry_device(hass, config_entry, device_entry):
+    async def async_remove_config_entry_device(
+        hass: HomeAssistant, config_entry: ConfigEntry, device_entry: dr.DeviceEntry
+    ) -> bool:
         return True
 
     mock_integration(

--- a/tests/components/tasmota/test_light.py
+++ b/tests/components/tasmota/test_light.py
@@ -2,6 +2,7 @@
 
 import copy
 import json
+from typing import Any
 from unittest.mock import patch
 
 from hatasmota.const import CONF_MAC
@@ -1478,7 +1479,13 @@ async def test_relay_as_light(
     assert state is not None
 
 
-async def _test_split_light(hass, mqtt_mock, config, num_lights, num_switches):
+async def _test_split_light(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    config: dict[str, Any],
+    num_lights: int,
+    num_switches: int,
+) -> None:
     """Test multi-channel light split to single-channel dimmers."""
     mac = config["mac"]
 
@@ -1553,7 +1560,12 @@ async def test_split_light2(
     await _test_split_light(hass, mqtt_mock, config, 5, 2)
 
 
-async def _test_unlinked_light(hass, mqtt_mock, config, num_switches):
+async def _test_unlinked_light(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    config: dict[str, Any],
+    num_switches: int,
+) -> None:
     """Test rgbww light split to rgb+ww."""
     mac = config["mac"]
     num_lights = 2

--- a/tests/components/tellduslive/test_config_flow.py
+++ b/tests/components/tellduslive/test_config_flow.py
@@ -20,7 +20,9 @@ from homeassistant.data_entry_flow import FlowResultType
 from tests.common import MockConfigEntry
 
 
-def init_config_flow(hass, side_effect=None):
+def init_config_flow(
+    hass: HomeAssistant, side_effect: type[Exception] | None = None
+) -> config_flow.FlowHandler:
     """Init a configuration flow."""
     flow = config_flow.FlowHandler()
     flow.hass = hass

--- a/tests/components/template/test_button.py
+++ b/tests/components/template/test_button.py
@@ -1,6 +1,7 @@
 """The tests for the Template button platform."""
 
 import datetime as dt
+from typing import Any
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
@@ -232,11 +233,11 @@ async def test_unique_id(hass: HomeAssistant) -> None:
 
 
 def _verify(
-    hass,
-    expected_value,
-    attributes=None,
-    entity_id=_TEST_BUTTON,
-):
+    hass: HomeAssistant,
+    expected_value: str,
+    attributes: dict[str, Any] | None = None,
+    entity_id: str = _TEST_BUTTON,
+) -> None:
     """Verify button's state."""
     attributes = attributes or {}
     if CONF_FRIENDLY_NAME not in attributes:

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -699,13 +699,13 @@ async def test_set_invalid_osc(hass: HomeAssistant, calls: list[ServiceCall]) ->
 
 
 def _verify(
-    hass,
-    expected_state,
-    expected_percentage,
-    expected_oscillating,
-    expected_direction,
-    expected_preset_mode,
-):
+    hass: HomeAssistant,
+    expected_state: str,
+    expected_percentage: int | None,
+    expected_oscillating: bool | None,
+    expected_direction: str | None,
+    expected_preset_mode: str | None,
+) -> None:
     """Verify fan's state, speed and osc."""
     state = hass.states.get(_TEST_FAN)
     attributes = state.attributes
@@ -716,7 +716,7 @@ def _verify(
     assert attributes.get(ATTR_PRESET_MODE) == expected_preset_mode
 
 
-async def _register_fan_sources(hass):
+async def _register_fan_sources(hass: HomeAssistant) -> None:
     with assert_setup_component(1, "input_boolean"):
         assert await setup.async_setup_component(
             hass, "input_boolean", {"input_boolean": {"state": None}}
@@ -760,8 +760,11 @@ async def _register_fan_sources(hass):
 
 
 async def _register_components(
-    hass, speed_list=None, preset_modes=None, speed_count=None
-):
+    hass: HomeAssistant,
+    speed_list: list[str] | None = None,
+    preset_modes: list[str] | None = None,
+    speed_count: int | None = None,
+) -> None:
     """Register basic components for testing."""
     await _register_fan_sources(hass)
 

--- a/tests/components/template/test_init.py
+++ b/tests/components/template/test_init.py
@@ -258,7 +258,7 @@ async def test_reload_sensors_that_reference_other_template_sensors(
     assert hass.states.get("sensor.test3").state == "2"
 
 
-async def async_yaml_patch_helper(hass, filename):
+async def async_yaml_patch_helper(hass: HomeAssistant, filename: str) -> None:
     """Help update configuration.yaml."""
     yaml_path = get_fixture_path(filename, "template")
     with patch.object(config, "YAML_CONFIG_FILE", yaml_path):

--- a/tests/components/template/test_number.py
+++ b/tests/components/template/test_number.py
@@ -364,12 +364,12 @@ async def test_trigger_number(hass: HomeAssistant) -> None:
 
 
 def _verify(
-    hass,
-    expected_value,
-    expected_step,
-    expected_minimum,
-    expected_maximum,
-):
+    hass: HomeAssistant,
+    expected_value: int,
+    expected_step: int,
+    expected_minimum: int,
+    expected_maximum: int,
+) -> None:
     """Verify number's state."""
     state = hass.states.get(_TEST_NUMBER)
     attributes = state.attributes

--- a/tests/components/template/test_select.py
+++ b/tests/components/template/test_select.py
@@ -318,7 +318,12 @@ async def test_trigger_select(hass: HomeAssistant) -> None:
     assert events[0].event_type == "test_number_event"
 
 
-def _verify(hass, expected_current_option, expected_options, entity_name=_TEST_SELECT):
+def _verify(
+    hass: HomeAssistant,
+    expected_current_option: str,
+    expected_options: list[str],
+    entity_name: str = _TEST_SELECT,
+) -> None:
     """Verify select's state."""
     state = hass.states.get(entity_name)
     attributes = state.attributes

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -23,7 +23,9 @@ from homeassistant.const import (
 from homeassistant.core import Context, CoreState, HomeAssistant, State, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.template import Template
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.setup import ATTR_COMPONENT, async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -374,7 +376,7 @@ async def test_creating_sensor_loads_group(hass: HomeAssistant) -> None:
     order = []
     after_dep_event = Event()
 
-    async def async_setup_group(hass, config):
+    async def async_setup_group(hass: HomeAssistant, config: ConfigType) -> bool:
         # Make sure group takes longer to load, so that it won't
         # be loaded first by chance
         await after_dep_event.wait()
@@ -383,8 +385,11 @@ async def test_creating_sensor_loads_group(hass: HomeAssistant) -> None:
         return True
 
     async def async_setup_template(
-        hass, config, async_add_entities, discovery_info=None
-    ):
+        hass: HomeAssistant,
+        config: ConfigType,
+        async_add_entities: AddEntitiesCallback,
+        discovery_info: DiscoveryInfoType | None = None,
+    ) -> bool:
         order.append("sensor.template")
         return True
 

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -484,7 +484,9 @@ async def test_set_invalid_fan_speed(
     assert hass.states.get(_FAN_SPEED_INPUT_SELECT).state == "high"
 
 
-def _verify(hass, expected_state, expected_battery_level):
+def _verify(
+    hass: HomeAssistant, expected_state: str, expected_battery_level: int
+) -> None:
     """Verify vacuum's state and speed."""
     state = hass.states.get(_TEST_VACUUM)
     attributes = state.attributes
@@ -492,7 +494,7 @@ def _verify(hass, expected_state, expected_battery_level):
     assert attributes.get(ATTR_BATTERY_LEVEL) == expected_battery_level
 
 
-async def _register_basic_vacuum(hass):
+async def _register_basic_vacuum(hass: HomeAssistant) -> None:
     """Register basic vacuum with only required options for testing."""
     with assert_setup_component(1, "input_select"):
         assert await setup.async_setup_component(
@@ -528,7 +530,7 @@ async def _register_basic_vacuum(hass):
     await hass.async_block_till_done()
 
 
-async def _register_components(hass):
+async def _register_components(hass: HomeAssistant) -> None:
     """Register basic components for testing."""
     with assert_setup_component(2, "input_boolean"):
         assert await setup.async_setup_component(

--- a/tests/components/toon/test_config_flow.py
+++ b/tests/components/toon/test_config_flow.py
@@ -20,7 +20,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 from tests.typing import ClientSessionGenerator
 
 
-async def setup_component(hass):
+async def setup_component(hass: HomeAssistant) -> None:
     """Set up Toon component."""
     await async_process_ha_core_config(
         hass,

--- a/tests/components/totalconnect/common.py
+++ b/tests/components/totalconnect/common.py
@@ -5,7 +5,8 @@ from unittest.mock import patch
 from total_connect_client import ArmingState, ResultCode, ZoneStatus, ZoneType
 
 from homeassistant.components.totalconnect.const import CONF_USERCODES, DOMAIN
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -394,7 +395,7 @@ TOTALCONNECT_REQUEST = (
 )
 
 
-async def setup_platform(hass, platform):
+async def setup_platform(hass: HomeAssistant, platform: Platform) -> MockConfigEntry:
     """Set up the TotalConnect platform."""
     # first set up a config entry and add it to hass
     mock_entry = MockConfigEntry(domain=DOMAIN, data=CONFIG_DATA)
@@ -422,7 +423,7 @@ async def setup_platform(hass, platform):
     return mock_entry
 
 
-async def init_integration(hass):
+async def init_integration(hass: HomeAssistant) -> MockConfigEntry:
     """Set up the TotalConnect integration."""
     # first set up a config entry and add it to hass
     mock_entry = MockConfigEntry(domain=DOMAIN, data=CONFIG_DATA)

--- a/tests/components/tplink_omada/test_switch.py
+++ b/tests/components/tplink_omada/test_switch.py
@@ -19,7 +19,7 @@ from tplink_omada_client.exceptions import InvalidDevice
 from homeassistant.components import switch
 from homeassistant.components.tplink_omada.coordinator import POLL_GATEWAY
 from homeassistant.const import ATTR_ENTITY_ID
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceResponse
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util.dt import utcnow
 
@@ -336,7 +336,7 @@ def _get_updated_gateway_port_status(
     return OmadaGatewayPortStatus(gateway_data["portStats"][port])
 
 
-def call_service(hass: HomeAssistant, service: str, entity_id: str):
+def call_service(hass: HomeAssistant, service: str, entity_id: str) -> ServiceResponse:
     """Call any service on entity."""
     return hass.services.async_call(
         switch.DOMAIN, service, {ATTR_ENTITY_ID: entity_id}, blocking=True

--- a/tests/components/trace/test_websocket_api.py
+++ b/tests/components/trace/test_websocket_api.py
@@ -39,8 +39,12 @@ def _find_traces(traces, trace_type, item_id):
 
 
 async def _setup_automation_or_script(
-    hass, domain, configs, script_config=None, stored_traces=None
-):
+    hass: HomeAssistant,
+    domain: str,
+    configs: list[dict[str, Any]],
+    script_config: dict[str, Any] | None = None,
+    stored_traces: int | None = None,
+) -> None:
     """Set up automations or scripts from automation config."""
     if domain == "script":
         configs = {config["id"]: {"sequence": config["action"]} for config in configs}
@@ -66,7 +70,13 @@ async def _setup_automation_or_script(
     assert await async_setup_component(hass, domain, {domain: configs})
 
 
-async def _run_automation_or_script(hass, domain, config, event, context=None):
+async def _run_automation_or_script(
+    hass: HomeAssistant,
+    domain: str,
+    config: dict[str, Any],
+    event: str,
+    context: dict[str, Any] | None = None,
+) -> None:
     if domain == "automation":
         hass.bus.async_fire(event, context=context)
     else:

--- a/tests/components/tractive/conftest.py
+++ b/tests/components/tractive/conftest.py
@@ -10,6 +10,7 @@ import pytest
 
 from homeassistant.components.tractive.const import DOMAIN, SERVER_UNAVAILABLE
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from tests.common import MockConfigEntry, load_json_object_fixture
@@ -76,7 +77,7 @@ def mock_tractive_client() -> Generator[AsyncMock]:
             }
         entry.runtime_data.client._send_switch_update(event)
 
-    def send_server_unavailable_event(hass):
+    def send_server_unavailable_event(hass: HomeAssistant) -> None:
         """Send server unavailable event."""
         async_dispatcher_send(hass, f"{SERVER_UNAVAILABLE}-12345")
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #120302

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
