### PR TITLE
Improve type hints in nina config flow

### DIFF
--- a/homeassistant/components/nina/config_flow.py
+++ b/homeassistant/components/nina/config_flow.py
@@ -250,7 +250,7 @@ class OptionsFlowHandler(OptionsFlow):
 
             errors["base"] = "no_selection"
 
-        schema: dict[vol.Marker, Any] = {
+        schema: VolDictType = {
             **{
                 vol.Optional(region, default=self.data[region]): cv.multi_select(
                     self.regions[region]

--- a/homeassistant/components/nina/config_flow.py
+++ b/homeassistant/components/nina/config_flow.py
@@ -182,9 +182,11 @@ class OptionsFlowHandler(OptionsFlow):
             if name not in self.data:
                 self.data[name] = []
 
-    async def async_step_init(self, user_input=None):
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Handle options flow."""
-        errors: dict[str, Any] = {}
+        errors: dict[str, str] = {}
 
         if not self._all_region_codes_sorted:
             nina: Nina = Nina(async_get_clientsession(self.hass))
@@ -244,33 +246,33 @@ class OptionsFlowHandler(OptionsFlow):
                     self.config_entry, data=user_input
                 )
 
-                return self.async_create_entry(title="", data=None)
+                return self.async_create_entry(title="", data={})
 
             errors["base"] = "no_selection"
 
+        schema: dict[vol.Marker, Any] = {
+            **{
+                vol.Optional(region, default=self.data[region]): cv.multi_select(
+                    self.regions[region]
+                )
+                for region in CONST_REGIONS
+            },
+            vol.Required(
+                CONF_MESSAGE_SLOTS,
+                default=self.data[CONF_MESSAGE_SLOTS],
+            ): vol.All(int, vol.Range(min=1, max=20)),
+            vol.Optional(
+                CONF_HEADLINE_FILTER,
+                default=self.data[CONF_HEADLINE_FILTER],
+            ): cv.string,
+            vol.Optional(
+                CONF_AREA_FILTER,
+                default=self.data[CONF_AREA_FILTER],
+            ): cv.string,
+        }
+
         return self.async_show_form(
             step_id="init",
-            data_schema=vol.Schema(
-                {
-                    **{
-                        vol.Optional(
-                            region, default=self.data[region]
-                        ): cv.multi_select(self.regions[region])
-                        for region in CONST_REGIONS
-                    },
-                    vol.Required(
-                        CONF_MESSAGE_SLOTS,
-                        default=self.data[CONF_MESSAGE_SLOTS],
-                    ): vol.All(int, vol.Range(min=1, max=20)),
-                    vol.Optional(
-                        CONF_HEADLINE_FILTER,
-                        default=self.data[CONF_HEADLINE_FILTER],
-                    ): cv.string,
-                    vol.Optional(
-                        CONF_AREA_FILTER,
-                        default=self.data[CONF_AREA_FILTER],
-                    ): cv.string,
-                }
-            ),
+            data_schema=vol.Schema(schema),
             errors=errors,
         )

--- a/tests/components/nina/test_config_flow.py
+++ b/tests/components/nina/test_config_flow.py
@@ -188,7 +188,7 @@ async def test_options_flow_init(hass: HomeAssistant) -> None:
         )
 
         assert result["type"] is FlowResultType.CREATE_ENTRY
-        assert result["data"] is None
+        assert result["data"] == {}
 
         assert dict(config_entry.data) == {
             CONF_HEADLINE_FILTER: deepcopy(DUMMY_DATA[CONF_HEADLINE_FILTER]),


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #124316

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
