### PR TITLE
Fix missing id in Habitica completed todos API response

### DIFF
--- a/homeassistant/components/habitica/coordinator.py
+++ b/homeassistant/components/habitica/coordinator.py
@@ -56,7 +56,13 @@ class HabiticaDataUpdateCoordinator(DataUpdateCoordinator[HabiticaData]):
         try:
             user_response = await self.api.user.get()
             tasks_response = await self.api.tasks.user.get()
-            tasks_response.extend(await self.api.tasks.user.get(type="completedTodos"))
+            tasks_response.extend(
+                [
+                    {**task, "id": task["_id"]}
+                    for task in await self.api.tasks.user.get(type="completedTodos")
+                ]
+            )
+
         except ClientResponseError as error:
             if error.status == HTTPStatus.TOO_MANY_REQUESTS:
                 _LOGGER.debug("Currently rate limited, skipping update")

--- a/homeassistant/components/habitica/coordinator.py
+++ b/homeassistant/components/habitica/coordinator.py
@@ -58,7 +58,7 @@ class HabiticaDataUpdateCoordinator(DataUpdateCoordinator[HabiticaData]):
             tasks_response = await self.api.tasks.user.get()
             tasks_response.extend(
                 [
-                    {**task, "id": task.get("id", task["_id"])}
+                    {"id": task["_id"], **task}
                     for task in await self.api.tasks.user.get(type="completedTodos")
                     if task.get("_id")
                 ]

--- a/homeassistant/components/habitica/coordinator.py
+++ b/homeassistant/components/habitica/coordinator.py
@@ -58,8 +58,9 @@ class HabiticaDataUpdateCoordinator(DataUpdateCoordinator[HabiticaData]):
             tasks_response = await self.api.tasks.user.get()
             tasks_response.extend(
                 [
-                    {**task, "id": task["_id"]}
+                    {**task, "id": task.get("id", task["_id"])}
                     for task in await self.api.tasks.user.get(type="completedTodos")
+                    if task.get("_id")
                 ]
             )
 

--- a/tests/components/habitica/test_init.py
+++ b/tests/components/habitica/test_init.py
@@ -73,7 +73,20 @@ def common_requests(aioclient_mock: AiohttpClientMocker) -> AiohttpClientMocker:
             }
         },
     )
-
+    aioclient_mock.get(
+        "https://habitica.com/api/v3/tasks/user?type=completedTodos",
+        json={
+            "data": [
+                {
+                    "text": "this is a mock todo #5",
+                    "id": 5,
+                    "_id": 5,
+                    "type": "todo",
+                    "completed": True,
+                }
+            ]
+        },
+    )
     aioclient_mock.get(
         "https://habitica.com/api/v3/tasks/user",
         json={
@@ -85,19 +98,6 @@ def common_requests(aioclient_mock: AiohttpClientMocker) -> AiohttpClientMocker:
                     "completed": False,
                 }
                 for i, task in enumerate(("habit", "daily", "todo", "reward"), start=1)
-            ]
-        },
-    )
-    aioclient_mock.get(
-        "https://habitica.com/api/v3/tasks/user?type=completedTodos",
-        json={
-            "data": [
-                {
-                    "text": "this is a mock todo #5",
-                    "id": 5,
-                    "type": "todo",
-                    "completed": True,
-                }
             ]
         },
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This is a quick workaround for a bug that was introduced in the Habitica API in v. 5.27.4 last week. The field `id` is missing from the API's json response. This broke the Habitica to-do list in the HA integration. This workaround simply copies the uuid from the field `_id` to `id`. When the Habitica API gets fixed this change can be reverted.


A PR that fixes this already exists but it's unclear when this gets fixed in production:
- https://github.com/HabitRPG/habitica/pull/15301

Hope this can be shipped with patch release 2024.8.3 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
