### PR TITLE
Handle KNX expose conversion exceptions and unavailable states

### DIFF
--- a/homeassistant/components/knx/expose.py
+++ b/homeassistant/components/knx/expose.py
@@ -125,6 +125,8 @@ class KNXExposeSensor:
     def _get_expose_value(self, state: State | None) -> bool | int | float | str | None:
         """Extract value from state."""
         if state is None or state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+            if self.expose_default is None:
+                return None
             value = self.expose_default
         elif self.expose_attribute is not None:
             _attr = state.attributes.get(self.expose_attribute)
@@ -154,12 +156,22 @@ class KNXExposeSensor:
         if value is not None and (
             isinstance(self.device.sensor_value, RemoteValueSensor)
         ):
-            if issubclass(self.device.sensor_value.dpt_class, DPTNumeric):
-                return float(value)
-            if issubclass(self.device.sensor_value.dpt_class, DPTString):
-                # DPT 16.000 only allows up to 14 Bytes
-                return str(value)[:14]
-        return value
+            try:
+                if issubclass(self.device.sensor_value.dpt_class, DPTNumeric):
+                    return float(value)
+                if issubclass(self.device.sensor_value.dpt_class, DPTString):
+                    # DPT 16.000 only allows up to 14 Bytes
+                    return str(value)[:14]
+            except (ValueError, TypeError) as err:
+                _LOGGER.warning(
+                    'Could not expose %s %s value "%s" to KNX: Conversion failed: %s',
+                    self.entity_id,
+                    self.expose_attribute or "state",
+                    value,
+                    err,
+                )
+                return None
+        return value  # type: ignore[no-any-return]
 
     async def _async_entity_changed(self, event: Event[EventStateChangedData]) -> None:
         """Handle entity change."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- ignore unknown/unavailable entity states (when no default)
- catch conversion exceptions

Previously, if no default was set and the exposed entity wasn't available at instantiation time, this could lead to an uncatched exception (`float("unknown")`) in `async_setup_entry()` - leading to not loading the integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
