### PR TITLE
Reolink add 100% coverage of number platform

### DIFF
--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -471,7 +471,7 @@ async def test_dhcp_ip_update(
 
     if not last_update_success:
         # ensure the last_update_succes is False for the device_coordinator.
-        reolink_connect.get_states = AsyncMock(side_effect=ReolinkError("Test error"))
+        reolink_connect.get_states.side_effect = ReolinkError("Test error")
         freezer.tick(DEVICE_UPDATE_INTERVAL)
         async_fire_time_changed(hass)
         await hass.async_block_till_done()

--- a/tests/components/reolink/test_host.py
+++ b/tests/components/reolink/test_host.py
@@ -59,9 +59,7 @@ async def test_webhook_callback(
 
     # test webhook callback single channel with error in event callback
     signal_ch.reset_mock()
-    reolink_connect.ONVIF_event_callback = AsyncMock(
-        side_effect=Exception("Test error")
-    )
+    reolink_connect.ONVIF_event_callback.side_effect = Exception("Test error")
     await client.post(f"/api/webhook/{webhook_id}", data="test_data")
     signal_ch.assert_not_called()
 

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -108,9 +108,7 @@ async def test_firmware_error_twice(
     config_entry: MockConfigEntry,
 ) -> None:
     """Test when the firmware update fails 2 times."""
-    reolink_connect.check_new_firmware = AsyncMock(
-        side_effect=ReolinkError("Test error")
-    )
+    reolink_connect.check_new_firmware.side_effect = ReolinkError("Test error")
     with patch("homeassistant.components.reolink.PLATFORMS", [Platform.UPDATE]):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -140,9 +138,7 @@ async def test_credential_error_three(
     await hass.async_block_till_done()
     assert config_entry.state is ConfigEntryState.LOADED
 
-    reolink_connect.get_states = AsyncMock(
-        side_effect=CredentialsInvalidError("Test error")
-    )
+    reolink_connect.get_states.side_effect = CredentialsInvalidError("Test error")
 
     issue_id = f"config_entry_reauth_{const.DOMAIN}_{config_entry.entry_id}"
     for _ in range(NUM_CRED_ERRORS):
@@ -549,7 +545,7 @@ async def test_port_repair_issue(
     issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test repairs issue is raised when auto enable of ports fails."""
-    reolink_connect.set_net_port = AsyncMock(side_effect=ReolinkError("Test error"))
+    reolink_connect.set_net_port.side_effect = ReolinkError("Test error")
     reolink_connect.onvif_enabled = False
     reolink_connect.rtsp_enabled = False
     reolink_connect.rtmp_enabled = False

--- a/tests/components/reolink/test_media_source.py
+++ b/tests/components/reolink/test_media_source.py
@@ -318,7 +318,7 @@ async def test_browsing_not_loaded(
         assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    reolink_connect.get_host_data = AsyncMock(side_effect=ReolinkError("Test error"))
+    reolink_connect.get_host_data.side_effect = ReolinkError("Test error")
     config_entry2 = MockConfigEntry(
         domain=const.DOMAIN,
         unique_id=format_mac(TEST_MAC2),

--- a/tests/components/reolink/test_number.py
+++ b/tests/components/reolink/test_number.py
@@ -1,6 +1,6 @@
 """Test the Reolink number platform."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from reolink_aio.api import Chime

--- a/tests/components/reolink/test_number.py
+++ b/tests/components/reolink/test_number.py
@@ -1,6 +1,6 @@
 """Test the Reolink number platform."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from reolink_aio.api import Chime
@@ -83,6 +83,7 @@ async def test_chime_number(
 
     assert hass.states.get(entity_id).state == "3"
 
+    test_chime.set_option = AsyncMock()
     await hass.services.async_call(
         NUMBER_DOMAIN,
         SERVICE_SET_VALUE,

--- a/tests/components/reolink/test_number.py
+++ b/tests/components/reolink/test_number.py
@@ -38,7 +38,6 @@ async def test_number(
 
     assert hass.states.get(entity_id).state == "80"
 
-    reolink_connect.set_volume = AsyncMock()
     await hass.services.async_call(
         NUMBER_DOMAIN,
         SERVICE_SET_VALUE,
@@ -47,7 +46,7 @@ async def test_number(
     )
     reolink_connect.set_volume.assert_called_with(0, volume=50)
 
-    reolink_connect.set_volume = AsyncMock(side_effect=ReolinkError("Test error"))
+    reolink_connect.set_volume.side_effect = ReolinkError("Test error")
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             NUMBER_DOMAIN,
@@ -56,9 +55,7 @@ async def test_number(
             blocking=True,
         )
 
-    reolink_connect.set_volume = AsyncMock(
-        side_effect=InvalidParameterError("Test error")
-    )
+    reolink_connect.set_volume.side_effect = InvalidParameterError("Test error")
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             NUMBER_DOMAIN,
@@ -86,7 +83,6 @@ async def test_chime_number(
 
     assert hass.states.get(entity_id).state == "3"
 
-    test_chime.set_option = AsyncMock()
     await hass.services.async_call(
         NUMBER_DOMAIN,
         SERVICE_SET_VALUE,
@@ -95,7 +91,7 @@ async def test_chime_number(
     )
     test_chime.set_option.assert_called_with(volume=2)
 
-    test_chime.set_option = AsyncMock(side_effect=ReolinkError("Test error"))
+    test_chime.set_option.side_effect = ReolinkError("Test error")
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             NUMBER_DOMAIN,
@@ -104,7 +100,7 @@ async def test_chime_number(
             blocking=True,
         )
 
-    test_chime.set_option = AsyncMock(side_effect=InvalidParameterError("Test error"))
+    test_chime.set_option.side_effect = InvalidParameterError("Test error")
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             NUMBER_DOMAIN,

--- a/tests/components/reolink/test_number.py
+++ b/tests/components/reolink/test_number.py
@@ -1,0 +1,114 @@
+"""Test the Reolink number platform."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from reolink_aio.api import Chime
+from reolink_aio.exceptions import InvalidParameterError, ReolinkError
+
+from homeassistant.components.number import (
+    ATTR_VALUE,
+    DOMAIN as NUMBER_DOMAIN,
+    SERVICE_SET_VALUE,
+)
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from .conftest import TEST_NVR_NAME
+
+from tests.common import MockConfigEntry
+
+
+async def test_number(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_connect: MagicMock,
+) -> None:
+    """Test number entity with volume."""
+    reolink_connect.volume.return_value = 80
+
+    with patch("homeassistant.components.reolink.PLATFORMS", [Platform.NUMBER]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    entity_id = f"{Platform.NUMBER}.{TEST_NVR_NAME}_volume"
+
+    assert hass.states.get(entity_id).state == "80"
+
+    reolink_connect.set_volume = AsyncMock()
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: 50},
+        blocking=True,
+    )
+    reolink_connect.set_volume.assert_called_with(0, volume=50)
+
+    reolink_connect.set_volume = AsyncMock(side_effect=ReolinkError("Test error"))
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: 50},
+            blocking=True,
+        )
+
+    reolink_connect.set_volume = AsyncMock(
+        side_effect=InvalidParameterError("Test error")
+    )
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: 50},
+            blocking=True,
+        )
+
+
+async def test_chime_number(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_connect: MagicMock,
+    test_chime: Chime,
+) -> None:
+    """Test number entity of a chime with chime volume."""
+    test_chime.volume = 3
+
+    with patch("homeassistant.components.reolink.PLATFORMS", [Platform.NUMBER]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    entity_id = f"{Platform.NUMBER}.test_chime_volume"
+
+    assert hass.states.get(entity_id).state == "3"
+
+    test_chime.set_option = AsyncMock()
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: 2},
+        blocking=True,
+    )
+    test_chime.set_option.assert_called_with(volume=2)
+
+    test_chime.set_option = AsyncMock(side_effect=ReolinkError("Test error"))
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: 1},
+            blocking=True,
+        )
+
+    test_chime.set_option = AsyncMock(side_effect=InvalidParameterError("Test error"))
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: 1},
+            blocking=True,
+        )

--- a/tests/components/reolink/test_select.py
+++ b/tests/components/reolink/test_select.py
@@ -1,6 +1,6 @@
 """Test the Reolink select platform."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
@@ -118,6 +118,7 @@ async def test_chime_select(
     entity_id = f"{Platform.SELECT}.test_chime_visitor_ringtone"
     assert hass.states.get(entity_id).state == "pianokey"
 
+    test_chime.set_tone = AsyncMock()
     await hass.services.async_call(
         SELECT_DOMAIN,
         SERVICE_SELECT_OPTION,

--- a/tests/components/reolink/test_select.py
+++ b/tests/components/reolink/test_select.py
@@ -1,6 +1,6 @@
 """Test the Reolink select platform."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest

--- a/tests/components/reolink/test_select.py
+++ b/tests/components/reolink/test_select.py
@@ -41,7 +41,6 @@ async def test_floodlight_mode_select(
     entity_id = f"{Platform.SELECT}.{TEST_NVR_NAME}_floodlight_mode"
     assert hass.states.get(entity_id).state == "auto"
 
-    reolink_connect.set_whiteled = AsyncMock()
     await hass.services.async_call(
         SELECT_DOMAIN,
         SERVICE_SELECT_OPTION,
@@ -50,7 +49,7 @@ async def test_floodlight_mode_select(
     )
     reolink_connect.set_whiteled.assert_called_once()
 
-    reolink_connect.set_whiteled = AsyncMock(side_effect=ReolinkError("Test error"))
+    reolink_connect.set_whiteled.side_effect = ReolinkError("Test error")
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             SELECT_DOMAIN,
@@ -59,9 +58,7 @@ async def test_floodlight_mode_select(
             blocking=True,
         )
 
-    reolink_connect.set_whiteled = AsyncMock(
-        side_effect=InvalidParameterError("Test error")
-    )
+    reolink_connect.set_whiteled.side_effect = InvalidParameterError("Test error")
     with pytest.raises(ServiceValidationError):
         await hass.services.async_call(
             SELECT_DOMAIN,
@@ -94,7 +91,6 @@ async def test_play_quick_reply_message(
     entity_id = f"{Platform.SELECT}.{TEST_NVR_NAME}_play_quick_reply_message"
     assert hass.states.get(entity_id).state == STATE_UNKNOWN
 
-    reolink_connect.play_quick_reply = AsyncMock()
     await hass.services.async_call(
         SELECT_DOMAIN,
         SERVICE_SELECT_OPTION,
@@ -122,7 +118,6 @@ async def test_chime_select(
     entity_id = f"{Platform.SELECT}.test_chime_visitor_ringtone"
     assert hass.states.get(entity_id).state == "pianokey"
 
-    test_chime.set_tone = AsyncMock()
     await hass.services.async_call(
         SELECT_DOMAIN,
         SERVICE_SELECT_OPTION,
@@ -131,7 +126,7 @@ async def test_chime_select(
     )
     test_chime.set_tone.assert_called_once()
 
-    test_chime.set_tone = AsyncMock(side_effect=ReolinkError("Test error"))
+    test_chime.set_tone.side_effect = ReolinkError("Test error")
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             SELECT_DOMAIN,
@@ -140,7 +135,7 @@ async def test_chime_select(
             blocking=True,
         )
 
-    test_chime.set_tone = AsyncMock(side_effect=InvalidParameterError("Test error"))
+    test_chime.set_tone.side_effect = InvalidParameterError("Test error")
     with pytest.raises(ServiceValidationError):
         await hass.services.async_call(
             SELECT_DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add tests for the number platform.

Working towards platinum quality scale such that Reolink can join the Works With HomeAssistant program.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
