### PR TITLE
Add new method version_is_newer to Update platform

### DIFF
--- a/homeassistant/components/update/__init__.py
+++ b/homeassistant/components/update/__init__.py
@@ -180,9 +180,12 @@ class UpdateEntityDescription(EntityDescription, frozen_or_thawed=True):
 
 
 @lru_cache(maxsize=256)
-def _version_is_newer(latest_version: str, installed_version: str) -> bool:
+def _version_is_newer(
+    latest_version: str, installed_version: str, compare_by_string: bool = False
+) -> bool:
     """Return True if version is newer."""
-    return AwesomeVersion(latest_version) > installed_version
+    latest_ver = latest_version if compare_by_string else AwesomeVersion(latest_version)
+    return latest_ver > installed_version
 
 
 CACHED_PROPERTIES_WITH_ATTR_ = {
@@ -211,6 +214,7 @@ class UpdateEntity(
 
     entity_description: UpdateEntityDescription
     _attr_auto_update: bool = False
+    _attr_compare_by_strings: bool = False
     _attr_installed_version: str | None = None
     _attr_device_class: UpdateDeviceClass | None
     _attr_in_progress: bool | int = False
@@ -399,7 +403,9 @@ class UpdateEntity(
             return STATE_OFF
 
         try:
-            newer = _version_is_newer(latest_version, installed_version)
+            newer = _version_is_newer(
+                latest_version, installed_version, self._attr_compare_by_strings
+            )
         except AwesomeVersionCompareException:
             # Can't compare versions, already tried exact match
             return STATE_ON

--- a/homeassistant/components/update/__init__.py
+++ b/homeassistant/components/update/__init__.py
@@ -214,7 +214,6 @@ class UpdateEntity(
 
     entity_description: UpdateEntityDescription
     _attr_auto_update: bool = False
-    _attr_compare_by_strings: bool = False
     _attr_installed_version: str | None = None
     _attr_device_class: UpdateDeviceClass | None
     _attr_in_progress: bool | int = False
@@ -388,6 +387,11 @@ class UpdateEntity(
         """
         raise NotImplementedError
 
+    def version_is_newer(self, latest_version: str, installed_version: str) -> bool:
+        """Return True if installed version is newer that available."""
+        # We don't inline the method because of caching
+        return _version_is_newer(latest_version, installed_version)
+
     @property
     @final
     def state(self) -> str | None:
@@ -403,9 +407,7 @@ class UpdateEntity(
             return STATE_OFF
 
         try:
-            newer = _version_is_newer(
-                latest_version, installed_version, self._attr_compare_by_strings
-            )
+            newer = self.version_is_newer(latest_version, installed_version)
         except AwesomeVersionCompareException:
             # Can't compare versions, already tried exact match
             return STATE_ON

--- a/homeassistant/components/update/__init__.py
+++ b/homeassistant/components/update/__init__.py
@@ -181,7 +181,7 @@ class UpdateEntityDescription(EntityDescription, frozen_or_thawed=True):
 
 @lru_cache(maxsize=256)
 def _version_is_newer(latest_version: str, installed_version: str) -> bool:
-    """Return True if version is newer."""
+    """Return True if latest_version is newer than installed_version."""
     return AwesomeVersion(latest_version) > installed_version
 
 
@@ -385,7 +385,7 @@ class UpdateEntity(
         raise NotImplementedError
 
     def version_is_newer(self, latest_version: str, installed_version: str) -> bool:
-        """Return True if installed version is newer than available."""
+        """Return True if latest_version is newer than installed_version."""
         # We don't inline the `_version_is_newer` function because of caching
         return _version_is_newer(latest_version, installed_version)
 

--- a/homeassistant/components/update/__init__.py
+++ b/homeassistant/components/update/__init__.py
@@ -180,12 +180,9 @@ class UpdateEntityDescription(EntityDescription, frozen_or_thawed=True):
 
 
 @lru_cache(maxsize=256)
-def _version_is_newer(
-    latest_version: str, installed_version: str, compare_by_string: bool = False
-) -> bool:
+def _version_is_newer(latest_version: str, installed_version: str) -> bool:
     """Return True if version is newer."""
-    latest_ver = latest_version if compare_by_string else AwesomeVersion(latest_version)
-    return latest_ver > installed_version
+    return AwesomeVersion(latest_version) > installed_version
 
 
 CACHED_PROPERTIES_WITH_ATTR_ = {

--- a/homeassistant/components/update/__init__.py
+++ b/homeassistant/components/update/__init__.py
@@ -386,7 +386,7 @@ class UpdateEntity(
 
     def version_is_newer(self, latest_version: str, installed_version: str) -> bool:
         """Return True if installed version is newer that available."""
-        # We don't inline the method because of caching
+        # We don't inline the `_version_is_newer` function because of caching
         return _version_is_newer(latest_version, installed_version)
 
     @property

--- a/homeassistant/components/update/__init__.py
+++ b/homeassistant/components/update/__init__.py
@@ -385,7 +385,7 @@ class UpdateEntity(
         raise NotImplementedError
 
     def version_is_newer(self, latest_version: str, installed_version: str) -> bool:
-        """Return True if installed version is newer that available."""
+        """Return True if installed version is newer than available."""
         # We don't inline the `_version_is_newer` function because of caching
         return _version_is_newer(latest_version, installed_version)
 

--- a/tests/components/update/test_init.py
+++ b/tests/components/update/test_init.py
@@ -964,7 +964,7 @@ async def test_custom_version_is_newer(hass: HomeAssistant) -> None:
 
     class MockUpdateEntity(UpdateEntity):
         def version_is_newer(self, latest_version: str, installed_version: str) -> bool:
-            """Return True if available version is newer than installed version."""
+            """Return True if latest_version is newer than installed_version."""
             return AwesomeVersion(
                 latest_version,
                 find_first_match=True,

--- a/tests/components/update/test_init.py
+++ b/tests/components/update/test_init.py
@@ -960,7 +960,7 @@ async def test_deprecated_supported_features_ints_with_service_call(
 
 
 async def test_custom_version_is_newer(hass: HomeAssistant) -> None:
-    """Test using custom version metho."""
+    """Test UpdateEntity with overridden version_is_newer method."""
 
     class MockUpdateEntity(UpdateEntity):
         def version_is_newer(self, latest_version: str, installed_version: str) -> bool:

--- a/tests/components/update/test_init.py
+++ b/tests/components/update/test_init.py
@@ -3,6 +3,7 @@
 from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
+from awesomeversion import AwesomeVersion, AwesomeVersionStrategy
 import pytest
 
 from homeassistant.components.update import (
@@ -956,3 +957,43 @@ async def test_deprecated_supported_features_ints_with_service_call(
             },
             blocking=True,
         )
+
+
+async def test_custom_version(hass: HomeAssistant) -> None:
+    """Test using custom version metho."""
+
+    class MockUpdateEntity(UpdateEntity):
+        def version_is_newer(self, latest_version: str, installed_version: str) -> bool:
+            """Return True if available version is newer then installed version."""
+            return AwesomeVersion(
+                latest_version,
+                find_first_match=True,
+                ensure_strategy=[AwesomeVersionStrategy.SEMVER],
+            ) > AwesomeVersion(
+                installed_version,
+                find_first_match=True,
+                ensure_strategy=[AwesomeVersionStrategy.SEMVER],
+            )
+
+    update = MockUpdateEntity()
+    update.hass = hass
+    update.platform = MockEntityPlatform(hass)
+
+    STABLE = "20230913-111730/v1.14.0-gcb84623"
+    BETA = "20231107-162609/v1.14.1-rc1-g0617c15"
+
+    # Set current installed version to STABLE
+    update._attr_installed_version = STABLE
+    update._attr_latest_version = BETA
+
+    assert update.installed_version == STABLE
+    assert update.latest_version == BETA
+    assert update.state == STATE_ON
+
+    # Set current installed version to BETA
+    update._attr_installed_version = BETA
+    update._attr_latest_version = STABLE
+
+    assert update.installed_version == BETA
+    assert update.latest_version == STABLE
+    assert update.state == STATE_OFF

--- a/tests/components/update/test_init.py
+++ b/tests/components/update/test_init.py
@@ -959,7 +959,7 @@ async def test_deprecated_supported_features_ints_with_service_call(
         )
 
 
-async def test_custom_version(hass: HomeAssistant) -> None:
+async def test_custom_version_is_newer(hass: HomeAssistant) -> None:
     """Test using custom version metho."""
 
     class MockUpdateEntity(UpdateEntity):

--- a/tests/components/update/test_init.py
+++ b/tests/components/update/test_init.py
@@ -964,7 +964,7 @@ async def test_custom_version_is_newer(hass: HomeAssistant) -> None:
 
     class MockUpdateEntity(UpdateEntity):
         def version_is_newer(self, latest_version: str, installed_version: str) -> bool:
-            """Return True if available version is newer then installed version."""
+            """Return True if available version is newer than installed version."""
             return AwesomeVersion(
                 latest_version,
                 find_first_match=True,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update platform compare versions using `AwesomeVersion` library.
For some devices this comparison always fails with `AwesomeVersionCompareException`.

Introducing a method that can be overwritten in order to address those scenarios.
Nothing changes for current implementations as default is the previous code path.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to dev docs pull request:
https://github.com/home-assistant/developers.home-assistant/pull/2307

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
