### PR TITLE
Ensure all chars are polling when requesting manual update in homekit_controller

### DIFF
--- a/tests/components/homekit_controller/test_connection.py
+++ b/tests/components/homekit_controller/test_connection.py
@@ -12,6 +12,7 @@ from aiohomekit.testing import FakeController
 import pytest
 
 from homeassistant.components.homekit_controller.const import (
+    DEBOUNCE_COOLDOWN,
     DOMAIN,
     IDENTIFIER_ACCESSORY_ID,
     IDENTIFIER_LEGACY_ACCESSORY_ID,
@@ -22,12 +23,14 @@ from homeassistant.const import STATE_OFF, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.entity_component import async_update_entity
 
 from .common import (
     setup_accessories_from_file,
     setup_platform,
     setup_test_accessories,
     setup_test_component,
+    time_changed,
 )
 
 from tests.common import MockConfigEntry
@@ -399,3 +402,40 @@ async def test_poll_firmware_version_only_all_watchable_accessory_mode(
         state = await helper.poll_and_get_state()
         assert state.state == STATE_OFF
         assert mock_get_characteristics.call_count == 8
+
+
+async def test_manual_poll_all_chars(
+    hass: HomeAssistant, get_next_aid: Callable[[], int]
+) -> None:
+    """Test that a manual poll will check all chars."""
+
+    def _create_accessory(accessory: Accessory) -> Service:
+        service = accessory.add_service(ServicesTypes.LIGHTBULB, name="TestDevice")
+
+        on_char = service.add_char(CharacteristicsTypes.ON)
+        on_char.value = 0
+
+        brightness = service.add_char(CharacteristicsTypes.BRIGHTNESS)
+        brightness.value = 0
+
+        return service
+
+    helper = await setup_test_component(hass, get_next_aid(), _create_accessory)
+
+    with mock.patch.object(
+        helper.pairing,
+        "get_characteristics",
+        wraps=helper.pairing.get_characteristics,
+    ) as mock_get_characteristics:
+        # Initial state is that the light is off
+        await helper.poll_and_get_state()
+        # Verify only firmware version is polled
+        assert mock_get_characteristics.call_args_list[0][0][0] == {(1, 7)}
+
+        # Now do a manual poll to ensure all chars are polled
+        mock_get_characteristics.reset_mock()
+        await async_update_entity(hass, helper.entity_id)
+        await time_changed(hass, 60)
+        await time_changed(hass, DEBOUNCE_COOLDOWN)
+        await hass.async_block_till_done()
+        assert len(mock_get_characteristics.call_args_list[0][0][0]) > 1


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

related issue #123963

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
