### PR TITLE
Convert Google travel time string attributes to float

### DIFF
--- a/homeassistant/components/google_travel_time/sensor.py
+++ b/homeassistant/components/google_travel_time/sensor.py
@@ -132,11 +132,11 @@ class GoogleTravelTimeSensor(SensorEntity):
         del res["rows"]
         _data = self._matrix["rows"][0]["elements"][0]
         if "duration_in_traffic" in _data:
-            res["duration_in_traffic"] = _data["duration_in_traffic"]["text"]
+            res["duration_in_traffic"] = _data["duration_in_traffic"]["value"] / 60
         if "duration" in _data:
-            res["duration"] = _data["duration"]["text"]
+            res["duration"] = _data["duration"]["value"] / 60
         if "distance" in _data:
-            res["distance"] = _data["distance"]["text"]
+            res["distance"] = _data["distance"]["value"] / 1000
         res["origin"] = self._resolved_origin
         res["destination"] = self._resolved_destination
         return res

--- a/tests/components/google_travel_time/test_sensor.py
+++ b/tests/components/google_travel_time/test_sensor.py
@@ -47,7 +47,7 @@ def mock_update_fixture() -> Generator[MagicMock]:
                                 "value": 1560,
                                 "text": "26 mins",
                             },
-                            "distance": {"text": "21.3 km"},
+                            "distance": {"value": 21300, "text": "21.3 km"},
                         }
                     ]
                 }
@@ -68,7 +68,7 @@ def mock_update_duration_fixture(mock_update: MagicMock) -> MagicMock:
                             "value": 1560,
                             "text": "26 mins",
                         },
-                        "distance": {"text": "21.3 km"},
+                        "distance": {"value": 21300, "text": "21.3 km"},
                     }
                 ]
             }
@@ -96,16 +96,12 @@ async def test_sensor(hass: HomeAssistant) -> None:
         hass.states.get("sensor.google_travel_time").attributes["attribution"]
         == "Powered by Google"
     )
-    assert (
-        hass.states.get("sensor.google_travel_time").attributes["duration"] == "26 mins"
-    )
+    assert hass.states.get("sensor.google_travel_time").attributes["duration"] == 26.0
     assert (
         hass.states.get("sensor.google_travel_time").attributes["duration_in_traffic"]
-        == "27 mins"
+        == 27.0
     )
-    assert (
-        hass.states.get("sensor.google_travel_time").attributes["distance"] == "21.3 km"
-    )
+    assert hass.states.get("sensor.google_travel_time").attributes["distance"] == 21.3
     assert (
         hass.states.get("sensor.google_travel_time").attributes["origin"] == "location1"
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The Google travel time attributes "duration_in_traffic", "duration", and "distance" have been changed from strings to floats


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This pull request standardizes the attributes reported by the Google Travel Time integration to align with those of the Waze Travel Time integration. Previously, the Google integration provided values as strings (e.g., "21.3 km"), which made it difficult to work with these values. In contrast, the Waze integration reported these values as floats, representing time in minutes and distance in kilometers.

With this change, the Google Travel Time attributes ("duration_in_traffic", "duration", and "distance") are now reported as floats, making them easier to handle and manipulate in automations. As a result, automations that were compatible with Waze Travel Time can now seamlessly integrate with Google Maps as well.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
<!--
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository] -> not needed

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
