### PR TITLE
Improve intent recognition in default conversation agent

### DIFF
--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -14,6 +14,7 @@ import yaml
 from homeassistant.components import conversation, cover, media_player
 from homeassistant.components.conversation import default_agent
 from homeassistant.components.conversation.const import DATA_DEFAULT_ENTITY
+from homeassistant.components.conversation.default_agent import METADATA_CUSTOM_SENTENCE
 from homeassistant.components.conversation.models import ConversationInput
 from homeassistant.components.cover import SERVICE_OPEN_COVER
 from homeassistant.components.homeassistant.exposed_entities import (
@@ -2551,13 +2552,15 @@ async def test_light_area_same_name(
     device_registry.async_update_device(device.id, area_id=kitchen_area.id)
 
     kitchen_light = entity_registry.async_get_or_create(
-        "light", "demo", "1234", original_name="kitchen light"
+        "light", "demo", "1234", original_name="light in the kitchen"
     )
     entity_registry.async_update_entity(
         kitchen_light.entity_id, area_id=kitchen_area.id
     )
     hass.states.async_set(
-        kitchen_light.entity_id, "off", attributes={ATTR_FRIENDLY_NAME: "kitchen light"}
+        kitchen_light.entity_id,
+        "off",
+        attributes={ATTR_FRIENDLY_NAME: "light in the kitchen"},
     )
 
     ceiling_light = entity_registry.async_get_or_create(
@@ -2570,12 +2573,19 @@ async def test_light_area_same_name(
         ceiling_light.entity_id, "off", attributes={ATTR_FRIENDLY_NAME: "ceiling light"}
     )
 
+    bathroom_light = entity_registry.async_get_or_create(
+        "light", "demo", "9012", original_name="light"
+    )
+    hass.states.async_set(
+        bathroom_light.entity_id, "off", attributes={ATTR_FRIENDLY_NAME: "light"}
+    )
+
     calls = async_mock_service(hass, LIGHT_DOMAIN, "turn_on")
 
     await hass.services.async_call(
         "conversation",
         "process",
-        {conversation.ATTR_TEXT: "turn on kitchen light"},
+        {conversation.ATTR_TEXT: "turn on light in the kitchen"},
     )
     await hass.async_block_till_done()
 
@@ -2592,7 +2602,10 @@ async def test_custom_sentences_priority(
     hass_admin_user: MockUser,
     snapshot: SnapshotAssertion,
 ) -> None:
-    """Test that user intents from custom_sentences have priority over builtin intents/sentences."""
+    """Test that user intents from custom_sentences have priority over builtin intents/sentences.
+
+    Also test that they follow proper selection logic.
+    """
     with tempfile.NamedTemporaryFile(
         mode="w+",
         encoding="utf-8",
@@ -2605,7 +2618,11 @@ async def test_custom_sentences_priority(
             {
                 "language": "en",
                 "intents": {
-                    "CustomIntent": {"data": [{"sentences": ["turn on the lamp"]}]}
+                    "CustomIntent": {"data": [{"sentences": ["turn on <name>"]}]},
+                    "WorseCustomIntent": {
+                        "data": [{"sentences": ["turn on the lamp"]}]
+                    },
+                    "FakeCustomIntent": {"data": [{"sentences": ["turn on <name>"]}]},
                 },
             },
             custom_sentences_file,
@@ -2622,10 +2639,20 @@ async def test_custom_sentences_priority(
             "intent_script",
             {
                 "intent_script": {
-                    "CustomIntent": {"speech": {"text": "custom response"}}
+                    "CustomIntent": {"speech": {"text": "custom response"}},
+                    "WorseCustomIntent": {"speech": {"text": "worse custom response"}},
+                    "FakeCustomIntent": {"speech": {"text": "fake custom response"}},
                 }
             },
         )
+
+        # Fake intent not being custom
+        intents = (
+            await conversation.async_get_agent(hass).async_get_or_load_intents(
+                hass.config.language
+            )
+        ).intents.intents
+        intents["FakeCustomIntent"].data[0].metadata[METADATA_CUSTOM_SENTENCE] = False
 
         # Ensure that a "lamp" exists so that we can verify the custom intent
         # overrides the builtin sentence.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve intent recognition in default conversation agent:
- use the same logic for custom sentences
- prefer higher quality (longer) names

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
