### PR TITLE
Auto recover mqtt config entry secret if Mosquitto add-on was re-installed

### DIFF
--- a/tests/components/mqtt/test_config_flow.py
+++ b/tests/components/mqtt/test_config_flow.py
@@ -1587,6 +1587,108 @@ async def test_step_reauth(
     await hass.async_block_till_done()
 
 
+@pytest.mark.parametrize("discovery_info", [{"config": ADD_ON_DISCOVERY_INFO.copy()}])
+@pytest.mark.usefixtures(
+    "mqtt_client_mock", "mock_reload_after_entry_update", "supervisor", "addon_running"
+)
+async def test_step_hassio_reauth(
+    hass: HomeAssistant, mock_try_connection: MagicMock, addon_info: AsyncMock
+) -> None:
+    """Test that the reauth step works in case the Mosquitto broker add-on was re-installed."""
+
+    # Set up entry data based on the discovery data, but with a stale password
+    entry_data = {
+        mqtt.CONF_BROKER: "core-mosquitto",
+        CONF_PORT: 1883,
+        CONF_USERNAME: "mock-user",
+        CONF_PASSWORD: "stale-secret",
+    }
+
+    addon_info["hostname"] = "core-mosquitto"
+
+    # Prepare the config entry
+    config_entry = MockConfigEntry(domain=mqtt.DOMAIN, data=entry_data)
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+    assert config_entry.data.get(CONF_PASSWORD) == "stale-secret"
+
+    # Start reauth flow
+    mock_try_connection.reset_mock()
+    mock_try_connection.return_value = True
+    config_entry.async_start_reauth(hass)
+    await hass.async_block_till_done()
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 0
+
+    # Assert the entry is updated automatically
+    assert config_entry.data.get(CONF_PASSWORD) == "mock-pass"
+    mock_try_connection.assert_called_once_with(
+        {
+            "broker": "core-mosquitto",
+            "port": 1883,
+            "username": "mock-user",
+            "password": "mock-pass",
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    ("discovery_info", "discovery_info_side_effect", "broker"),
+    [
+        ({"config": ADD_ON_DISCOVERY_INFO.copy()}, AddonError, "core-mosquitto"),
+        ({"config": ADD_ON_DISCOVERY_INFO.copy()}, None, "broker-not-addon"),
+    ],
+)
+@pytest.mark.usefixtures(
+    "mqtt_client_mock", "mock_reload_after_entry_update", "supervisor", "addon_running"
+)
+async def test_step_hassio_reauth_no_discovery_info(
+    hass: HomeAssistant,
+    mock_try_connection: MagicMock,
+    addon_info: AsyncMock,
+    broker: str,
+) -> None:
+    """Test hassio reauth flow defaults to manual flow.
+
+    Test that the reauth step defaults to
+    normal reauth flow if fetching add-on discovery info failed,
+    or the broker is not the add-on.
+    """
+
+    # Set up entry data based on the discovery data, but with a stale password
+    entry_data = {
+        mqtt.CONF_BROKER: broker,
+        CONF_PORT: 1883,
+        CONF_USERNAME: "mock-user",
+        CONF_PASSWORD: "wrong-pass",
+    }
+
+    addon_info["hostname"] = "core-mosquitto"
+
+    # Prepare the config entry
+    config_entry = MockConfigEntry(domain=mqtt.DOMAIN, data=entry_data)
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+    assert config_entry.data.get(CONF_PASSWORD) == "wrong-pass"
+
+    # Start reauth flow
+    mock_try_connection.reset_mock()
+    mock_try_connection.return_value = True
+    config_entry.async_start_reauth(hass)
+    await hass.async_block_till_done()
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    result = flows[0]
+    assert result["step_id"] == "reauth_confirm"
+    assert result["context"]["source"] == "reauth"
+
+    # Assert the entry is not updated
+    assert config_entry.data.get(CONF_PASSWORD) == "wrong-pass"
+    mock_try_connection.assert_not_called()
+
+
 async def test_options_user_connection_fails(
     hass: HomeAssistant, mock_try_connection_time_out: MagicMock
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When the MQTT integration is configured using the official Mosquitto broker addon, and this add-on is re-installed, this PR will automatically handle the reauth flow and update the mqtt entry with the new broker password. This avoids that a user needs to re-create the mqtt entry and loosing information.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/34423

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
