### PR TITLE
Fix ZHA device lookup when ZHA devices are shared with additional integrations

### DIFF
--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -1013,7 +1013,11 @@ def async_get_zha_device_proxy(hass: HomeAssistant, device_id: str) -> ZHADevice
         raise KeyError(f"Device id `{device_id}` not found in registry.")
     zha_gateway_proxy = get_zha_gateway_proxy(hass)
     try:
-        ieee_address = list(registry_device.identifiers)[0][1]
+        ieee_address = next(
+            identifier
+            for domain, identifier in registry_device.identifiers
+            if domain == DOMAIN
+        )
         ieee = EUI64.convert(ieee_address)
     except (IndexError, ValueError) as ex:
         _LOGGER.error(

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -1019,7 +1019,7 @@ def async_get_zha_device_proxy(hass: HomeAssistant, device_id: str) -> ZHADevice
             if domain == DOMAIN
         )
         ieee = EUI64.convert(ieee_address)
-    except (IndexError, ValueError) as ex:
+    except (StopIteration, ValueError) as ex:
         _LOGGER.error(
             "Unable to determine device IEEE for device with device id `%s`", device_id
         )

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -1012,20 +1012,12 @@ def async_get_zha_device_proxy(hass: HomeAssistant, device_id: str) -> ZHADevice
         _LOGGER.error("Device id `%s` not found in registry", device_id)
         raise KeyError(f"Device id `{device_id}` not found in registry.")
     zha_gateway_proxy = get_zha_gateway_proxy(hass)
-    try:
-        ieee_address = next(
-            identifier
-            for domain, identifier in registry_device.identifiers
-            if domain == DOMAIN
-        )
-        ieee = EUI64.convert(ieee_address)
-    except (StopIteration, ValueError) as ex:
-        _LOGGER.error(
-            "Unable to determine device IEEE for device with device id `%s`", device_id
-        )
-        raise KeyError(
-            f"Unable to determine device IEEE for device with device id `{device_id}`."
-        ) from ex
+    ieee_address = next(
+        identifier
+        for domain, identifier in registry_device.identifiers
+        if domain == DOMAIN
+    )
+    ieee = EUI64.convert(ieee_address)
     return zha_gateway_proxy.device_proxies[ieee]
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR prevents config validation errors when ZHA devices are shared with other integrations. Previously we naively assumed that our IEEE was always identifier 0 and this is not always the case. 

<img width="1387" alt="image" src="https://github.com/user-attachments/assets/1326c1b9-e1af-466c-afab-9d127b3b79b0">


<img width="551" alt="image" src="https://github.com/user-attachments/assets/8aa7a172-23c4-43a6-9f7e-af79e5562c7e">


Truncated device entry:
```json
{"area_id":"a971cb6d957b4a33b0f0ec58a54db0a6","config_entries":["01J5X758K6N3NNRTJT5N9J9K3P","e29ceebf7c284fe6a18d61622537f595"],"configuration_url":null,"connections":[["zigbee","70:ac:08:ff:fe:70:dd:84"]],"created_at":"1970-01-01T00:00:00+00:00","disabled_by":null,"entry_type":null,"hw_version":null,"id":"c94add60bd3926c5bb79ed4619203db4","identifiers":[["ha_sense","inovelli_vzm31_sn_active_power_2_reporting_to_sense"],["zha","70:ac:08:ff:fe:70:dd:84"]]}
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
