### PR TITLE
Improve type hints in hvv_departures config flow

### DIFF
--- a/homeassistant/components/hvv_departures/config_flow.py
+++ b/homeassistant/components/hvv_departures/config_flow.py
@@ -49,10 +49,11 @@ class HVVDeparturesConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    hub: GTIHub
+    data: dict[str, Any]
+
     def __init__(self) -> None:
         """Initialize component."""
-        self.hub: GTIHub | None = None
-        self.data: dict[str, Any] | None = None
         self.stations: dict[str, Any] = {}
 
     async def async_step_user(
@@ -86,7 +87,9 @@ class HVVDeparturesConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user", data_schema=SCHEMA_STEP_USER, errors=errors
         )
 
-    async def async_step_station(self, user_input=None):
+    async def async_step_station(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Handle the step where the user inputs his/her station."""
         if user_input is not None:
             errors = {}
@@ -116,7 +119,9 @@ class HVVDeparturesConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(step_id="station", data_schema=SCHEMA_STEP_STATION)
 
-    async def async_step_station_select(self, user_input=None):
+    async def async_step_station_select(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Handle the step where the user inputs his/her station."""
 
         schema = vol.Schema({vol.Required(CONF_STATION): vol.In(list(self.stations))})
@@ -148,7 +153,9 @@ class OptionsFlowHandler(OptionsFlow):
         self.options = dict(config_entry.options)
         self.departure_filters: dict[str, Any] = {}
 
-    async def async_step_init(self, user_input=None):
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Manage the options."""
         errors = {}
         if not self.departure_filters:
@@ -177,7 +184,7 @@ class OptionsFlowHandler(OptionsFlow):
             if not errors:
                 self.departure_filters = {
                     str(i): departure_filter
-                    for i, departure_filter in enumerate(departure_list.get("filter"))
+                    for i, departure_filter in enumerate(departure_list["filter"])
                 }
 
         if user_input is not None and not errors:
@@ -195,7 +202,7 @@ class OptionsFlowHandler(OptionsFlow):
             old_filter = [
                 i
                 for (i, f) in self.departure_filters.items()
-                if f in self.config_entry.options.get(CONF_FILTER)
+                if f in self.config_entry.options[CONF_FILTER]
             ]
         else:
             old_filter = []


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #124316

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
