### PR TITLE
Bump ring quality scale to gold

### DIFF
--- a/homeassistant/components/ring/manifest.json
+++ b/homeassistant/components/ring/manifest.json
@@ -13,6 +13,6 @@
   "documentation": "https://www.home-assistant.io/integrations/ring",
   "iot_class": "cloud_polling",
   "loggers": ["ring_doorbell"],
-  "quality_scale": "silver",
+  "quality_scale": "gold",
   "requirements": ["ring-doorbell[listen]==0.9.3"]
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Draft until two outstanding PRs merged.

Bump ring integration quality scale to gold.

- [x] Satisfying all Silver level requirements.
- [x] Configurable via config entries.
  - [x] Don't allow configuring already configured device/service (example: no 2 entries for same hub) - [PR 125120](https://github.com/home-assistant/core/pull/125120)
  - [ ] Discoverable (if available) - [PR 126661](https://github.com/home-assistant/core/pull/126661)
  - [x] Set unique ID in config flow (if available) - [config_flow.py-L76](https://github.com/home-assistant/core/blob/7c223db1d5df60fb8e2a7fa8818d077b2b751c4f/homeassistant/components/ring/config_flow.py#L76)
  - [x] Raise [`ConfigEntryNotReady`](integration_setup_failures.md#integrations-using-async_setup_entry) if unable to connect during entry setup (if appropriate) - Uses [DataUpdateCoordinator](https://github.com/home-assistant/core/blob/dev/homeassistant/components/ring/coordinator.py)
- [x] Entities have device info (if available) ([docs](device_registry_index.md#defining-devices)) - [entity.py - L72](https://github.com/home-assistant/core/blob/7c223db1d5df60fb8e2a7fa8818d077b2b751c4f/homeassistant/components/ring/entity.py#L72)
- [x] Tests
  - [x] Full test coverage for the config flow - [codecov](https://app.codecov.io/gh/home-assistant/core/blob/dev/homeassistant%2Fcomponents%2Fring%2Fconfig_flow.py)
  - [x] Above average test coverage for all integration modules - [codecov](https://app.codecov.io/gh/home-assistant/core/tree/dev/homeassistant%2Fcomponents%2Fring)
  - [x] Tests for fetching data from the integration and controlling it ([docs](development_testing.md)) - [tests](https://github.com/home-assistant/core/tree/dev/tests/components/ring)
- [x] Has a code owner ([docs](creating_integration_manifest.md#code-owners)) - [manifest.json](https://github.com/home-assistant/core/blob/7c223db1d5df60fb8e2a7fa8818d077b2b751c4f/homeassistant/components/ring/manifest.json#L4)
- [x] Entities only subscribe to updates inside `async_added_to_hass` and unsubscribe inside `async_will_remove_from_hass` ([docs](core/entity.md#lifecycle-hooks)) - [CoordinatorEntity](https://github.com/home-assistant/core/blob/7c223db1d5df60fb8e2a7fa8818d077b2b751c4f/homeassistant/components/ring/entity.py#L55)
- [x] Entities have correct device classes where appropriate ([docs](core/entity.md#generic-properties)) - [RingSensorEntityDescription](https://github.com/home-assistant/core/blob/7c223db1d5df60fb8e2a7fa8818d077b2b751c4f/homeassistant/components/ring/sensor.py#L140)
- [x] Supports entities being disabled and leverages `Entity.entity_registry_enabled_default` to disable less popular entities ([docs](core/entity.md#advanced-properties)) - [wifi signal sensors](https://github.com/home-assistant/core/blob/7c223db1d5df60fb8e2a7fa8818d077b2b751c4f/homeassistant/components/ring/sensor.py#L222)
- [ ] If the device/service API can remove entities, the integration should make sure to clean up the entity and device registry. - [PR 126554](https://github.com/home-assistant/core/pull/126554)
- [x] When communicating with a device or service, the integration implements the diagnostics platform which redacts sensitive information. - [diagnostics.py](https://github.com/home-assistant/core/blob/dev/homeassistant/components/ring/diagnostics.py)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/34548

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
