### PR TITLE
Handle LCN entity instances only in corresponding platform

### DIFF
--- a/homeassistant/components/lcn/binary_sensor.py
+++ b/homeassistant/components/lcn/binary_sensor.py
@@ -1,6 +1,7 @@
 """Support for LCN binary sensors."""
 
-from __future__ import annotations
+from collections.abc import Iterable
+from functools import partial
 
 import pypck
 
@@ -25,22 +26,37 @@ from .const import (
 from .helpers import DeviceConnectionType, InputType, get_device_connection
 
 
-def create_lcn_binary_sensor_entity(
-    hass: HomeAssistant, entity_config: ConfigType, config_entry: ConfigEntry
-) -> LcnEntity:
-    """Set up an entity for this domain."""
-    device_connection = get_device_connection(
-        hass, entity_config[CONF_ADDRESS], config_entry
-    )
-
-    if entity_config[CONF_DOMAIN_DATA][CONF_SOURCE] in SETPOINTS:
-        return LcnRegulatorLockSensor(
-            entity_config, config_entry.entry_id, device_connection
+def add_lcn_entities(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+    entity_configs: Iterable[ConfigType],
+) -> None:
+    """Add entities for this domain."""
+    entities: list[LcnRegulatorLockSensor | LcnBinarySensor | LcnLockKeysSensor] = []
+    for entity_config in entity_configs:
+        device_connection = get_device_connection(
+            hass, entity_config[CONF_ADDRESS], config_entry
         )
-    if entity_config[CONF_DOMAIN_DATA][CONF_SOURCE] in BINSENSOR_PORTS:
-        return LcnBinarySensor(entity_config, config_entry.entry_id, device_connection)
-    # in KEY
-    return LcnLockKeysSensor(entity_config, config_entry.entry_id, device_connection)
+
+        if entity_config[CONF_DOMAIN_DATA][CONF_SOURCE] in SETPOINTS:
+            entities.append(
+                LcnRegulatorLockSensor(
+                    entity_config, config_entry.entry_id, device_connection
+                )
+            )
+        elif entity_config[CONF_DOMAIN_DATA][CONF_SOURCE] in BINSENSOR_PORTS:
+            entities.append(
+                LcnBinarySensor(entity_config, config_entry.entry_id, device_connection)
+            )
+        else:  # in KEY
+            entities.append(
+                LcnLockKeysSensor(
+                    entity_config, config_entry.entry_id, device_connection
+                )
+            )
+
+    async_add_entities(entities)
 
 
 async def async_setup_entry(
@@ -49,14 +65,23 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up LCN switch entities from a config entry."""
-    hass.data[DOMAIN][config_entry.entry_id][ADD_ENTITIES_CALLBACKS].update(
-        {DOMAIN_BINARY_SENSOR: (async_add_entities, create_lcn_binary_sensor_entity)}
+    add_entities = partial(
+        add_lcn_entities,
+        hass,
+        config_entry,
+        async_add_entities,
     )
 
-    async_add_entities(
-        create_lcn_binary_sensor_entity(hass, entity_config, config_entry)
-        for entity_config in config_entry.data[CONF_ENTITIES]
-        if entity_config[CONF_DOMAIN] == DOMAIN_BINARY_SENSOR
+    hass.data[DOMAIN][config_entry.entry_id][ADD_ENTITIES_CALLBACKS].update(
+        {DOMAIN_BINARY_SENSOR: add_entities}
+    )
+
+    add_entities(
+        (
+            entity_config
+            for entity_config in config_entry.data[CONF_ENTITIES]
+            if entity_config[CONF_DOMAIN] == DOMAIN_BINARY_SENSOR
+        ),
     )
 
 

--- a/homeassistant/components/lcn/climate.py
+++ b/homeassistant/components/lcn/climate.py
@@ -1,7 +1,7 @@
 """Support for LCN climate control."""
 
-from __future__ import annotations
-
+from collections.abc import Iterable
+from functools import partial
 from typing import Any, cast
 
 import pypck
@@ -41,15 +41,24 @@ from .helpers import DeviceConnectionType, InputType, get_device_connection
 PARALLEL_UPDATES = 0
 
 
-def create_lcn_climate_entity(
-    hass: HomeAssistant, entity_config: ConfigType, config_entry: ConfigEntry
-) -> LcnEntity:
-    """Set up an entity for this domain."""
-    device_connection = get_device_connection(
-        hass, entity_config[CONF_ADDRESS], config_entry
-    )
+def add_lcn_entities(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+    entity_configs: Iterable[ConfigType],
+) -> None:
+    """Add entities for this domain."""
+    entities: list[LcnClimate] = []
+    for entity_config in entity_configs:
+        device_connection = get_device_connection(
+            hass, entity_config[CONF_ADDRESS], config_entry
+        )
 
-    return LcnClimate(entity_config, config_entry.entry_id, device_connection)
+        entities.append(
+            LcnClimate(entity_config, config_entry.entry_id, device_connection)
+        )
+
+    async_add_entities(entities)
 
 
 async def async_setup_entry(
@@ -58,14 +67,23 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up LCN switch entities from a config entry."""
-    hass.data[DOMAIN][config_entry.entry_id][ADD_ENTITIES_CALLBACKS].update(
-        {DOMAIN_CLIMATE: (async_add_entities, create_lcn_climate_entity)}
+    add_entities = partial(
+        add_lcn_entities,
+        hass,
+        config_entry,
+        async_add_entities,
     )
 
-    async_add_entities(
-        create_lcn_climate_entity(hass, entity_config, config_entry)
-        for entity_config in config_entry.data[CONF_ENTITIES]
-        if entity_config[CONF_DOMAIN] == DOMAIN_CLIMATE
+    hass.data[DOMAIN][config_entry.entry_id][ADD_ENTITIES_CALLBACKS].update(
+        {DOMAIN_CLIMATE: add_entities}
+    )
+
+    add_entities(
+        (
+            entity_config
+            for entity_config in config_entry.data[CONF_ENTITIES]
+            if entity_config[CONF_DOMAIN] == DOMAIN_CLIMATE
+        ),
     )
 
 

--- a/homeassistant/components/lcn/light.py
+++ b/homeassistant/components/lcn/light.py
@@ -1,7 +1,7 @@
 """Support for LCN lights."""
 
-from __future__ import annotations
-
+from collections.abc import Iterable
+from functools import partial
 from typing import Any
 
 import pypck
@@ -35,18 +35,29 @@ from .helpers import DeviceConnectionType, InputType, get_device_connection
 PARALLEL_UPDATES = 0
 
 
-def create_lcn_light_entity(
-    hass: HomeAssistant, entity_config: ConfigType, config_entry: ConfigEntry
-) -> LcnEntity:
-    """Set up an entity for this domain."""
-    device_connection = get_device_connection(
-        hass, entity_config[CONF_ADDRESS], config_entry
-    )
+def add_lcn_entities(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+    entity_configs: Iterable[ConfigType],
+) -> None:
+    """Add entities for this domain."""
+    entities: list[LcnOutputLight | LcnRelayLight] = []
+    for entity_config in entity_configs:
+        device_connection = get_device_connection(
+            hass, entity_config[CONF_ADDRESS], config_entry
+        )
 
-    if entity_config[CONF_DOMAIN_DATA][CONF_OUTPUT] in OUTPUT_PORTS:
-        return LcnOutputLight(entity_config, config_entry.entry_id, device_connection)
-    # in RELAY_PORTS
-    return LcnRelayLight(entity_config, config_entry.entry_id, device_connection)
+        if entity_config[CONF_DOMAIN_DATA][CONF_OUTPUT] in OUTPUT_PORTS:
+            entities.append(
+                LcnOutputLight(entity_config, config_entry.entry_id, device_connection)
+            )
+        else:  # in RELAY_PORTS
+            entities.append(
+                LcnRelayLight(entity_config, config_entry.entry_id, device_connection)
+            )
+
+    async_add_entities(entities)
 
 
 async def async_setup_entry(
@@ -55,14 +66,23 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up LCN light entities from a config entry."""
-    hass.data[DOMAIN][config_entry.entry_id][ADD_ENTITIES_CALLBACKS].update(
-        {DOMAIN_LIGHT: (async_add_entities, create_lcn_light_entity)}
+    add_entities = partial(
+        add_lcn_entities,
+        hass,
+        config_entry,
+        async_add_entities,
     )
 
-    async_add_entities(
-        create_lcn_light_entity(hass, entity_config, config_entry)
-        for entity_config in config_entry.data[CONF_ENTITIES]
-        if entity_config[CONF_DOMAIN] == DOMAIN_LIGHT
+    hass.data[DOMAIN][config_entry.entry_id][ADD_ENTITIES_CALLBACKS].update(
+        {DOMAIN_LIGHT: add_entities}
+    )
+
+    add_entities(
+        (
+            entity_config
+            for entity_config in config_entry.data[CONF_ENTITIES]
+            if entity_config[CONF_DOMAIN] == DOMAIN_LIGHT
+        ),
     )
 
 

--- a/homeassistant/components/lcn/scene.py
+++ b/homeassistant/components/lcn/scene.py
@@ -1,7 +1,7 @@
 """Support for LCN scenes."""
 
-from __future__ import annotations
-
+from collections.abc import Iterable
+from functools import partial
 from typing import Any
 
 import pypck
@@ -28,15 +28,24 @@ from .helpers import DeviceConnectionType, get_device_connection
 PARALLEL_UPDATES = 0
 
 
-def create_lcn_scene_entity(
-    hass: HomeAssistant, entity_config: ConfigType, config_entry: ConfigEntry
-) -> LcnEntity:
-    """Set up an entity for this domain."""
-    device_connection = get_device_connection(
-        hass, entity_config[CONF_ADDRESS], config_entry
-    )
+def add_lcn_entities(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+    entity_configs: Iterable[ConfigType],
+) -> None:
+    """Add entities for this domain."""
+    entities: list[LcnScene] = []
+    for entity_config in entity_configs:
+        device_connection = get_device_connection(
+            hass, entity_config[CONF_ADDRESS], config_entry
+        )
 
-    return LcnScene(entity_config, config_entry.entry_id, device_connection)
+        entities.append(
+            LcnScene(entity_config, config_entry.entry_id, device_connection)
+        )
+
+    async_add_entities(entities)
 
 
 async def async_setup_entry(
@@ -45,14 +54,23 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up LCN switch entities from a config entry."""
-    hass.data[DOMAIN][config_entry.entry_id][ADD_ENTITIES_CALLBACKS].update(
-        {DOMAIN_SCENE: (async_add_entities, create_lcn_scene_entity)}
+    add_entities = partial(
+        add_lcn_entities,
+        hass,
+        config_entry,
+        async_add_entities,
     )
 
-    async_add_entities(
-        create_lcn_scene_entity(hass, entity_config, config_entry)
-        for entity_config in config_entry.data[CONF_ENTITIES]
-        if entity_config[CONF_DOMAIN] == DOMAIN_SCENE
+    hass.data[DOMAIN][config_entry.entry_id][ADD_ENTITIES_CALLBACKS].update(
+        {DOMAIN_SCENE: add_entities}
+    )
+
+    add_entities(
+        (
+            entity_config
+            for entity_config in config_entry.data[CONF_ENTITIES]
+            if entity_config[CONF_DOMAIN] == DOMAIN_SCENE
+        ),
     )
 
 

--- a/homeassistant/components/lcn/sensor.py
+++ b/homeassistant/components/lcn/sensor.py
@@ -1,7 +1,7 @@
 """Support for LCN sensors."""
 
-from __future__ import annotations
-
+from collections.abc import Iterable
+from functools import partial
 from itertools import chain
 from typing import cast
 
@@ -34,22 +34,35 @@ from .const import (
 from .helpers import DeviceConnectionType, InputType, get_device_connection
 
 
-def create_lcn_sensor_entity(
-    hass: HomeAssistant, entity_config: ConfigType, config_entry: ConfigEntry
-) -> LcnEntity:
-    """Set up an entity for this domain."""
-    device_connection = get_device_connection(
-        hass, entity_config[CONF_ADDRESS], config_entry
-    )
-
-    if entity_config[CONF_DOMAIN_DATA][CONF_SOURCE] in chain(
-        VARIABLES, SETPOINTS, THRESHOLDS, S0_INPUTS
-    ):
-        return LcnVariableSensor(
-            entity_config, config_entry.entry_id, device_connection
+def add_lcn_entities(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+    entity_configs: Iterable[ConfigType],
+) -> None:
+    """Add entities for this domain."""
+    entities: list[LcnVariableSensor | LcnLedLogicSensor] = []
+    for entity_config in entity_configs:
+        device_connection = get_device_connection(
+            hass, entity_config[CONF_ADDRESS], config_entry
         )
-    # in LED_PORTS + LOGICOP_PORTS
-    return LcnLedLogicSensor(entity_config, config_entry.entry_id, device_connection)
+
+        if entity_config[CONF_DOMAIN_DATA][CONF_SOURCE] in chain(
+            VARIABLES, SETPOINTS, THRESHOLDS, S0_INPUTS
+        ):
+            entities.append(
+                LcnVariableSensor(
+                    entity_config, config_entry.entry_id, device_connection
+                )
+            )
+        else:  # in LED_PORTS + LOGICOP_PORTS
+            entities.append(
+                LcnLedLogicSensor(
+                    entity_config, config_entry.entry_id, device_connection
+                )
+            )
+
+    async_add_entities(entities)
 
 
 async def async_setup_entry(
@@ -58,14 +71,23 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up LCN switch entities from a config entry."""
-    hass.data[DOMAIN][config_entry.entry_id][ADD_ENTITIES_CALLBACKS].update(
-        {DOMAIN_SENSOR: (async_add_entities, create_lcn_sensor_entity)}
+    add_entities = partial(
+        add_lcn_entities,
+        hass,
+        config_entry,
+        async_add_entities,
     )
 
-    async_add_entities(
-        create_lcn_sensor_entity(hass, entity_config, config_entry)
-        for entity_config in config_entry.data[CONF_ENTITIES]
-        if entity_config[CONF_DOMAIN] == DOMAIN_SENSOR
+    hass.data[DOMAIN][config_entry.entry_id][ADD_ENTITIES_CALLBACKS].update(
+        {DOMAIN_SENSOR: add_entities}
+    )
+
+    add_entities(
+        (
+            entity_config
+            for entity_config in config_entry.data[CONF_ENTITIES]
+            if entity_config[CONF_DOMAIN] == DOMAIN_SENSOR
+        ),
     )
 
 

--- a/homeassistant/components/lcn/switch.py
+++ b/homeassistant/components/lcn/switch.py
@@ -1,7 +1,7 @@
 """Support for LCN switches."""
 
-from __future__ import annotations
-
+from collections.abc import Iterable
+from functools import partial
 from typing import Any
 
 import pypck
@@ -26,18 +26,29 @@ from .helpers import DeviceConnectionType, InputType, get_device_connection
 PARALLEL_UPDATES = 0
 
 
-def create_lcn_switch_entity(
-    hass: HomeAssistant, entity_config: ConfigType, config_entry: ConfigEntry
-) -> LcnEntity:
-    """Set up an entity for this domain."""
-    device_connection = get_device_connection(
-        hass, entity_config[CONF_ADDRESS], config_entry
-    )
+def add_lcn_switch_entities(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+    entity_configs: Iterable[ConfigType],
+) -> None:
+    """Add entities for this domain."""
+    entities: list[LcnOutputSwitch | LcnRelaySwitch] = []
+    for entity_config in entity_configs:
+        device_connection = get_device_connection(
+            hass, entity_config[CONF_ADDRESS], config_entry
+        )
 
-    if entity_config[CONF_DOMAIN_DATA][CONF_OUTPUT] in OUTPUT_PORTS:
-        return LcnOutputSwitch(entity_config, config_entry.entry_id, device_connection)
-    # in RELAY_PORTS
-    return LcnRelaySwitch(entity_config, config_entry.entry_id, device_connection)
+        if entity_config[CONF_DOMAIN_DATA][CONF_OUTPUT] in OUTPUT_PORTS:
+            entities.append(
+                LcnOutputSwitch(entity_config, config_entry.entry_id, device_connection)
+            )
+        else:  # in RELAY_PORTS
+            entities.append(
+                LcnRelaySwitch(entity_config, config_entry.entry_id, device_connection)
+            )
+
+    async_add_entities(entities)
 
 
 async def async_setup_entry(
@@ -46,14 +57,23 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up LCN switch entities from a config entry."""
-    hass.data[DOMAIN][config_entry.entry_id][ADD_ENTITIES_CALLBACKS].update(
-        {DOMAIN_SWITCH: (async_add_entities, create_lcn_switch_entity)}
+    add_entities = partial(
+        add_lcn_switch_entities,
+        hass,
+        config_entry,
+        async_add_entities,
     )
 
-    async_add_entities(
-        create_lcn_switch_entity(hass, entity_config, config_entry)
-        for entity_config in config_entry.data[CONF_ENTITIES]
-        if entity_config[CONF_DOMAIN] == DOMAIN_SWITCH
+    hass.data[DOMAIN][config_entry.entry_id][ADD_ENTITIES_CALLBACKS].update(
+        {DOMAIN_SWITCH: add_entities}
+    )
+
+    add_entities(
+        (
+            entity_config
+            for entity_config in config_entry.data[CONF_ENTITIES]
+            if entity_config[CONF_DOMAIN] == DOMAIN_SWITCH
+        ),
     )
 
 

--- a/homeassistant/components/lcn/websocket.py
+++ b/homeassistant/components/lcn/websocket.py
@@ -341,11 +341,10 @@ async def websocket_add_entity(
     }
 
     # Create new entity and add to corresponding component
-    callbacks = hass.data[DOMAIN][msg["entry_id"]][ADD_ENTITIES_CALLBACKS]
-    async_add_entities, create_lcn_entity = callbacks[msg[CONF_DOMAIN]]
-
-    entity = create_lcn_entity(hass, entity_config, config_entry)
-    async_add_entities([entity])
+    add_entities = hass.data[DOMAIN][msg["entry_id"]][ADD_ENTITIES_CALLBACKS][
+        msg[CONF_DOMAIN]
+    ]
+    add_entities([entity_config])
 
     # Add entity config to config_entry
     entity_configs = [*config_entry.data[CONF_ENTITIES], entity_config]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
When adding new entities by a websocket command, the created entity instance was exposed outside of the corresponding platform.
With the proposed changes the platform is providing just an ´add_entities` function which hides the created entity instances.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
