### PR TITLE
blebox: use blebox_uniapi.cover.BleboxCoverState enum members instead of plain integers

### DIFF
--- a/homeassistant/components/blebox/cover.py
+++ b/homeassistant/components/blebox/cover.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from blebox_uniapi.box import Box
 import blebox_uniapi.cover
+from blebox_uniapi.cover import BleboxCoverState
 
 from homeassistant.components.cover import (
     ATTR_POSITION,
@@ -32,15 +33,15 @@ BLEBOX_TO_COVER_DEVICE_CLASSES = {
 BLEBOX_TO_HASS_COVER_STATES = {
     None: None,
     # all blebox covers
-    blebox_uniapi.cover.BleboxCoverState.MOVING_DOWN: STATE_CLOSING,
-    blebox_uniapi.cover.BleboxCoverState.MOVING_UP: STATE_OPENING,
-    blebox_uniapi.cover.BleboxCoverState.MANUALLY_STOPPED: STATE_OPEN,
-    blebox_uniapi.cover.BleboxCoverState.LOWER_LIMIT_REACHED: STATE_CLOSED,
-    blebox_uniapi.cover.BleboxCoverState.UPPER_LIMIT_REACHED: STATE_OPEN,
+    BleboxCoverState.MOVING_DOWN: STATE_CLOSING,
+    BleboxCoverState.MOVING_UP: STATE_OPENING,
+    BleboxCoverState.MANUALLY_STOPPED: STATE_OPEN,
+    BleboxCoverState.LOWER_LIMIT_REACHED: STATE_CLOSED,
+    BleboxCoverState.UPPER_LIMIT_REACHED: STATE_OPEN,
     # extra states of gateController product
-    blebox_uniapi.cover.BleboxCoverState.OVERLOAD: STATE_OPEN,
-    blebox_uniapi.cover.BleboxCoverState.MOTOR_FAILURE: STATE_OPEN,
-    blebox_uniapi.cover.BleboxCoverState.SAFETY_STOP: STATE_OPEN,
+    BleboxCoverState.OVERLOAD: STATE_OPEN,
+    BleboxCoverState.MOTOR_FAILURE: STATE_OPEN,
+    BleboxCoverState.SAFETY_STOP: STATE_OPEN,
 }
 
 

--- a/homeassistant/components/blebox/cover.py
+++ b/homeassistant/components/blebox/cover.py
@@ -31,16 +31,16 @@ BLEBOX_TO_COVER_DEVICE_CLASSES = {
 
 BLEBOX_TO_HASS_COVER_STATES = {
     None: None,
-    0: STATE_CLOSING,  # moving down
-    1: STATE_OPENING,  # moving up
-    2: STATE_OPEN,  # manually stopped
-    3: STATE_CLOSED,  # lower limit
-    4: STATE_OPEN,  # upper limit / open
-    # gateController
-    5: STATE_OPEN,  # overload
-    6: STATE_OPEN,  # motor failure
-    # 7 is not used
-    8: STATE_OPEN,  # safety stop
+    # all blebox covers
+    blebox_uniapi.cover.BleboxCoverState.MOVING_DOWN: STATE_CLOSING,
+    blebox_uniapi.cover.BleboxCoverState.MOVING_UP: STATE_OPENING,
+    blebox_uniapi.cover.BleboxCoverState.MANUALLY_STOPPED: STATE_OPEN,
+    blebox_uniapi.cover.BleboxCoverState.LOWER_LIMIT_REACHED: STATE_CLOSED,
+    blebox_uniapi.cover.BleboxCoverState.UPPER_LIMIT_REACHED: STATE_OPEN,
+    # extra states of gateController product
+    blebox_uniapi.cover.BleboxCoverState.OVERLOAD: STATE_OPEN,
+    blebox_uniapi.cover.BleboxCoverState.MOTOR_FAILURE: STATE_OPEN,
+    blebox_uniapi.cover.BleboxCoverState.SAFETY_STOP: STATE_OPEN,
 }
 
 


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This replaces plain integers in blebox_uniapi <-> homeassistant cover states mapping with actual IntEnum values exported by blebox_uniapi package. No actual integer value changes, just plain code quality improvement.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
This is a spinoff from #110547. 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
