### PR TITLE
Rename OpenThermGatewayDevice to OpenThermGatewayHub

### DIFF
--- a/homeassistant/components/opentherm_gw/__init__.py
+++ b/homeassistant/components/opentherm_gw/__init__.py
@@ -99,7 +99,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     if DATA_OPENTHERM_GW not in hass.data:
         hass.data[DATA_OPENTHERM_GW] = {DATA_GATEWAYS: {}}
 
-    gateway = OpenThermGatewayDevice(hass, config_entry)
+    gateway = OpenThermGatewayHub(hass, config_entry)
     hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][config_entry.data[CONF_ID]] = gateway
 
     if config_entry.options.get(CONF_PRECISION):
@@ -273,9 +273,9 @@ def register_services(hass: HomeAssistant) -> None:
 
     async def reset_gateway(call: ServiceCall) -> None:
         """Reset the OpenTherm Gateway."""
-        gw_dev = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][call.data[ATTR_GW_ID]]
+        gw_hub = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][call.data[ATTR_GW_ID]]
         mode_rst = gw_vars.OTGW_MODE_RESET
-        await gw_dev.gateway.set_mode(mode_rst)
+        await gw_hub.gateway.set_mode(mode_rst)
 
     hass.services.async_register(
         DOMAIN, SERVICE_RESET_GATEWAY, reset_gateway, service_reset_schema
@@ -283,8 +283,8 @@ def register_services(hass: HomeAssistant) -> None:
 
     async def set_ch_ovrd(call: ServiceCall) -> None:
         """Set the central heating override on the OpenTherm Gateway."""
-        gw_dev = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][call.data[ATTR_GW_ID]]
-        await gw_dev.gateway.set_ch_enable_bit(1 if call.data[ATTR_CH_OVRD] else 0)
+        gw_hub = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][call.data[ATTR_GW_ID]]
+        await gw_hub.gateway.set_ch_enable_bit(1 if call.data[ATTR_CH_OVRD] else 0)
 
     hass.services.async_register(
         DOMAIN,
@@ -295,8 +295,8 @@ def register_services(hass: HomeAssistant) -> None:
 
     async def set_control_setpoint(call: ServiceCall) -> None:
         """Set the control setpoint on the OpenTherm Gateway."""
-        gw_dev = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][call.data[ATTR_GW_ID]]
-        await gw_dev.gateway.set_control_setpoint(call.data[ATTR_TEMPERATURE])
+        gw_hub = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][call.data[ATTR_GW_ID]]
+        await gw_hub.gateway.set_control_setpoint(call.data[ATTR_TEMPERATURE])
 
     hass.services.async_register(
         DOMAIN,
@@ -307,8 +307,8 @@ def register_services(hass: HomeAssistant) -> None:
 
     async def set_dhw_ovrd(call: ServiceCall) -> None:
         """Set the domestic hot water override on the OpenTherm Gateway."""
-        gw_dev = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][call.data[ATTR_GW_ID]]
-        await gw_dev.gateway.set_hot_water_ovrd(call.data[ATTR_DHW_OVRD])
+        gw_hub = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][call.data[ATTR_GW_ID]]
+        await gw_hub.gateway.set_hot_water_ovrd(call.data[ATTR_DHW_OVRD])
 
     hass.services.async_register(
         DOMAIN,
@@ -319,8 +319,8 @@ def register_services(hass: HomeAssistant) -> None:
 
     async def set_dhw_setpoint(call: ServiceCall) -> None:
         """Set the domestic hot water setpoint on the OpenTherm Gateway."""
-        gw_dev = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][call.data[ATTR_GW_ID]]
-        await gw_dev.gateway.set_dhw_setpoint(call.data[ATTR_TEMPERATURE])
+        gw_hub = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][call.data[ATTR_GW_ID]]
+        await gw_hub.gateway.set_dhw_setpoint(call.data[ATTR_TEMPERATURE])
 
     hass.services.async_register(
         DOMAIN,
@@ -331,10 +331,10 @@ def register_services(hass: HomeAssistant) -> None:
 
     async def set_device_clock(call: ServiceCall) -> None:
         """Set the clock on the OpenTherm Gateway."""
-        gw_dev = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][call.data[ATTR_GW_ID]]
+        gw_hub = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][call.data[ATTR_GW_ID]]
         attr_date = call.data[ATTR_DATE]
         attr_time = call.data[ATTR_TIME]
-        await gw_dev.gateway.set_clock(datetime.combine(attr_date, attr_time))
+        await gw_hub.gateway.set_clock(datetime.combine(attr_date, attr_time))
 
     hass.services.async_register(
         DOMAIN, SERVICE_SET_CLOCK, set_device_clock, service_set_clock_schema
@@ -342,10 +342,10 @@ def register_services(hass: HomeAssistant) -> None:
 
     async def set_gpio_mode(call: ServiceCall) -> None:
         """Set the OpenTherm Gateway GPIO modes."""
-        gw_dev = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][call.data[ATTR_GW_ID]]
+        gw_hub = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][call.data[ATTR_GW_ID]]
         gpio_id = call.data[ATTR_ID]
         gpio_mode = call.data[ATTR_MODE]
-        await gw_dev.gateway.set_gpio_mode(gpio_id, gpio_mode)
+        await gw_hub.gateway.set_gpio_mode(gpio_id, gpio_mode)
 
     hass.services.async_register(
         DOMAIN, SERVICE_SET_GPIO_MODE, set_gpio_mode, service_set_gpio_mode_schema
@@ -353,10 +353,10 @@ def register_services(hass: HomeAssistant) -> None:
 
     async def set_led_mode(call: ServiceCall) -> None:
         """Set the OpenTherm Gateway LED modes."""
-        gw_dev = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][call.data[ATTR_GW_ID]]
+        gw_hub = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][call.data[ATTR_GW_ID]]
         led_id = call.data[ATTR_ID]
         led_mode = call.data[ATTR_MODE]
-        await gw_dev.gateway.set_led_mode(led_id, led_mode)
+        await gw_hub.gateway.set_led_mode(led_id, led_mode)
 
     hass.services.async_register(
         DOMAIN, SERVICE_SET_LED_MODE, set_led_mode, service_set_led_mode_schema
@@ -364,12 +364,12 @@ def register_services(hass: HomeAssistant) -> None:
 
     async def set_max_mod(call: ServiceCall) -> None:
         """Set the max modulation level."""
-        gw_dev = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][call.data[ATTR_GW_ID]]
+        gw_hub = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][call.data[ATTR_GW_ID]]
         level = call.data[ATTR_LEVEL]
         if level == -1:
             # Backend only clears setting on non-numeric values.
             level = "-"
-        await gw_dev.gateway.set_max_relative_mod(level)
+        await gw_hub.gateway.set_max_relative_mod(level)
 
     hass.services.async_register(
         DOMAIN, SERVICE_SET_MAX_MOD, set_max_mod, service_set_max_mod_schema
@@ -377,8 +377,8 @@ def register_services(hass: HomeAssistant) -> None:
 
     async def set_outside_temp(call: ServiceCall) -> None:
         """Provide the outside temperature to the OpenTherm Gateway."""
-        gw_dev = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][call.data[ATTR_GW_ID]]
-        await gw_dev.gateway.set_outside_temp(call.data[ATTR_TEMPERATURE])
+        gw_hub = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][call.data[ATTR_GW_ID]]
+        await gw_hub.gateway.set_outside_temp(call.data[ATTR_TEMPERATURE])
 
     hass.services.async_register(
         DOMAIN, SERVICE_SET_OAT, set_outside_temp, service_set_oat_schema
@@ -386,8 +386,8 @@ def register_services(hass: HomeAssistant) -> None:
 
     async def set_setback_temp(call: ServiceCall) -> None:
         """Set the OpenTherm Gateway SetBack temperature."""
-        gw_dev = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][call.data[ATTR_GW_ID]]
-        await gw_dev.gateway.set_setback_temp(call.data[ATTR_TEMPERATURE])
+        gw_hub = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][call.data[ATTR_GW_ID]]
+        await gw_hub.gateway.set_setback_temp(call.data[ATTR_TEMPERATURE])
 
     hass.services.async_register(
         DOMAIN, SERVICE_SET_SB_TEMP, set_setback_temp, service_set_sb_temp_schema
@@ -395,10 +395,10 @@ def register_services(hass: HomeAssistant) -> None:
 
     async def send_transparent_cmd(call: ServiceCall) -> None:
         """Send a transparent OpenTherm Gateway command."""
-        gw_dev = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][call.data[ATTR_GW_ID]]
+        gw_hub = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][call.data[ATTR_GW_ID]]
         transp_cmd = call.data[ATTR_TRANSP_CMD]
         transp_arg = call.data[ATTR_TRANSP_ARG]
-        await gw_dev.gateway.send_transparent_command(transp_cmd, transp_arg)
+        await gw_hub.gateway.send_transparent_command(transp_cmd, transp_arg)
 
     hass.services.async_register(
         DOMAIN,
@@ -416,20 +416,20 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
-class OpenThermGatewayDevice:
-    """OpenTherm Gateway device class."""
+class OpenThermGatewayHub:
+    """OpenTherm Gateway hub class."""
 
     def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
         """Initialize the OpenTherm Gateway."""
         self.hass = hass
         self.device_path = config_entry.data[CONF_DEVICE]
-        self.gw_id = config_entry.data[CONF_ID]
+        self.hub_id = config_entry.data[CONF_ID]
         self.name = config_entry.data[CONF_NAME]
         self.climate_config = config_entry.options
         self.config_entry_id = config_entry.entry_id
         self.status = gw_vars.DEFAULT_STATUS
-        self.update_signal = f"{DATA_OPENTHERM_GW}_{self.gw_id}_update"
-        self.options_update_signal = f"{DATA_OPENTHERM_GW}_{self.gw_id}_options_update"
+        self.update_signal = f"{DATA_OPENTHERM_GW}_{self.hub_id}_update"
+        self.options_update_signal = f"{DATA_OPENTHERM_GW}_{self.hub_id}_options_update"
         self.gateway = pyotgw.OpenThermGateway()
         self.gw_version = None
 
@@ -453,7 +453,7 @@ class OpenThermGatewayDevice:
         dev_reg = dr.async_get(self.hass)
         gw_dev = dev_reg.async_get_or_create(
             config_entry_id=self.config_entry_id,
-            identifiers={(DOMAIN, self.gw_id)},
+            identifiers={(DOMAIN, self.hub_id)},
             name=self.name,
             manufacturer="Schelte Bron",
             model="OpenTherm Gateway",

--- a/homeassistant/components/opentherm_gw/binary_sensor.py
+++ b/homeassistant/components/opentherm_gw/binary_sensor.py
@@ -16,7 +16,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import OpenThermGatewayDevice
+from . import OpenThermGatewayHub
 from .const import DATA_GATEWAYS, DATA_OPENTHERM_GW
 from .entity import OpenThermEntity, OpenThermEntityDescription
 
@@ -290,10 +290,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the OpenTherm Gateway binary sensors."""
-    gw_dev = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][config_entry.data[CONF_ID]]
+    gw_hub = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][config_entry.data[CONF_ID]]
 
     async_add_entities(
-        OpenThermBinarySensor(gw_dev, source, description)
+        OpenThermBinarySensor(gw_hub, source, description)
         for sources, description in BINARY_SENSOR_INFO
         for source in sources
     )
@@ -306,17 +306,17 @@ class OpenThermBinarySensor(OpenThermEntity, BinarySensorEntity):
 
     def __init__(
         self,
-        gw_dev: OpenThermGatewayDevice,
+        gw_hub: OpenThermGatewayHub,
         source: str,
         description: OpenThermBinarySensorEntityDescription,
     ) -> None:
         """Initialize the binary sensor."""
         self.entity_id = async_generate_entity_id(
             ENTITY_ID_FORMAT,
-            f"{description.key}_{source}_{gw_dev.gw_id}",
-            hass=gw_dev.hass,
+            f"{description.key}_{source}_{gw_hub.hub_id}",
+            hass=gw_hub.hass,
         )
-        super().__init__(gw_dev, source, description)
+        super().__init__(gw_hub, source, description)
 
     @callback
     def receive_report(self, status: dict[str, dict]) -> None:

--- a/homeassistant/components/opentherm_gw/climate.py
+++ b/homeassistant/components/opentherm_gw/climate.py
@@ -87,13 +87,13 @@ class OpenThermClimate(ClimateEntity):
     _current_operation: HVACAction | None = None
     _enable_turn_on_off_backwards_compatibility = False
 
-    def __init__(self, gw_dev, options):
+    def __init__(self, gw_hub, options):
         """Initialize the device."""
-        self._gateway = gw_dev
+        self._gateway = gw_hub
         self.entity_id = async_generate_entity_id(
-            ENTITY_ID_FORMAT, gw_dev.gw_id, hass=gw_dev.hass
+            ENTITY_ID_FORMAT, gw_hub.hub_id, hass=gw_hub.hass
         )
-        self.friendly_name = gw_dev.name
+        self.friendly_name = gw_hub.name
         self._attr_name = self.friendly_name
         self.floor_temp = options.get(CONF_FLOOR_TEMP, DEFAULT_FLOOR_TEMP)
         self.temp_read_precision = options.get(CONF_READ_PRECISION)
@@ -102,13 +102,13 @@ class OpenThermClimate(ClimateEntity):
         self._unsub_options = None
         self._unsub_updates = None
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, gw_dev.gw_id)},
+            identifiers={(DOMAIN, gw_hub.hub_id)},
             manufacturer="Schelte Bron",
             model="OpenTherm Gateway",
-            name=gw_dev.name,
-            sw_version=gw_dev.gw_version,
+            name=gw_hub.name,
+            sw_version=gw_hub.gw_version,
         )
-        self._attr_unique_id = gw_dev.gw_id
+        self._attr_unique_id = gw_hub.hub_id
 
     @callback
     def update_options(self, entry):

--- a/homeassistant/components/opentherm_gw/entity.py
+++ b/homeassistant/components/opentherm_gw/entity.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity, EntityDescription
 
-from . import OpenThermGatewayDevice
+from . import OpenThermGatewayHub
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -37,27 +37,27 @@ class OpenThermEntity(Entity):
 
     def __init__(
         self,
-        gw_dev: OpenThermGatewayDevice,
+        gw_hub: OpenThermGatewayHub,
         source: str,
         description: OpenThermEntityDescription,
     ) -> None:
         """Initialize the entity."""
         self.entity_description = description
-        self._gateway = gw_dev
+        self._gateway = gw_hub
         self._source = source
         friendly_name_format = (
             f"{description.friendly_name_format} ({TRANSLATE_SOURCE[source]})"
             if TRANSLATE_SOURCE[source] is not None
             else description.friendly_name_format
         )
-        self._attr_name = friendly_name_format.format(gw_dev.name)
-        self._attr_unique_id = f"{gw_dev.gw_id}-{source}-{description.key}"
+        self._attr_name = friendly_name_format.format(gw_hub.name)
+        self._attr_unique_id = f"{gw_hub.hub_id}-{source}-{description.key}"
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, gw_dev.gw_id)},
+            identifiers={(DOMAIN, gw_hub.hub_id)},
             manufacturer="Schelte Bron",
             model="OpenTherm Gateway",
-            name=gw_dev.name,
-            sw_version=gw_dev.gw_version,
+            name=gw_hub.name,
+            sw_version=gw_hub.gw_version,
         )
 
     async def async_added_to_hass(self) -> None:

--- a/homeassistant/components/opentherm_gw/sensor.py
+++ b/homeassistant/components/opentherm_gw/sensor.py
@@ -25,7 +25,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import OpenThermGatewayDevice
+from . import OpenThermGatewayHub
 from .const import DATA_GATEWAYS, DATA_OPENTHERM_GW
 from .entity import OpenThermEntity, OpenThermEntityDescription
 
@@ -624,11 +624,11 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the OpenTherm Gateway sensors."""
-    gw_dev = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][config_entry.data[CONF_ID]]
+    gw_hub = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][config_entry.data[CONF_ID]]
 
     async_add_entities(
         OpenThermSensor(
-            gw_dev,
+            gw_hub,
             source,
             description,
         )
@@ -644,17 +644,17 @@ class OpenThermSensor(OpenThermEntity, SensorEntity):
 
     def __init__(
         self,
-        gw_dev: OpenThermGatewayDevice,
+        gw_hub: OpenThermGatewayHub,
         source: str,
         description: OpenThermSensorEntityDescription,
     ) -> None:
         """Initialize the OpenTherm Gateway sensor."""
         self.entity_id = async_generate_entity_id(
             ENTITY_ID_FORMAT,
-            f"{description.key}_{source}_{gw_dev.gw_id}",
-            hass=gw_dev.hass,
+            f"{description.key}_{source}_{gw_hub.hub_id}",
+            hass=gw_hub.hass,
         )
-        super().__init__(gw_dev, source, description)
+        super().__init__(gw_hub, source, description)
 
     @callback
     def receive_report(self, status: dict[str, dict]) -> None:

--- a/tests/components/opentherm_gw/test_config_flow.py
+++ b/tests/components/opentherm_gw/test_config_flow.py
@@ -223,7 +223,7 @@ async def test_options_migration(hass: HomeAssistant) -> None:
 
     with (
         patch(
-            "homeassistant.components.opentherm_gw.OpenThermGatewayDevice.connect_and_subscribe",
+            "homeassistant.components.opentherm_gw.OpenThermGatewayHub.connect_and_subscribe",
             return_value=True,
         ),
         patch(

--- a/tests/components/opentherm_gw/test_init.py
+++ b/tests/components/opentherm_gw/test_init.py
@@ -40,7 +40,7 @@ async def test_device_registry_insert(
 
     with (
         patch(
-            "homeassistant.components.opentherm_gw.OpenThermGatewayDevice.cleanup",
+            "homeassistant.components.opentherm_gw.OpenThermGatewayHub.cleanup",
             return_value=None,
         ),
         patch("pyotgw.OpenThermGateway.connect", return_value=MINIMAL_STATUS),
@@ -72,7 +72,7 @@ async def test_device_registry_update(
 
     with (
         patch(
-            "homeassistant.components.opentherm_gw.OpenThermGatewayDevice.cleanup",
+            "homeassistant.components.opentherm_gw.OpenThermGatewayHub.cleanup",
             return_value=None,
         ),
         patch("pyotgw.OpenThermGateway.connect", return_value=MINIMAL_STATUS_UPD),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The opentherm_gw integration uses a central hub to connect to the OpenTherm Gateway and coordinate the information flows between the various platforms and the actual gateway.
Until now, this hub class had the unfortunate name `OpenThermGatewayDevice`, with references mostly using `device`-type names. This is causing confusion with the Home Assistant device structure during development.
This PR changes the class name and its references to `OpenThermGatewayHub` and `hub`-type reference names, to make the distinction between the hub and Home Assistant devices clear.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
