### PR TITLE
Allow specifying icons for service sections

### DIFF
--- a/homeassistant/components/kitchen_sink/__init__.py
+++ b/homeassistant/components/kitchen_sink/__init__.py
@@ -18,7 +18,7 @@ from homeassistant.components.recorder.statistics import (
 )
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import Platform, UnitOfEnergy, UnitOfTemperature, UnitOfVolume
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.typing import ConfigType
@@ -48,6 +48,13 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             DOMAIN, context={"source": SOURCE_IMPORT}, data={}
         )
     )
+
+    @callback
+    def service_handler(call: ServiceCall | None = None) -> None:
+        """Do nothing."""
+
+    hass.services.async_register(DOMAIN, "test_service_1", service_handler)
+
     return True
 
 

--- a/homeassistant/components/kitchen_sink/__init__.py
+++ b/homeassistant/components/kitchen_sink/__init__.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import datetime
 from random import random
 
+import voluptuous as vol
+
 from homeassistant.components.recorder import DOMAIN as RECORDER_DOMAIN, get_instance
 from homeassistant.components.recorder.models import StatisticData, StatisticMetaData
 from homeassistant.components.recorder.statistics import (
@@ -40,6 +42,15 @@ COMPONENTS_WITH_DEMO_PLATFORM = [
 
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
+SCHEMA_SERVICE_TEST_SERVICE_1 = vol.Schema(
+    {
+        vol.Required("field_1"): vol.Coerce(int),
+        vol.Required("field_2"): vol.In(["off", "auto", "cool"]),
+        vol.Optional("field_3"): vol.Coerce(int),
+        vol.Optional("field_4"): vol.In(["forwards", "reverse"]),
+    }
+)
+
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the demo environment."""
@@ -53,7 +64,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     def service_handler(call: ServiceCall | None = None) -> None:
         """Do nothing."""
 
-    hass.services.async_register(DOMAIN, "test_service_1", service_handler)
+    hass.services.async_register(
+        DOMAIN, "test_service_1", service_handler, SCHEMA_SERVICE_TEST_SERVICE_1
+    )
 
     return True
 

--- a/homeassistant/components/kitchen_sink/icons.json
+++ b/homeassistant/components/kitchen_sink/icons.json
@@ -7,5 +7,13 @@
         }
       }
     }
+  },
+  "services": {
+    "test_service_1": {
+      "service": "mdi:flask",
+      "sections": {
+        "section_1": "mdi:test-tube"
+      }
+    }
   }
 }

--- a/homeassistant/components/kitchen_sink/icons.json
+++ b/homeassistant/components/kitchen_sink/icons.json
@@ -12,7 +12,7 @@
     "test_service_1": {
       "service": "mdi:flask",
       "sections": {
-        "section_1": "mdi:test-tube"
+        "advanced_fields": "mdi:test-tube"
       }
     }
   }

--- a/homeassistant/components/kitchen_sink/services.yaml
+++ b/homeassistant/components/kitchen_sink/services.yaml
@@ -1,0 +1,30 @@
+test_service_1:
+  fields:
+    field_1:
+      selector:
+        number:
+          min: 0
+          max: 60
+          unit_of_measurement: seconds
+    field_2:
+      selector:
+        select:
+          options:
+            - "off"
+            - "auto"
+            - "cool"
+    advanced_fields:
+      collapsed: true
+      fields:
+        field_3:
+          selector:
+            number:
+              min: 0
+              max: 24
+              unit_of_measurement: hours
+        field_4:
+          selector:
+            select:
+              options:
+                - "forward"
+                - "reverse"

--- a/homeassistant/components/kitchen_sink/services.yaml
+++ b/homeassistant/components/kitchen_sink/services.yaml
@@ -1,12 +1,14 @@
 test_service_1:
   fields:
     field_1:
+      required: true
       selector:
         number:
           min: 0
           max: 60
           unit_of_measurement: seconds
     field_2:
+      required: true
       selector:
         select:
           options:

--- a/homeassistant/components/kitchen_sink/strings.json
+++ b/homeassistant/components/kitchen_sink/strings.json
@@ -71,5 +71,35 @@
       "title": "This is not a fixable problem",
       "description": "This issue is never going to give up."
     }
+  },
+  "services": {
+    "test_service_1": {
+      "name": "Test service 1",
+      "description": "Fake service for testing",
+      "fields": {
+        "field_1": {
+          "name": "Field 1",
+          "description": "Number of seconds"
+        },
+        "field_2": {
+          "name": "Field 2",
+          "description": "Mode"
+        },
+        "field_3": {
+          "name": "Field 3",
+          "description": "Number of hours"
+        },
+        "field_4": {
+          "name": "Field 4",
+          "description": "Direction"
+        }
+      },
+      "sections": {
+        "advanced_fields": {
+          "name": "Advanced options",
+          "description": "Some very advanced things"
+        }
+      }
+    }
   }
 }

--- a/script/hassfest/icons.py
+++ b/script/hassfest/icons.py
@@ -9,6 +9,7 @@ import voluptuous as vol
 from voluptuous.humanize import humanize_error
 
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.icon import convert_shorthand_service_icon
 
 from .model import Config, Integration
 from .translations import translation_key_validator
@@ -60,6 +61,22 @@ DATA_ENTRY_ICONS_SCHEMA = vol.Schema(
 )
 
 
+SERVICE_ICONS_SCHEMA = cv.schema_with_slug_keys(
+    vol.All(
+        convert_shorthand_service_icon,
+        vol.Schema(
+            {
+                vol.Optional("service"): icon_value_validator,
+                vol.Optional("sections"): cv.schema_with_slug_keys(
+                    icon_value_validator, slug_validator=translation_key_validator
+                ),
+            }
+        ),
+    ),
+    slug_validator=translation_key_validator,
+)
+
+
 def icon_schema(integration_type: str, no_entity_platform: bool) -> vol.Schema:
     """Create an icon schema."""
 
@@ -91,7 +108,7 @@ def icon_schema(integration_type: str, no_entity_platform: bool) -> vol.Schema:
                 {str: {"fix_flow": DATA_ENTRY_ICONS_SCHEMA}}
             ),
             vol.Optional("options"): DATA_ENTRY_ICONS_SCHEMA,
-            vol.Optional("services"): state_validator,
+            vol.Optional("services"): SERVICE_ICONS_SCHEMA,
         }
     )
 

--- a/tests/components/kitchen_sink/test_init.py
+++ b/tests/components/kitchen_sink/test_init.py
@@ -5,6 +5,7 @@ from http import HTTPStatus
 from unittest.mock import ANY
 
 import pytest
+import voluptuous as vol
 
 from homeassistant.components.kitchen_sink import DOMAIN
 from homeassistant.components.recorder import get_instance
@@ -324,3 +325,24 @@ async def test_issues_created(
             },
         ]
     }
+
+
+async def test_service(
+    hass: HomeAssistant,
+) -> None:
+    """Test we can call the service."""
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+
+    with pytest.raises(vol.error.MultipleInvalid):
+        await hass.services.async_call(DOMAIN, "test_service_1", blocking=True)
+
+    await hass.services.async_call(
+        DOMAIN, "test_service_1", {"field_1": 1, "field_2": "auto"}, blocking=True
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        "test_service_1",
+        {"field_1": 1, "field_2": "auto", "field_3": 1, "field_4": "forwards"},
+        blocking=True,
+    )

--- a/tests/helpers/test_icon.py
+++ b/tests/helpers/test_icon.py
@@ -101,7 +101,7 @@ async def test_get_icons(hass: HomeAssistant) -> None:
     # Test services icons are available
     icons = await icon.async_get_icons(hass, "services")
     assert len(icons) == 1
-    assert icons["switch"]["turn_off"] == "mdi:toggle-switch-variant-off"
+    assert icons["switch"]["turn_off"] == {"service": "mdi:toggle-switch-variant-off"}
 
     # Ensure icons file for platform isn't loaded, as that isn't supported
     icons = await icon.async_get_icons(hass, "entity")
@@ -126,7 +126,7 @@ async def test_get_icons(hass: HomeAssistant) -> None:
 
     icons = await icon.async_get_icons(hass, "services")
     assert len(icons) == 2
-    assert icons["test_package"]["enable_god_mode"] == "mdi:shield"
+    assert icons["test_package"]["enable_god_mode"] == {"service": "mdi:shield"}
 
     # Load another one
     hass.config.components.add("test_embedded")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow specifying icons for service sections

This allows specifying service icons like this:
```json
  "services": {
    "test_service_1": {
      "service": "mdi:flask",
      "sections": {
        "section_1": "mdi:test-tube"
      }
    }
  }
```

The old format is still supported for custom integration during a deprecation period of one year:
```json
  "services": {
    "randomize_device_tracker_data": "mdi:dice-multiple"
  }
```

Icons data sent to frontend will always be according to the new format; `icons.json` will be converted to the new format when loaded.

Core integrations' `icons.json` will be converted in a series of follow-up PRs.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
  - Dev blog: https://github.com/home-assistant/developers.home-assistant/pull/2290
  - Dev docs: https://github.com/home-assistant/developers.home-assistant/pull/2291

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
