### PR TITLE
Remove HVAC Modes when no scopes in Teslemetry

### DIFF
--- a/homeassistant/components/teslemetry/climate.py
+++ b/homeassistant/components/teslemetry/climate.py
@@ -84,13 +84,14 @@ class TeslemetryClimateEntity(TeslemetryVehicleEntity, ClimateEntity):
     ) -> None:
         """Initialize the climate."""
         self.scoped = Scope.VEHICLE_CMDS in scopes
-        if not self.scoped:
-            self._attr_supported_features = ClimateEntityFeature(0)
 
         super().__init__(
             data,
             side,
         )
+
+        if not self.scoped:
+            self._attr_supported_features = ClimateEntityFeature(0)
 
     def _async_update_attrs(self) -> None:
         """Update the attributes of the entity."""
@@ -211,18 +212,17 @@ class TeslemetryCabinOverheatProtectionEntity(TeslemetryVehicleEntity, ClimateEn
     ) -> None:
         """Initialize the climate."""
 
+        self.scoped = Scope.VEHICLE_CMDS in scopes
         super().__init__(data, "climate_state_cabin_overheat_protection")
 
         # Supported Features
-        self._attr_supported_features = (
-            ClimateEntityFeature.TURN_ON | ClimateEntityFeature.TURN_OFF
-        )
-        if self.get("vehicle_config_cop_user_set_temp_supported"):
-            self._attr_supported_features |= ClimateEntityFeature.TARGET_TEMPERATURE
-
-        # Scopes
-        self.scoped = Scope.VEHICLE_CMDS in scopes
-        if not self.scoped:
+        if self.scoped:
+            self._attr_supported_features = (
+                ClimateEntityFeature.TURN_ON | ClimateEntityFeature.TURN_OFF
+            )
+            if self.get("vehicle_config_cop_user_set_temp_supported"):
+                self._attr_supported_features |= ClimateEntityFeature.TARGET_TEMPERATURE
+        else:
             self._attr_supported_features = ClimateEntityFeature(0)
 
     def _async_update_attrs(self) -> None:

--- a/homeassistant/components/teslemetry/climate.py
+++ b/homeassistant/components/teslemetry/climate.py
@@ -102,6 +102,10 @@ class TeslemetryClimateEntity(TeslemetryVehicleEntity, ClimateEntity):
         else:
             self._attr_hvac_mode = HVACMode.OFF
 
+        # If not scoped, prevent the user from changing the HVAC mode by making it the only option
+        if self._attr_hvac_mode and not self.scoped:
+            self._attr_hvac_modes = [self._attr_hvac_mode]
+
         self._attr_current_temperature = self.get("climate_state_inside_temp")
         self._attr_target_temperature = self.get(f"climate_state_{self.key}_setting")
         self._attr_preset_mode = self.get("climate_state_climate_keeper_mode")
@@ -228,6 +232,10 @@ class TeslemetryCabinOverheatProtectionEntity(TeslemetryVehicleEntity, ClimateEn
             self._attr_hvac_mode = None
         else:
             self._attr_hvac_mode = COP_MODES.get(state)
+
+        # If not scoped, prevent the user from changing the HVAC mode by making it the only option
+        if self._attr_hvac_mode and not self.scoped:
+            self._attr_hvac_modes = [self._attr_hvac_mode]
 
         if (level := self.get("climate_state_cop_activation_temperature")) is None:
             self._attr_target_temperature = None

--- a/homeassistant/components/teslemetry/climate.py
+++ b/homeassistant/components/teslemetry/climate.py
@@ -119,7 +119,6 @@ class TeslemetryClimateEntity(TeslemetryVehicleEntity, ClimateEntity):
 
     async def async_turn_on(self) -> None:
         """Set the climate state to on."""
-
         self.raise_for_scope()
         await self.wake_up_if_asleep()
         await handle_vehicle_command(self.api.auto_conditioning_start())
@@ -129,7 +128,6 @@ class TeslemetryClimateEntity(TeslemetryVehicleEntity, ClimateEntity):
 
     async def async_turn_off(self) -> None:
         """Set the climate state to off."""
-
         self.raise_for_scope()
         await self.wake_up_if_asleep()
         await handle_vehicle_command(self.api.auto_conditioning_stop())
@@ -140,7 +138,7 @@ class TeslemetryClimateEntity(TeslemetryVehicleEntity, ClimateEntity):
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set the climate temperature."""
-
+        self.raise_for_scope()
         if temp := kwargs.get(ATTR_TEMPERATURE):
             await self.wake_up_if_asleep()
             await handle_vehicle_command(
@@ -166,6 +164,7 @@ class TeslemetryClimateEntity(TeslemetryVehicleEntity, ClimateEntity):
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the climate preset mode."""
+        self.raise_for_scope()
         await self.wake_up_if_asleep()
         await handle_vehicle_command(
             self.api.set_climate_keeper_mode(

--- a/homeassistant/components/teslemetry/climate.py
+++ b/homeassistant/components/teslemetry/climate.py
@@ -138,7 +138,6 @@ class TeslemetryClimateEntity(TeslemetryVehicleEntity, ClimateEntity):
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set the climate temperature."""
-        self.raise_for_scope()
         if temp := kwargs.get(ATTR_TEMPERATURE):
             await self.wake_up_if_asleep()
             await handle_vehicle_command(
@@ -164,7 +163,6 @@ class TeslemetryClimateEntity(TeslemetryVehicleEntity, ClimateEntity):
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the climate preset mode."""
-        self.raise_for_scope()
         await self.wake_up_if_asleep()
         await handle_vehicle_command(
             self.api.set_climate_keeper_mode(
@@ -253,8 +251,6 @@ class TeslemetryCabinOverheatProtectionEntity(TeslemetryVehicleEntity, ClimateEn
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set the climate temperature."""
-        self.raise_for_scope()
-
         if not (temp := kwargs.get(ATTR_TEMPERATURE)):
             return
 

--- a/homeassistant/components/teslemetry/climate.py
+++ b/homeassistant/components/teslemetry/climate.py
@@ -85,13 +85,14 @@ class TeslemetryClimateEntity(TeslemetryVehicleEntity, ClimateEntity):
         """Initialize the climate."""
         self.scoped = Scope.VEHICLE_CMDS in scopes
 
+        if not self.scoped:
+            self._attr_supported_features = ClimateEntityFeature(0)
+            self._attr_hvac_modes = []
+
         super().__init__(
             data,
             side,
         )
-
-        if not self.scoped:
-            self._attr_supported_features = ClimateEntityFeature(0)
 
     def _async_update_attrs(self) -> None:
         """Update the attributes of the entity."""
@@ -210,17 +211,19 @@ class TeslemetryCabinOverheatProtectionEntity(TeslemetryVehicleEntity, ClimateEn
         """Initialize the climate."""
 
         self.scoped = Scope.VEHICLE_CMDS in scopes
-        super().__init__(data, "climate_state_cabin_overheat_protection")
-
-        # Supported Features
         if self.scoped:
             self._attr_supported_features = (
                 ClimateEntityFeature.TURN_ON | ClimateEntityFeature.TURN_OFF
             )
-            if self.get("vehicle_config_cop_user_set_temp_supported"):
-                self._attr_supported_features |= ClimateEntityFeature.TARGET_TEMPERATURE
         else:
             self._attr_supported_features = ClimateEntityFeature(0)
+            self._attr_hvac_modes = []
+
+        super().__init__(data, "climate_state_cabin_overheat_protection")
+
+        # Supported Features from data
+        if self.scoped and self.get("vehicle_config_cop_user_set_temp_supported"):
+            self._attr_supported_features |= ClimateEntityFeature.TARGET_TEMPERATURE
 
     def _async_update_attrs(self) -> None:
         """Update the attributes of the entity."""

--- a/tests/components/teslemetry/snapshots/test_climate.ambr
+++ b/tests/components/teslemetry/snapshots/test_climate.ambr
@@ -280,6 +280,85 @@
     'state': 'off',
   })
 # ---
+# name: test_climate_noscope[climate.test_cabin_overheat_protection-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.COOL: 'cool'>,
+      ]),
+      'max_temp': 40,
+      'min_temp': 30,
+      'target_temp_step': 5,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.test_cabin_overheat_protection',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Cabin overheat protection',
+    'platform': 'teslemetry',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'climate_state_cabin_overheat_protection',
+    'unique_id': 'LRWXF7EK4KC700000-climate_state_cabin_overheat_protection',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_climate_noscope[climate.test_climate-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.HEAT_COOL: 'heat_cool'>,
+      ]),
+      'max_temp': 28.0,
+      'min_temp': 15.0,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.test_climate',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Climate',
+    'platform': 'teslemetry',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': <TeslemetryClimateSide.DRIVER: 'driver_temp'>,
+    'unique_id': 'LRWXF7EK4KC700000-driver_temp',
+    'unit_of_measurement': None,
+  })
+# ---
 # name: test_climate_offline[climate.test_cabin_overheat_protection-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently if a user doesnt have the scope to make changes to the Climate entity it still shows the HVAC Modes since this cannot be removed with supported features. This PR takes feedback from https://github.com/home-assistant/core/pull/123169 and limits the HVAC modes to the currently mode when the user hasnt provided the required scope.

It also does a small refactor of how supported features are set.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
