### PR TITLE
Fix BTHome validate triggers for device with multiple buttons

### DIFF
--- a/homeassistant/components/bthome/device_trigger.py
+++ b/homeassistant/components/bthome/device_trigger.py
@@ -67,10 +67,8 @@ async def async_validate_trigger_config(
         for entry_id in device.config_entries
     ]
     bthome_config_entry = next(
-        iter(entry for entry in config_entries if entry and entry.domain == DOMAIN),
-        None,
+        iter(entry for entry in config_entries if entry and entry.domain == DOMAIN)
     )
-    assert bthome_config_entry is not None
     event_classes: list[str] = bthome_config_entry.data.get(
         CONF_DISCOVERED_EVENT_CLASSES, []
     )

--- a/homeassistant/components/bthome/device_trigger.py
+++ b/homeassistant/components/bthome/device_trigger.py
@@ -7,6 +7,9 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
+from homeassistant.components.device_automation.exceptions import (
+    InvalidDeviceAutomationConfig,
+)
 from homeassistant.components.homeassistant.triggers import event as event_trigger
 from homeassistant.const import (
     CONF_DEVICE_ID,
@@ -43,33 +46,48 @@ TRIGGERS_BY_EVENT_CLASS = {
     EVENT_CLASS_DIMMER: {"rotate_left", "rotate_right"},
 }
 
-SCHEMA_BY_EVENT_CLASS = {
-    EVENT_CLASS_BUTTON: DEVICE_TRIGGER_BASE_SCHEMA.extend(
-        {
-            vol.Required(CONF_TYPE): vol.In([EVENT_CLASS_BUTTON]),
-            vol.Required(CONF_SUBTYPE): vol.In(
-                TRIGGERS_BY_EVENT_CLASS[EVENT_CLASS_BUTTON]
-            ),
-        }
-    ),
-    EVENT_CLASS_DIMMER: DEVICE_TRIGGER_BASE_SCHEMA.extend(
-        {
-            vol.Required(CONF_TYPE): vol.In([EVENT_CLASS_DIMMER]),
-            vol.Required(CONF_SUBTYPE): vol.In(
-                TRIGGERS_BY_EVENT_CLASS[EVENT_CLASS_DIMMER]
-            ),
-        }
-    ),
-}
+TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
+    {vol.Required(CONF_TYPE): str, vol.Required(CONF_SUBTYPE): str}
+)
 
 
 async def async_validate_trigger_config(
     hass: HomeAssistant, config: ConfigType
 ) -> ConfigType:
     """Validate trigger config."""
-    return SCHEMA_BY_EVENT_CLASS.get(config[CONF_TYPE], DEVICE_TRIGGER_BASE_SCHEMA)(  # type: ignore[no-any-return]
-        config
+    config = TRIGGER_SCHEMA(config)
+    event_class = config[CONF_TYPE]
+    event_type = config[CONF_SUBTYPE]
+
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get(config[CONF_DEVICE_ID])
+    assert device is not None
+    config_entries = [
+        hass.config_entries.async_get_entry(entry_id)
+        for entry_id in device.config_entries
+    ]
+    bthome_config_entry = next(
+        iter(entry for entry in config_entries if entry and entry.domain == DOMAIN),
+        None,
     )
+    assert bthome_config_entry is not None
+    event_classes: list[str] = bthome_config_entry.data.get(
+        CONF_DISCOVERED_EVENT_CLASSES, []
+    )
+
+    if event_class not in event_classes:
+        raise InvalidDeviceAutomationConfig(
+            f"BTHome trigger {event_class} is not valid for device "
+            f"{device} ({config[CONF_DEVICE_ID]})"
+        )
+
+    if event_type not in TRIGGERS_BY_EVENT_CLASS.get(event_class.split("_")[0], ()):
+        raise InvalidDeviceAutomationConfig(
+            f"BTHome trigger {event_type} is not valid for device "
+            f"{device} ({config[CONF_DEVICE_ID]})"
+        )
+
+    return config
 
 
 async def async_get_triggers(

--- a/tests/components/bthome/test_device_trigger.py
+++ b/tests/components/bthome/test_device_trigger.py
@@ -1,10 +1,19 @@
 """Test BTHome BLE events."""
 
+import pytest
+
 from homeassistant.components import automation
 from homeassistant.components.bluetooth import DOMAIN as BLUETOOTH_DOMAIN
 from homeassistant.components.bthome.const import CONF_SUBTYPE, DOMAIN
 from homeassistant.components.device_automation import DeviceAutomationType
-from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF_TYPE
+from homeassistant.const import (
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_PLATFORM,
+    CONF_TYPE,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
@@ -116,6 +125,117 @@ async def test_get_triggers_button(
         hass, DeviceAutomationType.TRIGGER, device.id
     )
     assert expected_trigger in triggers
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_get_triggers_multiple_buttons(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test that we get the expected triggers for multiple buttons device."""
+    mac = "A4:C1:38:8D:18:B2"
+    entry = await _async_setup_bthome_device(hass, mac)
+    events = async_capture_events(hass, "bthome_ble_event")
+
+    # Emit button_1 long press and button_2 press events
+    # so it creates the device in the registry
+    inject_bluetooth_service_info_bleak(
+        hass,
+        make_bthome_v2_adv(mac, b"\x40\x3a\x04\x3a\x01"),
+    )
+
+    # wait for the event
+    await hass.async_block_till_done()
+    assert len(events) == 2
+
+    device = device_registry.async_get_device(identifiers={get_device_id(mac)})
+    assert device
+    expected_trigger1 = {
+        CONF_PLATFORM: "device",
+        CONF_DOMAIN: DOMAIN,
+        CONF_DEVICE_ID: device.id,
+        CONF_TYPE: "button_1",
+        CONF_SUBTYPE: "long_press",
+        "metadata": {},
+    }
+    expected_trigger2 = {
+        CONF_PLATFORM: "device",
+        CONF_DOMAIN: DOMAIN,
+        CONF_DEVICE_ID: device.id,
+        CONF_TYPE: "button_2",
+        CONF_SUBTYPE: "press",
+        "metadata": {},
+    }
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device.id
+    )
+    assert expected_trigger1 in triggers
+    assert expected_trigger2 in triggers
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+@pytest.mark.parametrize(
+    ("event_class", "event_type", "expected"),
+    [
+        ("button_1", "long_press", STATE_ON),
+        ("button_2", "press", STATE_ON),
+        ("button_3", "long_press", STATE_UNAVAILABLE),
+        ("button", "long_press", STATE_UNAVAILABLE),
+        ("button_1", "invalid_press", STATE_UNAVAILABLE),
+    ],
+)
+async def test_validate_trigger_config(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    event_class: str,
+    event_type: str,
+    expected: str,
+) -> None:
+    """Test unsupported trigger does not return a trigger config."""
+    mac = "A4:C1:38:8D:18:B2"
+    entry = await _async_setup_bthome_device(hass, mac)
+
+    # Emit button_1 long press and button_2 press events
+    # so it creates the device in the registry
+    inject_bluetooth_service_info_bleak(
+        hass,
+        make_bthome_v2_adv(mac, b"\x40\x3a\x04\x3a\x01"),
+    )
+
+    # wait for the event
+    await hass.async_block_till_done()
+
+    device = device_registry.async_get_device(identifiers={get_device_id(mac)})
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        CONF_PLATFORM: "device",
+                        CONF_DOMAIN: DOMAIN,
+                        CONF_DEVICE_ID: device.id,
+                        CONF_TYPE: event_class,
+                        CONF_SUBTYPE: event_type,
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {"some": "test_trigger_button_long_press"},
+                    },
+                },
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+
+    automations = hass.states.async_entity_ids(automation.DOMAIN)
+    assert len(automations) == 1
+    assert hass.states.get(automations[0]).state == expected
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
@@ -235,7 +355,7 @@ async def test_if_fires_on_motion_detected(
         make_bthome_v2_adv(mac, b"\x40\x3a\x03"),
     )
 
-    #     # wait for the event
+    # wait for the event
     await hass.async_block_till_done()
 
     device = device_registry.async_get_device(identifiers={get_device_id(mac)})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix BTHome validate triggers for device with multiple buttons, with multiple buttons validation can't be static since we only know the number of buttons from the device events.

Fixes https://github.com/home-assistant/core/issues/124851, tested with `Shelly BLU RC Button 4`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/124851
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
