### PR TITLE
Fix ZHA group removal entity registry cleanup

### DIFF
--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -814,9 +814,12 @@ class ZHAGatewayProxy(EventBase):
         # then we get all group entity entries tied to the coordinator
         entity_registry = er.async_get(self.hass)
         assert self.gateway.coordinator_zha_device
+        coordinator_proxy = self.device_proxies[
+            self.gateway.coordinator_zha_device.ieee
+        ]
         all_group_entity_entries = er.async_entries_for_device(
             entity_registry,
-            self.gateway.coordinator_zha_device.device_id,
+            coordinator_proxy.device_id,
             include_disabled_entities=True,
         )
 

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -802,12 +802,12 @@ class ZHAGatewayProxy(EventBase):
                 )
 
     def _cleanup_group_entity_registry_entries(
-        self, zigpy_group: zigpy.group.Group
+        self, zha_group_proxy: ZHAGroupProxy
     ) -> None:
         """Remove entity registry entries for group entities when the groups are removed from HA."""
         # first we collect the potential unique ids for entities that could be created from this group
         possible_entity_unique_ids = [
-            f"{domain}_zha_group_0x{zigpy_group.group_id:04x}"
+            f"{domain}_zha_group_0x{zha_group_proxy.group.group_id:04x}"
             for domain in GROUP_ENTITY_DOMAINS
         ]
 

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -813,10 +813,10 @@ class ZHAGatewayProxy(EventBase):
 
         # then we get all group entity entries tied to the coordinator
         entity_registry = er.async_get(self.hass)
-        assert self.coordinator_zha_device
+        assert self.gateway.coordinator_zha_device
         all_group_entity_entries = er.async_entries_for_device(
             entity_registry,
-            self.coordinator_zha_device.device_id,
+            self.gateway.coordinator_zha_device.device_id,
             include_disabled_entities=True,
         )
 


### PR DESCRIPTION
## Proposed change
This fixes an issue where the entity registry wasn't cleaned up correctly when removing a ZHA group (with group entities attached to the coordinator device).
The issues were suppressed when running tests. The following issues are fixed:
- The caller method passes in a `ZHAGroupProxy`, not a zigpy group. To stay consistent with all other methods, `_cleanup_group_entity_registry_entries` now also expects a `ZHAGroupProxy` and then accesses the zigpy group via `zha_group_proxy.group`.
- The coordinator device needs to be accessed through `self.gateway.coordinator_zha_device`, not just `self.coordinator_zha_device`.
- When getting the `device_id` for the coordinator device, we need to get it from the `ZHADeviceProxy`.

In the future, we should consider improving the (actual) test coverage for this.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
