### PR TITLE
Revert "Disable IPv6 in the opower integration to fix AEP utilities"

### DIFF
--- a/homeassistant/components/opower/config_flow.py
+++ b/homeassistant/components/opower/config_flow.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 import logging
-import socket
 from typing import Any
 
 from opower import (
@@ -40,7 +39,7 @@ async def _validate_login(
 ) -> dict[str, str]:
     """Validate login data and return any errors."""
     api = Opower(
-        async_create_clientsession(hass, family=socket.AF_INET),
+        async_create_clientsession(hass),
         login_data[CONF_UTILITY],
         login_data[CONF_USERNAME],
         login_data[CONF_PASSWORD],

--- a/homeassistant/components/opower/coordinator.py
+++ b/homeassistant/components/opower/coordinator.py
@@ -2,7 +2,6 @@
 
 from datetime import datetime, timedelta
 import logging
-import socket
 from types import MappingProxyType
 from typing import Any, cast
 
@@ -54,7 +53,7 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
             update_interval=timedelta(hours=12),
         )
         self.api = Opower(
-            aiohttp_client.async_get_clientsession(hass, family=socket.AF_INET),
+            aiohttp_client.async_get_clientsession(hass),
             entry_data[CONF_UTILITY],
             entry_data[CONF_USERNAME],
             entry_data[CONF_PASSWORD],


### PR DESCRIPTION
Reverts home-assistant/core#107203

This should no longer be needed with aiohttp 3.10.x since it supports happyeyeballs