### PR TITLE
Add 100% coverage of Reolink sensor platform

### DIFF
--- a/tests/components/reolink/test_sensor.py
+++ b/tests/components/reolink/test_sensor.py
@@ -1,0 +1,105 @@
+"""Test the Reolink sensor platform."""
+
+from unittest.mock import MagicMock, patch
+
+from freezegun.api import FrozenDateTimeFactory
+
+from homeassistant.components.reolink import DEVICE_UPDATE_INTERVAL, const
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import STATE_UNAVAILABLE, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .conftest import TEST_NVR_NAME, TEST_UID
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+async def test_sensors(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+    reolink_connect: MagicMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test sensor entities."""
+    reolink_connect.ptz_pan_position.return_value = 1200
+    reolink_connect.wifi_connection = True
+    reolink_connect.wifi_signal = 3
+    reolink_connect.hdd_list = [0]
+    reolink_connect.hdd_storage.return_value = 95
+
+    # enable the wifi_signal entity
+    unique_id = f"{TEST_UID}_wifi_signal"
+    entity_registry.async_get_or_create(
+        domain=Platform.SENSOR,
+        platform=const.DOMAIN,
+        unique_id=unique_id,
+        config_entry=config_entry,
+        suggested_object_id=f"{TEST_NVR_NAME}_wi_fi_signal",
+        disabled_by=None,
+    )
+
+    # enable the SD entity
+    unique_id = f"{TEST_UID}_0_storage"
+    entity_registry.async_get_or_create(
+        domain=Platform.SENSOR,
+        platform=const.DOMAIN,
+        unique_id=unique_id,
+        config_entry=config_entry,
+        suggested_object_id=f"{TEST_NVR_NAME}_sd_0_storage",
+        disabled_by=None,
+    )
+
+    with patch("homeassistant.components.reolink.PLATFORMS", [Platform.SENSOR]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    entity_id = f"{Platform.SENSOR}.{TEST_NVR_NAME}_ptz_pan_position"
+    assert hass.states.get(entity_id).state == "1200"
+
+    entity_id = f"{Platform.SENSOR}.{TEST_NVR_NAME}_wi_fi_signal"
+    assert hass.states.get(entity_id).state == "3"
+
+    entity_id = f"{Platform.SENSOR}.{TEST_NVR_NAME}_sd_0_storage"
+    assert hass.states.get(entity_id).state == "95"
+
+    reolink_connect.hdd_available.return_value = False
+    freezer.tick(DEVICE_UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
+
+
+async def test_HDD_sensors(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+    reolink_connect: MagicMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test hdd sensor entity."""
+    reolink_connect.hdd_list = [0]
+    reolink_connect.hdd_type.return_value = "HDD"
+    reolink_connect.hdd_storage.return_value = 85
+
+    # enable the HDD entity
+    unique_id = f"{TEST_UID}_0_storage"
+    entity_registry.async_get_or_create(
+        domain=Platform.SENSOR,
+        platform=const.DOMAIN,
+        unique_id=unique_id,
+        config_entry=config_entry,
+        suggested_object_id=f"{TEST_NVR_NAME}_hdd_0_storage",
+        disabled_by=None,
+    )
+
+    with patch("homeassistant.components.reolink.PLATFORMS", [Platform.SENSOR]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    entity_id = f"{Platform.SENSOR}.{TEST_NVR_NAME}_hdd_0_storage"
+    assert hass.states.get(entity_id).state == "85"

--- a/tests/components/reolink/test_sensor.py
+++ b/tests/components/reolink/test_sensor.py
@@ -19,7 +19,6 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 async def test_sensors(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-    freezer: FrozenDateTimeFactory,
     reolink_connect: MagicMock,
     entity_registry: er.EntityRegistry,
 ) -> None:
@@ -66,18 +65,10 @@ async def test_sensors(
     entity_id = f"{Platform.SENSOR}.{TEST_NVR_NAME}_sd_0_storage"
     assert hass.states.get(entity_id).state == "95"
 
-    reolink_connect.hdd_available.return_value = False
-    freezer.tick(DEVICE_UPDATE_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-
-    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
-
 
 async def test_hdd_sensors(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-    freezer: FrozenDateTimeFactory,
     reolink_connect: MagicMock,
     entity_registry: er.EntityRegistry,
 ) -> None:
@@ -85,6 +76,7 @@ async def test_hdd_sensors(
     reolink_connect.hdd_list = [0]
     reolink_connect.hdd_type.return_value = "HDD"
     reolink_connect.hdd_storage.return_value = 85
+    reolink_connect.hdd_available.return_value = False
 
     # enable the HDD entity
     unique_id = f"{TEST_UID}_0_storage"
@@ -103,4 +95,4 @@ async def test_hdd_sensors(
     assert config_entry.state is ConfigEntryState.LOADED
 
     entity_id = f"{Platform.SENSOR}.{TEST_NVR_NAME}_hdd_0_storage"
-    assert hass.states.get(entity_id).state == "85"
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE

--- a/tests/components/reolink/test_sensor.py
+++ b/tests/components/reolink/test_sensor.py
@@ -2,23 +2,22 @@
 
 from unittest.mock import MagicMock, patch
 
-from homeassistant.components.reolink import DEVICE_UPDATE_INTERVAL
-from homeassistant.components.reolink.const import DOMAIN
+import pytest
+
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
 
-from .conftest import TEST_NVR_NAME, TEST_UID
+from .conftest import TEST_NVR_NAME
 
 from tests.common import MockConfigEntry
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensors(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     reolink_connect: MagicMock,
-    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test sensor entities."""
     reolink_connect.ptz_pan_position.return_value = 1200
@@ -26,28 +25,6 @@ async def test_sensors(
     reolink_connect.wifi_signal = 3
     reolink_connect.hdd_list = [0]
     reolink_connect.hdd_storage.return_value = 95
-
-    # enable the wifi_signal entity
-    unique_id = f"{TEST_UID}_wifi_signal"
-    entity_registry.async_get_or_create(
-        domain=Platform.SENSOR,
-        platform=DOMAIN,
-        unique_id=unique_id,
-        config_entry=config_entry,
-        suggested_object_id=f"{TEST_NVR_NAME}_wi_fi_signal",
-        disabled_by=None,
-    )
-
-    # enable the SD entity
-    unique_id = f"{TEST_UID}_0_storage"
-    entity_registry.async_get_or_create(
-        domain=Platform.SENSOR,
-        platform=DOMAIN,
-        unique_id=unique_id,
-        config_entry=config_entry,
-        suggested_object_id=f"{TEST_NVR_NAME}_sd_0_storage",
-        disabled_by=None,
-    )
 
     with patch("homeassistant.components.reolink.PLATFORMS", [Platform.SENSOR]):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -64,28 +41,17 @@ async def test_sensors(
     assert hass.states.get(entity_id).state == "95"
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_hdd_sensors(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     reolink_connect: MagicMock,
-    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test hdd sensor entity."""
     reolink_connect.hdd_list = [0]
     reolink_connect.hdd_type.return_value = "HDD"
     reolink_connect.hdd_storage.return_value = 85
     reolink_connect.hdd_available.return_value = False
-
-    # enable the HDD entity
-    unique_id = f"{TEST_UID}_0_storage"
-    entity_registry.async_get_or_create(
-        domain=Platform.SENSOR,
-        platform=DOMAIN,
-        unique_id=unique_id,
-        config_entry=config_entry,
-        suggested_object_id=f"{TEST_NVR_NAME}_hdd_0_storage",
-        disabled_by=None,
-    )
 
     with patch("homeassistant.components.reolink.PLATFORMS", [Platform.SENSOR]):
         assert await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/components/reolink/test_sensor.py
+++ b/tests/components/reolink/test_sensor.py
@@ -74,7 +74,7 @@ async def test_sensors(
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
 
-async def test_HDD_sensors(
+async def test_hdd_sensors(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     freezer: FrozenDateTimeFactory,

--- a/tests/components/reolink/test_sensor.py
+++ b/tests/components/reolink/test_sensor.py
@@ -4,7 +4,8 @@ from unittest.mock import MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 
-from homeassistant.components.reolink import DEVICE_UPDATE_INTERVAL, const
+from homeassistant.components.reolink import DEVICE_UPDATE_INTERVAL
+from homeassistant.components.reolink.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
@@ -33,7 +34,7 @@ async def test_sensors(
     unique_id = f"{TEST_UID}_wifi_signal"
     entity_registry.async_get_or_create(
         domain=Platform.SENSOR,
-        platform=const.DOMAIN,
+        platform=DOMAIN,
         unique_id=unique_id,
         config_entry=config_entry,
         suggested_object_id=f"{TEST_NVR_NAME}_wi_fi_signal",
@@ -44,7 +45,7 @@ async def test_sensors(
     unique_id = f"{TEST_UID}_0_storage"
     entity_registry.async_get_or_create(
         domain=Platform.SENSOR,
-        platform=const.DOMAIN,
+        platform=DOMAIN,
         unique_id=unique_id,
         config_entry=config_entry,
         suggested_object_id=f"{TEST_NVR_NAME}_sd_0_storage",
@@ -89,7 +90,7 @@ async def test_HDD_sensors(
     unique_id = f"{TEST_UID}_0_storage"
     entity_registry.async_get_or_create(
         domain=Platform.SENSOR,
-        platform=const.DOMAIN,
+        platform=DOMAIN,
         unique_id=unique_id,
         config_entry=config_entry,
         suggested_object_id=f"{TEST_NVR_NAME}_hdd_0_storage",

--- a/tests/components/reolink/test_sensor.py
+++ b/tests/components/reolink/test_sensor.py
@@ -2,8 +2,6 @@
 
 from unittest.mock import MagicMock, patch
 
-from freezegun.api import FrozenDateTimeFactory
-
 from homeassistant.components.reolink import DEVICE_UPDATE_INTERVAL
 from homeassistant.components.reolink.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -13,7 +11,7 @@ from homeassistant.helpers import entity_registry as er
 
 from .conftest import TEST_NVR_NAME, TEST_UID
 
-from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.common import MockConfigEntry
 
 
 async def test_sensors(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add tests for the sensor platform.

Working towards platinum quality scale such that Reolink can join the Works With HomeAssistant program.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
