### PR TITLE
Use speex for noise suppression and auto gain

### DIFF
--- a/homeassistant/components/assist_pipeline/manifest.json
+++ b/homeassistant/components/assist_pipeline/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "system",
   "iot_class": "local_push",
   "quality_scale": "internal",
-  "requirements": ["pymicro-vad==1.0.1"]
+  "requirements": ["pymicro-vad==1.0.1", "pyspeex-noise==1.0.0"]
 }

--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -49,7 +49,7 @@ from homeassistant.util import (
 )
 from homeassistant.util.limited_size_dict import LimitedSizeDict
 
-from .audio_enhancer import AudioEnhancer, EnhancedAudioChunk, MicroVadEnhancer
+from .audio_enhancer import AudioEnhancer, EnhancedAudioChunk, MicroVadSpeexEnhancer
 from .const import (
     BYTES_PER_CHUNK,
     CONF_DEBUG_RECORDING_DIR,
@@ -589,7 +589,7 @@ class PipelineRun:
         # Initialize with audio settings
         if self.audio_settings.needs_processor and (self.audio_enhancer is None):
             # Default audio enhancer
-            self.audio_enhancer = MicroVadEnhancer(
+            self.audio_enhancer = MicroVadSpeexEnhancer(
                 self.audio_settings.auto_gain_dbfs,
                 self.audio_settings.noise_suppression_level,
                 self.audio_settings.is_vad_enabled,

--- a/homeassistant/components/voip/voip.py
+++ b/homeassistant/components/voip/voip.py
@@ -33,7 +33,7 @@ from homeassistant.components.assist_pipeline import (
 )
 from homeassistant.components.assist_pipeline.audio_enhancer import (
     AudioEnhancer,
-    MicroVadEnhancer,
+    MicroVadSpeexEnhancer,
 )
 from homeassistant.components.assist_pipeline.vad import (
     AudioBuffer,
@@ -235,7 +235,7 @@ class PipelineRtpDatagramProtocol(RtpDatagramProtocol):
         try:
             # Wait for speech before starting pipeline
             segmenter = VoiceCommandSegmenter(silence_seconds=self.silence_seconds)
-            audio_enhancer = MicroVadEnhancer(0, 0, True)
+            audio_enhancer = MicroVadSpeexEnhancer(0, 0, True)
             chunk_buffer: deque[bytes] = deque(
                 maxlen=self.buffered_chunks_before_speech,
             )

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -49,6 +49,7 @@ pymicro-vad==1.0.1
 PyNaCl==1.5.0
 pyOpenSSL==24.2.1
 pyserial==3.5
+pyspeex-noise==1.0.0
 python-slugify==8.0.4
 PyTurboJPEG==1.7.1
 pyudev==0.24.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2228,6 +2228,9 @@ pysoma==0.0.12
 # homeassistant.components.spc
 pyspcwebgw==0.7.0
 
+# homeassistant.components.assist_pipeline
+pyspeex-noise==1.0.0
+
 # homeassistant.components.squeezebox
 pysqueezebox==0.7.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1782,6 +1782,9 @@ pysoma==0.0.12
 # homeassistant.components.spc
 pyspcwebgw==0.7.0
 
+# homeassistant.components.assist_pipeline
+pyspeex-noise==1.0.0
+
 # homeassistant.components.squeezebox
 pysqueezebox==0.7.1
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Audio enhancement using webrtc in Assist was removed in 2024.8 due to it being a complex dependency to manage. However, some users have reported difficulties with voice recognition without noise suppression and automatic gain control.

There are plans to move the old webrtc functionality into an add-on, but this will take time. For now this PR adds **speex**, an older (but much easier to compile) audio enhancement library. A wrapper library `pyspeex-noise` is used around the original C code: https://github.com/rhasspy/pyspeex-noise/releases/tag/1.0.0

Other than an additional dependency, the only complexity added is that the `auto_gain` and `noise_suppression` parameters used in Assist are automatically scaled from the ranges in webrtc to the ranges in speex.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
