### PR TITLE
Add Button platform for Smlight integration

### DIFF
--- a/homeassistant/components/smlight/__init__.py
+++ b/homeassistant/components/smlight/__init__.py
@@ -9,6 +9,7 @@ from homeassistant.core import HomeAssistant
 from .coordinator import SmDataUpdateCoordinator
 
 PLATFORMS: list[Platform] = [
+    Platform.BUTTON,
     Platform.SENSOR,
 ]
 type SmConfigEntry = ConfigEntry[SmDataUpdateCoordinator]

--- a/homeassistant/components/smlight/button.py
+++ b/homeassistant/components/smlight/button.py
@@ -48,6 +48,7 @@ BUTTONS: Final = [
     SmButtonDescription(
         key="zigbee_flash_mode",
         translation_key="zigbee_flash_mode",
+        entity_registry_enabled_default=False,
         press_fn=lambda cmd: cmd.zb_bootloader(),
     ),
 ]

--- a/homeassistant/components/smlight/button.py
+++ b/homeassistant/components/smlight/button.py
@@ -1,0 +1,86 @@
+"""Support for SLZB-06 buttons."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+import logging
+from typing import Final
+
+from pysmlight.web import CmdWrapper
+
+from homeassistant.components.button import (
+    ButtonDeviceClass,
+    ButtonEntity,
+    ButtonEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .coordinator import SmDataUpdateCoordinator
+from .entity import SmEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True)
+class SmButtonDescription(ButtonEntityDescription):
+    """Class to describe a Button entity."""
+
+    entity_category = EntityCategory.CONFIG
+    press_fn: Callable[[CmdWrapper], Awaitable[None]]
+
+
+BUTTONS: Final = [
+    SmButtonDescription(
+        key="core_restart",
+        translation_key="core_restart",
+        device_class=ButtonDeviceClass.RESTART,
+        press_fn=lambda cmd: cmd.reboot(),
+    ),
+    SmButtonDescription(
+        key="zigbee_restart",
+        translation_key="zigbee_restart",
+        device_class=ButtonDeviceClass.RESTART,
+        press_fn=lambda cmd: cmd.zb_restart(),
+    ),
+    SmButtonDescription(
+        key="zigbee_flash_mode",
+        translation_key="zigbee_flash_mode",
+        press_fn=lambda cmd: cmd.zb_bootloader(),
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up SMLIGHT buttons based on a config entry."""
+    coordinator = entry.runtime_data
+
+    async_add_entities(SmButton(coordinator, button) for button in BUTTONS)
+
+
+class SmButton(SmEntity, ButtonEntity):
+    """Defines a SLZB-06 button."""
+
+    entity_description: SmButtonDescription
+
+    def __init__(
+        self,
+        coordinator: SmDataUpdateCoordinator,
+        description: SmButtonDescription,
+    ) -> None:
+        """Initialize SLZB-06 button entity."""
+        super().__init__(coordinator)
+
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.unique_id}-{description.key}"
+
+    async def async_press(self) -> None:
+        """Trigger button press."""
+        await self.entity_description.press_fn(self.coordinator.client.cmds)

--- a/homeassistant/components/smlight/button.py
+++ b/homeassistant/components/smlight/button.py
@@ -29,7 +29,6 @@ _LOGGER = logging.getLogger(__name__)
 class SmButtonDescription(ButtonEntityDescription):
     """Class to describe a Button entity."""
 
-    entity_category = EntityCategory.CONFIG
     press_fn: Callable[[CmdWrapper], Awaitable[None]]
 
 
@@ -69,6 +68,7 @@ class SmButton(SmEntity, ButtonEntity):
     """Defines a SLZB-06 button."""
 
     entity_description: SmButtonDescription
+    _attr_entity_category = EntityCategory.CONFIG
 
     def __init__(
         self,

--- a/homeassistant/components/smlight/strings.json
+++ b/homeassistant/components/smlight/strings.json
@@ -44,6 +44,17 @@
       "ram_usage": {
         "name": "RAM usage"
       }
+    },
+    "button": {
+      "core_restart": {
+        "name": "Core restart"
+      },
+      "zigbee_restart": {
+        "name": "Zigbee restart"
+      },
+      "zigbee_flash_mode": {
+        "name": "Zigbee flash mode"
+      }
     }
   }
 }

--- a/tests/components/smlight/conftest.py
+++ b/tests/components/smlight/conftest.py
@@ -3,7 +3,7 @@
 from collections.abc import AsyncGenerator, Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from pysmlight.web import Info, Sensors
+from pysmlight.web import CmdWrapper, Info, Sensors
 import pytest
 
 from homeassistant.components.smlight import PLATFORMS
@@ -74,6 +74,8 @@ def mock_smlight_client(request: pytest.FixtureRequest) -> Generator[MagicMock]:
 
         api.check_auth_needed.return_value = False
         api.authenticate.return_value = True
+
+        api.cmds = AsyncMock(spec_set=CmdWrapper)
 
         yield api
 

--- a/tests/components/smlight/test_button.py
+++ b/tests/components/smlight/test_button.py
@@ -28,6 +28,7 @@ def platforms() -> Platform | list[Platform]:
         ("zigbee_restart", "zb_restart"),
     ],
 )
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_buttons(
     hass: HomeAssistant,
     entity_id: str,
@@ -58,3 +59,19 @@ async def test_buttons(
 
     assert len(mock_method.mock_calls) == 1
     mock_method.assert_called_with()
+
+
+@pytest.mark.usefixtures("mock_smlight_client")
+async def test_disabled_by_default_button(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the disabled by default flash mode button."""
+    await setup_integration(hass, mock_config_entry)
+
+    assert not hass.states.get("button.mock_title_zigbee_flash_mode")
+
+    assert (entry := entity_registry.async_get("button.mock_title_zigbee_flash_mode"))
+    assert entry.disabled
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION

--- a/tests/components/smlight/test_button.py
+++ b/tests/components/smlight/test_button.py
@@ -1,0 +1,60 @@
+"""Tests for SMLIGHT SLZB-06 button entities."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .conftest import setup_integration
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def platforms() -> Platform | list[Platform]:
+    """Platforms, which should be loaded during the test."""
+    return [Platform.BUTTON]
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "method"),
+    [
+        ("core_restart", "reboot"),
+        ("zigbee_flash_mode", "zb_bootloader"),
+        ("zigbee_restart", "zb_restart"),
+    ],
+)
+async def test_buttons(
+    hass: HomeAssistant,
+    entity_id: str,
+    entity_registry: er.EntityRegistry,
+    method: str,
+    mock_config_entry: MockConfigEntry,
+    mock_smlight_client: MagicMock,
+) -> None:
+    """Test creation of button entities."""
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get(f"button.mock_title_{entity_id}")
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+    entry = entity_registry.async_get(f"button.mock_title_{entity_id}")
+    assert entry is not None
+    assert entry.unique_id == f"aa:bb:cc:dd:ee:ff-{entity_id}"
+
+    mock_method = getattr(mock_smlight_client.cmds, method)
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: f"button.mock_title_{entity_id}"},
+        blocking=True,
+    )
+
+    assert len(mock_method.mock_calls) == 1
+    mock_method.assert_called_with()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add button platform for SMLIGHT integration allowing to restart SLZB-06 device. This is one of the most requested features from customers.

There are three buttons included
* Core Restart - Restart Core (ESP32) module
* Zigbee restart - Restart Zigbee chip only
* Zigbee Flash Mode - Trigger the Zigbee chip into bootloader mode so it can be flashed. It is possible to flash zigbee firmware over network socket once this is activated.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/34512

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
