### PR TITLE
Allow intercepting wake words for assist satellite

### DIFF
--- a/homeassistant/components/assist_satellite/__init__.py
+++ b/homeassistant/components/assist_satellite/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.helpers.typing import ConfigType
 from .const import DOMAIN
 from .entity import AssistSatelliteEntity, AssistSatelliteEntityDescription
 from .models import AssistSatelliteEntityFeature, AssistSatelliteState
+from .websocket_api import async_register_websocket_api
 
 __all__ = [
     "DOMAIN",
@@ -47,6 +48,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         "async_internal_announce",
         [AssistSatelliteEntityFeature.ANNOUNCE],
     )
+    async_register_websocket_api(hass)
 
     return True
 

--- a/homeassistant/components/assist_satellite/entity.py
+++ b/homeassistant/components/assist_satellite/entity.py
@@ -1,7 +1,9 @@
 """Assist satellite entity."""
 
 from abc import abstractmethod
+import asyncio
 from collections.abc import AsyncIterable
+import logging
 import time
 from typing import Any, Final
 
@@ -26,10 +28,12 @@ from homeassistant.helpers import entity
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.util import ulid
 
-from .errors import SatelliteBusyError
+from .errors import AssistSatelliteError, SatelliteBusyError
 from .models import AssistSatelliteState
 
 _CONVERSATION_TIMEOUT_SEC: Final = 5 * 60  # 5 minutes
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class AssistSatelliteEntityDescription(EntityDescription, frozen_or_thawed=True):
@@ -50,6 +54,7 @@ class AssistSatelliteEntity(entity.Entity):
 
     _run_has_tts: bool = False
     _is_announcing = False
+    _wake_word_intercept_future: asyncio.Future[str | None] | None = None
 
     @property
     def pipeline_entity_id(self) -> str | None:
@@ -60,6 +65,25 @@ class AssistSatelliteEntity(entity.Entity):
     def vad_sensitivity_entity_id(self) -> str | None:
         """Entity ID of the VAD sensitivity to use for the next conversation."""
         return self._attr_vad_sensitivity_entity_id
+
+    async def async_intercept_wake_word(self) -> str | None:
+        """Intercept the next wake word from the satellite.
+
+        Returns the detected wake word phrase or None.
+        """
+        if self._wake_word_intercept_future is not None:
+            raise SatelliteBusyError
+
+        # Will cause next wake word to be intercepted in
+        # _async_accept_pipeline_from_satellite
+        self._wake_word_intercept_future = asyncio.Future()
+
+        _LOGGER.debug("Next wake word will be intercepted: %s", self.entity_id)
+
+        try:
+            return await self._wake_word_intercept_future
+        finally:
+            self._wake_word_intercept_future = None
 
     async def async_internal_announce(
         self,
@@ -130,6 +154,34 @@ class AssistSatelliteEntity(entity.Entity):
         wake_word_phrase: str | None = None,
     ) -> None:
         """Triggers an Assist pipeline in Home Assistant from a satellite."""
+        if self._wake_word_intercept_future and start_stage in (
+            PipelineStage.WAKE_WORD,
+            PipelineStage.STT,
+        ):
+            if start_stage == PipelineStage.WAKE_WORD:
+                self._wake_word_intercept_future.set_exception(
+                    AssistSatelliteError(
+                        "Only on-device wake words currently supported"
+                    )
+                )
+                return
+
+            # Intercepting wake word and immediately end pipeline
+            _LOGGER.debug(
+                "Intercepted wake word: %s (entity_id=%s)",
+                wake_word_phrase,
+                self.entity_id,
+            )
+
+            if wake_word_phrase is None:
+                self._wake_word_intercept_future.set_exception(
+                    AssistSatelliteError("No wake word phrase provided")
+                )
+            else:
+                self._wake_word_intercept_future.set_result(wake_word_phrase)
+            self._internal_on_pipeline_event(PipelineEvent(PipelineEventType.RUN_END))
+            return
+
         device_id = self.registry_entry.device_id if self.registry_entry else None
 
         # Refresh context if necessary

--- a/homeassistant/components/assist_satellite/entity.py
+++ b/homeassistant/components/assist_satellite/entity.py
@@ -72,7 +72,7 @@ class AssistSatelliteEntity(entity.Entity):
         Returns the detected wake word phrase or None.
         """
         if self._wake_word_intercept_future is not None:
-            raise SatelliteBusyError
+            raise SatelliteBusyError("Wake word interception already in progress")
 
         # Will cause next wake word to be intercepted in
         # async_accept_pipeline_from_satellite

--- a/homeassistant/components/assist_satellite/entity.py
+++ b/homeassistant/components/assist_satellite/entity.py
@@ -75,7 +75,7 @@ class AssistSatelliteEntity(entity.Entity):
             raise SatelliteBusyError
 
         # Will cause next wake word to be intercepted in
-        # _async_accept_pipeline_from_satellite
+        # async_accept_pipeline_from_satellite
         self._wake_word_intercept_future = asyncio.Future()
 
         _LOGGER.debug("Next wake word will be intercepted: %s", self.entity_id)

--- a/homeassistant/components/assist_satellite/websocket_api.py
+++ b/homeassistant/components/assist_satellite/websocket_api.py
@@ -6,6 +6,7 @@ import voluptuous as vol
 
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_component import EntityComponent
 
 from .const import DOMAIN
@@ -22,7 +23,7 @@ def async_register_websocket_api(hass: HomeAssistant) -> None:
 @websocket_api.websocket_command(
     {
         vol.Required("type"): "assist_satellite/intercept_wake_word",
-        vol.Required("entity_id"): str,
+        vol.Required("entity_id"): cv.entity_domain(DOMAIN),
     }
 )
 @websocket_api.require_admin

--- a/homeassistant/components/assist_satellite/websocket_api.py
+++ b/homeassistant/components/assist_satellite/websocket_api.py
@@ -1,0 +1,45 @@
+"""Assist satellite Websocket API."""
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components import websocket_api
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_component import EntityComponent
+
+from .const import DOMAIN
+from .entity import AssistSatelliteEntity
+
+
+@callback
+def async_register_websocket_api(hass: HomeAssistant) -> None:
+    """Register the websocket API."""
+    websocket_api.async_register_command(hass, websocket_intercept_wake_word)
+
+
+@callback
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "assist_satellite/intercept_wake_word",
+        vol.Required("entity_id"): str,
+    }
+)
+@websocket_api.require_admin
+@websocket_api.async_response
+async def websocket_intercept_wake_word(
+    hass: HomeAssistant,
+    connection: websocket_api.connection.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Intercept the next wake word from a satellite."""
+    component: EntityComponent[AssistSatelliteEntity] = hass.data[DOMAIN]
+    satellite = component.get_entity(msg["entity_id"])
+    if satellite is None:
+        connection.send_error(
+            msg["id"], websocket_api.ERR_NOT_FOUND, "Entity not found"
+        )
+        return
+
+    wake_word_phrase = await satellite.async_intercept_wake_word()
+    connection.send_result(msg["id"], {"wake_word_phrase": wake_word_phrase})

--- a/tests/components/assist_satellite/__init__.py
+++ b/tests/components/assist_satellite/__init__.py
@@ -1,1 +1,3 @@
 """Tests for Assist Satellite."""
+
+ENTITY_ID = "assist_satellite.test_entity"

--- a/tests/components/assist_satellite/test_entity.py
+++ b/tests/components/assist_satellite/test_entity.py
@@ -20,9 +20,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import Context, HomeAssistant
 
+from . import ENTITY_ID
 from .conftest import MockAssistSatellite
-
-ENTITY_ID = "assist_satellite.test_entity"
 
 
 async def test_entity_state(

--- a/tests/components/assist_satellite/test_websocket_api.py
+++ b/tests/components/assist_satellite/test_websocket_api.py
@@ -1,0 +1,86 @@
+"""Test WebSocket API."""
+
+import asyncio
+
+from homeassistant.components.assist_pipeline import PipelineStage
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from . import ENTITY_ID
+from .conftest import MockAssistSatellite
+
+from tests.common import MockUser
+from tests.typing import WebSocketGenerator
+
+
+async def test_entity_state(
+    hass: HomeAssistant,
+    init_components: ConfigEntry,
+    entity: MockAssistSatellite,
+    hass_ws_client: WebSocketGenerator,
+    hass_admin_user: MockUser,
+) -> None:
+    """Test entity state represent events."""
+    ws_client = await hass_ws_client(hass)
+
+    await ws_client.send_json_auto_id(
+        {
+            "type": "assist_satellite/intercept_wake_word",
+            "entity_id": ENTITY_ID,
+        }
+    )
+
+    for _ in range(3):
+        await asyncio.sleep(0)
+
+    await entity.async_accept_pipeline_from_satellite(
+        object(),
+        start_stage=PipelineStage.STT,
+        wake_word_phrase="ok, nabu",
+    )
+
+    response = await ws_client.receive_json()
+
+    assert response["success"]
+    assert response["result"] == {"wake_word_phrase": "ok, nabu"}
+
+    # Ensure we error out for wake word processing in Home Assistant
+    await ws_client.send_json_auto_id(
+        {
+            "type": "assist_satellite/intercept_wake_word",
+            "entity_id": ENTITY_ID,
+        }
+    )
+
+    for _ in range(3):
+        await asyncio.sleep(0)
+
+    await entity.async_accept_pipeline_from_satellite(
+        object(),
+        # Emulate wake word processing in Home Assistant
+        start_stage=PipelineStage.WAKE_WORD,
+    )
+
+    response = await ws_client.receive_json()
+    assert not response["success"]
+    assert response["error"] == {
+        "code": "home_assistant_error",
+        "message": "Only on-device wake words currently supported",
+    }
+
+    # Remove admin permission and verify we're not allowed
+    hass_admin_user.groups = []
+
+    await ws_client.send_json_auto_id(
+        {
+            "type": "assist_satellite/intercept_wake_word",
+            "entity_id": ENTITY_ID,
+        }
+    )
+    response = await ws_client.receive_json()
+
+    assert not response["success"]
+    assert response["error"] == {
+        "code": "unauthorized",
+        "message": "Unauthorized",
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Extract intercepting wake word calls from #124886

This PR adds a websocket API to allow detecting when a wake word says a wake word. Currently only supports on-device wake words. Will error out when using a pipeline that depends on HA processing audio stream for wake words.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
