### PR TITLE
Update overkiz Atlantic Water Heater operation mode switching

### DIFF
--- a/homeassistant/components/overkiz/binary_sensor.py
+++ b/homeassistant/components/overkiz/binary_sensor.py
@@ -115,14 +115,16 @@ BINARY_SENSOR_DESCRIPTIONS: list[OverkizBinarySensorDescription] = [
     OverkizBinarySensorDescription(
         key=OverkizState.MODBUSLINK_DHW_ABSENCE_MODE,
         name="Absence mode",
-        value_fn=lambda state: state
-        in (OverkizCommandParam.ON, OverkizCommandParam.PROG),
+        value_fn=(
+            lambda state: state in (OverkizCommandParam.ON, OverkizCommandParam.PROG)
+        ),
     ),
     OverkizBinarySensorDescription(
         key=OverkizState.MODBUSLINK_DHW_BOOST_MODE,
         name="Boost mode",
-        value_fn=lambda state: state
-        in (OverkizCommandParam.ON, OverkizCommandParam.PROG),
+        value_fn=(
+            lambda state: state in (OverkizCommandParam.ON, OverkizCommandParam.PROG)
+        ),
     ),
 ]
 

--- a/homeassistant/components/overkiz/binary_sensor.py
+++ b/homeassistant/components/overkiz/binary_sensor.py
@@ -126,6 +126,14 @@ BINARY_SENSOR_DESCRIPTIONS: list[OverkizBinarySensorDescription] = [
             lambda state: state in (OverkizCommandParam.ON, OverkizCommandParam.PROG)
         ),
     ),
+    OverkizBinarySensorDescription(
+        key=OverkizState.MODBUSLINK_DHW_MODE,
+        name="Manual mode",
+        value_fn=(
+            lambda state: state
+            in (OverkizCommandParam.MANUAL, OverkizCommandParam.MANUAL_ECO_INACTIVE)
+        ),
+    ),
 ]
 
 SUPPORTED_STATES = {

--- a/homeassistant/components/overkiz/water_heater_entities/atlantic_domestic_hot_water_production_mlb_component.py
+++ b/homeassistant/components/overkiz/water_heater_entities/atlantic_domestic_hot_water_production_mlb_component.py
@@ -147,6 +147,8 @@ class AtlanticDomesticHotWaterProductionMBLComponent(OverkizEntity, WaterHeaterE
             await self.executor.async_execute_command(
                 OverkizCommand.SET_DHW_MODE, OverkizCommandParam.MANUAL_ECO_INACTIVE
             )
+        elif operation_mode == STATE_OFF:
+            await self.async_turn_away_mode_on()
 
     async def async_turn_away_mode_on(self) -> None:
         """Turn away mode on."""

--- a/homeassistant/components/overkiz/water_heater_entities/atlantic_domestic_hot_water_production_mlb_component.py
+++ b/homeassistant/components/overkiz/water_heater_entities/atlantic_domestic_hot_water_production_mlb_component.py
@@ -147,14 +147,6 @@ class AtlanticDomesticHotWaterProductionMBLComponent(OverkizEntity, WaterHeaterE
             await self.executor.async_execute_command(
                 OverkizCommand.SET_DHW_MODE, OverkizCommandParam.MANUAL_ECO_INACTIVE
             )
-        else:
-            if self.is_away_mode_on:
-                await self.async_turn_away_mode_off()
-            if self.is_boost_mode_on:
-                await self.async_turn_boost_mode_off()
-            await self.executor.async_execute_command(
-                OverkizCommand.SET_DHW_MODE, operation_mode
-            )
 
     async def async_turn_away_mode_on(self) -> None:
         """Turn away mode on."""

--- a/homeassistant/components/overkiz/water_heater_entities/atlantic_domestic_hot_water_production_mlb_component.py
+++ b/homeassistant/components/overkiz/water_heater_entities/atlantic_domestic_hot_water_production_mlb_component.py
@@ -6,6 +6,7 @@ from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
 from homeassistant.components.water_heater import (
     STATE_ECO,
+    STATE_ELECTRIC,
     STATE_OFF,
     STATE_PERFORMANCE,
     WaterHeaterEntity,
@@ -28,9 +29,10 @@ class AtlanticDomesticHotWaterProductionMBLComponent(OverkizEntity, WaterHeaterE
         | WaterHeaterEntityFeature.ON_OFF
     )
     _attr_operation_list = [
-        OverkizCommandParam.PERFORMANCE,
-        OverkizCommandParam.ECO,
-        OverkizCommandParam.MANUAL,
+        STATE_ECO,
+        STATE_OFF,
+        STATE_PERFORMANCE,
+        STATE_ELECTRIC,
     ]
 
     def __init__(
@@ -116,7 +118,10 @@ class AtlanticDomesticHotWaterProductionMBLComponent(OverkizEntity, WaterHeaterE
             cast(str, self.executor.select_state(OverkizState.MODBUSLINK_DHW_MODE))
             == OverkizCommandParam.MANUAL_ECO_INACTIVE
         ):
-            return OverkizCommandParam.MANUAL
+            # STATE_ELECTRIC is a substitution for OverkizCommandParam.MANUAL
+            # to keep up with the conventional state usage only
+            # https://developers.home-assistant.io/docs/core/entity/water-heater/#states
+            return STATE_ELECTRIC
 
         return STATE_OFF
 
@@ -140,6 +145,7 @@ class AtlanticDomesticHotWaterProductionMBLComponent(OverkizEntity, WaterHeaterE
         elif operation_mode in (
             OverkizCommandParam.MANUAL,
             OverkizCommandParam.MANUAL_ECO_INACTIVE,
+            STATE_ELECTRIC,
         ):
             if self.is_away_mode_on:
                 await self.async_turn_away_mode_off()

--- a/homeassistant/components/overkiz/water_heater_entities/atlantic_domestic_hot_water_production_mlb_component.py
+++ b/homeassistant/components/overkiz/water_heater_entities/atlantic_domestic_hot_water_production_mlb_component.py
@@ -127,14 +127,11 @@ class AtlanticDomesticHotWaterProductionMBLComponent(OverkizEntity, WaterHeaterE
 
     async def async_set_operation_mode(self, operation_mode: str) -> None:
         """Set new operation mode."""
-        if operation_mode in (STATE_PERFORMANCE, OverkizCommandParam.BOOST):
+        if operation_mode == STATE_PERFORMANCE:
             if self.is_away_mode_on:
                 await self.async_turn_away_mode_off()
             await self.async_turn_boost_mode_on()
-        elif operation_mode in (
-            OverkizCommandParam.ECO,
-            OverkizCommandParam.MANUAL_ECO_ACTIVE,
-        ):
+        elif operation_mode == STATE_ECO:
             if self.is_away_mode_on:
                 await self.async_turn_away_mode_off()
             if self.is_boost_mode_on:
@@ -142,11 +139,7 @@ class AtlanticDomesticHotWaterProductionMBLComponent(OverkizEntity, WaterHeaterE
             await self.executor.async_execute_command(
                 OverkizCommand.SET_DHW_MODE, OverkizCommandParam.AUTO_MODE
             )
-        elif operation_mode in (
-            OverkizCommandParam.MANUAL,
-            OverkizCommandParam.MANUAL_ECO_INACTIVE,
-            STATE_ELECTRIC,
-        ):
+        elif operation_mode == STATE_ELECTRIC:
             if self.is_away_mode_on:
                 await self.async_turn_away_mode_off()
             if self.is_boost_mode_on:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
As discussed here https://github.com/home-assistant/core/pull/114178#discussion_r1730404393 , for Atlantic CozyTouch Water Heaters to support only conventional operation states, Manual operation mode should be triggered via one of the conventional operation modes. For the sake of consistency, the `electric` mode was chosen. For users to clearly distinguish the Manual mode state without confusion, a binary sensor for the Manual operation mode has also been introduced. Users that have automations or scripts using these entities together with the Manual mode should update the automations or scripts accordingly.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Based on @MartinHjelmare request https://github.com/home-assistant/core/pull/114178#discussion_r1730404393 to keep up with the [conventional water heater operation state](https://developers.home-assistant.io/docs/core/entity/water-heater/#states) usage, this PR proposes changing Cozytouch unconventional `manual` operation state for the Atlantic CozyTouch Water Heaters to the conventional `STATE_ELECTRIC`.
For the users to be able to correctly distinguish the manual mode, a binary sensor has been provided.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #114178
- This PR is related to issue: #114178
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
