### PR TITLE
Add conversation agent to Wyoming

### DIFF
--- a/homeassistant/components/wyoming/__init__.py
+++ b/homeassistant/components/wyoming/__init__.py
@@ -23,7 +23,6 @@ SATELLITE_PLATFORMS = [
     Platform.SELECT,
     Platform.SWITCH,
     Platform.NUMBER,
-    Platform.CONVERSATION,
 ]
 
 __all__ = [

--- a/homeassistant/components/wyoming/__init__.py
+++ b/homeassistant/components/wyoming/__init__.py
@@ -23,6 +23,7 @@ SATELLITE_PLATFORMS = [
     Platform.SELECT,
     Platform.SWITCH,
     Platform.NUMBER,
+    Platform.CONVERSATION,
 ]
 
 __all__ = [

--- a/homeassistant/components/wyoming/conversation.py
+++ b/homeassistant/components/wyoming/conversation.py
@@ -1,0 +1,207 @@
+"""Support for Wyoming intent recognition services."""
+
+import logging
+
+from wyoming.asr import Transcript
+from wyoming.client import AsyncTcpClient
+from wyoming.handle import Handled, NotHandled
+from wyoming.info import HandleProgram, IntentProgram
+from wyoming.intent import Intent, NotRecognized
+
+from homeassistant.components import conversation
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import intent
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import ulid
+
+from .const import DOMAIN
+from .data import WyomingService
+from .error import WyomingError
+from .models import DomainDataItem
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Wyoming conversation."""
+    item: DomainDataItem = hass.data[DOMAIN][config_entry.entry_id]
+    async_add_entities(
+        [
+            WyomingConversationEntity(config_entry, item.service),
+        ]
+    )
+
+
+class WyomingConversationEntity(
+    conversation.ConversationEntity, conversation.AbstractConversationAgent
+):
+    """Wyoming conversation agent."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        config_entry: ConfigEntry,
+        service: WyomingService,
+    ) -> None:
+        """Set up provider."""
+        super().__init__()
+
+        self.entry = config_entry
+        self.service = service
+
+        self._intent_service: IntentProgram | None = None
+        self._handle_service: HandleProgram | None = None
+
+        for maybe_intent in self.service.info.intent:
+            if maybe_intent.installed:
+                self._intent_service = maybe_intent
+                break
+
+        for maybe_handle in self.service.info.handle:
+            if maybe_handle.installed:
+                self._handle_service = maybe_handle
+                break
+
+        model_languages: set[str] = set()
+
+        if self._intent_service is not None:
+            for intent_model in self._intent_service.models:
+                if intent_model.installed:
+                    model_languages.update(intent_model.languages)
+
+            self._attr_name = self._intent_service.name
+            self._attr_supported_features = (
+                conversation.ConversationEntityFeature.CONTROL
+            )
+        elif self._handle_service is not None:
+            for handle_model in self._handle_service.models:
+                if handle_model.installed:
+                    model_languages.update(handle_model.languages)
+
+            self._attr_name = self._handle_service.name
+        else:
+            raise ValueError("No intent or handle service")
+
+        self._supported_languages = list(model_languages)
+        self._attr_unique_id = f"{config_entry.entry_id}-conversation"
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to Home Assistant."""
+        await super().async_added_to_hass()
+        conversation.async_set_agent(self.hass, self.entry, self)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """When entity will be removed from Home Assistant."""
+        conversation.async_unset_agent(self.hass, self.entry)
+        await super().async_will_remove_from_hass()
+
+    @property
+    def supported_languages(self) -> list[str]:
+        """Return a list of supported languages."""
+        return self._supported_languages
+
+    async def async_process(
+        self, user_input: conversation.ConversationInput
+    ) -> conversation.ConversationResult:
+        """Process a sentence."""
+        conversation_id = user_input.conversation_id or ulid.ulid_now()
+        intent_response = intent.IntentResponse(language=user_input.language)
+
+        try:
+            async with AsyncTcpClient(self.service.host, self.service.port) as client:
+                await client.write_event(
+                    Transcript(
+                        user_input.text, context={"conversation_id": conversation_id}
+                    ).event()
+                )
+
+                while True:
+                    event = await client.read_event()
+                    if event is None:
+                        _LOGGER.debug("Connection lost")
+                        intent_response.async_set_error(
+                            intent.IntentResponseErrorCode.UNKNOWN,
+                            "Connection to service was lost",
+                        )
+                        return conversation.ConversationResult(
+                            response=intent_response,
+                            conversation_id=user_input.conversation_id,
+                        )
+
+                    if Intent.is_type(event.type):
+                        # Success
+                        recognized_intent = Intent.from_event(event)
+                        _LOGGER.debug("Recognized intent: %s", recognized_intent)
+
+                        intent_type = recognized_intent.name
+                        intent_slots = {
+                            e.name: {"value": e.value}
+                            for e in recognized_intent.entities
+                        }
+                        intent_response = await intent.async_handle(
+                            self.hass,
+                            DOMAIN,
+                            intent_type,
+                            intent_slots,
+                            text_input=user_input.text,
+                            language=user_input.language,
+                        )
+
+                        if (not intent_response.speech) and recognized_intent.text:
+                            intent_response.async_set_speech(recognized_intent.text)
+
+                        break
+
+                    if NotRecognized.is_type(event.type):
+                        not_recognized = NotRecognized.from_event(event)
+                        intent_response.async_set_error(
+                            intent.IntentResponseErrorCode.NO_INTENT_MATCH,
+                            not_recognized.text,
+                        )
+                        break
+
+                    if Handled.is_type(event.type):
+                        # Success
+                        handled = Handled.from_event(event)
+                        intent_response.async_set_speech(handled.text)
+                        break
+
+                    if NotHandled.is_type(event.type):
+                        not_handled = NotHandled.from_event(event)
+                        intent_response.async_set_error(
+                            intent.IntentResponseErrorCode.FAILED_TO_HANDLE,
+                            not_handled.text,
+                        )
+                        break
+
+        except (OSError, WyomingError) as err:
+            _LOGGER.exception("Unexpected error while communicating with service")
+            intent_response.async_set_error(
+                intent.IntentResponseErrorCode.UNKNOWN,
+                f"Error communicating with service: {err}",
+            )
+            return conversation.ConversationResult(
+                response=intent_response,
+                conversation_id=user_input.conversation_id,
+            )
+        except intent.IntentError as err:
+            _LOGGER.exception("Unexpected error while handling intent")
+            intent_response.async_set_error(
+                intent.IntentResponseErrorCode.FAILED_TO_HANDLE,
+                f"Error handling intent: {err}",
+            )
+            return conversation.ConversationResult(
+                response=intent_response,
+                conversation_id=user_input.conversation_id,
+            )
+
+        # Success
+        return conversation.ConversationResult(
+            response=intent_response, conversation_id=conversation_id
+        )

--- a/homeassistant/components/wyoming/conversation.py
+++ b/homeassistant/components/wyoming/conversation.py
@@ -92,11 +92,9 @@ class WyomingConversationEntity(
     async def async_added_to_hass(self) -> None:
         """When entity is added to Home Assistant."""
         await super().async_added_to_hass()
-        conversation.async_set_agent(self.hass, self.entry, self)
 
     async def async_will_remove_from_hass(self) -> None:
         """When entity will be removed from Home Assistant."""
-        conversation.async_unset_agent(self.hass, self.entry)
         await super().async_will_remove_from_hass()
 
     @property

--- a/homeassistant/components/wyoming/conversation.py
+++ b/homeassistant/components/wyoming/conversation.py
@@ -52,7 +52,6 @@ class WyomingConversationEntity(
         """Set up provider."""
         super().__init__()
 
-        self.entry = config_entry
         self.service = service
 
         self._intent_service: IntentProgram | None = None

--- a/homeassistant/components/wyoming/conversation.py
+++ b/homeassistant/components/wyoming/conversation.py
@@ -85,8 +85,6 @@ class WyomingConversationEntity(
                     model_languages.update(handle_model.languages)
 
             self._attr_name = self._handle_service.name
-        else:
-            raise ValueError("No intent or handle service")
 
         self._supported_languages = list(model_languages)
         self._attr_unique_id = f"{config_entry.entry_id}-conversation"

--- a/homeassistant/components/wyoming/conversation.py
+++ b/homeassistant/components/wyoming/conversation.py
@@ -89,14 +89,6 @@ class WyomingConversationEntity(
         self._supported_languages = list(model_languages)
         self._attr_unique_id = f"{config_entry.entry_id}-conversation"
 
-    async def async_added_to_hass(self) -> None:
-        """When entity is added to Home Assistant."""
-        await super().async_added_to_hass()
-
-    async def async_will_remove_from_hass(self) -> None:
-        """When entity will be removed from Home Assistant."""
-        await super().async_will_remove_from_hass()
-
     @property
     def supported_languages(self) -> list[str]:
         """Return a list of supported languages."""

--- a/homeassistant/components/wyoming/data.py
+++ b/homeassistant/components/wyoming/data.py
@@ -37,6 +37,10 @@ class WyomingService:
             self.platforms.append(Platform.TTS)
         if any(wake.installed for wake in info.wake):
             self.platforms.append(Platform.WAKE_WORD)
+        if any(intent.installed for intent in info.intent) or any(
+            handle.installed for handle in info.handle
+        ):
+            self.platforms.append(Platform.CONVERSATION)
 
     def has_services(self) -> bool:
         """Return True if services are installed that Home Assistant can use."""
@@ -44,6 +48,8 @@ class WyomingService:
             any(asr for asr in self.info.asr if asr.installed)
             or any(tts for tts in self.info.tts if tts.installed)
             or any(wake for wake in self.info.wake if wake.installed)
+            or any(intent for intent in self.info.intent if intent.installed)
+            or any(handle for handle in self.info.handle if handle.installed)
             or ((self.info.satellite is not None) and self.info.satellite.installed)
         )
 
@@ -69,6 +75,16 @@ class WyomingService:
         wake_installed = [wake for wake in self.info.wake if wake.installed]
         if wake_installed:
             return wake_installed[0].name
+
+        # intent recognition (text -> intent)
+        intent_installed = [intent for intent in self.info.intent if intent.installed]
+        if intent_installed:
+            return intent_installed[0].name
+
+        # intent handling (text -> text)
+        handle_installed = [handle for handle in self.info.handle if handle.installed]
+        if handle_installed:
+            return handle_installed[0].name
 
         return None
 

--- a/tests/components/wyoming/__init__.py
+++ b/tests/components/wyoming/__init__.py
@@ -8,7 +8,11 @@ from wyoming.info import (
     AsrModel,
     AsrProgram,
     Attribution,
+    HandleModel,
+    HandleProgram,
     Info,
+    IntentModel,
+    IntentProgram,
     Satellite,
     TtsProgram,
     TtsVoice,
@@ -77,6 +81,48 @@ WAKE_WORD_INFO = Info(
                     name="Test Model",
                     description="Test Model",
                     phrase="Test Phrase",
+                    installed=True,
+                    attribution=TEST_ATTR,
+                    languages=["en-US"],
+                    version=None,
+                )
+            ],
+            version=None,
+        )
+    ]
+)
+INTENT_INFO = Info(
+    intent=[
+        IntentProgram(
+            name="Test Intent",
+            description="Test Intent",
+            installed=True,
+            attribution=TEST_ATTR,
+            models=[
+                IntentModel(
+                    name="Test Model",
+                    description="Test Model",
+                    installed=True,
+                    attribution=TEST_ATTR,
+                    languages=["en-US"],
+                    version=None,
+                )
+            ],
+            version=None,
+        )
+    ]
+)
+HANDLE_INFO = Info(
+    handle=[
+        HandleProgram(
+            name="Test Handle",
+            description="Test Handle",
+            installed=True,
+            attribution=TEST_ATTR,
+            models=[
+                HandleModel(
+                    name="Test Model",
+                    description="Test Model",
                     installed=True,
                     attribution=TEST_ATTR,
                     languages=["en-US"],

--- a/tests/components/wyoming/conftest.py
+++ b/tests/components/wyoming/conftest.py
@@ -13,7 +13,14 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from . import SATELLITE_INFO, STT_INFO, TTS_INFO, WAKE_WORD_INFO
+from . import (
+    HANDLE_INFO,
+    INTENT_INFO,
+    SATELLITE_INFO,
+    STT_INFO,
+    TTS_INFO,
+    WAKE_WORD_INFO,
+)
 
 from tests.common import MockConfigEntry
 
@@ -84,6 +91,36 @@ def wake_word_config_entry(hass: HomeAssistant) -> ConfigEntry:
 
 
 @pytest.fixture
+def intent_config_entry(hass: HomeAssistant) -> ConfigEntry:
+    """Create a config entry."""
+    entry = MockConfigEntry(
+        domain="wyoming",
+        data={
+            "host": "1.2.3.4",
+            "port": 1234,
+        },
+        title="Test Intent",
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+@pytest.fixture
+def handle_config_entry(hass: HomeAssistant) -> ConfigEntry:
+    """Create a config entry."""
+    entry = MockConfigEntry(
+        domain="wyoming",
+        data={
+            "host": "1.2.3.4",
+            "port": 1234,
+        },
+        title="Test Handle",
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+@pytest.fixture
 async def init_wyoming_stt(hass: HomeAssistant, stt_config_entry: ConfigEntry):
     """Initialize Wyoming STT."""
     with patch(
@@ -113,6 +150,34 @@ async def init_wyoming_wake_word(
         return_value=WAKE_WORD_INFO,
     ):
         await hass.config_entries.async_setup(wake_word_config_entry.entry_id)
+
+
+@pytest.fixture
+async def init_wyoming_intent(
+    hass: HomeAssistant, intent_config_entry: ConfigEntry
+) -> ConfigEntry:
+    """Initialize Wyoming intent recognizer."""
+    with patch(
+        "homeassistant.components.wyoming.data.load_wyoming_info",
+        return_value=INTENT_INFO,
+    ):
+        await hass.config_entries.async_setup(intent_config_entry.entry_id)
+
+    return intent_config_entry
+
+
+@pytest.fixture
+async def init_wyoming_handle(
+    hass: HomeAssistant, handle_config_entry: ConfigEntry
+) -> ConfigEntry:
+    """Initialize Wyoming intent handler."""
+    with patch(
+        "homeassistant.components.wyoming.data.load_wyoming_info",
+        return_value=HANDLE_INFO,
+    ):
+        await hass.config_entries.async_setup(handle_config_entry.entry_id)
+
+    return handle_config_entry
 
 
 @pytest.fixture

--- a/tests/components/wyoming/snapshots/test_conversation.ambr
+++ b/tests/components/wyoming/snapshots/test_conversation.ambr
@@ -1,0 +1,7 @@
+# serializer version: 1
+# name: test_connection_lost
+  'Connection to service was lost'
+# ---
+# name: test_oserror
+  'Error communicating with service: Boom!'
+# ---

--- a/tests/components/wyoming/test_conversation.py
+++ b/tests/components/wyoming/test_conversation.py
@@ -1,0 +1,239 @@
+"""Test conversation."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from syrupy import SnapshotAssertion
+from wyoming.asr import Transcript
+from wyoming.handle import Handled, NotHandled
+from wyoming.intent import Entity, Intent, NotRecognized
+
+from homeassistant.components import conversation
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.helpers import intent
+
+from . import MockAsyncTcpClient
+
+
+async def test_intent(hass: HomeAssistant, init_wyoming_intent: ConfigEntry) -> None:
+    """Test when an intent is recognized."""
+    agent = conversation.async_get_agent(hass, init_wyoming_intent.entry_id)
+    assert agent is not None
+    assert agent.supported_languages == ["en-US"]
+
+    conversation_id = "conversation-1234"
+    test_intent = Intent(
+        name="TestIntent",
+        entities=[Entity(name="entity", value="value")],
+        text="success",
+    )
+
+    class TestIntentHandler(intent.IntentHandler):
+        """Test Intent Handler."""
+
+        intent_type = "TestIntent"
+
+        async def async_handle(self, intent_obj: intent.Intent):
+            """Handle the intent."""
+            assert intent_obj.slots.get("entity", {}).get("value") == "value"
+            return intent_obj.create_response()
+
+    intent.async_register(hass, TestIntentHandler())
+
+    with patch(
+        "homeassistant.components.wyoming.conversation.AsyncTcpClient",
+        MockAsyncTcpClient([test_intent.event()]),
+    ):
+        result = await agent.async_process(
+            conversation.ConversationInput(
+                "test text",
+                Context(),
+                conversation_id=conversation_id,
+                device_id=None,
+                language=hass.config.language,
+            )
+        )
+
+    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.speech, "No speech"
+    assert result.response.speech.get("plain", {}).get("speech") == "success"
+    assert result.conversation_id == conversation_id
+
+
+async def test_intent_handle_error(
+    hass: HomeAssistant, init_wyoming_intent: ConfigEntry
+) -> None:
+    """Test error during handling when an intent is recognized."""
+    agent = conversation.async_get_agent(hass, init_wyoming_intent.entry_id)
+    assert agent is not None
+
+    test_intent = Intent(name="TestIntent", entities=[], text="success")
+
+    class TestIntentHandler(intent.IntentHandler):
+        """Test Intent Handler."""
+
+        intent_type = "TestIntent"
+
+        async def async_handle(self, intent_obj: intent.Intent):
+            """Handle the intent."""
+            raise intent.IntentError
+
+    intent.async_register(hass, TestIntentHandler())
+
+    with patch(
+        "homeassistant.components.wyoming.conversation.AsyncTcpClient",
+        MockAsyncTcpClient([test_intent.event()]),
+    ):
+        result = await agent.async_process(
+            conversation.ConversationInput(
+                "test text",
+                Context(),
+                conversation_id=None,
+                device_id=None,
+                language=hass.config.language,
+            )
+        )
+
+    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.error_code == intent.IntentResponseErrorCode.FAILED_TO_HANDLE
+
+
+async def test_not_recognized(
+    hass: HomeAssistant, init_wyoming_intent: ConfigEntry
+) -> None:
+    """Test when an intent is not recognized."""
+    agent = conversation.async_get_agent(hass, init_wyoming_intent.entry_id)
+    assert agent is not None
+
+    with patch(
+        "homeassistant.components.wyoming.conversation.AsyncTcpClient",
+        MockAsyncTcpClient([NotRecognized(text="failure").event()]),
+    ):
+        result = await agent.async_process(
+            conversation.ConversationInput(
+                "test text",
+                Context(),
+                conversation_id=None,
+                device_id=None,
+                language=hass.config.language,
+            )
+        )
+
+    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.error_code == intent.IntentResponseErrorCode.NO_INTENT_MATCH
+    assert result.response.speech, "No speech"
+    assert result.response.speech.get("plain", {}).get("speech") == "failure"
+
+
+async def test_handle(hass: HomeAssistant, init_wyoming_handle: ConfigEntry) -> None:
+    """Test when an intent is handled."""
+    agent = conversation.async_get_agent(hass, init_wyoming_handle.entry_id)
+    assert agent is not None
+
+    conversation_id = "conversation-1234"
+
+    with patch(
+        "homeassistant.components.wyoming.conversation.AsyncTcpClient",
+        MockAsyncTcpClient([Handled(text="success").event()]),
+    ):
+        result = await agent.async_process(
+            conversation.ConversationInput(
+                "test text",
+                Context(),
+                conversation_id=conversation_id,
+                device_id=None,
+                language=hass.config.language,
+            )
+        )
+
+    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.speech, "No speech"
+    assert result.response.speech.get("plain", {}).get("speech") == "success"
+    assert result.conversation_id == conversation_id
+
+
+async def test_not_handled(
+    hass: HomeAssistant, init_wyoming_handle: ConfigEntry
+) -> None:
+    """Test when an intent is not handled."""
+    agent = conversation.async_get_agent(hass, init_wyoming_handle.entry_id)
+    assert agent is not None
+
+    with patch(
+        "homeassistant.components.wyoming.conversation.AsyncTcpClient",
+        MockAsyncTcpClient([NotHandled(text="failure").event()]),
+    ):
+        result = await agent.async_process(
+            conversation.ConversationInput(
+                "test text",
+                Context(),
+                conversation_id=None,
+                device_id=None,
+                language=hass.config.language,
+            )
+        )
+
+    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.error_code == intent.IntentResponseErrorCode.FAILED_TO_HANDLE
+    assert result.response.speech, "No speech"
+    assert result.response.speech.get("plain", {}).get("speech") == "failure"
+
+
+async def test_connection_lost(
+    hass: HomeAssistant, init_wyoming_handle: ConfigEntry, snapshot: SnapshotAssertion
+) -> None:
+    """Test connection to client is lost."""
+    agent = conversation.async_get_agent(hass, init_wyoming_handle.entry_id)
+    assert agent is not None
+
+    with patch(
+        "homeassistant.components.wyoming.conversation.AsyncTcpClient",
+        MockAsyncTcpClient([None]),
+    ):
+        result = await agent.async_process(
+            conversation.ConversationInput(
+                "test text",
+                Context(),
+                conversation_id=None,
+                device_id=None,
+                language=hass.config.language,
+            )
+        )
+
+    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.error_code == intent.IntentResponseErrorCode.UNKNOWN
+    assert result.response.speech, "No speech"
+    assert result.response.speech.get("plain", {}).get("speech") == snapshot()
+
+
+async def test_oserror(
+    hass: HomeAssistant, init_wyoming_handle: ConfigEntry, snapshot: SnapshotAssertion
+) -> None:
+    """Test connection error."""
+    agent = conversation.async_get_agent(hass, init_wyoming_handle.entry_id)
+    assert agent is not None
+
+    mock_client = MockAsyncTcpClient([Transcript("success").event()])
+
+    with (
+        patch(
+            "homeassistant.components.wyoming.conversation.AsyncTcpClient", mock_client
+        ),
+        patch.object(mock_client, "read_event", side_effect=OSError("Boom!")),
+    ):
+        result = await agent.async_process(
+            conversation.ConversationInput(
+                "test text",
+                Context(),
+                conversation_id=None,
+                device_id=None,
+                language=hass.config.language,
+            )
+        )
+
+    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.error_code == intent.IntentResponseErrorCode.UNKNOWN
+    assert result.response.speech, "No speech"
+    assert result.response.speech.get("plain", {}).get("speech") == snapshot()

--- a/tests/components/wyoming/test_conversation.py
+++ b/tests/components/wyoming/test_conversation.py
@@ -19,9 +19,7 @@ from . import MockAsyncTcpClient
 
 async def test_intent(hass: HomeAssistant, init_wyoming_intent: ConfigEntry) -> None:
     """Test when an intent is recognized."""
-    agent = conversation.async_get_agent(hass, init_wyoming_intent.entry_id)
-    assert agent is not None
-    assert agent.supported_languages == ["en-US"]
+    agent_id = "conversation.test_intent"
 
     conversation_id = "conversation-1234"
     test_intent = Intent(
@@ -46,14 +44,13 @@ async def test_intent(hass: HomeAssistant, init_wyoming_intent: ConfigEntry) -> 
         "homeassistant.components.wyoming.conversation.AsyncTcpClient",
         MockAsyncTcpClient([test_intent.event()]),
     ):
-        result = await agent.async_process(
-            conversation.ConversationInput(
-                "test text",
-                Context(),
-                conversation_id=conversation_id,
-                device_id=None,
-                language=hass.config.language,
-            )
+        result = await conversation.async_converse(
+            hass=hass,
+            text="test text",
+            conversation_id=conversation_id,
+            context=Context(),
+            language=hass.config.language,
+            agent_id=agent_id,
         )
 
     assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
@@ -66,8 +63,7 @@ async def test_intent_handle_error(
     hass: HomeAssistant, init_wyoming_intent: ConfigEntry
 ) -> None:
     """Test error during handling when an intent is recognized."""
-    agent = conversation.async_get_agent(hass, init_wyoming_intent.entry_id)
-    assert agent is not None
+    agent_id = "conversation.test_intent"
 
     test_intent = Intent(name="TestIntent", entities=[], text="success")
 
@@ -86,14 +82,13 @@ async def test_intent_handle_error(
         "homeassistant.components.wyoming.conversation.AsyncTcpClient",
         MockAsyncTcpClient([test_intent.event()]),
     ):
-        result = await agent.async_process(
-            conversation.ConversationInput(
-                "test text",
-                Context(),
-                conversation_id=None,
-                device_id=None,
-                language=hass.config.language,
-            )
+        result = await conversation.async_converse(
+            hass=hass,
+            text="test text",
+            conversation_id=None,
+            context=Context(),
+            language=hass.config.language,
+            agent_id=agent_id,
         )
 
     assert result.response.response_type == intent.IntentResponseType.ERROR
@@ -104,21 +99,19 @@ async def test_not_recognized(
     hass: HomeAssistant, init_wyoming_intent: ConfigEntry
 ) -> None:
     """Test when an intent is not recognized."""
-    agent = conversation.async_get_agent(hass, init_wyoming_intent.entry_id)
-    assert agent is not None
+    agent_id = "conversation.test_intent"
 
     with patch(
         "homeassistant.components.wyoming.conversation.AsyncTcpClient",
         MockAsyncTcpClient([NotRecognized(text="failure").event()]),
     ):
-        result = await agent.async_process(
-            conversation.ConversationInput(
-                "test text",
-                Context(),
-                conversation_id=None,
-                device_id=None,
-                language=hass.config.language,
-            )
+        result = await conversation.async_converse(
+            hass=hass,
+            text="test text",
+            conversation_id=None,
+            context=Context(),
+            language=hass.config.language,
+            agent_id=agent_id,
         )
 
     assert result.response.response_type == intent.IntentResponseType.ERROR
@@ -129,8 +122,7 @@ async def test_not_recognized(
 
 async def test_handle(hass: HomeAssistant, init_wyoming_handle: ConfigEntry) -> None:
     """Test when an intent is handled."""
-    agent = conversation.async_get_agent(hass, init_wyoming_handle.entry_id)
-    assert agent is not None
+    agent_id = "conversation.test_handle"
 
     conversation_id = "conversation-1234"
 
@@ -138,14 +130,13 @@ async def test_handle(hass: HomeAssistant, init_wyoming_handle: ConfigEntry) -> 
         "homeassistant.components.wyoming.conversation.AsyncTcpClient",
         MockAsyncTcpClient([Handled(text="success").event()]),
     ):
-        result = await agent.async_process(
-            conversation.ConversationInput(
-                "test text",
-                Context(),
-                conversation_id=conversation_id,
-                device_id=None,
-                language=hass.config.language,
-            )
+        result = await conversation.async_converse(
+            hass=hass,
+            text="test text",
+            conversation_id=conversation_id,
+            context=Context(),
+            language=hass.config.language,
+            agent_id=agent_id,
         )
 
     assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
@@ -158,21 +149,19 @@ async def test_not_handled(
     hass: HomeAssistant, init_wyoming_handle: ConfigEntry
 ) -> None:
     """Test when an intent is not handled."""
-    agent = conversation.async_get_agent(hass, init_wyoming_handle.entry_id)
-    assert agent is not None
+    agent_id = "conversation.test_handle"
 
     with patch(
         "homeassistant.components.wyoming.conversation.AsyncTcpClient",
         MockAsyncTcpClient([NotHandled(text="failure").event()]),
     ):
-        result = await agent.async_process(
-            conversation.ConversationInput(
-                "test text",
-                Context(),
-                conversation_id=None,
-                device_id=None,
-                language=hass.config.language,
-            )
+        result = await conversation.async_converse(
+            hass=hass,
+            text="test text",
+            conversation_id=None,
+            context=Context(),
+            language=hass.config.language,
+            agent_id=agent_id,
         )
 
     assert result.response.response_type == intent.IntentResponseType.ERROR
@@ -185,21 +174,19 @@ async def test_connection_lost(
     hass: HomeAssistant, init_wyoming_handle: ConfigEntry, snapshot: SnapshotAssertion
 ) -> None:
     """Test connection to client is lost."""
-    agent = conversation.async_get_agent(hass, init_wyoming_handle.entry_id)
-    assert agent is not None
+    agent_id = "conversation.test_handle"
 
     with patch(
         "homeassistant.components.wyoming.conversation.AsyncTcpClient",
         MockAsyncTcpClient([None]),
     ):
-        result = await agent.async_process(
-            conversation.ConversationInput(
-                "test text",
-                Context(),
-                conversation_id=None,
-                device_id=None,
-                language=hass.config.language,
-            )
+        result = await conversation.async_converse(
+            hass=hass,
+            text="test text",
+            conversation_id=None,
+            context=Context(),
+            language=hass.config.language,
+            agent_id=agent_id,
         )
 
     assert result.response.response_type == intent.IntentResponseType.ERROR
@@ -212,8 +199,7 @@ async def test_oserror(
     hass: HomeAssistant, init_wyoming_handle: ConfigEntry, snapshot: SnapshotAssertion
 ) -> None:
     """Test connection error."""
-    agent = conversation.async_get_agent(hass, init_wyoming_handle.entry_id)
-    assert agent is not None
+    agent_id = "conversation.test_handle"
 
     mock_client = MockAsyncTcpClient([Transcript("success").event()])
 
@@ -223,14 +209,13 @@ async def test_oserror(
         ),
         patch.object(mock_client, "read_event", side_effect=OSError("Boom!")),
     ):
-        result = await agent.async_process(
-            conversation.ConversationInput(
-                "test text",
-                Context(),
-                conversation_id=None,
-                device_id=None,
-                language=hass.config.language,
-            )
+        result = await conversation.async_converse(
+            hass=hass,
+            text="test text",
+            conversation_id=None,
+            context=Context(),
+            language=hass.config.language,
+            agent_id=agent_id,
         )
 
     assert result.response.response_type == intent.IntentResponseType.ERROR


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a `conversation` entity to the `wyoming` integration. This entity supports both intent recognition (text to intent) and intent handling (text to text) services.

If the external service supports intent recognition, recognized intents will be automatically handled. This will allow for more sophisticated intent recognizers to be included as HA add-ons.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
