### PR TITLE
Allow set ScreenCap interval as option for AndroidTV

### DIFF
--- a/homeassistant/components/androidtv/__init__.py
+++ b/homeassistant/components/androidtv/__init__.py
@@ -41,11 +41,9 @@ from .const import (
     CONF_ADB_SERVER_IP,
     CONF_ADB_SERVER_PORT,
     CONF_ADBKEY,
-    CONF_SCREENCAP,
     CONF_SCREENCAP_INTERVAL,
     CONF_STATE_DETECTION_RULES,
     DEFAULT_ADB_SERVER_PORT,
-    DEFAULT_SCREENCAP_INTERVAL,
     DEVICE_ANDROIDTV,
     DEVICE_FIRETV,
     PROP_ETHMAC,
@@ -169,22 +167,16 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "Migrating configuration from version %s.%s", entry.version, entry.minor_version
     )
 
-    if entry.version > 1:
-        # This means the user has downgraded from a future version
-        return False
-
     if entry.version == 1:
         new_options = {**entry.options}
 
         # Migrate MinorVersion 1 -> MinorVersion 2: New option
         if entry.minor_version < 2:
-            if (old_value := new_options.get(CONF_SCREENCAP)) is not None:
-                new_value = DEFAULT_SCREENCAP_INTERVAL if old_value else 0
-                new_options = {**new_options, CONF_SCREENCAP_INTERVAL: new_value}
+            new_options = {**new_options, CONF_SCREENCAP_INTERVAL: 0}
 
-        hass.config_entries.async_update_entry(
-            entry, options=new_options, minor_version=2, version=1
-        )
+            hass.config_entries.async_update_entry(
+                entry, options=new_options, minor_version=2, version=1
+            )
 
     _LOGGER.debug(
         "Migration to configuration version %s.%s successful",

--- a/homeassistant/components/androidtv/config_flow.py
+++ b/homeassistant/components/androidtv/config_flow.py
@@ -34,7 +34,7 @@ from .const import (
     CONF_APPS,
     CONF_EXCLUDE_UNNAMED_APPS,
     CONF_GET_SOURCES,
-    CONF_SCREENCAP,
+    CONF_SCREENCAP_INTERVAL,
     CONF_STATE_DETECTION_RULES,
     CONF_TURN_OFF_COMMAND,
     CONF_TURN_ON_COMMAND,
@@ -43,7 +43,7 @@ from .const import (
     DEFAULT_EXCLUDE_UNNAMED_APPS,
     DEFAULT_GET_SOURCES,
     DEFAULT_PORT,
-    DEFAULT_SCREENCAP,
+    DEFAULT_SCREENCAP_INTERVAL,
     DEVICE_CLASSES,
     DOMAIN,
     PROP_ETHMAC,
@@ -253,10 +253,12 @@ class OptionsFlowHandler(OptionsFlowWithConfigEntry):
                         CONF_EXCLUDE_UNNAMED_APPS, DEFAULT_EXCLUDE_UNNAMED_APPS
                     ),
                 ): bool,
-                vol.Optional(
-                    CONF_SCREENCAP,
-                    default=options.get(CONF_SCREENCAP, DEFAULT_SCREENCAP),
-                ): bool,
+                vol.Required(
+                    CONF_SCREENCAP_INTERVAL,
+                    default=options.get(
+                        CONF_SCREENCAP_INTERVAL, DEFAULT_SCREENCAP_INTERVAL
+                    ),
+                ): vol.All(vol.Coerce(int), vol.Clamp(min=0, max=15)),
                 vol.Optional(
                     CONF_TURN_OFF_COMMAND,
                     description={

--- a/homeassistant/components/androidtv/config_flow.py
+++ b/homeassistant/components/androidtv/config_flow.py
@@ -76,6 +76,7 @@ class AndroidTVFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle a config flow."""
 
     VERSION = 1
+    MINOR_VERSION = 2
 
     @callback
     def _show_setup_form(

--- a/homeassistant/components/androidtv/const.py
+++ b/homeassistant/components/androidtv/const.py
@@ -9,6 +9,7 @@ CONF_APPS = "apps"
 CONF_EXCLUDE_UNNAMED_APPS = "exclude_unnamed_apps"
 CONF_GET_SOURCES = "get_sources"
 CONF_SCREENCAP = "screencap"
+CONF_SCREENCAP_INTERVAL = "screencap_interval"
 CONF_STATE_DETECTION_RULES = "state_detection_rules"
 CONF_TURN_OFF_COMMAND = "turn_off_command"
 CONF_TURN_ON_COMMAND = "turn_on_command"
@@ -18,7 +19,7 @@ DEFAULT_DEVICE_CLASS = "auto"
 DEFAULT_EXCLUDE_UNNAMED_APPS = False
 DEFAULT_GET_SOURCES = True
 DEFAULT_PORT = 5555
-DEFAULT_SCREENCAP = True
+DEFAULT_SCREENCAP_INTERVAL = 5
 
 DEVICE_ANDROIDTV = "androidtv"
 DEVICE_FIRETV = "firetv"

--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 import hashlib
 import logging
-from typing import Any
 
 from androidtv.constants import APPS, KEYS
 from androidtv.setup_async import AndroidTVAsync, FireTVAsync
@@ -23,19 +22,19 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.util import Throttle
+from homeassistant.util.dt import utcnow
 
 from . import AndroidTVConfigEntry
 from .const import (
     CONF_APPS,
     CONF_EXCLUDE_UNNAMED_APPS,
     CONF_GET_SOURCES,
-    CONF_SCREENCAP,
+    CONF_SCREENCAP_INTERVAL,
     CONF_TURN_OFF_COMMAND,
     CONF_TURN_ON_COMMAND,
     DEFAULT_EXCLUDE_UNNAMED_APPS,
     DEFAULT_GET_SOURCES,
-    DEFAULT_SCREENCAP,
+    DEFAULT_SCREENCAP_INTERVAL,
     DEVICE_ANDROIDTV,
     SIGNAL_CONFIG_ENTITY,
 )
@@ -47,8 +46,6 @@ ATTR_ADB_RESPONSE = "adb_response"
 ATTR_DEVICE_PATH = "device_path"
 ATTR_HDMI_INPUT = "hdmi_input"
 ATTR_LOCAL_PATH = "local_path"
-
-MIN_TIME_BETWEEN_SCREENCAPS = timedelta(seconds=60)
 
 SERVICE_ADB_COMMAND = "adb_command"
 SERVICE_DOWNLOAD = "download"
@@ -125,7 +122,8 @@ class ADBDevice(AndroidTVEntity, MediaPlayerEntity):
         self._app_name_to_id: dict[str, str] = {}
         self._get_sources = DEFAULT_GET_SOURCES
         self._exclude_unnamed_apps = DEFAULT_EXCLUDE_UNNAMED_APPS
-        self._screencap = DEFAULT_SCREENCAP
+        self._screencap_delta: timedelta | None = None
+        self._last_screencap: datetime | None = None
         self.turn_on_command: str | None = None
         self.turn_off_command: str | None = None
 
@@ -159,7 +157,13 @@ class ADBDevice(AndroidTVEntity, MediaPlayerEntity):
         self._exclude_unnamed_apps = options.get(
             CONF_EXCLUDE_UNNAMED_APPS, DEFAULT_EXCLUDE_UNNAMED_APPS
         )
-        self._screencap = options.get(CONF_SCREENCAP, DEFAULT_SCREENCAP)
+        screencap_interval: int = options.get(
+            CONF_SCREENCAP_INTERVAL, DEFAULT_SCREENCAP_INTERVAL
+        )
+        if screencap_interval > 0:
+            self._screencap_delta = timedelta(minutes=screencap_interval)
+        else:
+            self._screencap_delta = None
         self.turn_off_command = options.get(CONF_TURN_OFF_COMMAND)
         self.turn_on_command = options.get(CONF_TURN_ON_COMMAND)
 
@@ -183,7 +187,7 @@ class ADBDevice(AndroidTVEntity, MediaPlayerEntity):
     async def _async_get_screencap(self, prev_app_id: str | None = None) -> None:
         """Take a screen capture from the device when enabled."""
         if (
-            not self._screencap
+            not self._screencap_delta
             or self.state in {MediaPlayerState.OFF, None}
             or not self.available
         ):
@@ -193,11 +197,18 @@ class ADBDevice(AndroidTVEntity, MediaPlayerEntity):
             force: bool = prev_app_id is not None
             if force:
                 force = prev_app_id != self._attr_app_id
-            await self._adb_get_screencap(no_throttle=force)
+            await self._adb_get_screencap(force)
 
-    @Throttle(MIN_TIME_BETWEEN_SCREENCAPS)
-    async def _adb_get_screencap(self, **kwargs: Any) -> None:
-        """Take a screen capture from the device every 60 seconds."""
+    async def _adb_get_screencap(self, force: bool = False) -> None:
+        """Take a screen capture from the device every configured minutes."""
+        time_elapsed = self._screencap_delta is not None and (
+            self._last_screencap is None
+            or (utcnow() - self._last_screencap) >= self._screencap_delta
+        )
+        if not (force or time_elapsed):
+            return
+
+        self._last_screencap = utcnow()
         if media_data := await self._adb_screencap():
             self._media_image = media_data, "image/png"
             self._attr_media_image_hash = hashlib.sha256(media_data).hexdigest()[:16]

--- a/homeassistant/components/androidtv/strings.json
+++ b/homeassistant/components/androidtv/strings.json
@@ -31,7 +31,7 @@
           "apps": "Configure applications list",
           "get_sources": "Retrieve the running apps as the list of sources",
           "exclude_unnamed_apps": "Exclude apps with unknown name from the sources list",
-          "screencap": "Use screen capture for album art",
+          "screencap_interval": "Interval in minutes between screen capture for album art (set 0 to disable)",
           "state_detection_rules": "Configure state detection rules",
           "turn_off_command": "ADB shell turn off command (leave empty for default)",
           "turn_on_command": "ADB shell turn on command (leave empty for default)"

--- a/tests/components/androidtv/common.py
+++ b/tests/components/androidtv/common.py
@@ -100,7 +100,12 @@ CONFIG_FIRETV_DEFAULT = CONFIG_FIRETV_PYTHON_ADB
 
 
 def setup_mock_entry(
-    config: dict[str, Any], entity_domain: str
+    config: dict[str, Any],
+    entity_domain: str,
+    *,
+    options=None,
+    version=1,
+    minor_version=2,
 ) -> tuple[str, str, MockConfigEntry]:
     """Prepare mock entry for entities tests."""
     patch_key = config[ADB_PATCH_KEY]
@@ -109,6 +114,9 @@ def setup_mock_entry(
         domain=DOMAIN,
         data=config[DOMAIN],
         unique_id="a1:b1:c1:d1:e1:f1",
+        options=options,
+        version=version,
+        minor_version=minor_version,
     )
 
     return patch_key, entity_id, config_entry

--- a/tests/components/androidtv/test_config_flow.py
+++ b/tests/components/androidtv/test_config_flow.py
@@ -22,7 +22,7 @@ from homeassistant.components.androidtv.const import (
     CONF_APPS,
     CONF_EXCLUDE_UNNAMED_APPS,
     CONF_GET_SOURCES,
-    CONF_SCREENCAP,
+    CONF_SCREENCAP_INTERVAL,
     CONF_STATE_DETECTION_RULES,
     CONF_TURN_OFF_COMMAND,
     CONF_TURN_ON_COMMAND,
@@ -501,7 +501,7 @@ async def test_options_flow(hass: HomeAssistant) -> None:
             user_input={
                 CONF_GET_SOURCES: True,
                 CONF_EXCLUDE_UNNAMED_APPS: True,
-                CONF_SCREENCAP: True,
+                CONF_SCREENCAP_INTERVAL: 1,
                 CONF_TURN_OFF_COMMAND: "off",
                 CONF_TURN_ON_COMMAND: "on",
             },
@@ -515,6 +515,6 @@ async def test_options_flow(hass: HomeAssistant) -> None:
 
         assert config_entry.options[CONF_GET_SOURCES] is True
         assert config_entry.options[CONF_EXCLUDE_UNNAMED_APPS] is True
-        assert config_entry.options[CONF_SCREENCAP] is True
+        assert config_entry.options[CONF_SCREENCAP_INTERVAL] == 1
         assert config_entry.options[CONF_TURN_OFF_COMMAND] == "off"
         assert config_entry.options[CONF_TURN_ON_COMMAND] == "on"

--- a/tests/components/androidtv/test_init.py
+++ b/tests/components/androidtv/test_init.py
@@ -1,0 +1,34 @@
+"""Tests for AndroidTV integration initialization."""
+
+from homeassistant.components.androidtv.const import (
+    CONF_SCREENCAP,
+    CONF_SCREENCAP_INTERVAL,
+)
+from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
+from homeassistant.core import HomeAssistant
+
+from . import patchers
+from .common import CONFIG_ANDROID_DEFAULT, SHELL_RESPONSE_OFF, setup_mock_entry
+
+
+async def test_migrate_version(
+    hass: HomeAssistant,
+) -> None:
+    """Test migration to new version."""
+    patch_key, _, mock_config_entry = setup_mock_entry(
+        CONFIG_ANDROID_DEFAULT,
+        MP_DOMAIN,
+        options={CONF_SCREENCAP: False},
+        minor_version=1,
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    with (
+        patchers.patch_connect(True)[patch_key],
+        patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key],
+    ):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert mock_config_entry.options[CONF_SCREENCAP_INTERVAL] == 0
+        assert mock_config_entry.minor_version == 2

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -14,6 +14,7 @@ from homeassistant.components.androidtv.const import (
     CONF_APPS,
     CONF_EXCLUDE_UNNAMED_APPS,
     CONF_SCREENCAP,
+    CONF_SCREENCAP_INTERVAL,
     CONF_STATE_DETECTION_RULES,
     CONF_TURN_OFF_COMMAND,
     CONF_TURN_ON_COMMAND,
@@ -801,6 +802,9 @@ async def test_get_image_http(
     """
     patch_key, entity_id, config_entry = _setup(CONFIG_ANDROID_DEFAULT)
     config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        config_entry, options={CONF_SCREENCAP_INTERVAL: 2}
+    )
 
     with (
         patchers.patch_connect(True)[patch_key],
@@ -828,21 +832,27 @@ async def test_get_image_http(
     content = await resp.read()
     assert content == b"image"
 
-    next_update = utcnow() + timedelta(seconds=30)
+    next_update = utcnow() + timedelta(minutes=1)
     with (
         patchers.patch_shell("11")[patch_key],
         patchers.PATCH_SCREENCAP as patch_screen_cap,
-        patch("homeassistant.util.utcnow", return_value=next_update),
+        patch(
+            "homeassistant.components.androidtv.media_player.utcnow",
+            return_value=next_update,
+        ),
     ):
         async_fire_time_changed(hass, next_update, True)
         await hass.async_block_till_done()
         patch_screen_cap.assert_not_called()
 
-    next_update = utcnow() + timedelta(seconds=60)
+    next_update = utcnow() + timedelta(minutes=2)
     with (
         patchers.patch_shell("11")[patch_key],
         patchers.PATCH_SCREENCAP as patch_screen_cap,
-        patch("homeassistant.util.utcnow", return_value=next_update),
+        patch(
+            "homeassistant.components.androidtv.media_player.utcnow",
+            return_value=next_update,
+        ),
     ):
         async_fire_time_changed(hass, next_update, True)
         await hass.async_block_till_done()
@@ -854,6 +864,9 @@ async def test_get_image_http_fail(hass: HomeAssistant) -> None:
 
     patch_key, entity_id, config_entry = _setup(CONFIG_ANDROID_DEFAULT)
     config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        config_entry, options={CONF_SCREENCAP_INTERVAL: 2}
+    )
 
     with (
         patchers.patch_connect(True)[patch_key],
@@ -885,7 +898,7 @@ async def test_get_image_disabled(hass: HomeAssistant) -> None:
     patch_key, entity_id, config_entry = _setup(CONFIG_ANDROID_DEFAULT)
     config_entry.add_to_hass(hass)
     hass.config_entries.async_update_entry(
-        config_entry, options={CONF_SCREENCAP: False}
+        config_entry, options={CONF_SCREENCAP_INTERVAL: 0}
     )
 
     with (
@@ -1133,7 +1146,7 @@ async def test_options_reload(hass: HomeAssistant) -> None:
         with patchers.PATCH_SETUP_ENTRY as setup_entry_call:
             # change an option that not require integration reload
             hass.config_entries.async_update_entry(
-                config_entry, options={CONF_SCREENCAP: False}
+                config_entry, options={CONF_EXCLUDE_UNNAMED_APPS: True}
             )
             await hass.async_block_till_done()
 
@@ -1147,3 +1160,20 @@ async def test_options_reload(hass: HomeAssistant) -> None:
 
             assert setup_entry_call.called
             assert config_entry.state is ConfigEntryState.LOADED
+
+
+async def test_screencap_options_migration(hass: HomeAssistant) -> None:
+    """Test changing an option that will cause integration reload."""
+    patch_key, _, config_entry = _setup(CONFIG_ANDROID_DEFAULT)
+    config_entry.options = {CONF_SCREENCAP: False}
+    config_entry.add_to_hass(hass)
+
+    with (
+        patchers.patch_connect(True)[patch_key],
+        patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key],
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert CONF_SCREENCAP not in config_entry.options
+        assert config_entry.options[CONF_SCREENCAP_INTERVAL] == 0

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -13,7 +13,6 @@ import pytest
 from homeassistant.components.androidtv.const import (
     CONF_APPS,
     CONF_EXCLUDE_UNNAMED_APPS,
-    CONF_SCREENCAP,
     CONF_SCREENCAP_INTERVAL,
     CONF_STATE_DETECTION_RULES,
     CONF_TURN_OFF_COMMAND,
@@ -1160,20 +1159,3 @@ async def test_options_reload(hass: HomeAssistant) -> None:
 
             assert setup_entry_call.called
             assert config_entry.state is ConfigEntryState.LOADED
-
-
-async def test_screencap_options_migration(hass: HomeAssistant) -> None:
-    """Test changing an option that will cause integration reload."""
-    patch_key, _, config_entry = _setup(CONFIG_ANDROID_DEFAULT)
-    config_entry.options = {CONF_SCREENCAP: False}
-    config_entry.add_to_hass(hass)
-
-    with (
-        patchers.patch_connect(True)[patch_key],
-        patchers.patch_shell(SHELL_RESPONSE_OFF)[patch_key],
-    ):
-        assert await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-
-        assert CONF_SCREENCAP not in config_entry.options
-        assert config_entry.options[CONF_SCREENCAP_INTERVAL] == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Scope of this PR is to give the possibility to set the interval in minutes between execution of 2 `screencaps`. The reason for this is because `screencaps` can cause performance issue on devices, so the boolean option `CONF_SCREENCAP` is replaced with the integer `CONF_SCREENCAP_INTERVAL` than can vary from 0 (disabled) to 15 minutes.
The default value is set to 5 minutes to limit in any case the number of consecutive calls.
Implemented also migration from old option to the new one,

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes 
- This PR is related to issue: #119416, #116856
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
