### PR TITLE
Fix OAuth reauth in Tesla Fleet

### DIFF
--- a/homeassistant/components/tesla_fleet/__init__.py
+++ b/homeassistant/components/tesla_fleet/__init__.py
@@ -70,7 +70,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -
             try:
                 await oauth_session.async_ensure_token_valid()
             except ClientResponseError as e:
-                raise ConfigEntryAuthFailed from e
+                if e.status == 401:
+                    raise ConfigEntryAuthFailed from e
+                raise ConfigEntryNotReady from e
             token: str = oauth_session.token[CONF_ACCESS_TOKEN]
             return token
 

--- a/homeassistant/components/tesla_fleet/__init__.py
+++ b/homeassistant/components/tesla_fleet/__init__.py
@@ -3,6 +3,7 @@
 import asyncio
 from typing import Final
 
+from aiohttp.client_exceptions import ClientResponseError
 import jwt
 from tesla_fleet_api import EnergySpecific, TeslaFleetApi, VehicleSpecific
 from tesla_fleet_api.const import Scope
@@ -66,7 +67,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -
 
     async def _refresh_token() -> str:
         async with refresh_lock:
-            await oauth_session.async_ensure_token_valid()
+            try:
+                await oauth_session.async_ensure_token_valid()
+            except ClientResponseError as e:
+                raise ConfigEntryAuthFailed from e
             token: str = oauth_session.token[CONF_ACCESS_TOKEN]
             return token
 

--- a/homeassistant/components/tesla_fleet/config_flow.py
+++ b/homeassistant/components/tesla_fleet/config_flow.py
@@ -83,5 +83,8 @@ class OAuth2FlowHandler(
     ) -> ConfigFlowResult:
         """Confirm reauth dialog."""
         if user_input is None:
-            return self.async_show_form(step_id="reauth_confirm")
+            return self.async_show_form(
+                step_id="reauth_confirm",
+                description_placeholders={"name": "Tesla Fleet"},
+            )
         return await self.async_step_user()

--- a/homeassistant/components/tesla_fleet/strings.json
+++ b/homeassistant/components/tesla_fleet/strings.json
@@ -19,7 +19,7 @@
       },
       "reauth_confirm": {
         "title": "[%key:common::config_flow::title::reauth%]",
-        "description": "The Withings integration needs to re-authenticate your account"
+        "description": "The Tesla Fleet integration needs to re-authenticate your account"
       }
     },
     "create_entry": {

--- a/homeassistant/components/tesla_fleet/strings.json
+++ b/homeassistant/components/tesla_fleet/strings.json
@@ -19,7 +19,7 @@
       },
       "reauth_confirm": {
         "title": "[%key:common::config_flow::title::reauth%]",
-        "description": "The Tesla Fleet integration needs to re-authenticate your account"
+        "description": "The {name} integration needs to re-authenticate your account"
       }
     },
     "create_entry": {

--- a/tests/components/tesla_fleet/conftest.py
+++ b/tests/components/tesla_fleet/conftest.py
@@ -124,7 +124,7 @@ def mock_site_info() -> Generator[AsyncMock]:
         yield mock_live_status
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def mock_find_server() -> Generator[AsyncMock]:
     """Mock Tesla Fleet find server method."""
     with patch(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
OAuth refresh token failures are not triggering reauth flow in Tesla Fleet

Please hotfix/beta

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
