### PR TITLE
Add 100% coverage of Reolink update platform

### DIFF
--- a/homeassistant/components/reolink/update.py
+++ b/homeassistant/components/reolink/update.py
@@ -137,8 +137,7 @@ class ReolinkUpdateEntity(
     async def async_release_notes(self) -> str | None:
         """Return the release notes."""
         new_firmware = self._host.api.firmware_update_available(self._channel)
-        if not isinstance(new_firmware, NewSoftwareVersion):
-            return None
+        assert isinstance(new_firmware, NewSoftwareVersion)
 
         return (
             "If the install button fails, download this"
@@ -229,8 +228,7 @@ class ReolinkHostUpdateEntity(
     async def async_release_notes(self) -> str | None:
         """Return the release notes."""
         new_firmware = self._host.api.firmware_update_available()
-        if not isinstance(new_firmware, NewSoftwareVersion):
-            return None
+        assert isinstance(new_firmware, NewSoftwareVersion)
 
         return (
             "If the install button fails, download this"

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -34,6 +34,7 @@ TEST_UID_CAM = "DEF7654321D89GHT"
 TEST_PORT = 1234
 TEST_NVR_NAME = "test_reolink_name"
 TEST_NVR_NAME2 = "test2_reolink_name"
+TEST_CAM_NAME = "test_reolink_cam"
 TEST_USE_HTTPS = True
 TEST_HOST_MODEL = "RLN8-410"
 TEST_ITEM_NUMBER = "P000"

--- a/tests/components/reolink/test_update.py
+++ b/tests/components/reolink/test_update.py
@@ -1,0 +1,127 @@
+"""Test the Reolink update platform."""
+
+from unittest.mock import MagicMock, patch
+
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+from reolink_aio.exceptions import ReolinkError
+from reolink_aio.software_version import NewSoftwareVersion
+
+from homeassistant.components.reolink.update import POLL_AFTER_INSTALL
+from homeassistant.components.update import DOMAIN as UPDATE_DOMAIN, SERVICE_INSTALL
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from .conftest import TEST_CAM_NAME, TEST_NVR_NAME
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.typing import WebSocketGenerator
+
+TEST_DOWNLOAD_URL = "https://reolink.com/test"
+TEST_RELEASE_NOTES = "bugfix 1, bugfix 2"
+
+
+@pytest.mark.parametrize("entity_name", [TEST_NVR_NAME, TEST_CAM_NAME])
+async def test_no_update(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_connect: MagicMock,
+    entity_name: str,
+) -> None:
+    """Test update state when no update available."""
+    reolink_connect.camera_name.return_value = TEST_CAM_NAME
+
+    with patch("homeassistant.components.reolink.PLATFORMS", [Platform.UPDATE]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    entity_id = f"{Platform.UPDATE}.{entity_name}_firmware"
+    assert hass.states.get(entity_id).state == STATE_OFF
+
+
+@pytest.mark.parametrize("entity_name", [TEST_NVR_NAME, TEST_CAM_NAME])
+async def test_update_str(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_connect: MagicMock,
+    entity_name: str,
+) -> None:
+    """Test update state when update available with string from API."""
+    reolink_connect.camera_name.return_value = TEST_CAM_NAME
+    reolink_connect.firmware_update_available.return_value = "New firmware available"
+
+    with patch("homeassistant.components.reolink.PLATFORMS", [Platform.UPDATE]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    entity_id = f"{Platform.UPDATE}.{entity_name}_firmware"
+    assert hass.states.get(entity_id).state == STATE_ON
+
+
+@pytest.mark.parametrize("entity_name", [TEST_NVR_NAME, TEST_CAM_NAME])
+async def test_update_firm(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_connect: MagicMock,
+    hass_ws_client: WebSocketGenerator,
+    freezer: FrozenDateTimeFactory,
+    entity_name: str,
+) -> None:
+    """Test update state when update available with firmware info from reolink.com."""
+    reolink_connect.camera_name.return_value = TEST_CAM_NAME
+    new_firmware = NewSoftwareVersion(
+        version_string="v3.3.0.226_23031644",
+        download_url=TEST_DOWNLOAD_URL,
+        release_notes=TEST_RELEASE_NOTES,
+    )
+    reolink_connect.firmware_update_available.return_value = new_firmware
+
+    with patch("homeassistant.components.reolink.PLATFORMS", [Platform.UPDATE]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    entity_id = f"{Platform.UPDATE}.{entity_name}_firmware"
+    assert hass.states.get(entity_id).state == STATE_ON
+
+    # release notes
+    client = await hass_ws_client(hass)
+    await hass.async_block_till_done()
+
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "update/release_notes",
+            "entity_id": entity_id,
+        }
+    )
+    result = await client.receive_json()
+    assert TEST_DOWNLOAD_URL in result["result"]
+    assert TEST_RELEASE_NOTES in result["result"]
+
+    # test install
+    await hass.services.async_call(
+        UPDATE_DOMAIN,
+        SERVICE_INSTALL,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    reolink_connect.update_firmware.assert_called()
+
+    reolink_connect.update_firmware.side_effect = ReolinkError("Test error")
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            UPDATE_DOMAIN,
+            SERVICE_INSTALL,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+
+    # test _async_update_future
+    freezer.tick(POLL_AFTER_INSTALL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()

--- a/tests/components/reolink/test_update.py
+++ b/tests/components/reolink/test_update.py
@@ -122,6 +122,10 @@ async def test_update_firm(
         )
 
     # test _async_update_future
+    reolink_connect.camera_sw_version.return_value = "v3.3.0.226_23031644"
+    reolink_connect.firmware_update_available.return_value = False
     freezer.tick(POLL_AFTER_INSTALL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == STATE_OFF


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add tests for the update platform.

Working towards platinum quality scale such that Reolink can join the Works With HomeAssistant program.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
