### PR TITLE
Allow Switchbot users to force nightlatch

### DIFF
--- a/homeassistant/components/switchbot/config_flow.py
+++ b/homeassistant/components/switchbot/config_flow.py
@@ -39,8 +39,10 @@ from .const import (
     CONF_ENCRYPTION_KEY,
     CONF_KEY_ID,
     CONF_RETRY_COUNT,
+    CONF_LOCK_NIGHTLATCH,
     CONNECTABLE_SUPPORTED_MODEL_TYPES,
     DEFAULT_RETRY_COUNT,
+    DEFAULT_LOCK_NIGHTLATCH,
     DOMAIN,
     NON_CONNECTABLE_SUPPORTED_MODEL_TYPES,
     SUPPORTED_LOCK_MODELS,
@@ -361,7 +363,13 @@ class SwitchbotOptionsFlowHandler(OptionsFlow):
                 default=self.config_entry.options.get(
                     CONF_RETRY_COUNT, DEFAULT_RETRY_COUNT
                 ),
-            ): int
+            ): int,
+            vol.Optional(
+                CONF_LOCK_NIGHTLATCH,
+                default=self.config_entry.options.get(
+                    CONF_LOCK_NIGHTLATCH, DEFAULT_LOCK_NIGHTLATCH
+                ),
+            ): bool
         }
 
         return self.async_show_form(step_id="init", data_schema=vol.Schema(options))

--- a/homeassistant/components/switchbot/config_flow.py
+++ b/homeassistant/components/switchbot/config_flow.py
@@ -11,7 +11,6 @@ from switchbot import (
     SwitchbotApiError,
     SwitchbotAuthenticationError,
     SwitchbotLock,
-    SwitchbotModel,
     parse_advertisement_data,
 )
 import voluptuous as vol
@@ -48,6 +47,7 @@ from .const import (
     NON_CONNECTABLE_SUPPORTED_MODEL_TYPES,
     SUPPORTED_LOCK_MODELS,
     SUPPORTED_MODEL_TYPES,
+    SupportedModels,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -366,7 +366,7 @@ class SwitchbotOptionsFlowHandler(OptionsFlow):
                 ),
             ): int
         }
-        if self.config_entry.runtime_data.model == SwitchbotModel.LOCK_PRO:
+        if self.config_entry.data.get(CONF_SENSOR_TYPE) == SupportedModels.LOCK_PRO:
             options.update(
                 {
                     vol.Optional(

--- a/homeassistant/components/switchbot/config_flow.py
+++ b/homeassistant/components/switchbot/config_flow.py
@@ -38,11 +38,11 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from .const import (
     CONF_ENCRYPTION_KEY,
     CONF_KEY_ID,
-    CONF_RETRY_COUNT,
     CONF_LOCK_NIGHTLATCH,
+    CONF_RETRY_COUNT,
     CONNECTABLE_SUPPORTED_MODEL_TYPES,
-    DEFAULT_RETRY_COUNT,
     DEFAULT_LOCK_NIGHTLATCH,
+    DEFAULT_RETRY_COUNT,
     DOMAIN,
     NON_CONNECTABLE_SUPPORTED_MODEL_TYPES,
     SUPPORTED_LOCK_MODELS,
@@ -369,7 +369,7 @@ class SwitchbotOptionsFlowHandler(OptionsFlow):
                 default=self.config_entry.options.get(
                     CONF_LOCK_NIGHTLATCH, DEFAULT_LOCK_NIGHTLATCH
                 ),
-            ): bool
+            ): bool,
         }
 
         return self.async_show_form(step_id="init", data_schema=vol.Schema(options))

--- a/homeassistant/components/switchbot/config_flow.py
+++ b/homeassistant/components/switchbot/config_flow.py
@@ -11,6 +11,7 @@ from switchbot import (
     SwitchbotApiError,
     SwitchbotAuthenticationError,
     SwitchbotLock,
+    SwitchbotModel,
     parse_advertisement_data,
 )
 import voluptuous as vol
@@ -357,19 +358,24 @@ class SwitchbotOptionsFlowHandler(OptionsFlow):
             # Update common entity options for all other entities.
             return self.async_create_entry(title="", data=user_input)
 
-        options = {
+        options: dict[vol.Optional, Any] = {
             vol.Optional(
                 CONF_RETRY_COUNT,
                 default=self.config_entry.options.get(
                     CONF_RETRY_COUNT, DEFAULT_RETRY_COUNT
                 ),
-            ): int,
-            vol.Optional(
-                CONF_LOCK_NIGHTLATCH,
-                default=self.config_entry.options.get(
-                    CONF_LOCK_NIGHTLATCH, DEFAULT_LOCK_NIGHTLATCH
-                ),
-            ): bool,
+            ): int
         }
+        if self.config_entry.runtime_data.model == SwitchbotModel.LOCK_PRO:
+            options.update(
+                {
+                    vol.Optional(
+                        CONF_LOCK_NIGHTLATCH,
+                        default=self.config_entry.options.get(
+                            CONF_LOCK_NIGHTLATCH, DEFAULT_LOCK_NIGHTLATCH
+                        ),
+                    ): bool
+                }
+            )
 
         return self.async_show_form(step_id="init", data_schema=vol.Schema(options))

--- a/homeassistant/components/switchbot/const.py
+++ b/homeassistant/components/switchbot/const.py
@@ -64,11 +64,13 @@ HASS_SENSOR_TYPE_TO_SWITCHBOT_MODEL = {
 
 # Config Defaults
 DEFAULT_RETRY_COUNT = 3
+DEFAULT_LOCK_NIGHTLATCH = False
 
 # Config Options
 CONF_RETRY_COUNT = "retry_count"
 CONF_KEY_ID = "key_id"
 CONF_ENCRYPTION_KEY = "encryption_key"
+CONF_LOCK_NIGHTLATCH = "lock_force_nightlatch"
 
 # Deprecated config Entry Options to be removed in 2023.4
 CONF_TIME_BETWEEN_UPDATE_COMMAND = "update_time"

--- a/homeassistant/components/switchbot/lock.py
+++ b/homeassistant/components/switchbot/lock.py
@@ -12,6 +12,11 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .coordinator import SwitchbotConfigEntry, SwitchbotDataUpdateCoordinator
 from .entity import SwitchbotEntity
 
+from .const import (
+    CONF_LOCK_NIGHTLATCH,
+    DEFAULT_LOCK_NIGHTLATCH,
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -19,7 +24,8 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Switchbot lock based on a config entry."""
-    async_add_entities([(SwitchBotLock(entry.runtime_data))])
+    force_nightlatch = entry.options.get(CONF_LOCK_NIGHTLATCH, DEFAULT_LOCK_NIGHTLATCH)
+    async_add_entities([(SwitchBotLock(entry.runtime_data, force_nightlatch))])
 
 
 # noinspection PyAbstractClass
@@ -30,11 +36,11 @@ class SwitchBotLock(SwitchbotEntity, LockEntity):
     _attr_name = None
     _device: switchbot.SwitchbotLock
 
-    def __init__(self, coordinator: SwitchbotDataUpdateCoordinator) -> None:
+    def __init__(self, coordinator: SwitchbotDataUpdateCoordinator, force_nightlatch) -> None:
         """Initialize the entity."""
         super().__init__(coordinator)
         self._async_update_attrs()
-        if self._device.is_night_latch_enabled():
+        if self._device.is_night_latch_enabled() or force_nightlatch:
             self._attr_supported_features = LockEntityFeature.OPEN
 
     def _async_update_attrs(self) -> None:
@@ -55,7 +61,7 @@ class SwitchBotLock(SwitchbotEntity, LockEntity):
 
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the lock."""
-        if self._device.is_night_latch_enabled():
+        if self._attr_supported_features  & (LockEntityFeature.OPEN):
             self._last_run_success = await self._device.unlock_without_unlatch()
         else:
             self._last_run_success = await self._device.unlock()

--- a/homeassistant/components/switchbot/lock.py
+++ b/homeassistant/components/switchbot/lock.py
@@ -9,13 +9,9 @@ from homeassistant.components.lock import LockEntity, LockEntityFeature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .const import CONF_LOCK_NIGHTLATCH, DEFAULT_LOCK_NIGHTLATCH
 from .coordinator import SwitchbotConfigEntry, SwitchbotDataUpdateCoordinator
 from .entity import SwitchbotEntity
-
-from .const import (
-    CONF_LOCK_NIGHTLATCH,
-    DEFAULT_LOCK_NIGHTLATCH,
-)
 
 
 async def async_setup_entry(
@@ -36,7 +32,9 @@ class SwitchBotLock(SwitchbotEntity, LockEntity):
     _attr_name = None
     _device: switchbot.SwitchbotLock
 
-    def __init__(self, coordinator: SwitchbotDataUpdateCoordinator, force_nightlatch) -> None:
+    def __init__(
+        self, coordinator: SwitchbotDataUpdateCoordinator, force_nightlatch
+    ) -> None:
         """Initialize the entity."""
         super().__init__(coordinator)
         self._async_update_attrs()
@@ -61,7 +59,7 @@ class SwitchBotLock(SwitchbotEntity, LockEntity):
 
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the lock."""
-        if self._attr_supported_features  & (LockEntityFeature.OPEN):
+        if self._attr_supported_features & (LockEntityFeature.OPEN):
             self._last_run_success = await self._device.unlock_without_unlatch()
         else:
             self._last_run_success = await self._device.unlock()

--- a/homeassistant/components/switchbot/lock.py
+++ b/homeassistant/components/switchbot/lock.py
@@ -21,7 +21,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up Switchbot lock based on a config entry."""
     force_nightlatch = entry.options.get(CONF_LOCK_NIGHTLATCH, DEFAULT_LOCK_NIGHTLATCH)
-    async_add_entities([(SwitchBotLock(entry.runtime_data, force_nightlatch))])
+    async_add_entities([SwitchBotLock(entry.runtime_data, force_nightlatch)])
 
 
 # noinspection PyAbstractClass

--- a/homeassistant/components/switchbot/strings.json
+++ b/homeassistant/components/switchbot/strings.json
@@ -54,7 +54,8 @@
     "step": {
       "init": {
         "data": {
-          "retry_count": "Retry count"
+          "retry_count": "Retry count",
+          "lock_force_nightlatch": "Force Nightlatch operation mode"
         }
       }
     }

--- a/tests/components/switchbot/test_config_flow.py
+++ b/tests/components/switchbot/test_config_flow.py
@@ -7,6 +7,7 @@ from switchbot import SwitchbotAccountConnectionError, SwitchbotAuthenticationEr
 from homeassistant.components.switchbot.const import (
     CONF_ENCRYPTION_KEY,
     CONF_KEY_ID,
+    CONF_LOCK_NIGHTLATCH,
     CONF_RETRY_COUNT,
 )
 from homeassistant.config_entries import SOURCE_BLUETOOTH, SOURCE_USER
@@ -782,3 +783,65 @@ async def test_options_flow(hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
     assert entry.options[CONF_RETRY_COUNT] == 6
+
+
+async def test_options_flow_lock_pro(hass: HomeAssistant) -> None:
+    """Test updating options."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_ADDRESS: "aa:bb:cc:dd:ee:ff",
+            CONF_NAME: "test-name",
+            CONF_PASSWORD: "test-password",
+            CONF_SENSOR_TYPE: "lock_pro",
+        },
+        options={CONF_RETRY_COUNT: 10},
+        unique_id="aabbccddeeff",
+    )
+    entry.add_to_hass(hass)
+
+    # Test Force night_latch should be disabled by default.
+    with patch_async_setup_entry() as mock_setup_entry:
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "init"
+        assert result["errors"] is None
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_RETRY_COUNT: 3,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_LOCK_NIGHTLATCH] is False
+
+    assert len(mock_setup_entry.mock_calls) == 1
+
+    # Test Set force night_latch to be enabled.
+
+    with patch_async_setup_entry() as mock_setup_entry:
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "init"
+        assert result["errors"] is None
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_LOCK_NIGHTLATCH: True,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_LOCK_NIGHTLATCH] is True
+
+    assert len(mock_setup_entry.mock_calls) == 0
+
+    assert entry.options[CONF_LOCK_NIGHTLATCH] is True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds boolean option to force lock to operate as if night latch was detected. This is easiest way I found around the broken night latch detection in pySwitchbot library for the new Lock Pro. It will be easily removable if someone found way to correctly detect night latch.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
We currently don't know how to fix night latch detection on Lock Pro. So i decided to crate this PR which simply allow users force night latch operation (enables action OPEN).
Links for discussions around this issue:
https://github.com/Danielhiversen/pySwitchbot/pull/245
https://github.com/Danielhiversen/pySwitchbot/issues/233

- This PR fixes or closes issue: fixes #123899, #121165
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
