### PR TITLE
Add extra prompt to assist pipeline and conversation

### DIFF
--- a/homeassistant/components/assist_pipeline/__init__.py
+++ b/homeassistant/components/assist_pipeline/__init__.py
@@ -108,6 +108,7 @@ async def async_pipeline_from_audio_stream(
     device_id: str | None = None,
     start_stage: PipelineStage = PipelineStage.STT,
     end_stage: PipelineStage = PipelineStage.TTS,
+    conversation_extra_prompt: str | None = None,
 ) -> None:
     """Create an audio pipeline from an audio stream.
 
@@ -119,6 +120,7 @@ async def async_pipeline_from_audio_stream(
         stt_metadata=stt_metadata,
         stt_stream=stt_stream,
         wake_word_phrase=wake_word_phrase,
+        conversation_extra_prompt=conversation_extra_prompt,
         run=PipelineRun(
             hass,
             context=context,

--- a/homeassistant/components/assist_pipeline/__init__.py
+++ b/homeassistant/components/assist_pipeline/__init__.py
@@ -108,7 +108,7 @@ async def async_pipeline_from_audio_stream(
     device_id: str | None = None,
     start_stage: PipelineStage = PipelineStage.STT,
     end_stage: PipelineStage = PipelineStage.TTS,
-    conversation_extra_prompt: str | None = None,
+    conversation_extra_system_prompt: str | None = None,
 ) -> None:
     """Create an audio pipeline from an audio stream.
 
@@ -120,7 +120,7 @@ async def async_pipeline_from_audio_stream(
         stt_metadata=stt_metadata,
         stt_stream=stt_stream,
         wake_word_phrase=wake_word_phrase,
-        conversation_extra_prompt=conversation_extra_prompt,
+        conversation_extra_system_prompt=conversation_extra_system_prompt,
         run=PipelineRun(
             hass,
             context=context,

--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -1010,7 +1010,11 @@ class PipelineRun:
         self.intent_agent = agent_info.id
 
     async def recognize_intent(
-        self, intent_input: str, conversation_id: str | None, device_id: str | None
+        self,
+        intent_input: str,
+        conversation_id: str | None,
+        device_id: str | None,
+        conversation_extra_prompt: str | None,
     ) -> str:
         """Run intent recognition portion of pipeline. Returns text to speak."""
         if self.intent_agent is None:
@@ -1045,6 +1049,7 @@ class PipelineRun:
                 device_id=device_id,
                 language=input_language,
                 agent_id=self.intent_agent,
+                extra_prompt=conversation_extra_prompt,
             )
             processed_locally = self.intent_agent == conversation.HOME_ASSISTANT_AGENT
 
@@ -1392,8 +1397,13 @@ class PipelineInput:
     """Input for text-to-speech. Required when start_stage = tts."""
 
     conversation_id: str | None = None
+    """Identifier for the conversation."""
+
+    conversation_extra_prompt: str | None = None
+    """Extra prompt information for the conversation agent."""
 
     device_id: str | None = None
+    """Identifier of the device that is processing the input/output of the pipeline."""
 
     async def execute(self) -> None:
         """Run pipeline."""
@@ -1483,6 +1493,7 @@ class PipelineInput:
                         intent_input,
                         self.conversation_id,
                         self.device_id,
+                        self.conversation_extra_prompt,
                     )
                     if tts_input.strip():
                         current_stage = PipelineStage.TTS

--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -1014,7 +1014,7 @@ class PipelineRun:
         intent_input: str,
         conversation_id: str | None,
         device_id: str | None,
-        conversation_extra_prompt: str | None,
+        conversation_extra_system_prompt: str | None,
     ) -> str:
         """Run intent recognition portion of pipeline. Returns text to speak."""
         if self.intent_agent is None:
@@ -1049,7 +1049,7 @@ class PipelineRun:
                 device_id=device_id,
                 language=input_language,
                 agent_id=self.intent_agent,
-                extra_prompt=conversation_extra_prompt,
+                extra_system_prompt=conversation_extra_system_prompt,
             )
             processed_locally = self.intent_agent == conversation.HOME_ASSISTANT_AGENT
 
@@ -1399,7 +1399,7 @@ class PipelineInput:
     conversation_id: str | None = None
     """Identifier for the conversation."""
 
-    conversation_extra_prompt: str | None = None
+    conversation_extra_system_prompt: str | None = None
     """Extra prompt information for the conversation agent."""
 
     device_id: str | None = None
@@ -1493,7 +1493,7 @@ class PipelineInput:
                         intent_input,
                         self.conversation_id,
                         self.device_id,
-                        self.conversation_extra_prompt,
+                        self.conversation_extra_system_prompt,
                     )
                     if tts_input.strip():
                         current_stage = PipelineStage.TTS

--- a/homeassistant/components/conversation/agent_manager.py
+++ b/homeassistant/components/conversation/agent_manager.py
@@ -75,7 +75,7 @@ async def async_converse(
     language: str | None = None,
     agent_id: str | None = None,
     device_id: str | None = None,
-    extra_prompt: str | None = None,
+    extra_system_prompt: str | None = None,
 ) -> ConversationResult:
     """Process text and get intent."""
     agent = async_get_agent(hass, agent_id)
@@ -100,7 +100,7 @@ async def async_converse(
         device_id=device_id,
         language=language,
         agent_id=agent_id,
-        extra_prompt=extra_prompt,
+        extra_system_prompt=extra_system_prompt,
     )
     with async_conversation_trace() as trace:
         trace.add_event(

--- a/homeassistant/components/conversation/agent_manager.py
+++ b/homeassistant/components/conversation/agent_manager.py
@@ -75,6 +75,7 @@ async def async_converse(
     language: str | None = None,
     agent_id: str | None = None,
     device_id: str | None = None,
+    extra_prompt: str | None = None,
 ) -> ConversationResult:
     """Process text and get intent."""
     agent = async_get_agent(hass, agent_id)
@@ -99,6 +100,7 @@ async def async_converse(
         device_id=device_id,
         language=language,
         agent_id=agent_id,
+        extra_prompt=extra_prompt,
     )
     with async_conversation_trace() as trace:
         trace.add_event(

--- a/homeassistant/components/conversation/models.py
+++ b/homeassistant/components/conversation/models.py
@@ -40,7 +40,7 @@ class ConversationInput:
     agent_id: str | None = None
     """Agent to use for processing."""
 
-    extra_prompt: str | None = None
+    extra_system_prompt: str | None = None
     """Extra prompt to provide extra info to LLMs how to understand the command."""
 
     def as_dict(self) -> dict[str, Any]:

--- a/homeassistant/components/conversation/models.py
+++ b/homeassistant/components/conversation/models.py
@@ -52,7 +52,7 @@ class ConversationInput:
             "device_id": self.device_id,
             "language": self.language,
             "agent_id": self.agent_id,
-            "extra_prompt": self.extra_prompt,
+            "extra_system_prompt": self.extra_system_prompt,
         }
 
 

--- a/homeassistant/components/conversation/models.py
+++ b/homeassistant/components/conversation/models.py
@@ -40,6 +40,9 @@ class ConversationInput:
     agent_id: str | None = None
     """Agent to use for processing."""
 
+    extra_prompt: str | None = None
+    """Extra prompt to provide extra info to LLMs how to understand the command."""
+
     def as_dict(self) -> dict[str, Any]:
         """Return input as a dict."""
         return {
@@ -49,6 +52,7 @@ class ConversationInput:
             "device_id": self.device_id,
             "language": self.language,
             "agent_id": self.agent_id,
+            "extra_prompt": self.extra_prompt,
         }
 
 

--- a/tests/components/conversation/test_agent_manager.py
+++ b/tests/components/conversation/test_agent_manager.py
@@ -22,7 +22,7 @@ async def test_async_converse(hass: HomeAssistant, init_components) -> None:
             language="test lang",
             agent_id="conversation.home_assistant",
             device_id="test device id",
-            extra_prompt="test extra prompt",
+            extra_system_prompt="test extra prompt",
         )
 
     assert mock_process.called
@@ -33,3 +33,4 @@ async def test_async_converse(hass: HomeAssistant, init_components) -> None:
     assert conversation_input.language == "test lang"
     assert conversation_input.agent_id == "conversation.home_assistant"
     assert conversation_input.device_id == "test device id"
+    assert conversation_input.extra_system_prompt == "test extra prompt"

--- a/tests/components/conversation/test_agent_manager.py
+++ b/tests/components/conversation/test_agent_manager.py
@@ -22,6 +22,7 @@ async def test_async_converse(hass: HomeAssistant, init_components) -> None:
             language="test lang",
             agent_id="conversation.home_assistant",
             device_id="test device id",
+            extra_prompt="test extra prompt",
         )
 
     assert mock_process.called

--- a/tests/components/conversation/test_trigger.py
+++ b/tests/components/conversation/test_trigger.py
@@ -88,6 +88,7 @@ async def test_if_fires_on_event(
             "device_id": None,
             "language": "en",
             "text": "Ha ha ha",
+            "extra_system_prompt": None,
         },
     }
 
@@ -235,6 +236,7 @@ async def test_response_same_sentence(
             "device_id": None,
             "language": "en",
             "text": "test sentence",
+            "extra_system_prompt": None,
         },
     }
 
@@ -412,6 +414,7 @@ async def test_same_trigger_multiple_sentences(
             "device_id": None,
             "language": "en",
             "text": "hello",
+            "extra_system_prompt": None,
         },
     }
 
@@ -639,6 +642,7 @@ async def test_wildcards(hass: HomeAssistant, service_calls: list[ServiceCall]) 
             "device_id": None,
             "language": "en",
             "text": "play the white album by the beatles",
+            "extra_system_prompt": None,
         },
     }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds a new `extra_prompt` parameter to conversation agents.

When an automation calls a service to trigger an assist pipeline (a feature that's WIP), they will be able to provide extra information for the LLM to understand the response from the user. Example how `extra_prompt` contains the entity ID of the device that the user wants to interact with:

- Automation calls service: (not final syntax)
  ```yaml
  service: assist_satellite.start_conversation
  target:
    entity_id: assist_satellite.living_room
  data:
    start_message: You have left the garage door open. Should we close it?
    extra_system_prompt: garage door cover.garage was left open.
  ```
- Device tells user: You have left the garage door open. Should we close it?
- User tells device: yes
- LLM receives
  - `input:`
    - System: You have left the garage door open. Should we close it?
    - User: yes
  - `extra_system_prompt:` garage door cover.garage was left open.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
