### PR TITLE
Add button platform to opentherm_gw

### DIFF
--- a/homeassistant/components/opentherm_gw/__init__.py
+++ b/homeassistant/components/opentherm_gw/__init__.py
@@ -90,7 +90,7 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.CLIMATE, Platform.SENSOR]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.CLIMATE, Platform.SENSOR]
 
 
 async def options_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/homeassistant/components/opentherm_gw/button.py
+++ b/homeassistant/components/opentherm_gw/button.py
@@ -1,0 +1,73 @@
+"""Support for OpenTherm Gateway buttons."""
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+import pyotgw.vars as gw_vars
+
+from homeassistant.components.button import (
+    ButtonDeviceClass,
+    ButtonEntity,
+    ButtonEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_ID, EntityCategory
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import OpenThermGatewayHub
+from .const import (
+    DATA_GATEWAYS,
+    DATA_OPENTHERM_GW,
+    GATEWAY_DEVICE_DESCRIPTION,
+    OpenThermDataSource,
+)
+from .entity import OpenThermEntity, OpenThermEntityDescription
+
+
+@dataclass(frozen=True, kw_only=True)
+class OpenThermButtonEntityDescription(
+    ButtonEntityDescription, OpenThermEntityDescription
+):
+    """Describes an opentherm_gw button entity."""
+
+    action: Callable[[OpenThermGatewayHub], Awaitable]
+
+
+BUTTON_DESCRIPTIONS: tuple[OpenThermButtonEntityDescription, ...] = (
+    OpenThermButtonEntityDescription(
+        key="restart_button",
+        device_class=ButtonDeviceClass.RESTART,
+        device_description=GATEWAY_DEVICE_DESCRIPTION,
+        action=lambda hub: hub.gateway.set_mode(gw_vars.OTGW_MODE_RESET),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the OpenTherm Gateway buttons."""
+    gw_hub = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][config_entry.data[CONF_ID]]
+
+    async_add_entities(
+        OpenThermButton(gw_hub, description) for description in BUTTON_DESCRIPTIONS
+    )
+
+
+class OpenThermButton(OpenThermEntity, ButtonEntity):
+    """Representation of an OpenTherm button."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    entity_description: OpenThermButtonEntityDescription
+
+    @callback
+    def receive_report(self, status: dict[OpenThermDataSource, dict]) -> None:
+        """Handle status updates from the component."""
+        # We don't need any information from the reports here
+
+    async def async_press(self) -> None:
+        """Perform button action."""
+        await self.entity_description.action(self._gateway)

--- a/tests/components/opentherm_gw/test_button.py
+++ b/tests/components/opentherm_gw/test_button.py
@@ -1,11 +1,51 @@
 """Test opentherm_gw buttons."""
 
+from unittest.mock import AsyncMock, MagicMock
+
+from pyotgw.vars import OTGW_MODE_RESET
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.components.opentherm_gw import DOMAIN as OPENTHERM_DOMAIN
+from homeassistant.components.opentherm_gw.const import OpenThermDeviceIdentifier
+from homeassistant.const import ATTR_ENTITY_ID, CONF_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
+from .conftest import MINIMAL_STATUS
 
-async def test_button_platform_setup(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry
+from tests.common import MockConfigEntry
+
+
+async def test_restart_button(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_pyotgw: MagicMock,
 ) -> None:
-    """Test buttons get added during setup."""
-    # We need a fixture for the mock config entry
+    """Test restart button."""
+
+    mock_pyotgw.return_value.set_mode = AsyncMock(return_value=MINIMAL_STATUS)
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        button_entity_id := entity_registry.async_get_entity_id(
+            BUTTON_DOMAIN,
+            OPENTHERM_DOMAIN,
+            f"{mock_config_entry.data[CONF_ID]}-{OpenThermDeviceIdentifier.GATEWAY}-restart_button",
+        )
+    ) is not None
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {
+            ATTR_ENTITY_ID: button_entity_id,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    mock_pyotgw.return_value.set_mode.assert_awaited_once_with(OTGW_MODE_RESET)

--- a/tests/components/opentherm_gw/test_button.py
+++ b/tests/components/opentherm_gw/test_button.py
@@ -1,0 +1,11 @@
+"""Test opentherm_gw buttons."""
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+
+async def test_button_platform_setup(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test buttons get added during setup."""
+    # We need a fixture for the mock config entry

--- a/tests/components/opentherm_gw/test_button.py
+++ b/tests/components/opentherm_gw/test_button.py
@@ -46,6 +46,5 @@ async def test_restart_button(
         },
         blocking=True,
     )
-    await hass.async_block_till_done()
 
     mock_pyotgw.return_value.set_mode.assert_awaited_once_with(OTGW_MODE_RESET)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We add a button platform to the opentherm_gw integration. Initially it only supports a `restart` button that can be used to reboot the OpenTherm Gateway. Later on, more buttons may be added as desired.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#34557

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
