### PR TITLE
Add Sonos tests for announce and update error handling

### DIFF
--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -542,8 +542,13 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
                 raise HomeAssistantError(
                     f"Error when calling Sonos websocket: {exc}"
                 ) from exc
-            if response["success"]:
+            if response.get("success"):
                 return
+            raise HomeAssistantError(
+                translation_domain=SONOS_DOMAIN,
+                translation_key="websocket_error",
+                translation_placeholders={"media_id": media_id, "response": response},
+            )
 
         if spotify.is_spotify_media_type(media_type):
             media_type = spotify.resolve_spotify_media_type(media_type)

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -546,7 +546,7 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
                 return
             raise HomeAssistantError(
                 translation_domain=SONOS_DOMAIN,
-                translation_key="websocket_error",
+                translation_key="announce_media_error",
                 translation_placeholders={"media_id": media_id, "response": response},
             )
 

--- a/homeassistant/components/sonos/strings.json
+++ b/homeassistant/components/sonos/strings.json
@@ -180,6 +180,9 @@
     },
     "invalid_sonos_playlist": {
       "message": "Could not find Sonos playlist: {name}"
+    },
+    "websocket_error": {
+      "message": "Announcing clip {media_id} failed {response}"
     }
   }
 }

--- a/homeassistant/components/sonos/strings.json
+++ b/homeassistant/components/sonos/strings.json
@@ -181,7 +181,7 @@
     "invalid_sonos_playlist": {
       "message": "Could not find Sonos playlist: {name}"
     },
-    "websocket_error": {
+    "announce_media_error": {
       "message": "Announcing clip {media_id} failed {response}"
     }
   }

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -255,6 +255,19 @@ def soco_sharelink():
         yield mock_instance
 
 
+@pytest.fixture(name="sonos_websocket")
+def sonos_websocket():
+    """Fixture to mock SonosWebSocket."""
+    with patch(
+        "homeassistant.components.sonos.speaker.SonosWebsocket"
+    ) as mock_sonos_ws:
+        mock_instance = AsyncMock()
+        mock_instance.play_clip = AsyncMock()
+        mock_instance.play_clip.return_value = [{"success": 1}, {}]
+        mock_sonos_ws.return_value = mock_instance
+        yield mock_instance
+
+
 @pytest.fixture(name="soco_factory")
 def soco_factory(
     music_library,
@@ -263,6 +276,7 @@ def soco_factory(
     battery_info,
     alarm_clock,
     sonos_playlists: SearchResult,
+    sonos_websocket,
 ):
     """Create factory for instantiating SoCo mocks."""
     factory = SoCoMockFactory(

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -5,13 +5,16 @@ from unittest.mock import patch
 
 import pytest
 from soco.data_structures import SearchResult
+from sonos_websocket.exception import SonosWebsocketError
 from syrupy import SnapshotAssertion
 
 from homeassistant.components.media_player import (
     ATTR_INPUT_SOURCE,
+    ATTR_MEDIA_ANNOUNCE,
     ATTR_MEDIA_CONTENT_ID,
     ATTR_MEDIA_CONTENT_TYPE,
     ATTR_MEDIA_ENQUEUE,
+    ATTR_MEDIA_EXTRA,
     ATTR_MEDIA_REPEAT,
     ATTR_MEDIA_SHUFFLE,
     ATTR_MEDIA_VOLUME_LEVEL,
@@ -47,7 +50,7 @@ from homeassistant.const import (
     SERVICE_VOLUME_UP,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import (
     CONNECTION_NETWORK_MAC,
@@ -1050,3 +1053,69 @@ async def test_media_transport(
         blocking=True,
     )
     assert getattr(soco, client_call).call_count == 1
+
+
+async def test_play_media_announce(
+    hass: HomeAssistant,
+    soco: MockSoCo,
+    async_autosetup_sonos,
+    sonos_websocket,
+) -> None:
+    """Test playing media with the announce."""
+    content_id: str = "http://10.0.0.1:8123/local/sounds/doorbell.mp3"
+    volume: float = 0.30
+
+    # Test the success path
+    await hass.services.async_call(
+        MP_DOMAIN,
+        SERVICE_PLAY_MEDIA,
+        {
+            ATTR_ENTITY_ID: "media_player.zone_a",
+            ATTR_MEDIA_CONTENT_TYPE: "music",
+            ATTR_MEDIA_CONTENT_ID: content_id,
+            ATTR_MEDIA_ANNOUNCE: True,
+            ATTR_MEDIA_EXTRA: {"volume": volume},
+        },
+        blocking=True,
+    )
+    assert sonos_websocket.play_clip.call_count == 1
+    sonos_websocket.play_clip.assert_called_with(content_id, volume=volume)
+
+    # Test receiving a websocket exception
+    sonos_websocket.play_clip.reset_mock()
+    sonos_websocket.play_clip.side_effect = SonosWebsocketError("The error message")
+    with pytest.raises(HomeAssistantError) as hae:
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_PLAY_MEDIA,
+            {
+                ATTR_ENTITY_ID: "media_player.zone_a",
+                ATTR_MEDIA_CONTENT_TYPE: "music",
+                ATTR_MEDIA_CONTENT_ID: content_id,
+                ATTR_MEDIA_ANNOUNCE: True,
+            },
+            blocking=True,
+        )
+    assert sonos_websocket.play_clip.call_count == 1
+    sonos_websocket.play_clip.assert_called_with(content_id, volume=None)
+    assert "The error message" in str(hae.value)
+
+    # Test receiving a non success result
+    sonos_websocket.play_clip.reset_mock()
+    sonos_websocket.play_clip.side_effect = None
+    sonos_websocket.play_clip.return_value = [{"success": 0}, {}]
+    with pytest.raises(HomeAssistantError) as hae:
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_PLAY_MEDIA,
+            {
+                ATTR_ENTITY_ID: "media_player.zone_a",
+                ATTR_MEDIA_CONTENT_TYPE: "music",
+                ATTR_MEDIA_CONTENT_ID: content_id,
+                ATTR_MEDIA_ANNOUNCE: True,
+            },
+            blocking=True,
+        )
+    assert sonos_websocket.play_clip.call_count == 1
+    assert "'success': 0" in str(hae.value)
+    assert content_id in str(hae.value)


### PR DESCRIPTION
## Proposed change
Add test coverage for the media_player.play_media "annouce" option.  

Improve handling of errors when a non-success result is returned when using "announce"

Targets these lines of code:

https://github.com/home-assistant/core/blob/156e39ebb23e2ed84a8b05d45e642280e3f7ac14/homeassistant/components/sonos/media_player.py#L532-L546

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
