### PR TITLE
Improve type hints in konnected config flow

### DIFF
--- a/homeassistant/components/konnected/config_flow.py
+++ b/homeassistant/components/konnected/config_flow.py
@@ -7,7 +7,7 @@ import copy
 import logging
 import random
 import string
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 import voluptuous as vol
@@ -227,8 +227,12 @@ class KonnectedFlowHandler(ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured()
         return await self.async_step_import_confirm()
 
-    async def async_step_import_confirm(self, user_input=None):
+    async def async_step_import_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Confirm the user wants to import the config entry."""
+        if TYPE_CHECKING:
+            assert self.unique_id is not None
         if user_input is None:
             return self.async_show_form(
                 step_id="import_confirm",
@@ -349,7 +353,9 @@ class KonnectedFlowHandler(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def async_step_confirm(self, user_input=None):
+    async def async_step_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Attempt to link with the Konnected panel.
 
         Given a configured host, will ask the user to confirm and finalize
@@ -401,8 +407,8 @@ class OptionsFlowHandler(OptionsFlow):
         self.current_opt = self.entry.options or self.entry.data[CONF_DEFAULT_OPTIONS]
 
         # as config proceeds we'll build up new options and then replace what's in the config entry
-        self.new_opt: dict[str, dict[str, Any]] = {CONF_IO: {}}
-        self.active_cfg = None
+        self.new_opt: dict[str, Any] = {CONF_IO: {}}
+        self.active_cfg: str | None = None
         self.io_cfg: dict[str, Any] = {}
         self.current_states: list[dict[str, Any]] = []
         self.current_state = 1
@@ -419,13 +425,17 @@ class OptionsFlowHandler(OptionsFlow):
             {},
         )
 
-    async def async_step_init(self, user_input=None):
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Handle options flow."""
         return await self.async_step_options_io()
 
-    async def async_step_options_io(self, user_input=None):
+    async def async_step_options_io(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Configure legacy panel IO or first half of pro IO."""
-        errors = {}
+        errors: dict[str, str] = {}
         current_io = self.current_opt.get(CONF_IO, {})
 
         if user_input is not None:
@@ -508,9 +518,11 @@ class OptionsFlowHandler(OptionsFlow):
 
         return self.async_abort(reason="not_konn_panel")
 
-    async def async_step_options_io_ext(self, user_input=None):
+    async def async_step_options_io_ext(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Allow the user to configure the extended IO for pro."""
-        errors = {}
+        errors: dict[str, str] = {}
         current_io = self.current_opt.get(CONF_IO, {})
 
         if user_input is not None:
@@ -566,10 +578,12 @@ class OptionsFlowHandler(OptionsFlow):
 
         return self.async_abort(reason="not_konn_panel")
 
-    async def async_step_options_binary(self, user_input=None):
+    async def async_step_options_binary(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Allow the user to configure the IO options for binary sensors."""
-        errors = {}
-        if user_input is not None:
+        errors: dict[str, str] = {}
+        if user_input is not None and self.active_cfg is not None:
             zone = {"zone": self.active_cfg}
             zone.update(user_input)
             self.new_opt[CONF_BINARY_SENSORS] = [
@@ -602,7 +616,7 @@ class OptionsFlowHandler(OptionsFlow):
                 description_placeholders={
                     "zone": f"Zone {self.active_cfg}"
                     if len(self.active_cfg) < 3
-                    else self.active_cfg.upper
+                    else self.active_cfg.upper()
                 },
                 errors=errors,
             )
@@ -635,17 +649,19 @@ class OptionsFlowHandler(OptionsFlow):
                     description_placeholders={
                         "zone": f"Zone {self.active_cfg}"
                         if len(self.active_cfg) < 3
-                        else self.active_cfg.upper
+                        else self.active_cfg.upper()
                     },
                     errors=errors,
                 )
 
         return await self.async_step_options_digital()
 
-    async def async_step_options_digital(self, user_input=None):
+    async def async_step_options_digital(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Allow the user to configure the IO options for digital sensors."""
-        errors = {}
-        if user_input is not None:
+        errors: dict[str, str] = {}
+        if user_input is not None and self.active_cfg is not None:
             zone = {"zone": self.active_cfg}
             zone.update(user_input)
             self.new_opt[CONF_SENSORS] = [*self.new_opt.get(CONF_SENSORS, []), zone]
@@ -710,10 +726,12 @@ class OptionsFlowHandler(OptionsFlow):
 
         return await self.async_step_options_switch()
 
-    async def async_step_options_switch(self, user_input=None):
+    async def async_step_options_switch(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Allow the user to configure the IO options for switches."""
-        errors = {}
-        if user_input is not None:
+        errors: dict[str, str] = {}
+        if user_input is not None and self.active_cfg is not None:
             zone = {"zone": self.active_cfg}
             zone.update(user_input)
             del zone[CONF_MORE_STATES]
@@ -825,7 +843,9 @@ class OptionsFlowHandler(OptionsFlow):
 
         return await self.async_step_options_misc()
 
-    async def async_step_options_misc(self, user_input=None):
+    async def async_step_options_misc(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Allow the user to configure the LED behavior."""
         errors = {}
         if user_input is not None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #124316

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
