### PR TITLE
Reolink add 100% coverage of siren platform

### DIFF
--- a/tests/components/reolink/test_siren.py
+++ b/tests/components/reolink/test_siren.py
@@ -1,0 +1,116 @@
+"""Test the Reolink siren platform."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from reolink_aio.exceptions import InvalidParameterError, ReolinkError
+
+from homeassistant.components.siren import (
+    ATTR_DURATION,
+    ATTR_VOLUME_LEVEL,
+    DOMAIN as SIREN_DOMAIN,
+)
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_UNKNOWN,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+
+from .conftest import TEST_NVR_NAME
+
+from tests.common import MockConfigEntry
+
+
+async def test_siren(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_connect: MagicMock,
+) -> None:
+    """Test siren entity."""
+    with patch("homeassistant.components.reolink.PLATFORMS", [Platform.SIREN]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    entity_id = f"{Platform.SIREN}.{TEST_NVR_NAME}_siren"
+    assert hass.states.get(entity_id).state == STATE_UNKNOWN
+
+    # test siren turn on
+    await hass.services.async_call(
+        SIREN_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    reolink_connect.set_volume.assert_not_called()
+    reolink_connect.set_siren.assert_called_with(0, True, None)
+
+    await hass.services.async_call(
+        SIREN_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id, ATTR_VOLUME_LEVEL: 0.85, ATTR_DURATION: 2},
+        blocking=True,
+    )
+    reolink_connect.set_volume.assert_called_with(0, volume=85)
+    reolink_connect.set_siren.assert_called_with(0, True, 2)
+
+    reolink_connect.set_volume.side_effect = ReolinkError("Test error")
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            SIREN_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: entity_id, ATTR_VOLUME_LEVEL: 0.85, ATTR_DURATION: 2},
+            blocking=True,
+        )
+
+    reolink_connect.set_volume.side_effect = InvalidParameterError("Test error")
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            SIREN_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: entity_id, ATTR_VOLUME_LEVEL: 0.85, ATTR_DURATION: 2},
+            blocking=True,
+        )
+
+    reolink_connect.set_volume.side_effect = None
+    reolink_connect.set_siren.side_effect = ReolinkError("Test error")
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            SIREN_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: entity_id, ATTR_DURATION: 2},
+            blocking=True,
+        )
+
+    reolink_connect.set_siren.side_effect = InvalidParameterError("Test error")
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            SIREN_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: entity_id, ATTR_DURATION: 2},
+            blocking=True,
+        )
+
+    # test siren turn off
+    reolink_connect.set_siren.side_effect = None
+    await hass.services.async_call(
+        SIREN_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    reolink_connect.set_siren.assert_called_with(0, False, None)
+
+    reolink_connect.set_siren.side_effect = ReolinkError("Test error")
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            SIREN_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )

--- a/tests/components/reolink/test_siren.py
+++ b/tests/components/reolink/test_siren.py
@@ -1,6 +1,7 @@
 """Test the Reolink siren platform."""
 
-from unittest.mock import MagicMock, patch
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from reolink_aio.exceptions import InvalidParameterError, ReolinkError
@@ -59,43 +60,6 @@ async def test_siren(
     reolink_connect.set_volume.assert_called_with(0, volume=85)
     reolink_connect.set_siren.assert_called_with(0, True, 2)
 
-    reolink_connect.set_volume.side_effect = ReolinkError("Test error")
-    with pytest.raises(HomeAssistantError):
-        await hass.services.async_call(
-            SIREN_DOMAIN,
-            SERVICE_TURN_ON,
-            {ATTR_ENTITY_ID: entity_id, ATTR_VOLUME_LEVEL: 0.85, ATTR_DURATION: 2},
-            blocking=True,
-        )
-
-    reolink_connect.set_volume.side_effect = InvalidParameterError("Test error")
-    with pytest.raises(ServiceValidationError):
-        await hass.services.async_call(
-            SIREN_DOMAIN,
-            SERVICE_TURN_ON,
-            {ATTR_ENTITY_ID: entity_id, ATTR_VOLUME_LEVEL: 0.85, ATTR_DURATION: 2},
-            blocking=True,
-        )
-
-    reolink_connect.set_volume.side_effect = None
-    reolink_connect.set_siren.side_effect = ReolinkError("Test error")
-    with pytest.raises(HomeAssistantError):
-        await hass.services.async_call(
-            SIREN_DOMAIN,
-            SERVICE_TURN_ON,
-            {ATTR_ENTITY_ID: entity_id, ATTR_DURATION: 2},
-            blocking=True,
-        )
-
-    reolink_connect.set_siren.side_effect = InvalidParameterError("Test error")
-    with pytest.raises(ServiceValidationError):
-        await hass.services.async_call(
-            SIREN_DOMAIN,
-            SERVICE_TURN_ON,
-            {ATTR_ENTITY_ID: entity_id, ATTR_DURATION: 2},
-            blocking=True,
-        )
-
     # test siren turn off
     reolink_connect.set_siren.side_effect = None
     await hass.services.async_call(
@@ -105,6 +69,71 @@ async def test_siren(
         blocking=True,
     )
     reolink_connect.set_siren.assert_called_with(0, False, None)
+
+
+@pytest.mark.parametrize(
+    ("attr", "value", "expected"),
+    [
+        (
+            "set_volume",
+            AsyncMock(side_effect=ReolinkError("Test error")),
+            HomeAssistantError,
+        ),
+        (
+            "set_volume",
+            AsyncMock(side_effect=InvalidParameterError("Test error")),
+            ServiceValidationError,
+        ),
+        (
+            "set_siren",
+            AsyncMock(side_effect=ReolinkError("Test error")),
+            HomeAssistantError,
+        ),
+        (
+            "set_siren",
+            AsyncMock(side_effect=InvalidParameterError("Test error")),
+            ServiceValidationError,
+        ),
+    ],
+)
+async def test_siren_turn_on_errors(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_connect: MagicMock,
+    attr: str,
+    value: Any,
+    expected: Any,
+) -> None:
+    """Test errors when calling siren turn on service."""
+    with patch("homeassistant.components.reolink.PLATFORMS", [Platform.SIREN]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    entity_id = f"{Platform.SIREN}.{TEST_NVR_NAME}_siren"
+
+    setattr(reolink_connect, attr, value)
+    with pytest.raises(expected):
+        await hass.services.async_call(
+            SIREN_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: entity_id, ATTR_VOLUME_LEVEL: 0.85, ATTR_DURATION: 2},
+            blocking=True,
+        )
+
+
+async def test_siren_turn_off_errors(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_connect: MagicMock,
+) -> None:
+    """Test errors when calling siren turn off service."""
+    with patch("homeassistant.components.reolink.PLATFORMS", [Platform.SIREN]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    entity_id = f"{Platform.SIREN}.{TEST_NVR_NAME}_siren"
 
     reolink_connect.set_siren.side_effect = ReolinkError("Test error")
     with pytest.raises(HomeAssistantError):

--- a/tests/components/reolink/test_siren.py
+++ b/tests/components/reolink/test_siren.py
@@ -71,26 +71,15 @@ async def test_siren(
     reolink_connect.set_siren.assert_called_with(0, False, None)
 
 
+@pytest.mark.parametrize("attr", ["set_volume", "set_siren"])
 @pytest.mark.parametrize(
-    ("attr", "value", "expected"),
+    ("value", "expected"),
     [
         (
-            "set_volume",
             AsyncMock(side_effect=ReolinkError("Test error")),
             HomeAssistantError,
         ),
         (
-            "set_volume",
-            AsyncMock(side_effect=InvalidParameterError("Test error")),
-            ServiceValidationError,
-        ),
-        (
-            "set_siren",
-            AsyncMock(side_effect=ReolinkError("Test error")),
-            HomeAssistantError,
-        ),
-        (
-            "set_siren",
             AsyncMock(side_effect=InvalidParameterError("Test error")),
             ServiceValidationError,
         ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add tests for the siren platform.

Working towards platinum quality scale such that Reolink can join the Works With HomeAssistant program.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
