### PR TITLE
Add missing units for `xpercent`, `xfreq` and `xcounts` Shelly sensors

### DIFF
--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -1082,6 +1082,7 @@ RPC_SENSORS: Final = {
             or config[key]["enable"] is False
             or status[key].get("xpercent") is None
         ),
+        unit=lambda config: config["xpercent"].get("unit"),
     ),
     "pulse_counter": RpcSensorDescription(
         key="input",
@@ -1104,6 +1105,7 @@ RPC_SENSORS: Final = {
             or config[key]["enable"] is False
             or status[key]["counts"].get("xtotal") is None
         ),
+        unit=lambda config: config["xcounts"].get("unit"),
     ),
     "counter_frequency": RpcSensorDescription(
         key="input",
@@ -1124,6 +1126,7 @@ RPC_SENSORS: Final = {
             or config[key]["enable"] is False
             or status[key].get("xfreq") is None
         ),
+        unit=lambda config: config["xfreq"].get("unit"),
     ),
     "text": RpcSensorDescription(
         key="text",

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -1082,9 +1082,7 @@ RPC_SENSORS: Final = {
             or config[key]["enable"] is False
             or status[key].get("xpercent") is None
         ),
-        unit=lambda config: config["xpercent"]["unit"]
-        if config["xpercent"]["unit"]
-        else None,
+        unit=lambda config: config["xpercent"]["unit"] or None,
     ),
     "pulse_counter": RpcSensorDescription(
         key="input",
@@ -1107,9 +1105,7 @@ RPC_SENSORS: Final = {
             or config[key]["enable"] is False
             or status[key]["counts"].get("xtotal") is None
         ),
-        unit=lambda config: config["xcounts"]["unit"]
-        if config["xcounts"]["unit"]
-        else None,
+        unit=lambda config: config["xcounts"]["unit"] or None,
     ),
     "counter_frequency": RpcSensorDescription(
         key="input",
@@ -1130,9 +1126,7 @@ RPC_SENSORS: Final = {
             or config[key]["enable"] is False
             or status[key].get("xfreq") is None
         ),
-        unit=lambda config: config["xfreq"]["unit"]
-        if config["xfreq"]["unit"]
-        else None,
+        unit=lambda config: config["xfreq"]["unit"] or None,
     ),
     "text": RpcSensorDescription(
         key="text",

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -1082,7 +1082,9 @@ RPC_SENSORS: Final = {
             or config[key]["enable"] is False
             or status[key].get("xpercent") is None
         ),
-        unit=lambda config: config["xpercent"].get("unit"),
+        unit=lambda config: config["xpercent"]["unit"]
+        if config["xpercent"]["unit"]
+        else None,
     ),
     "pulse_counter": RpcSensorDescription(
         key="input",
@@ -1105,7 +1107,9 @@ RPC_SENSORS: Final = {
             or config[key]["enable"] is False
             or status[key]["counts"].get("xtotal") is None
         ),
-        unit=lambda config: config["xcounts"].get("unit"),
+        unit=lambda config: config["xcounts"]["unit"]
+        if config["xcounts"]["unit"]
+        else None,
     ),
     "counter_frequency": RpcSensorDescription(
         key="input",
@@ -1126,7 +1130,9 @@ RPC_SENSORS: Final = {
             or config[key]["enable"] is False
             or status[key].get("xfreq") is None
         ),
-        unit=lambda config: config["xfreq"].get("unit"),
+        unit=lambda config: config["xfreq"]["unit"]
+        if config["xfreq"]["unit"]
+        else None,
     ),
     "text": RpcSensorDescription(
         key="text",

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -166,8 +166,20 @@ MOCK_BLOCKS = [
 
 MOCK_CONFIG = {
     "input:0": {"id": 0, "name": "Test name input 0", "type": "button"},
-    "input:1": {"id": 1, "type": "analog", "enable": True},
-    "input:2": {"id": 2, "name": "Gas", "type": "count", "enable": True},
+    "input:1": {
+        "id": 1,
+        "type": "analog",
+        "enable": True,
+        "xpercent": {"expr": None, "unit": None},
+    },
+    "input:2": {
+        "id": 2,
+        "name": "Gas",
+        "type": "count",
+        "enable": True,
+        "xcounts": {"expr": None, "unit": None},
+        "xfreq": {"expr": None, "unit": None},
+    },
     "light:0": {"name": "test light_0"},
     "light:1": {"name": "test light_1"},
     "light:2": {"name": "test light_2"},

--- a/tests/components/shelly/test_sensor.py
+++ b/tests/components/shelly/test_sensor.py
@@ -689,10 +689,27 @@ async def test_block_sleeping_update_entity_service(
     )
 
 
+@pytest.mark.parametrize(
+    ("original_unit", "expected_unit"),
+    [
+        ("m/s", "m/s"),
+        (None, None),
+        ("", None),
+    ],
+)
 async def test_rpc_analog_input_sensors(
-    hass: HomeAssistant, mock_rpc_device: Mock, entity_registry: EntityRegistry
+    hass: HomeAssistant,
+    mock_rpc_device: Mock,
+    entity_registry: EntityRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+    original_unit: str | None,
+    expected_unit: str | None,
 ) -> None:
     """Test RPC analog input xpercent sensor."""
+    config = deepcopy(mock_rpc_device.config)
+    config["input:1"]["xpercent"] = {"expr": "x*0.2995", "unit": original_unit}
+    monkeypatch.setattr(mock_rpc_device, "config", config)
+
     await init_integration(hass, 2)
 
     entity_id = f"{SENSOR_DOMAIN}.test_name_analog_input"
@@ -703,7 +720,10 @@ async def test_rpc_analog_input_sensors(
     assert entry.unique_id == "123456789ABC-input:1-analoginput"
 
     entity_id = f"{SENSOR_DOMAIN}.test_name_analog_value"
-    assert hass.states.get(entity_id).state == "8.9"
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "8.9"
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == expected_unit
 
     entry = entity_registry.async_get(entity_id)
     assert entry
@@ -747,13 +767,27 @@ async def test_rpc_disabled_xpercent(
     assert hass.states.get(entity_id) is None
 
 
+@pytest.mark.parametrize(
+    ("original_unit", "expected_unit"),
+    [
+        ("l/h", "l/h"),
+        (None, None),
+        ("", None),
+    ],
+)
 async def test_rpc_pulse_counter_sensors(
     hass: HomeAssistant,
     mock_rpc_device: Mock,
     entity_registry: EntityRegistry,
     monkeypatch: pytest.MonkeyPatch,
+    original_unit: str | None,
+    expected_unit: str | None,
 ) -> None:
     """Test RPC counter sensor."""
+    config = deepcopy(mock_rpc_device.config)
+    config["input:2"]["xcounts"] = {"expr": "x/10", "unit": original_unit}
+    monkeypatch.setattr(mock_rpc_device, "config", config)
+
     await init_integration(hass, 2)
 
     entity_id = f"{SENSOR_DOMAIN}.gas_pulse_counter"
@@ -767,7 +801,10 @@ async def test_rpc_pulse_counter_sensors(
     assert entry.unique_id == "123456789ABC-input:2-pulse_counter"
 
     entity_id = f"{SENSOR_DOMAIN}.gas_counter_value"
-    assert hass.states.get(entity_id).state == "561.74"
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "561.74"
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == expected_unit
 
     entry = entity_registry.async_get(entity_id)
     assert entry
@@ -811,12 +848,27 @@ async def test_rpc_disabled_xtotal_counter(
     assert hass.states.get(entity_id) is None
 
 
+@pytest.mark.parametrize(
+    ("original_unit", "expected_unit"),
+    [
+        ("W", "W"),
+        (None, None),
+        ("", None),
+    ],
+)
 async def test_rpc_pulse_counter_frequency_sensors(
     hass: HomeAssistant,
     mock_rpc_device: Mock,
     entity_registry: EntityRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+    original_unit: str | None,
+    expected_unit: str | None,
 ) -> None:
     """Test RPC counter sensor."""
+    config = deepcopy(mock_rpc_device.config)
+    config["input:2"]["xfreq"] = {"expr": "x**2", "unit": original_unit}
+    monkeypatch.setattr(mock_rpc_device, "config", config)
+
     await init_integration(hass, 2)
 
     entity_id = f"{SENSOR_DOMAIN}.gas_pulse_counter_frequency"
@@ -830,7 +882,10 @@ async def test_rpc_pulse_counter_frequency_sensors(
     assert entry.unique_id == "123456789ABC-input:2-counter_frequency"
 
     entity_id = f"{SENSOR_DOMAIN}.gas_pulse_counter_frequency_value"
-    assert hass.states.get(entity_id).state == "6.11"
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "6.11"
+    assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == expected_unit
 
     entry = entity_registry.async_get(entity_id)
     assert entry


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
While implementing Shelly virtual components I realized that we can get units for  `xpercent`, `xfreq` and `xcounts` sensors for Shelly Plus Uni from the device configuration. These are sensors for which the user creates an expression to calculate the value and sets unit.

Sample configuration:
```json
{
    "input:2": {
        "id": 2,
        "name": null,
        "type": "count",
        "enable": false,
        "count_rep_thr": 100,
        "freq_window": 1,
        "freq_rep_thr": 10,
        "xcounts": {
            "expr": null,
            "unit": null
        },
        "xfreq": {
            "expr": null,
            "unit": null
        }
    },
    "input:100": {
        "id": 100,
        "name": "Volts",
        "type": "analog",
        "enable": true,
        "invert": false,
        "report_thr": 1,
        "range_map": [
            0.3,
            100
        ],
        "xpercent": {
            "expr": "x*0.2995",
            "unit": "V"
        },
        "range": 1
	}
}
```

Documentation reference: https://shelly-api-docs.shelly.cloud/gen2/ComponentsAndServices/Input#configuration

_I don't have a Shelly Plus Uni so I can't test this change with a real device._

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
