### PR TITLE
Use start_reauth helper method in integration tests (s)

### DIFF
--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -1749,11 +1749,7 @@ async def test_form_reauth_legacy(hass: HomeAssistant) -> None:
     """Test reauthenticate legacy."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_OLD_ENTRY)
     entry.add_to_hass(hass)
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"entry_id": entry.entry_id, "source": config_entries.SOURCE_REAUTH},
-        data=entry.data,
-    )
+    result = await entry.start_reauth_flow(hass)
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
@@ -1773,11 +1769,7 @@ async def test_form_reauth_websocket(hass: HomeAssistant) -> None:
     entry.add_to_hass(hass)
     assert entry.state is ConfigEntryState.NOT_LOADED
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"entry_id": entry.entry_id, "source": config_entries.SOURCE_REAUTH},
-        data=entry.data,
-    )
+    result = await entry.start_reauth_flow(hass)
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
@@ -1798,11 +1790,7 @@ async def test_form_reauth_websocket_cannot_connect(
     """Test reauthenticate websocket when we cannot connect on the first attempt."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_ENTRYDATA_WS)
     entry.add_to_hass(hass)
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"entry_id": entry.entry_id, "source": config_entries.SOURCE_REAUTH},
-        data=entry.data,
-    )
+    result = await entry.start_reauth_flow(hass)
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
@@ -1830,11 +1818,7 @@ async def test_form_reauth_websocket_not_supported(hass: HomeAssistant) -> None:
     """Test reauthenticate websocket when the device is not supported."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_ENTRYDATA_WS)
     entry.add_to_hass(hass)
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"entry_id": entry.entry_id, "source": config_entries.SOURCE_REAUTH},
-        data=entry.data,
-    )
+    result = await entry.start_reauth_flow(hass)
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
@@ -1863,11 +1847,7 @@ async def test_form_reauth_encrypted(hass: HomeAssistant) -> None:
     entry.add_to_hass(hass)
     assert entry.state is ConfigEntryState.NOT_LOADED
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"entry_id": entry.entry_id, "source": config_entries.SOURCE_REAUTH},
-        data=entry.data,
-    )
+    result = await entry.start_reauth_flow(hass)
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 

--- a/tests/components/sense/test_config_flow.py
+++ b/tests/components/sense/test_config_flow.py
@@ -268,9 +268,7 @@ async def test_reauth_no_form(hass: HomeAssistant, mock_sense) -> None:
         "homeassistant.config_entries.ConfigEntries.async_reload",
         return_value=True,
     ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_REAUTH}, data=MOCK_CONFIG
-        )
+        result = await entry.start_reauth_flow(hass)
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
 
@@ -288,9 +286,7 @@ async def test_reauth_password(hass: HomeAssistant, mock_sense) -> None:
     mock_sense.return_value.authenticate.side_effect = SenseAuthenticationException
 
     # Reauth success without user input
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_REAUTH}, data=entry.data
-    )
+    result = await entry.start_reauth_flow(hass)
     assert result["type"] is FlowResultType.FORM
 
     mock_sense.return_value.authenticate.side_effect = None

--- a/tests/components/sensibo/test_config_flow.py
+++ b/tests/components/sensibo/test_config_flow.py
@@ -192,15 +192,7 @@ async def test_reauth_flow(hass: HomeAssistant) -> None:
     )
     entry.add_to_hass(hass)
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={
-            "source": config_entries.SOURCE_REAUTH,
-            "unique_id": entry.unique_id,
-            "entry_id": entry.entry_id,
-        },
-        data=entry.data,
-    )
+    result = await entry.start_reauth_flow(hass)
     assert result["step_id"] == "reauth_confirm"
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
@@ -254,15 +246,7 @@ async def test_reauth_flow_error(
     )
     entry.add_to_hass(hass)
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={
-            "source": config_entries.SOURCE_REAUTH,
-            "unique_id": entry.unique_id,
-            "entry_id": entry.entry_id,
-        },
-        data=entry.data,
-    )
+    result = await entry.start_reauth_flow(hass)
 
     with patch(
         "homeassistant.components.sensibo.util.SensiboClient.async_get_devices",
@@ -338,15 +322,7 @@ async def test_flow_reauth_no_username_or_device(
     )
     entry.add_to_hass(hass)
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={
-            "source": config_entries.SOURCE_REAUTH,
-            "unique_id": entry.unique_id,
-            "entry_id": entry.entry_id,
-        },
-        data=entry.data,
-    )
+    result = await entry.start_reauth_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"

--- a/tests/components/sfr_box/test_config_flow.py
+++ b/tests/components/sfr_box/test_config_flow.py
@@ -207,15 +207,7 @@ async def test_reauth(hass: HomeAssistant, config_entry_with_auth: ConfigEntry) 
     """Test the start of the config flow."""
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={
-            "source": config_entries.SOURCE_REAUTH,
-            "entry_id": config_entry_with_auth.entry_id,
-            "unique_id": config_entry_with_auth.unique_id,
-        },
-        data=config_entry_with_auth.data,
-    )
+    result = await config_entry_with_auth.start_reauth_flow(hass)
 
     assert result.get("type") is FlowResultType.FORM
     assert result.get("errors") == {}

--- a/tests/components/sharkiq/test_config_flow.py
+++ b/tests/components/sharkiq/test_config_flow.py
@@ -99,11 +99,7 @@ async def test_reauth_success(hass: HomeAssistant) -> None:
     mock_config = MockConfigEntry(domain=DOMAIN, unique_id=UNIQUE_ID, data=CONFIG)
     mock_config.add_to_hass(hass)
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_REAUTH, "unique_id": UNIQUE_ID},
-        data=mock_config.data,
-    )
+    result = await mock_config.start_reauth_flow(hass)
 
     with patch("sharkiq.AylaApi.async_sign_in", return_value=True):
         result = await hass.config_entries.flow.async_configure(
@@ -131,11 +127,10 @@ async def test_reauth(
     msg: str,
 ) -> None:
     """Test reauth failures."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_REAUTH, "unique_id": UNIQUE_ID},
-        data=CONFIG,
-    )
+    mock_config = MockConfigEntry(domain=DOMAIN, unique_id=UNIQUE_ID, data=CONFIG)
+    mock_config.add_to_hass(hass)
+
+    result = await mock_config.start_reauth_flow(hass)
 
     with patch("sharkiq.AylaApi.async_sign_in", side_effect=side_effect):
         result = await hass.config_entries.flow.async_configure(

--- a/tests/components/simplisafe/test_config_flow.py
+++ b/tests/components/simplisafe/test_config_flow.py
@@ -8,10 +8,12 @@ from simplipy.errors import InvalidCredentialsError, SimplipyError
 
 from homeassistant.components.simplisafe import DOMAIN
 from homeassistant.components.simplisafe.config_flow import CONF_AUTH_CODE
-from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
+from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_CODE, CONF_TOKEN, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
 
 VALID_AUTH_CODE = "code12345123451234512345123451234512345123451"
 
@@ -90,13 +92,11 @@ async def test_options_flow(config_entry, hass: HomeAssistant) -> None:
         assert config_entry.options == {CONF_CODE: "4321"}
 
 
-async def test_step_reauth(config_entry, hass: HomeAssistant, setup_simplisafe) -> None:
+async def test_step_reauth(
+    config_entry: MockConfigEntry, hass: HomeAssistant, setup_simplisafe
+) -> None:
     """Test the re-auth step."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_REAUTH},
-        data={CONF_USERNAME: "12345", CONF_TOKEN: "token123"},
-    )
+    result = await config_entry.start_reauth_flow(hass)
     assert result["step_id"] == "user"
 
     with (
@@ -118,14 +118,10 @@ async def test_step_reauth(config_entry, hass: HomeAssistant, setup_simplisafe) 
 
 @pytest.mark.parametrize("unique_id", ["some_other_id"])
 async def test_step_reauth_wrong_account(
-    config_entry, hass: HomeAssistant, setup_simplisafe
+    config_entry: MockConfigEntry, hass: HomeAssistant, setup_simplisafe
 ) -> None:
     """Test the re-auth step where the wrong account is used during login."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_REAUTH},
-        data={CONF_USERNAME: "12345", CONF_TOKEN: "token123"},
-    )
+    result = await config_entry.start_reauth_flow(hass)
     assert result["step_id"] == "user"
 
     with (

--- a/tests/components/skybell/test_config_flow.py
+++ b/tests/components/skybell/test_config_flow.py
@@ -5,10 +5,9 @@ from unittest.mock import patch
 from aioskybell import exceptions
 import pytest
 
-from homeassistant import config_entries
 from homeassistant.components.skybell.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
-from homeassistant.const import CONF_PASSWORD, CONF_SOURCE
+from homeassistant.const import CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -104,15 +103,7 @@ async def test_step_reauth(hass: HomeAssistant) -> None:
     entry = MockConfigEntry(domain=DOMAIN, unique_id=USER_ID, data=CONF_DATA)
     entry.add_to_hass(hass)
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={
-            CONF_SOURCE: config_entries.SOURCE_REAUTH,
-            "entry_id": entry.entry_id,
-            "unique_id": entry.unique_id,
-        },
-        data=entry.data,
-    )
+    result = await entry.start_reauth_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
@@ -130,15 +121,7 @@ async def test_step_reauth_failed(hass: HomeAssistant, skybell_mock) -> None:
     entry = MockConfigEntry(domain=DOMAIN, unique_id=USER_ID, data=CONF_DATA)
     entry.add_to_hass(hass)
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={
-            CONF_SOURCE: config_entries.SOURCE_REAUTH,
-            "entry_id": entry.entry_id,
-            "unique_id": entry.unique_id,
-        },
-        data=entry.data,
-    )
+    result = await entry.start_reauth_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"

--- a/tests/components/sleepiq/test_config_flow.py
+++ b/tests/components/sleepiq/test_config_flow.py
@@ -101,19 +101,7 @@ async def test_reauth_password(hass: HomeAssistant) -> None:
 
     # set up initially
     entry = await setup_platform(hass)
-    with patch(
-        "homeassistant.components.sleepiq.config_flow.AsyncSleepIQ.login",
-        side_effect=SleepIQLoginException,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={
-                "source": config_entries.SOURCE_REAUTH,
-                "entry_id": entry.entry_id,
-                "unique_id": entry.unique_id,
-            },
-            data=entry.data,
-        )
+    result = await entry.start_reauth_flow(hass)
 
     with patch(
         "homeassistant.components.sleepiq.config_flow.AsyncSleepIQ.login",

--- a/tests/components/smarttub/test_config_flow.py
+++ b/tests/components/smarttub/test_config_flow.py
@@ -66,15 +66,7 @@ async def test_reauth_success(hass: HomeAssistant, smarttub_api, account) -> Non
     )
     mock_entry.add_to_hass(hass)
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={
-            "source": config_entries.SOURCE_REAUTH,
-            "unique_id": mock_entry.unique_id,
-            "entry_id": mock_entry.entry_id,
-        },
-        data=mock_entry.data,
-    )
+    result = await mock_entry.start_reauth_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
@@ -107,15 +99,7 @@ async def test_reauth_wrong_account(hass: HomeAssistant, smarttub_api, account) 
 
     # we try to reauth account #2, and the user successfully authenticates to account #1
     account.id = mock_entry1.unique_id
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={
-            "source": config_entries.SOURCE_REAUTH,
-            "unique_id": mock_entry2.unique_id,
-            "entry_id": mock_entry2.entry_id,
-        },
-        data=mock_entry2.data,
-    )
+    result = await mock_entry2.start_reauth_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"

--- a/tests/components/sonarr/test_config_flow.py
+++ b/tests/components/sonarr/test_config_flow.py
@@ -11,7 +11,7 @@ from homeassistant.components.sonarr.const import (
     DEFAULT_WANTED_MAX_ITEMS,
     DOMAIN,
 )
-from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
+from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_API_KEY, CONF_SOURCE, CONF_URL, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -96,15 +96,7 @@ async def test_full_reauth_flow_implementation(
     """Test the manual reauth flow from start to finish."""
     entry = init_integration
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={
-            CONF_SOURCE: SOURCE_REAUTH,
-            "entry_id": entry.entry_id,
-            "unique_id": entry.unique_id,
-        },
-        data=entry.data,
-    )
+    result = await entry.start_reauth_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"

--- a/tests/components/spotify/test_config_flow.py
+++ b/tests/components/spotify/test_config_flow.py
@@ -13,7 +13,7 @@ from homeassistant.components.application_credentials import (
     async_import_client_credential,
 )
 from homeassistant.components.spotify.const import DOMAIN
-from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER, SOURCE_ZEROCONF
+from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import config_entry_oauth2_flow
@@ -201,15 +201,7 @@ async def test_reauthentication(
     )
     old_entry.add_to_hass(hass)
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={
-            "source": SOURCE_REAUTH,
-            "unique_id": old_entry.unique_id,
-            "entry_id": old_entry.entry_id,
-        },
-        data=old_entry.data,
-    )
+    result = await old_entry.start_reauth_flow(hass)
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1
@@ -269,15 +261,7 @@ async def test_reauth_account_mismatch(
     )
     old_entry.add_to_hass(hass)
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={
-            "source": SOURCE_REAUTH,
-            "unique_id": old_entry.unique_id,
-            "entry_id": old_entry.entry_id,
-        },
-        data=old_entry.data,
-    )
+    result = await old_entry.start_reauth_flow(hass)
 
     flows = hass.config_entries.flow.async_progress()
     result = await hass.config_entries.flow.async_configure(flows[0]["flow_id"], {})

--- a/tests/components/steam_online/test_config_flow.py
+++ b/tests/components/steam_online/test_config_flow.py
@@ -5,8 +5,8 @@ from unittest.mock import patch
 import steam
 
 from homeassistant.components.steam_online.const import CONF_ACCOUNTS, DOMAIN
-from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
-from homeassistant.const import CONF_API_KEY, CONF_SOURCE
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import entity_registry as er
@@ -111,18 +111,10 @@ async def test_flow_user_already_configured(hass: HomeAssistant) -> None:
 async def test_flow_reauth(hass: HomeAssistant) -> None:
     """Test reauth step."""
     entry = create_entry(hass)
+    result = await entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
     with patch_interface():
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={
-                CONF_SOURCE: SOURCE_REAUTH,
-                "entry_id": entry.entry_id,
-                "unique_id": entry.unique_id,
-            },
-            data=CONF_DATA,
-        )
-        assert result["type"] is FlowResultType.FORM
-        assert result["step_id"] == "reauth_confirm"
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={},

--- a/tests/components/sunweg/test_config_flow.py
+++ b/tests/components/sunweg/test_config_flow.py
@@ -69,14 +69,7 @@ async def test_reauth(hass: HomeAssistant, plant_fixture, inverter_fixture) -> N
     assert entries[0].data[CONF_USERNAME] == SUNWEG_MOCK_ENTRY.data[CONF_USERNAME]
     assert entries[0].data[CONF_PASSWORD] == SUNWEG_MOCK_ENTRY.data[CONF_PASSWORD]
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={
-            "source": config_entries.SOURCE_REAUTH,
-            "entry_id": mock_entry.entry_id,
-        },
-        data=mock_entry.data,
-    )
+    result = await mock_entry.start_reauth_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"

--- a/tests/components/surepetcare/test_config_flow.py
+++ b/tests/components/surepetcare/test_config_flow.py
@@ -155,15 +155,7 @@ async def test_reauthentication(hass: HomeAssistant) -> None:
     )
     old_entry.add_to_hass(hass)
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={
-            "source": config_entries.SOURCE_REAUTH,
-            "unique_id": old_entry.unique_id,
-            "entry_id": old_entry.entry_id,
-        },
-        data=old_entry.data,
-    )
+    result = await old_entry.start_reauth_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
@@ -192,15 +184,7 @@ async def test_reauthentication_failure(hass: HomeAssistant) -> None:
     )
     old_entry.add_to_hass(hass)
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={
-            "source": config_entries.SOURCE_REAUTH,
-            "unique_id": old_entry.unique_id,
-            "entry_id": old_entry.entry_id,
-        },
-        data=old_entry.data,
-    )
+    result = await old_entry.start_reauth_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
@@ -230,15 +214,7 @@ async def test_reauthentication_cannot_connect(hass: HomeAssistant) -> None:
     )
     old_entry.add_to_hass(hass)
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={
-            "source": config_entries.SOURCE_REAUTH,
-            "unique_id": old_entry.unique_id,
-            "entry_id": old_entry.entry_id,
-        },
-        data=old_entry.data,
-    )
+    result = await old_entry.start_reauth_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
@@ -268,15 +244,7 @@ async def test_reauthentication_unknown_failure(hass: HomeAssistant) -> None:
     )
     old_entry.add_to_hass(hass)
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={
-            "source": config_entries.SOURCE_REAUTH,
-            "unique_id": old_entry.unique_id,
-            "entry_id": old_entry.entry_id,
-        },
-        data=old_entry.data,
-    )
+    result = await old_entry.start_reauth_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}

--- a/tests/components/synology_dsm/test_config_flow.py
+++ b/tests/components/synology_dsm/test_config_flow.py
@@ -21,12 +21,7 @@ from homeassistant.components.synology_dsm.const import (
     DEFAULT_SNAPSHOT_QUALITY,
     DOMAIN,
 )
-from homeassistant.config_entries import (
-    SOURCE_REAUTH,
-    SOURCE_SSDP,
-    SOURCE_USER,
-    SOURCE_ZEROCONF,
-)
+from homeassistant.config_entries import SOURCE_SSDP, SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import (
     CONF_HOST,
     CONF_MAC,
@@ -297,24 +292,7 @@ async def test_reauth(hass: HomeAssistant, service: MagicMock) -> None:
     )
     entry.add_to_hass(hass)
 
-    with patch(
-        "homeassistant.config_entries.ConfigEntries.async_reload",
-        return_value=True,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={
-                "source": SOURCE_REAUTH,
-                "entry_id": entry.entry_id,
-                "unique_id": entry.unique_id,
-                "title_placeholders": {"name": entry.title},
-            },
-            data={
-                CONF_HOST: HOST,
-                CONF_USERNAME: USERNAME,
-                CONF_PASSWORD: PASSWORD,
-            },
-        )
+    result = await entry.start_reauth_flow(hass)
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, follow-up to https://github.com/home-assistant/core/pull/124767

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
