### PR TITLE
Add 100% coverage of Reolink host.py

### DIFF
--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -437,7 +437,15 @@ class ReolinkHost:
             self._long_poll_task.cancel()
             self._long_poll_task = None
 
-        await self._api.unsubscribe(sub_type=SubType.long_poll)
+        try:
+            await self._api.unsubscribe(sub_type=SubType.long_poll)
+        except ReolinkError as err:
+            _LOGGER.error(
+                "Reolink error while unsubscribing from host %s:%s: %s",
+                self._api.host,
+                self._api.port,
+                err,
+            )
 
     async def stop(self, event=None) -> None:
         """Disconnect the API."""
@@ -511,9 +519,7 @@ class ReolinkHost:
             )
             if sub_type == SubType.push:
                 await self.subscribe()
-            else:
-                await self._api.subscribe(self._webhook_url, sub_type)
-            return
+                return
 
         timer = self._api.renewtimer(sub_type)
         _LOGGER.debug(

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -94,6 +94,8 @@ async def test_config_flow_errors(
 
     reolink_connect.is_admin = False
     reolink_connect.user_level = "guest"
+    reolink_connect.unsubscribe.side_effect = ReolinkError("Test error")
+    reolink_connect.logout.side_effect = ReolinkError("Test error")
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {

--- a/tests/components/reolink/test_host.py
+++ b/tests/components/reolink/test_host.py
@@ -1,28 +1,43 @@
 """Test the Reolink host."""
 
 from asyncio import CancelledError
-from unittest.mock import AsyncMock, MagicMock
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from aiohttp import ClientResponseError
+from freezegun.api import FrozenDateTimeFactory
 import pytest
+from reolink_aio.enums import SubType
+from reolink_aio.exceptions import NotSupportedError, ReolinkError, SubscriptionError
 
-from homeassistant.components.reolink import const
+from homeassistant.components.reolink import DEVICE_UPDATE_INTERVAL
+from homeassistant.components.reolink.const import DOMAIN
+from homeassistant.components.reolink.host import (
+    FIRST_ONVIF_LONG_POLL_TIMEOUT,
+    FIRST_ONVIF_TIMEOUT,
+    LONG_POLL_COOLDOWN,
+    LONG_POLL_ERROR_COOLDOWN,
+    POLL_INTERVAL_NO_PUSH,
+)
 from homeassistant.components.webhook import async_handle_webhook
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.network import NoURLAvailableError
 from homeassistant.util.aiohttp import MockRequest
 
 from .conftest import TEST_UID
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
 
 
 async def test_webhook_callback(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,
+    freezer: FrozenDateTimeFactory,
     config_entry: MockConfigEntry,
     reolink_connect: MagicMock,
     entity_registry: er.EntityRegistry,
@@ -32,7 +47,7 @@ async def test_webhook_callback(
     await hass.async_block_till_done()
     assert config_entry.state is ConfigEntryState.LOADED
 
-    webhook_id = f"{const.DOMAIN}_{TEST_UID.replace(':', '')}_ONVIF"
+    webhook_id = f"{DOMAIN}_{TEST_UID.replace(':', '')}_ONVIF"
 
     signal_all = MagicMock()
     signal_ch = MagicMock()
@@ -45,6 +60,10 @@ async def test_webhook_callback(
     reolink_connect.ONVIF_event_callback.return_value = None
     await client.post(f"/api/webhook/{webhook_id}")
     signal_all.assert_called_once()
+
+    freezer.tick(timedelta(seconds=FIRST_ONVIF_TIMEOUT))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
     # test webhook callback all channels with failure to read motion_state
     signal_all.reset_mock()
@@ -59,7 +78,9 @@ async def test_webhook_callback(
 
     # test webhook callback single channel with error in event callback
     signal_ch.reset_mock()
-    reolink_connect.ONVIF_event_callback.side_effect = Exception("Test error")
+    reolink_connect.ONVIF_event_callback = AsyncMock(
+        side_effect=Exception("Test error")
+    )
     await client.post(f"/api/webhook/{webhook_id}", data="test_data")
     signal_ch.assert_not_called()
 
@@ -81,3 +102,285 @@ async def test_webhook_callback(
     with pytest.raises(CancelledError):
         await async_handle_webhook(hass, webhook_id, request)
     signal_all.assert_not_called()
+
+
+async def test_no_mac(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_connect: MagicMock,
+) -> None:
+    """Test setup of host with no mac."""
+    reolink_connect.mac_address = None
+    assert not await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_subscribe_error(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_connect: MagicMock,
+) -> None:
+    """Test error when subscribing to ONVIF does not block startup."""
+    reolink_connect.subscribe.side_effect = ReolinkError("Test Error")
+    reolink_connect.subscribed.return_value = False
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+
+
+async def test_subscribe_unsuccesfull(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_connect: MagicMock,
+) -> None:
+    """Test that a unsuccessful ONVIF subscription does not block startup."""
+    reolink_connect.subscribed.return_value = False
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+
+
+async def test_initial_ONVIF_not_supported(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_connect: MagicMock,
+) -> None:
+    """Test setup when initial ONVIF is not supported."""
+
+    def test_supported(ch, key):
+        """Test supported function."""
+        if key == "initial_ONVIF_state":
+            return False
+        return True
+
+    reolink_connect.supported = test_supported
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+
+
+async def test_ONVIF_not_supported(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_connect: MagicMock,
+) -> None:
+    """Test setup is not blocked when ONVIF API returns NotSupportedError."""
+
+    def test_supported(ch, key):
+        """Test supported function."""
+        if key == "initial_ONVIF_state":
+            return False
+        return True
+
+    reolink_connect.supported = test_supported
+    reolink_connect.subscribed.return_value = False
+    reolink_connect.subscribe.side_effect = NotSupportedError("Test error")
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+
+
+async def test_renew(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    config_entry: MockConfigEntry,
+    reolink_connect: MagicMock,
+) -> None:
+    """Test renew of the ONVIF subscription."""
+    reolink_connect.renewtimer.return_value = 1
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    freezer.tick(DEVICE_UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    reolink_connect.renew.assert_called()
+
+    reolink_connect.renew.side_effect = SubscriptionError("Test error")
+
+    freezer.tick(DEVICE_UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    reolink_connect.subscribe.assert_called()
+
+    reolink_connect.subscribe.reset_mock()
+    reolink_connect.subscribe.side_effect = SubscriptionError("Test error")
+
+    freezer.tick(DEVICE_UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    reolink_connect.subscribe.assert_called()
+
+
+async def test_long_poll_renew_fail(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    config_entry: MockConfigEntry,
+    reolink_connect: MagicMock,
+) -> None:
+    """Test ONVIF long polling errors while renewing."""
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    reolink_connect.subscribe.side_effect = NotSupportedError("Test error")
+
+    freezer.tick(timedelta(seconds=FIRST_ONVIF_TIMEOUT))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # ensure long polling continues
+    reolink_connect.pull_point_request.assert_called()
+
+
+async def test_register_webhook_errors(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_connect: MagicMock,
+) -> None:
+    """Test errors while registering the webhook."""
+    with patch(
+        "homeassistant.components.reolink.host.get_url",
+        side_effect=NoURLAvailableError("Test error"),
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id) is False
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_long_poll_stop_when_push(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    freezer: FrozenDateTimeFactory,
+    config_entry: MockConfigEntry,
+    reolink_connect: MagicMock,
+) -> None:
+    """Test ONVIF long polling stops when ONVIF push comes in."""
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    # start ONVIF long polling because ONVIF push did not came in
+    freezer.tick(timedelta(seconds=FIRST_ONVIF_TIMEOUT))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # simulate ONVIF push callback
+    client = await hass_client_no_auth()
+    reolink_connect.ONVIF_event_callback.return_value = None
+    webhook_id = f"{DOMAIN}_{TEST_UID.replace(':', '')}_ONVIF"
+    await client.post(f"/api/webhook/{webhook_id}")
+
+    freezer.tick(DEVICE_UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    reolink_connect.unsubscribe.assert_called_with(sub_type=SubType.long_poll)
+
+
+async def test_long_poll_errors(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    config_entry: MockConfigEntry,
+    reolink_connect: MagicMock,
+) -> None:
+    """Test errors during ONVIF long polling."""
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    reolink_connect.pull_point_request.side_effect = ReolinkError("Test error")
+
+    # start ONVIF long polling because ONVIF push did not came in
+    freezer.tick(timedelta(seconds=FIRST_ONVIF_TIMEOUT))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    reolink_connect.pull_point_request.assert_called_once()
+    reolink_connect.pull_point_request.side_effect = Exception("Test error")
+
+    freezer.tick(timedelta(seconds=LONG_POLL_ERROR_COOLDOWN))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(seconds=LONG_POLL_COOLDOWN))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    reolink_connect.unsubscribe.assert_called_with(sub_type=SubType.long_poll)
+
+
+async def test_fast_polling_errors(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    config_entry: MockConfigEntry,
+    reolink_connect: MagicMock,
+) -> None:
+    """Test errors during ONVIF fast polling."""
+    reolink_connect.get_motion_state_all_ch.side_effect = ReolinkError("Test error")
+    reolink_connect.pull_point_request.side_effect = ReolinkError("Test error")
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    # start ONVIF long polling because ONVIF push did not came in
+    freezer.tick(timedelta(seconds=FIRST_ONVIF_TIMEOUT))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # start ONVIF fast polling because ONVIF long polling did not came in
+    freezer.tick(timedelta(seconds=FIRST_ONVIF_LONG_POLL_TIMEOUT))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert reolink_connect.get_motion_state_all_ch.call_count == 1
+
+    freezer.tick(timedelta(seconds=POLL_INTERVAL_NO_PUSH))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # fast polling continues despite errors
+    assert reolink_connect.get_motion_state_all_ch.call_count == 2
+
+
+async def test_diagnostics_event_connection(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_client_no_auth: ClientSessionGenerator,
+    freezer: FrozenDateTimeFactory,
+    reolink_connect: MagicMock,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test Reolink diagnostics event connection return values."""
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    diag = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
+    assert diag["event connection"] == "Fast polling"
+
+    # start ONVIF long polling because ONVIF push did not came in
+    freezer.tick(timedelta(seconds=FIRST_ONVIF_TIMEOUT))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    diag = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
+    assert diag["event connection"] == "ONVIF long polling"
+
+    # simulate ONVIF push callback
+    client = await hass_client_no_auth()
+    reolink_connect.ONVIF_event_callback.return_value = None
+    webhook_id = f"{DOMAIN}_{TEST_UID.replace(':', '')}_ONVIF"
+    await client.post(f"/api/webhook/{webhook_id}")
+
+    diag = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
+    assert diag["event connection"] == "ONVIF push"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add tests for the host.py file

Working towards platinum quality scale such that Reolink can join the Works With HomeAssistant program.

Once this list of PRs is reviewd and merged, the Reolink integration will have 100% coverage:
- https://github.com/home-assistant/core/pull/124577
- https://github.com/home-assistant/core/pull/124380
- https://github.com/home-assistant/core/pull/124381
- https://github.com/home-assistant/core/pull/124382
- https://github.com/home-assistant/core/pull/124472
- https://github.com/home-assistant/core/pull/124482
- https://github.com/home-assistant/core/pull/124521
- https://github.com/home-assistant/core/pull/124474
- https://github.com/home-assistant/core/pull/124465
- https://github.com/home-assistant/core/pull/123862

![afbeelding](https://github.com/user-attachments/assets/7ad36de1-b7a9-4563-8036-aa1d13f9a362)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
