### PR TITLE
Add Aruba Instant On integration

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -92,6 +92,7 @@ homeassistant.components.aranet.*
 homeassistant.components.arcam_fmj.*
 homeassistant.components.arris_tg2492lg.*
 homeassistant.components.aruba.*
+homeassistant.components.aruba_instant_on.*
 homeassistant.components.arwn.*
 homeassistant.components.aseko_pool_live.*
 homeassistant.components.assist_pipeline.*

--- a/homeassistant/components/aruba_instant_on/__init__.py
+++ b/homeassistant/components/aruba_instant_on/__init__.py
@@ -1,0 +1,1 @@
+"""The Aruba Instant On component."""

--- a/homeassistant/components/aruba_instant_on/consts.py
+++ b/homeassistant/components/aruba_instant_on/consts.py
@@ -1,0 +1,3 @@
+"""Aruba Instant On constants."""
+
+CONF_SITE_ID = "site_id"

--- a/homeassistant/components/aruba_instant_on/device_tracker.py
+++ b/homeassistant/components/aruba_instant_on/device_tracker.py
@@ -1,0 +1,82 @@
+"""Support for Aruba Instant On Access Points."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+from ion_client import Client
+import voluptuous as vol
+
+from homeassistant.components.device_tracker import (
+    DOMAIN,
+    PLATFORM_SCHEMA as DEVICE_TRACKER_PLATFORM_SCHEMA,
+    DeviceScanner,
+)
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.typing import ConfigType
+
+from .consts import CONF_SITE_ID
+
+_LOGGER = logging.getLogger(__name__)
+
+
+PLATFORM_SCHEMA = DEVICE_TRACKER_PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Required(CONF_SITE_ID): cv.string,
+    }
+)
+
+
+def get_scanner(
+    hass: HomeAssistant, config: ConfigType
+) -> ArubaInstantOnDeviceScanner | None:
+    """Validate the configuration and return a Aruba Instant On scanner."""
+    scanner = ArubaInstantOnDeviceScanner(config[DOMAIN])
+
+    return scanner if scanner.success_init else None
+
+
+class ArubaInstantOnDeviceScanner(DeviceScanner):
+    """Query the Aruba Instant On API for connected devices."""
+
+    def __init__(self, config: dict[str, Any]) -> None:
+        """Initialize the scanner."""
+        self.client = Client(
+            username=config[CONF_USERNAME],
+            password=config[CONF_PASSWORD],
+        )
+        self.site_id = config[CONF_SITE_ID]
+        self.last_results: dict[str, dict[str, str]] = {}
+        self.success_init = self._update_info()
+
+    def scan_devices(self) -> list[str]:
+        """Scan for new devices and return a list with found device IDs."""
+        self._update_info()
+        return list(self.last_results)
+
+    def get_device_name(self, device: str) -> str | None:
+        """Return the name of the given device or None if we don't know."""
+        return self.last_results.get(device, {}).get("name")
+
+    def _update_info(self) -> bool:
+        """Ensure the information from the Aruba Instant On API is up to date.
+
+        Return true if scanning successful.
+        """
+        try:
+            clients = self.client.json(f"/sites/{self.site_id}/clientSummary")
+            self.last_results = {
+                client["id"]: {"mac": client["id"], "name": client["name"]}
+                for client in clients.get("elements", [])
+            }
+        except httpx.HTTPError as e:
+            _LOGGER.error("Aruba Instant On API error: %s", e)
+            return False
+
+        return True

--- a/homeassistant/components/aruba_instant_on/manifest.json
+++ b/homeassistant/components/aruba_instant_on/manifest.json
@@ -1,0 +1,9 @@
+{
+  "domain": "aruba_instant_on",
+  "name": "Aruba Instant On",
+  "codeowners": [],
+  "documentation": "https://www.home-assistant.io/integrations/aruba_instant_on",
+  "iot_class": "local_polling",
+  "loggers": ["ion_client"],
+  "requirements": ["ion-client==1.0.0"]
+}

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -477,6 +477,12 @@
         }
       }
     },
+    "aruba_instant_on": {
+      "name": "Aruba Instant On",
+      "integration_type": "hub",
+      "config_flow": false,
+      "iot_class": "local_polling"
+    },
     "arve": {
       "name": "Arve",
       "integration_type": "hub",

--- a/mypy.ini
+++ b/mypy.ini
@@ -675,6 +675,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.aruba_instant_on.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.arwn.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1181,6 +1181,9 @@ insteon-frontend-home-assistant==0.5.0
 # homeassistant.components.intellifire
 intellifire4py==2.2.2
 
+# homeassistant.components.aruba_instant_on
+ion-client==1.0.0
+
 # homeassistant.components.iotty
 iottycloud==0.1.3
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This adds a Device Tracker integration for [Aruba Instant On](https://www.arubainstanton.com) devices (ethernet switches and Wi-Fi access points). This is distinct from the existing [Aruba](https://www.home-assistant.io/integrations/aruba/) integration which targets higher-end access points with telnet access. Instant On devices are cloud managed and do not expose a local administration interface.

**Note: do not review yet, tests are still missing.**

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/34444

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
