### PR TITLE
Add uptime sensors for Smlight 

### DIFF
--- a/homeassistant/components/smlight/const.py
+++ b/homeassistant/components/smlight/const.py
@@ -9,3 +9,4 @@ ATTR_MANUFACTURER = "SMLIGHT"
 
 LOGGER = logging.getLogger(__package__)
 SCAN_INTERVAL = timedelta(seconds=300)
+UPTIME_DEVIATION = timedelta(seconds=5)

--- a/homeassistant/components/smlight/strings.json
+++ b/homeassistant/components/smlight/strings.json
@@ -43,6 +43,12 @@
       },
       "ram_usage": {
         "name": "RAM usage"
+      },
+      "core_uptime": {
+        "name": "Core uptime"
+      },
+      "socket_uptime": {
+        "name": "Zigbee uptime"
       }
     }
   }

--- a/tests/components/smlight/snapshots/test_sensor.ambr
+++ b/tests/components/smlight/snapshots/test_sensor.ambr
@@ -53,6 +53,53 @@
     'state': '35.0',
   })
 # ---
+# name: test_sensors[sensor.mock_title_core_uptime-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mock_title_core_uptime',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Core uptime',
+    'platform': 'smlight',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'core_uptime',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_core_uptime',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.mock_title_core_uptime-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Mock Title Core uptime',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_core_uptime',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-06-25T02:51:15+00:00',
+  })
+# ---
 # name: test_sensors[sensor.mock_title_filesystem_usage-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -149,6 +196,100 @@
     'state': '99',
   })
 # ---
+# name: test_sensors[sensor.mock_title_timestamp-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mock_title_timestamp',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Timestamp',
+    'platform': 'smlight',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'core_uptime',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_core_uptime',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.mock_title_timestamp-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Mock Title Timestamp',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_timestamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-06-25T02:51:15+00:00',
+  })
+# ---
+# name: test_sensors[sensor.mock_title_timestamp_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mock_title_timestamp_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Timestamp',
+    'platform': 'smlight',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'socket_uptime',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_socket_uptime',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.mock_title_timestamp_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Mock Title Timestamp',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_timestamp_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-06-30T23:57:53+00:00',
+  })
+# ---
 # name: test_sensors[sensor.mock_title_zigbee_chip_temp-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -201,6 +342,53 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '32.7',
+  })
+# ---
+# name: test_sensors[sensor.mock_title_zigbee_uptime-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mock_title_zigbee_uptime',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Zigbee uptime',
+    'platform': 'smlight',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'socket_uptime',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_socket_uptime',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.mock_title_zigbee_uptime-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Mock Title Zigbee uptime',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_zigbee_uptime',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-06-30T23:57:53+00:00',
   })
 # ---
 # name: test_sensors[sensor.slzb_06_core_chip_temp-entry]

--- a/tests/components/smlight/test_sensor.py
+++ b/tests/components/smlight/test_sensor.py
@@ -25,6 +25,7 @@ def platforms() -> Platform | list[Platform]:
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
+@pytest.mark.freeze_time("2024-07-01 00:00:00+00:00")
 async def test_sensors(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
@@ -46,7 +47,7 @@ async def test_disabled_by_default_sensors(
     """Test the disabled by default SMLIGHT sensors."""
     await setup_integration(hass, mock_config_entry)
 
-    for sensor in ("ram_usage", "filesystem_usage"):
+    for sensor in ("core_uptime", "filesystem_usage", "ram_usage", "zigbee_uptime"):
         assert not hass.states.get(f"sensor.mock_title_{sensor}")
 
         assert (entry := entity_registry.async_get(f"sensor.mock_title_{sensor}"))

--- a/tests/components/smlight/test_sensor.py
+++ b/tests/components/smlight/test_sensor.py
@@ -1,9 +1,12 @@
 """Tests for the SMLIGHT sensor platform."""
 
+from unittest.mock import MagicMock
+
+from pysmlight import Sensors
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.const import Platform
+from homeassistant.const import STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
@@ -53,3 +56,20 @@ async def test_disabled_by_default_sensors(
         assert (entry := entity_registry.async_get(f"sensor.mock_title_{sensor}"))
         assert entry.disabled
         assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_zigbee_uptime_disconnected(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_smlight_client: MagicMock,
+) -> None:
+    """Test for uptime when zigbee socket is disconnected.
+
+    In this case zigbee uptime state should be unknown.
+    """
+    mock_smlight_client.get_sensors.return_value = Sensors(socket_uptime=0)
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("sensor.mock_title_zigbee_uptime")
+    assert state.state == STATE_UNKNOWN


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add uptime sensors for SLZB-06 devices, there are two sensors:
* Core uptime - This is the uptime for the core (esp32) firmware.
* Socket uptime - This is how long the network socket for Zigbee has been connected.

Uptimes are reported in seconds, convert these to a fixed datetime value suitable for timestamp sensor. Allow a small deviation to account for clock skew, without causing unnecessary state updates on the sensor.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]
documentation for these sensors are already in -next from initial docs PR (uptime sensors got split out of initial integration PR)

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
