### PR TITLE
Use SnapshotAssertion in more AVM Fritz!Box Tools tests

### DIFF
--- a/tests/components/fritz/snapshots/test_button.ambr
+++ b/tests/components/fritz/snapshots/test_button.ambr
@@ -1,0 +1,235 @@
+# serializer version: 1
+# name: test_button_setup[button.mock_title_cleanup-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.mock_title_cleanup',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Cleanup',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'cleanup',
+    'unique_id': '1C:ED:6F:12:34:11-cleanup',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button_setup[button.mock_title_cleanup-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Cleanup',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.mock_title_cleanup',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button_setup[button.mock_title_firmware_update-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.mock_title_firmware_update',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <ButtonDeviceClass.UPDATE: 'update'>,
+    'original_icon': None,
+    'original_name': 'Firmware update',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'firmware_update',
+    'unique_id': '1C:ED:6F:12:34:11-firmware_update',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button_setup[button.mock_title_firmware_update-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'update',
+      'friendly_name': 'Mock Title Firmware update',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.mock_title_firmware_update',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button_setup[button.mock_title_reconnect-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.mock_title_reconnect',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <ButtonDeviceClass.RESTART: 'restart'>,
+    'original_icon': None,
+    'original_name': 'Reconnect',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'reconnect',
+    'unique_id': '1C:ED:6F:12:34:11-reconnect',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button_setup[button.mock_title_reconnect-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'restart',
+      'friendly_name': 'Mock Title Reconnect',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.mock_title_reconnect',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button_setup[button.mock_title_restart-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.mock_title_restart',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <ButtonDeviceClass.RESTART: 'restart'>,
+    'original_icon': None,
+    'original_name': 'Restart',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1C:ED:6F:12:34:11-reboot',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button_setup[button.mock_title_restart-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'restart',
+      'friendly_name': 'Mock Title Restart',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.mock_title_restart',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button_setup[button.printer_wake_on_lan-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.printer_wake_on_lan',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:lan-pending',
+    'original_name': 'printer Wake on LAN',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'AA:BB:CC:00:11:22_wake_on_lan',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button_setup[button.printer_wake_on_lan-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'printer Wake on LAN',
+      'icon': 'mdi:lan-pending',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.printer_wake_on_lan',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/fritz/snapshots/test_diagnostics.ambr
+++ b/tests/components/fritz/snapshots/test_diagnostics.ambr
@@ -1,0 +1,67 @@
+# serializer version: 1
+# name: test_entry_diagnostics
+  dict({
+    'device_info': dict({
+      'client_devices': list([
+        dict({
+          'connected_to': 'fritz.box',
+          'connection_type': 'LAN',
+          'hostname': 'printer',
+          'is_connected': True,
+          'wan_access': True,
+        }),
+      ]),
+      'connection_type': 'WANPPPConnection',
+      'current_firmware': '7.29',
+      'discovered_services': list([
+        'DeviceInfo1',
+        'Hosts1',
+        'LANEthernetInterfaceConfig1',
+        'Layer3Forwarding1',
+        'UserInterface1',
+        'WANCommonIFC1',
+        'WANCommonInterfaceConfig1',
+        'WANDSLInterfaceConfig1',
+        'WANIPConn1',
+        'WANPPPConnection1',
+        'WLANConfiguration1',
+        'X_AVM-DE_Homeauto1',
+        'X_AVM-DE_HostFilter1',
+      ]),
+      'is_router': True,
+      'last_exception': None,
+      'last_update success': True,
+      'latest_firmware': None,
+      'mesh_role': 'master',
+      'model': 'FRITZ!Box 7530 AX',
+      'unique_id': '1C:ED:XX:XX:34:11',
+      'update_available': False,
+      'wan_link_properties': dict({
+        'NewLayer1DownstreamMaxBitRate': 318557000,
+        'NewLayer1UpstreamMaxBitRate': 51805000,
+        'NewPhysicalLinkStatus': 'Up',
+        'NewWANAccessType': 'DSL',
+      }),
+    }),
+    'entry': dict({
+      'data': dict({
+        'host': 'fake_host',
+        'password': '**REDACTED**',
+        'port': '1234',
+        'ssl': False,
+        'username': '**REDACTED**',
+      }),
+      'disabled_by': None,
+      'domain': 'fritz',
+      'minor_version': 1,
+      'options': dict({
+      }),
+      'pref_disable_new_entities': False,
+      'pref_disable_polling': False,
+      'source': 'user',
+      'title': 'Mock Title',
+      'unique_id': None,
+      'version': 1,
+    }),
+  })
+# ---

--- a/tests/components/fritz/snapshots/test_sensor.ambr
+++ b/tests/components/fritz/snapshots/test_sensor.ambr
@@ -1,0 +1,771 @@
+# serializer version: 1
+# name: test_sensor_setup[sensor.mock_title_connection_uptime-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mock_title_connection_uptime',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Connection uptime',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'connection_uptime',
+    'unique_id': '1C:ED:6F:12:34:11-connection_uptime',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_connection_uptime-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Mock Title Connection uptime',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_connection_uptime',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-09-01T10:11:33+00:00',
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_download_throughput-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_title_download_throughput',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.DATA_RATE: 'data_rate'>,
+    'original_icon': None,
+    'original_name': 'Download throughput',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'kb_s_received',
+    'unique_id': '1C:ED:6F:12:34:11-kb_s_received',
+    'unit_of_measurement': <UnitOfDataRate.KILOBYTES_PER_SECOND: 'kB/s'>,
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_download_throughput-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'data_rate',
+      'friendly_name': 'Mock Title Download throughput',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfDataRate.KILOBYTES_PER_SECOND: 'kB/s'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_download_throughput',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '67.6',
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_external_ip-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_title_external_ip',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'External IP',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'external_ip',
+    'unique_id': '1C:ED:6F:12:34:11-external_ip',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_external_ip-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title External IP',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_external_ip',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1.2.3.4',
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_external_ipv6-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_title_external_ipv6',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'External IPv6',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'external_ipv6',
+    'unique_id': '1C:ED:6F:12:34:11-external_ipv6',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_external_ipv6-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title External IPv6',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_external_ipv6',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'fec0::1',
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_gb_received-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_title_gb_received',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.DATA_SIZE: 'data_size'>,
+    'original_icon': None,
+    'original_name': 'GB received',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'gb_received',
+    'unique_id': '1C:ED:6F:12:34:11-gb_received',
+    'unit_of_measurement': <UnitOfInformation.GIGABYTES: 'GB'>,
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_gb_received-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'data_size',
+      'friendly_name': 'Mock Title GB received',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfInformation.GIGABYTES: 'GB'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_gb_received',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '5.2',
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_gb_sent-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_title_gb_sent',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.DATA_SIZE: 'data_size'>,
+    'original_icon': None,
+    'original_name': 'GB sent',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'gb_sent',
+    'unique_id': '1C:ED:6F:12:34:11-gb_sent',
+    'unit_of_measurement': <UnitOfInformation.GIGABYTES: 'GB'>,
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_gb_sent-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'data_size',
+      'friendly_name': 'Mock Title GB sent',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfInformation.GIGABYTES: 'GB'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_gb_sent',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1.7',
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_last_restart-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mock_title_last_restart',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Last restart',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'device_uptime',
+    'unique_id': '1C:ED:6F:12:34:11-device_uptime',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_last_restart-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Mock Title Last restart',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_last_restart',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-08-03T16:30:21+00:00',
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_link_download_noise_margin-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_title_link_download_noise_margin',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Link download noise margin',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'link_noise_margin_received',
+    'unique_id': '1C:ED:6F:12:34:11-link_noise_margin_received',
+    'unit_of_measurement': 'dB',
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_link_download_noise_margin-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Link download noise margin',
+      'unit_of_measurement': 'dB',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_link_download_noise_margin',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '8.0',
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_link_download_power_attenuation-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_title_link_download_power_attenuation',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Link download power attenuation',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'link_attenuation_received',
+    'unique_id': '1C:ED:6F:12:34:11-link_attenuation_received',
+    'unit_of_measurement': 'dB',
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_link_download_power_attenuation-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Link download power attenuation',
+      'unit_of_measurement': 'dB',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_link_download_power_attenuation',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '12.0',
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_link_download_throughput-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_title_link_download_throughput',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.DATA_RATE: 'data_rate'>,
+    'original_icon': None,
+    'original_name': 'Link download throughput',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'link_kb_s_received',
+    'unique_id': '1C:ED:6F:12:34:11-link_kb_s_received',
+    'unit_of_measurement': <UnitOfDataRate.KILOBITS_PER_SECOND: 'kbit/s'>,
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_link_download_throughput-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'data_rate',
+      'friendly_name': 'Mock Title Link download throughput',
+      'unit_of_measurement': <UnitOfDataRate.KILOBITS_PER_SECOND: 'kbit/s'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_link_download_throughput',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '318557.0',
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_link_upload_noise_margin-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_title_link_upload_noise_margin',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Link upload noise margin',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'link_noise_margin_sent',
+    'unique_id': '1C:ED:6F:12:34:11-link_noise_margin_sent',
+    'unit_of_measurement': 'dB',
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_link_upload_noise_margin-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Link upload noise margin',
+      'unit_of_measurement': 'dB',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_link_upload_noise_margin',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '9.0',
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_link_upload_power_attenuation-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_title_link_upload_power_attenuation',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Link upload power attenuation',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'link_attenuation_sent',
+    'unique_id': '1C:ED:6F:12:34:11-link_attenuation_sent',
+    'unit_of_measurement': 'dB',
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_link_upload_power_attenuation-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Link upload power attenuation',
+      'unit_of_measurement': 'dB',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_link_upload_power_attenuation',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '7.0',
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_link_upload_throughput-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_title_link_upload_throughput',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.DATA_RATE: 'data_rate'>,
+    'original_icon': None,
+    'original_name': 'Link upload throughput',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'link_kb_s_sent',
+    'unique_id': '1C:ED:6F:12:34:11-link_kb_s_sent',
+    'unit_of_measurement': <UnitOfDataRate.KILOBITS_PER_SECOND: 'kbit/s'>,
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_link_upload_throughput-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'data_rate',
+      'friendly_name': 'Mock Title Link upload throughput',
+      'unit_of_measurement': <UnitOfDataRate.KILOBITS_PER_SECOND: 'kbit/s'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_link_upload_throughput',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '51805.0',
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_max_connection_download_throughput-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mock_title_max_connection_download_throughput',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.DATA_RATE: 'data_rate'>,
+    'original_icon': None,
+    'original_name': 'Max connection download throughput',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'max_kb_s_received',
+    'unique_id': '1C:ED:6F:12:34:11-max_kb_s_received',
+    'unit_of_measurement': <UnitOfDataRate.KILOBITS_PER_SECOND: 'kbit/s'>,
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_max_connection_download_throughput-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'data_rate',
+      'friendly_name': 'Mock Title Max connection download throughput',
+      'unit_of_measurement': <UnitOfDataRate.KILOBITS_PER_SECOND: 'kbit/s'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_max_connection_download_throughput',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '10087.0',
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_max_connection_upload_throughput-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mock_title_max_connection_upload_throughput',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.DATA_RATE: 'data_rate'>,
+    'original_icon': None,
+    'original_name': 'Max connection upload throughput',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'max_kb_s_sent',
+    'unique_id': '1C:ED:6F:12:34:11-max_kb_s_sent',
+    'unit_of_measurement': <UnitOfDataRate.KILOBITS_PER_SECOND: 'kbit/s'>,
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_max_connection_upload_throughput-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'data_rate',
+      'friendly_name': 'Mock Title Max connection upload throughput',
+      'unit_of_measurement': <UnitOfDataRate.KILOBITS_PER_SECOND: 'kbit/s'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_max_connection_upload_throughput',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2105.0',
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_upload_throughput-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_title_upload_throughput',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.DATA_RATE: 'data_rate'>,
+    'original_icon': None,
+    'original_name': 'Upload throughput',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'kb_s_sent',
+    'unique_id': '1C:ED:6F:12:34:11-kb_s_sent',
+    'unit_of_measurement': <UnitOfDataRate.KILOBYTES_PER_SECOND: 'kB/s'>,
+  })
+# ---
+# name: test_sensor_setup[sensor.mock_title_upload_throughput-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'data_rate',
+      'friendly_name': 'Mock Title Upload throughput',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfDataRate.KILOBYTES_PER_SECOND: 'kB/s'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_upload_throughput',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '3.4',
+  })
+# ---

--- a/tests/components/fritz/snapshots/test_switch.ambr
+++ b/tests/components/fritz/snapshots/test_switch.ambr
@@ -1,0 +1,424 @@
+# serializer version: 1
+# name: test_switch_setup[fc_data0-expected_wifi_names0][switch.mock_title_wi_fi_wifi_2_4ghz-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.mock_title_wi_fi_wifi_2_4ghz',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:wifi',
+    'original_name': 'Mock Title Wi-Fi WiFi (2.4Ghz)',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1C:ED:6F:12:34:11-wi_fi_wifi_2_4ghz',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_setup[fc_data0-expected_wifi_names0][switch.mock_title_wi_fi_wifi_2_4ghz-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Wi-Fi WiFi (2.4Ghz)',
+      'icon': 'mdi:wifi',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.mock_title_wi_fi_wifi_2_4ghz',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_setup[fc_data0-expected_wifi_names0][switch.mock_title_wi_fi_wifi_5ghz-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.mock_title_wi_fi_wifi_5ghz',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:wifi',
+    'original_name': 'Mock Title Wi-Fi WiFi (5Ghz)',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1C:ED:6F:12:34:11-wi_fi_wifi_5ghz',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_setup[fc_data0-expected_wifi_names0][switch.mock_title_wi_fi_wifi_5ghz-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Wi-Fi WiFi (5Ghz)',
+      'icon': 'mdi:wifi',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.mock_title_wi_fi_wifi_5ghz',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_setup[fc_data0-expected_wifi_names0][switch.printer_internet_access-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.printer_internet_access',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:router-wireless-settings',
+    'original_name': 'printer Internet Access',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'AA:BB:CC:00:11:22_internet_access',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_setup[fc_data0-expected_wifi_names0][switch.printer_internet_access-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'printer Internet Access',
+      'icon': 'mdi:router-wireless-settings',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.printer_internet_access',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_setup[fc_data1-expected_wifi_names1][switch.mock_title_wi_fi_wifi-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.mock_title_wi_fi_wifi',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:wifi',
+    'original_name': 'Mock Title Wi-Fi WiFi',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1C:ED:6F:12:34:11-wi_fi_wifi',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_setup[fc_data1-expected_wifi_names1][switch.mock_title_wi_fi_wifi-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Wi-Fi WiFi',
+      'icon': 'mdi:wifi',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.mock_title_wi_fi_wifi',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_setup[fc_data1-expected_wifi_names1][switch.mock_title_wi_fi_wifi2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.mock_title_wi_fi_wifi2',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:wifi',
+    'original_name': 'Mock Title Wi-Fi WiFi2',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1C:ED:6F:12:34:11-wi_fi_wifi2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_setup[fc_data1-expected_wifi_names1][switch.mock_title_wi_fi_wifi2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Wi-Fi WiFi2',
+      'icon': 'mdi:wifi',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.mock_title_wi_fi_wifi2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_setup[fc_data1-expected_wifi_names1][switch.printer_internet_access-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.printer_internet_access',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:router-wireless-settings',
+    'original_name': 'printer Internet Access',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'AA:BB:CC:00:11:22_internet_access',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_setup[fc_data1-expected_wifi_names1][switch.printer_internet_access-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'printer Internet Access',
+      'icon': 'mdi:router-wireless-settings',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.printer_internet_access',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_setup[fc_data2-expected_wifi_names2][switch.mock_title_wi_fi_wifi_2_4ghz-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.mock_title_wi_fi_wifi_2_4ghz',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:wifi',
+    'original_name': 'Mock Title Wi-Fi WiFi (2.4Ghz)',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1C:ED:6F:12:34:11-wi_fi_wifi_2_4ghz',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_setup[fc_data2-expected_wifi_names2][switch.mock_title_wi_fi_wifi_2_4ghz-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Wi-Fi WiFi (2.4Ghz)',
+      'icon': 'mdi:wifi',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.mock_title_wi_fi_wifi_2_4ghz',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_setup[fc_data2-expected_wifi_names2][switch.mock_title_wi_fi_wifi_5ghz-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.mock_title_wi_fi_wifi_5ghz',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:wifi',
+    'original_name': 'Mock Title Wi-Fi WiFi+ (5Ghz)',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1C:ED:6F:12:34:11-wi_fi_wifi_5ghz',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_setup[fc_data2-expected_wifi_names2][switch.mock_title_wi_fi_wifi_5ghz-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Wi-Fi WiFi+ (5Ghz)',
+      'icon': 'mdi:wifi',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.mock_title_wi_fi_wifi_5ghz',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_setup[fc_data2-expected_wifi_names2][switch.printer_internet_access-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.printer_internet_access',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:router-wireless-settings',
+    'original_name': 'printer Internet Access',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'AA:BB:CC:00:11:22_internet_access',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_setup[fc_data2-expected_wifi_names2][switch.printer_internet_access-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'printer Internet Access',
+      'icon': 'mdi:router-wireless-settings',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.printer_internet_access',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/fritz/snapshots/test_update.ambr
+++ b/tests/components/fritz/snapshots/test_update.ambr
@@ -1,0 +1,169 @@
+# serializer version: 1
+# name: test_available_update_can_be_installed[update.mock_title_fritz_os-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'update',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'update.mock_title_fritz_os',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'FRITZ!OS',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': <UpdateEntityFeature: 1>,
+    'translation_key': None,
+    'unique_id': '1C:ED:6F:12:34:11-update',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_available_update_can_be_installed[update.mock_title_fritz_os-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'auto_update': False,
+      'entity_picture': 'https://brands.home-assistant.io/_/fritz/icon.png',
+      'friendly_name': 'Mock Title FRITZ!OS',
+      'in_progress': False,
+      'installed_version': '7.29',
+      'latest_version': '7.50',
+      'release_summary': None,
+      'release_url': 'http://download.avm.de/fritzbox/fritzbox-7530-ax/deutschland/fritz.os/info_de.txt',
+      'skipped_version': None,
+      'supported_features': <UpdateEntityFeature: 1>,
+      'title': 'FRITZ!OS',
+    }),
+    'context': <ANY>,
+    'entity_id': 'update.mock_title_fritz_os',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_update_available[update.mock_title_fritz_os-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'update',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'update.mock_title_fritz_os',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'FRITZ!OS',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': <UpdateEntityFeature: 1>,
+    'translation_key': None,
+    'unique_id': '1C:ED:6F:12:34:11-update',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_update_available[update.mock_title_fritz_os-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'auto_update': False,
+      'entity_picture': 'https://brands.home-assistant.io/_/fritz/icon.png',
+      'friendly_name': 'Mock Title FRITZ!OS',
+      'in_progress': False,
+      'installed_version': '7.29',
+      'latest_version': '7.50',
+      'release_summary': None,
+      'release_url': 'http://download.avm.de/fritzbox/fritzbox-7530-ax/deutschland/fritz.os/info_de.txt',
+      'skipped_version': None,
+      'supported_features': <UpdateEntityFeature: 1>,
+      'title': 'FRITZ!OS',
+    }),
+    'context': <ANY>,
+    'entity_id': 'update.mock_title_fritz_os',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_update_entities_initialized[update.mock_title_fritz_os-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'update',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'update.mock_title_fritz_os',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'FRITZ!OS',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': <UpdateEntityFeature: 1>,
+    'translation_key': None,
+    'unique_id': '1C:ED:6F:12:34:11-update',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_update_entities_initialized[update.mock_title_fritz_os-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'auto_update': False,
+      'entity_picture': 'https://brands.home-assistant.io/_/fritz/icon.png',
+      'friendly_name': 'Mock Title FRITZ!OS',
+      'in_progress': False,
+      'installed_version': '7.29',
+      'latest_version': '7.29',
+      'release_summary': None,
+      'release_url': None,
+      'skipped_version': None,
+      'supported_features': <UpdateEntityFeature: 1>,
+      'title': 'FRITZ!OS',
+    }),
+    'context': <ANY>,
+    'entity_id': 'update.mock_title_fritz_os',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/fritz/test_diagnostics.py
+++ b/tests/components/fritz/test_diagnostics.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-from homeassistant.components.diagnostics import REDACTED
+from syrupy import SnapshotAssertion
+from syrupy.filters import props
+
 from homeassistant.components.fritz.const import DOMAIN
-from homeassistant.components.fritz.coordinator import AvmWrapper
-from homeassistant.components.fritz.diagnostics import TO_REDACT
-from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
-from .const import MOCK_MESH_MASTER_MAC, MOCK_USER_DATA
+from .const import MOCK_USER_DATA
 
 from tests.common import MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
@@ -21,64 +20,16 @@ async def test_entry_diagnostics(
     hass_client: ClientSessionGenerator,
     fc_class_mock,
     fh_class_mock,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test config entry diagnostics."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
     entry.add_to_hass(hass)
 
-    await hass.config_entries.async_setup(entry.entry_id)
+    assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state is ConfigEntryState.LOADED
 
-    entry_dict = entry.as_dict()
-    for key in TO_REDACT:
-        entry_dict["data"][key] = REDACTED
     result = await get_diagnostics_for_config_entry(hass, hass_client, entry)
-    avm_wrapper: AvmWrapper = hass.data[DOMAIN][entry.entry_id]
-    assert result == {
-        "entry": entry_dict,
-        "device_info": {
-            "client_devices": [
-                {
-                    "connected_to": device.connected_to,
-                    "connection_type": device.connection_type,
-                    "hostname": device.hostname,
-                    "is_connected": device.is_connected,
-                    "last_activity": device.last_activity.isoformat(),
-                    "wan_access": device.wan_access,
-                }
-                for _, device in avm_wrapper.devices.items()
-            ],
-            "connection_type": "WANPPPConnection",
-            "current_firmware": "7.29",
-            "discovered_services": [
-                "DeviceInfo1",
-                "Hosts1",
-                "LANEthernetInterfaceConfig1",
-                "Layer3Forwarding1",
-                "UserInterface1",
-                "WANCommonIFC1",
-                "WANCommonInterfaceConfig1",
-                "WANDSLInterfaceConfig1",
-                "WANIPConn1",
-                "WANPPPConnection1",
-                "WLANConfiguration1",
-                "X_AVM-DE_Homeauto1",
-                "X_AVM-DE_HostFilter1",
-            ],
-            "is_router": True,
-            "last_exception": None,
-            "last_update success": True,
-            "latest_firmware": None,
-            "mesh_role": "master",
-            "model": "FRITZ!Box 7530 AX",
-            "unique_id": MOCK_MESH_MASTER_MAC.replace("6F:12", "XX:XX"),
-            "update_available": False,
-            "wan_link_properties": {
-                "NewLayer1DownstreamMaxBitRate": 318557000,
-                "NewLayer1UpstreamMaxBitRate": 51805000,
-                "NewPhysicalLinkStatus": "Up",
-                "NewWANAccessType": "DSL",
-            },
-        },
-    }
+    assert result == snapshot(
+        exclude=props("created_at", "modified_at", "entry_id", "last_activity")
+    )

--- a/tests/components/fritz/test_sensor.py
+++ b/tests/components/fritz/test_sensor.py
@@ -2,123 +2,47 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
-from typing import Any
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
 
 from fritzconnection.core.exceptions import FritzConnectionException
+import pytest
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.fritz.const import DOMAIN
-from homeassistant.components.fritz.sensor import SENSOR_TYPES
-from homeassistant.components.sensor import (
-    ATTR_STATE_CLASS,
-    DOMAIN as SENSOR_DOMAIN,
-    SensorDeviceClass,
-    SensorStateClass,
-)
-from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import (
-    ATTR_DEVICE_CLASS,
-    ATTR_STATE,
-    ATTR_UNIT_OF_MEASUREMENT,
-    STATE_UNAVAILABLE,
-)
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.const import STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 import homeassistant.util.dt as dt_util
 
 from .const import MOCK_USER_DATA
 
-from tests.common import MockConfigEntry, async_fire_time_changed
-
-SENSOR_STATES: dict[str, dict[str, Any]] = {
-    "sensor.mock_title_external_ip": {
-        ATTR_STATE: "1.2.3.4",
-    },
-    "sensor.mock_title_external_ipv6": {
-        ATTR_STATE: "fec0::1",
-    },
-    "sensor.mock_title_last_restart": {
-        # ATTR_STATE: "2022-02-05T17:46:04+00:00",
-        ATTR_DEVICE_CLASS: SensorDeviceClass.TIMESTAMP,
-    },
-    "sensor.mock_title_connection_uptime": {
-        # ATTR_STATE: "2022-03-06T11:27:16+00:00",
-        ATTR_DEVICE_CLASS: SensorDeviceClass.TIMESTAMP,
-    },
-    "sensor.mock_title_upload_throughput": {
-        ATTR_STATE: "3.4",
-        ATTR_STATE_CLASS: SensorStateClass.MEASUREMENT,
-        ATTR_UNIT_OF_MEASUREMENT: "kB/s",
-    },
-    "sensor.mock_title_download_throughput": {
-        ATTR_STATE: "67.6",
-        ATTR_STATE_CLASS: SensorStateClass.MEASUREMENT,
-        ATTR_UNIT_OF_MEASUREMENT: "kB/s",
-    },
-    "sensor.mock_title_max_connection_upload_throughput": {
-        ATTR_STATE: "2105.0",
-        ATTR_UNIT_OF_MEASUREMENT: "kbit/s",
-    },
-    "sensor.mock_title_max_connection_download_throughput": {
-        ATTR_STATE: "10087.0",
-        ATTR_UNIT_OF_MEASUREMENT: "kbit/s",
-    },
-    "sensor.mock_title_gb_sent": {
-        ATTR_STATE: "1.7",
-        ATTR_STATE_CLASS: SensorStateClass.TOTAL_INCREASING,
-        ATTR_UNIT_OF_MEASUREMENT: "GB",
-    },
-    "sensor.mock_title_gb_received": {
-        ATTR_STATE: "5.2",
-        ATTR_STATE_CLASS: SensorStateClass.TOTAL_INCREASING,
-        ATTR_UNIT_OF_MEASUREMENT: "GB",
-    },
-    "sensor.mock_title_link_upload_throughput": {
-        ATTR_STATE: "51805.0",
-        ATTR_UNIT_OF_MEASUREMENT: "kbit/s",
-    },
-    "sensor.mock_title_link_download_throughput": {
-        ATTR_STATE: "318557.0",
-        ATTR_UNIT_OF_MEASUREMENT: "kbit/s",
-    },
-    "sensor.mock_title_link_upload_noise_margin": {
-        ATTR_STATE: "9.0",
-        ATTR_UNIT_OF_MEASUREMENT: "dB",
-    },
-    "sensor.mock_title_link_download_noise_margin": {
-        ATTR_STATE: "8.0",
-        ATTR_UNIT_OF_MEASUREMENT: "dB",
-    },
-    "sensor.mock_title_link_upload_power_attenuation": {
-        ATTR_STATE: "7.0",
-        ATTR_UNIT_OF_MEASUREMENT: "dB",
-    },
-    "sensor.mock_title_link_download_power_attenuation": {
-        ATTR_STATE: "12.0",
-        ATTR_UNIT_OF_MEASUREMENT: "dB",
-    },
-}
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
 
-async def test_sensor_setup(hass: HomeAssistant, fc_class_mock, fh_class_mock) -> None:
+@pytest.mark.freeze_time(datetime(2024, 9, 1, 20, tzinfo=UTC))
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_sensor_setup(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    fc_class_mock,
+    fh_class_mock,
+    snapshot: SnapshotAssertion,
+) -> None:
     """Test setup of Fritz!Tools sensors."""
 
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
     entry.add_to_hass(hass)
 
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-    assert entry.state is ConfigEntryState.LOADED
+    with patch("homeassistant.components.fritz.PLATFORMS", [Platform.SENSOR]):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
 
-    sensors = hass.states.async_all(SENSOR_DOMAIN)
-    assert len(sensors) == len(SENSOR_TYPES)
+    states = hass.states.async_all()
+    assert len(states) == 16
 
-    for sensor in sensors:
-        assert SENSOR_STATES.get(sensor.entity_id) is not None
-        for key, val in SENSOR_STATES[sensor.entity_id].items():
-            if key == ATTR_STATE:
-                assert sensor.state == val
-            else:
-                assert sensor.attributes.get(key) == val
+    await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
 
 
 async def test_sensor_update_fail(

--- a/tests/components/fritz/test_switch.py
+++ b/tests/components/fritz/test_switch.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.fritz.const import DOMAIN
-from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from .const import MOCK_FB_SERVICES, MOCK_USER_DATA
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, snapshot_platform
 
 MOCK_WLANCONFIGS_SAME_SSID: dict[str, dict] = {
     "WLANConfiguration1": {
@@ -179,23 +182,24 @@ MOCK_WLANCONFIGS_DIFF2_SSID: dict[str, dict] = {
         ),
     ],
 )
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_switch_setup(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     expected_wifi_names: list[str],
     fc_class_mock,
     fh_class_mock,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test setup of Fritz!Tools switches."""
-
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
     entry.add_to_hass(hass)
 
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done(wait_background_tasks=True)
-    assert entry.state is ConfigEntryState.LOADED
+    with patch("homeassistant.components.fritz.PLATFORMS", [Platform.SWITCH]):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done(wait_background_tasks=True)
 
-    switches = hass.states.async_all(Platform.SWITCH)
-    assert len(switches) == 3
-    assert switches[0].name == f"Mock Title Wi-Fi {expected_wifi_names[0]}"
-    assert switches[1].name == f"Mock Title Wi-Fi {expected_wifi_names[1]}"
-    assert switches[2].name == "printer Internet Access"
+    states = hass.states.async_all()
+    assert len(states) == 3
+
+    await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)

--- a/tests/components/fritz/test_update.py
+++ b/tests/components/fritz/test_update.py
@@ -2,10 +2,13 @@
 
 from unittest.mock import patch
 
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
 from homeassistant.components.fritz.const import DOMAIN
-from homeassistant.components.update import DOMAIN as UPDATE_DOMAIN
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from .const import (
     MOCK_FB_SERVICES,
@@ -14,8 +17,7 @@ from .const import (
     MOCK_USER_DATA,
 )
 
-from tests.common import MockConfigEntry
-from tests.typing import ClientSessionGenerator
+from tests.common import MockConfigEntry, snapshot_platform
 
 AVAILABLE_UPDATE = {
     "UserInterface1": {
@@ -27,30 +29,36 @@ AVAILABLE_UPDATE = {
 }
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_update_entities_initialized(
     hass: HomeAssistant,
-    hass_client: ClientSessionGenerator,
+    entity_registry: er.EntityRegistry,
     fc_class_mock,
     fh_class_mock,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test update entities."""
 
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
     entry.add_to_hass(hass)
 
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-    assert entry.state is ConfigEntryState.LOADED
+    with patch("homeassistant.components.fritz.PLATFORMS", [Platform.UPDATE]):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
 
-    updates = hass.states.async_all(UPDATE_DOMAIN)
-    assert len(updates) == 1
+    states = hass.states.async_all()
+    assert len(states) == 1
+
+    await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_update_available(
     hass: HomeAssistant,
-    hass_client: ClientSessionGenerator,
+    entity_registry: er.EntityRegistry,
     fc_class_mock,
     fh_class_mock,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test update entities."""
 
@@ -59,64 +67,45 @@ async def test_update_available(
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
     entry.add_to_hass(hass)
 
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-    assert entry.state is ConfigEntryState.LOADED
+    with patch("homeassistant.components.fritz.PLATFORMS", [Platform.UPDATE]):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
 
-    update = hass.states.get("update.mock_title_fritz_os")
-    assert update is not None
-    assert update.state == "on"
-    assert update.attributes.get("installed_version") == "7.29"
-    assert update.attributes.get("latest_version") == MOCK_FIRMWARE_AVAILABLE
-    assert update.attributes.get("release_url") == MOCK_FIRMWARE_RELEASE_URL
+    states = hass.states.async_all()
+    assert len(states) == 1
+
+    await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
 
 
-async def test_no_update_available(
-    hass: HomeAssistant,
-    hass_client: ClientSessionGenerator,
-    fc_class_mock,
-    fh_class_mock,
-) -> None:
-    """Test update entities."""
-
-    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
-    entry.add_to_hass(hass)
-
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-    assert entry.state is ConfigEntryState.LOADED
-
-    update = hass.states.get("update.mock_title_fritz_os")
-    assert update is not None
-    assert update.state == "off"
-    assert update.attributes.get("installed_version") == "7.29"
-    assert update.attributes.get("latest_version") == "7.29"
-
-
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_available_update_can_be_installed(
     hass: HomeAssistant,
-    hass_client: ClientSessionGenerator,
+    entity_registry: er.EntityRegistry,
     fc_class_mock,
     fh_class_mock,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test update entities."""
 
     fc_class_mock().override_services({**MOCK_FB_SERVICES, **AVAILABLE_UPDATE})
 
-    with patch(
-        "homeassistant.components.fritz.coordinator.FritzBoxTools.async_trigger_firmware_update",
-        return_value=True,
-    ) as mocked_update_call:
+    with (
+        patch(
+            "homeassistant.components.fritz.coordinator.FritzBoxTools.async_trigger_firmware_update",
+            return_value=True,
+        ) as mocked_update_call,
+        patch("homeassistant.components.fritz.PLATFORMS", [Platform.UPDATE]),
+    ):
         entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
         entry.add_to_hass(hass)
 
-        await hass.config_entries.async_setup(entry.entry_id)
+        assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
-        assert entry.state is ConfigEntryState.LOADED
 
-        update = hass.states.get("update.mock_title_fritz_os")
-        assert update is not None
-        assert update.state == "on"
+        states = hass.states.async_all()
+        assert len(states) == 1
+
+        await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
 
         await hass.services.async_call(
             "update",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
