### PR TITLE
Attempt to fix IndexError in Opower

### DIFF
--- a/homeassistant/components/opower/coordinator.py
+++ b/homeassistant/components/opower/coordinator.py
@@ -187,10 +187,20 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
                 else UnitOfVolume.CENTUM_CUBIC_FEET,
             )
 
-            async_add_external_statistics(self.hass, cost_metadata, cost_statistics)
+            _LOGGER.debug(
+                "Adding %s statistics for %s",
+                len(consumption_statistics),
+                consumption_statistic_id,
+            )
             async_add_external_statistics(
                 self.hass, consumption_metadata, consumption_statistics
             )
+            _LOGGER.debug(
+                "Adding %s statistics for %s",
+                len(cost_statistics),
+                cost_statistic_id,
+            )
+            async_add_external_statistics(self.hass, cost_metadata, cost_statistics)
 
     async def _async_get_cost_reads(
         self, account: Account, time_zone_str: str, start_time: float | None = None

--- a/homeassistant/components/opower/coordinator.py
+++ b/homeassistant/components/opower/coordinator.py
@@ -110,7 +110,7 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
             )
 
             last_stat = await get_instance(self.hass).async_add_executor_job(
-                get_last_statistics, self.hass, 1, cost_statistic_id, True, set()
+                get_last_statistics, self.hass, 1, consumption_statistic_id, True, set()
             )
             if not last_stat:
                 _LOGGER.debug("Updating statistic for the first time")
@@ -124,7 +124,7 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
                 cost_reads = await self._async_get_cost_reads(
                     account,
                     self.api.utility.timezone(),
-                    last_stat[cost_statistic_id][0]["start"],
+                    last_stat[consumption_statistic_id][0]["start"],
                 )
                 if not cost_reads:
                     _LOGGER.debug("No recent usage/cost data. Skipping update")
@@ -141,7 +141,7 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
                 )
                 cost_sum = cast(float, stats[cost_statistic_id][0]["sum"])
                 consumption_sum = cast(float, stats[consumption_statistic_id][0]["sum"])
-                last_stats_time = stats[cost_statistic_id][0]["start"]
+                last_stats_time = stats[consumption_statistic_id][0]["start"]
 
             cost_statistics = []
             consumption_statistics = []
@@ -189,18 +189,18 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
 
             _LOGGER.debug(
                 "Adding %s statistics for %s",
+                len(cost_statistics),
+                cost_statistic_id,
+            )
+            async_add_external_statistics(self.hass, cost_metadata, cost_statistics)
+            _LOGGER.debug(
+                "Adding %s statistics for %s",
                 len(consumption_statistics),
                 consumption_statistic_id,
             )
             async_add_external_statistics(
                 self.hass, consumption_metadata, consumption_statistics
             )
-            _LOGGER.debug(
-                "Adding %s statistics for %s",
-                len(cost_statistics),
-                cost_statistic_id,
-            )
-            async_add_external_statistics(self.hass, cost_metadata, cost_statistics)
 
     async def _async_get_cost_reads(
         self, account: Account, time_zone_str: str, start_time: float | None = None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Attempt to fix https://github.com/home-assistant/core/issues/123208
Line 113 calls get_last_statistics on cost_statistic_id. Under normal conditions the start time should match between cost and consumption statistics. My guess is that the first async_add_external_statistics call failed which caused IndexError at the next retry. Now we call get_last_statistics on the last inserted statistic, i.e. consumption instead of cost.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
