### PR TITLE
Add coverage for late unifiprotect person detection events

### DIFF
--- a/tests/components/unifiprotect/test_binary_sensor.py
+++ b/tests/components/unifiprotect/test_binary_sensor.py
@@ -575,3 +575,149 @@ async def test_binary_sensor_package_detected(
     ufp.ws_msg(mock_msg)
     await hass.async_block_till_done()
     assert len(state_changes) == 2
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_binary_sensor_person_detected(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+    doorbell: Camera,
+    unadopted_camera: Camera,
+    fixed_now: datetime,
+) -> None:
+    """Test binary_sensor person detected detection entity."""
+
+    await init_entry(hass, ufp, [doorbell, unadopted_camera])
+    assert_entity_counts(hass, Platform.BINARY_SENSOR, 15, 15)
+
+    doorbell.smart_detect_settings.object_types.append(SmartDetectObjectType.PERSON)
+
+    _, entity_id = ids_from_device_description(
+        Platform.BINARY_SENSOR, doorbell, EVENT_SENSORS[3]
+    )
+
+    events = async_capture_events(hass, EVENT_STATE_CHANGED)
+
+    event = Event(
+        model=ModelType.EVENT,
+        id="test_event_id",
+        type=EventType.SMART_DETECT,
+        start=fixed_now - timedelta(seconds=1),
+        end=None,
+        score=50,
+        smart_detect_types=[],
+        smart_detect_event_ids=[],
+        camera_id=doorbell.id,
+        api=ufp.api,
+    )
+
+    new_camera = doorbell.copy()
+    new_camera.is_smart_detected = True
+
+    ufp.api.bootstrap.cameras = {new_camera.id: new_camera}
+    ufp.api.bootstrap.events = {event.id: event}
+
+    mock_msg = Mock()
+    mock_msg.changed_data = {}
+    mock_msg.new_obj = event
+    ufp.ws_msg(mock_msg)
+
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_OFF
+
+    event = Event(
+        model=ModelType.EVENT,
+        id="test_event_id",
+        type=EventType.SMART_DETECT,
+        start=fixed_now - timedelta(seconds=1),
+        end=fixed_now + timedelta(seconds=1),
+        score=65,
+        smart_detect_types=[SmartDetectObjectType.PERSON],
+        smart_detect_event_ids=[],
+        camera_id=doorbell.id,
+        api=ufp.api,
+    )
+
+    new_camera = doorbell.copy()
+    new_camera.is_smart_detected = True
+    new_camera.last_smart_detect_event_ids[SmartDetectObjectType.PERSON] = event.id
+
+    ufp.api.bootstrap.cameras = {new_camera.id: new_camera}
+    ufp.api.bootstrap.events = {event.id: event}
+
+    mock_msg = Mock()
+    mock_msg.changed_data = {}
+    mock_msg.new_obj = event
+    ufp.ws_msg(mock_msg)
+
+    await hass.async_block_till_done()
+
+    entity_events = [event for event in events if event.data["entity_id"] == entity_id]
+    assert len(entity_events) == 3
+    assert entity_events[0].data["new_state"].state == STATE_OFF
+    assert entity_events[1].data["new_state"].state == STATE_ON
+    assert entity_events[2].data["new_state"].state == STATE_OFF
+
+    # Event is already seen and has end, should now be off
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_OFF
+
+    # Now send an event that has an end right away
+    event = Event(
+        model=ModelType.EVENT,
+        id="new_event_id",
+        type=EventType.SMART_DETECT,
+        start=fixed_now - timedelta(seconds=1),
+        end=fixed_now + timedelta(seconds=1),
+        score=80,
+        smart_detect_types=[SmartDetectObjectType.PERSON],
+        smart_detect_event_ids=[],
+        camera_id=doorbell.id,
+        api=ufp.api,
+    )
+
+    new_camera = doorbell.copy()
+    new_camera.is_smart_detected = True
+    new_camera.last_smart_detect_event_ids[SmartDetectObjectType.PERSON] = event.id
+
+    ufp.api.bootstrap.cameras = {new_camera.id: new_camera}
+    ufp.api.bootstrap.events = {event.id: event}
+
+    mock_msg = Mock()
+    mock_msg.changed_data = {}
+    mock_msg.new_obj = event
+
+    state_changes: list[HAEvent[EventStateChangedData]] = async_capture_events(
+        hass, EVENT_STATE_CHANGED
+    )
+    ufp.ws_msg(mock_msg)
+
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_OFF
+
+    assert len(state_changes) == 2
+
+    on_event = state_changes[0]
+    state = on_event.data["new_state"]
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
+    assert state.attributes[ATTR_EVENT_SCORE] == 80
+
+    off_event = state_changes[1]
+    state = off_event.data["new_state"]
+    assert state
+    assert state.state == STATE_OFF
+    assert ATTR_EVENT_SCORE not in state.attributes
+
+    # replay and ensure ignored
+    ufp.ws_msg(mock_msg)
+    await hass.async_block_till_done()
+    assert len(state_changes) == 2


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In protect 4.1.x the person detection is sometimes declared at the end of the event instead of when the event starts.

https://github.com/home-assistant/core/issues/124967#issuecomment-2325209802

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
