### PR TITLE
Disable sisyphus integration

### DIFF
--- a/homeassistant/components/sisyphus/__init__.py
+++ b/homeassistant/components/sisyphus/__init__.py
@@ -1,9 +1,10 @@
 """Support for controlling Sisyphus Kinetic Art Tables."""
 
+# mypy: ignore-errors
 import asyncio
 import logging
 
-from sisyphus_control import Table
+# from sisyphus_control import Table
 import voluptuous as vol
 
 from homeassistant.const import CONF_HOST, CONF_NAME, EVENT_HOMEASSISTANT_STOP, Platform

--- a/homeassistant/components/sisyphus/manifest.json
+++ b/homeassistant/components/sisyphus/manifest.json
@@ -2,6 +2,7 @@
   "domain": "sisyphus",
   "name": "Sisyphus",
   "codeowners": ["@jkeljo"],
+  "disabled": "This integration is disabled because it uses an old version of socketio.",
   "documentation": "https://www.home-assistant.io/integrations/sisyphus",
   "iot_class": "local_push",
   "loggers": ["sisyphus_control"],

--- a/homeassistant/components/sisyphus/media_player.py
+++ b/homeassistant/components/sisyphus/media_player.py
@@ -1,10 +1,11 @@
 """Support for track controls on the Sisyphus Kinetic Art Table."""
 
+# mypy: ignore-errors
 from __future__ import annotations
 
 import aiohttp
-from sisyphus_control import Track
 
+# from sisyphus_control import Track
 from homeassistant.components.media_player import (
     MediaPlayerEntity,
     MediaPlayerEntityFeature,

--- a/homeassistant/components/sisyphus/ruff.toml
+++ b/homeassistant/components/sisyphus/ruff.toml
@@ -1,0 +1,5 @@
+extend = "../../../pyproject.toml"
+
+lint.extend-ignore = [
+  "F821"
+]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2618,9 +2618,6 @@ simplepush==2.2.3
 # homeassistant.components.simplisafe
 simplisafe-python==2024.01.0
 
-# homeassistant.components.sisyphus
-sisyphus-control==3.1.3
-
 # homeassistant.components.slack
 slackclient==2.5.0
 


### PR DESCRIPTION
This breaking change can be dropped once https://github.com/home-assistant/core/pull/124749 merges

## Breaking change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This integration requires an [EOL](https://socket.io/docs/v3/) version of socketio which is no longer maintained for a few years now due to https://github.com/jkeljo/sisyphus-control/issues/6 and no solution has been reached. This is blocking us from using the newer protocol and has some unfixed issues (https://github.com/home-assistant/core/issues/113572).

We would like to re-enable this integration in the future, and the hope is that this PR can be reverted soon. The suggested resolution to get this integration re-enabled, is to fork the old version of socketio and publish it on PyPI: https://github.com/jkeljo/sisyphus-control/issues/6#issuecomment-1012595758

A fork is available at https://pypi.org/project/python-socketio-v4/

A pull request has been merged at https://github.com/jkeljo/sisyphus-control/pull/8 to switch to the fork, and is awaiting release which will allow us to revert this PR once sisyphus-control is bumped with that change or an alternate resolution.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #124742
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
