### PR TITLE
Use start_reauth helper method in broadlink and bthome

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1054,7 +1054,12 @@ class MockConfigEntry(config_entries.ConfigEntry):
         """
         self._async_set_state(hass, state, reason)
 
-    async def start_reauth_flow(self, hass: HomeAssistant) -> ConfigFlowResult:
+    async def start_reauth_flow(
+        self,
+        hass: HomeAssistant,
+        context: dict[str, Any] | None = None,
+        data: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
         """Start a reauthentication flow."""
         return await hass.config_entries.flow.async_init(
             self.domain,
@@ -1063,8 +1068,9 @@ class MockConfigEntry(config_entries.ConfigEntry):
                 "entry_id": self.entry_id,
                 "title_placeholders": {"name": self.title},
                 "unique_id": self.unique_id,
-            },
-            data=self.data,
+            }
+            | (context or {}),
+            data=self.data | (data or {}),
         )
 
 

--- a/tests/components/broadlink/test_config_flow.py
+++ b/tests/components/broadlink/test_config_flow.py
@@ -734,13 +734,9 @@ async def test_flow_reauth_works(hass: HomeAssistant) -> None:
     mock_entry.add_to_hass(hass)
     mock_api = device.get_mock_api()
     mock_api.auth.side_effect = blke.AuthenticationError()
-    data = {"name": device.name, **device.get_entry_data()}
 
     with patch(DEVICE_FACTORY, return_value=mock_api):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_REAUTH}, data=data
-        )
-
+        result = await mock_entry.start_reauth_flow(hass, data={"name": device.name})
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reset"
 
@@ -770,12 +766,8 @@ async def test_flow_reauth_invalid_host(hass: HomeAssistant) -> None:
     mock_entry.add_to_hass(hass)
     mock_api = device.get_mock_api()
     mock_api.auth.side_effect = blke.AuthenticationError()
-    data = {"name": device.name, **device.get_entry_data()}
-
     with patch(DEVICE_FACTORY, return_value=mock_api):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_REAUTH}, data=data
-        )
+        result = await mock_entry.start_reauth_flow(hass, data={"name": device.name})
 
     device.mac = get_device("Office").mac
     mock_api = device.get_mock_api()
@@ -804,12 +796,9 @@ async def test_flow_reauth_valid_host(hass: HomeAssistant) -> None:
     mock_entry.add_to_hass(hass)
     mock_api = device.get_mock_api()
     mock_api.auth.side_effect = blke.AuthenticationError()
-    data = {"name": device.name, **device.get_entry_data()}
 
     with patch(DEVICE_FACTORY, return_value=mock_api):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_REAUTH}, data=data
-        )
+        result = await mock_entry.start_reauth_flow(hass, data={"name": device.name})
 
     device.host = "192.168.1.128"
     mock_api = device.get_mock_api()

--- a/tests/components/bthome/test_config_flow.py
+++ b/tests/components/bthome/test_config_flow.py
@@ -563,16 +563,7 @@ async def test_async_step_reauth_abort_early(hass: HomeAssistant) -> None:
 
     device = DeviceData()
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={
-            "source": config_entries.SOURCE_REAUTH,
-            "entry_id": entry.entry_id,
-            "title_placeholders": {"name": entry.title},
-            "unique_id": entry.unique_id,
-        },
-        data=entry.data | {"device": device},
-    )
+    result = await entry.start_reauth_flow(hass, data={"device": device})
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, follow-up to #124767

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
