### PR TITLE
Update modified_at datetime on storage collection changes

### DIFF
--- a/homeassistant/helpers/collection.py
+++ b/homeassistant/helpers/collection.py
@@ -7,6 +7,7 @@ import asyncio
 from collections.abc import Awaitable, Callable, Coroutine, Iterable
 from dataclasses import dataclass
 from functools import partial
+from hashlib import md5
 from itertools import groupby
 import logging
 from operator import attrgetter
@@ -25,6 +26,7 @@ from homeassistant.util import slugify
 from . import entity_registry
 from .entity import Entity
 from .entity_component import EntityComponent
+from .json import json_bytes
 from .storage import Store
 from .typing import ConfigType, VolDictType
 
@@ -50,6 +52,7 @@ class CollectionChange:
     change_type: str
     item_id: str
     item: Any
+    item_hash: str | None = None
 
 
 type ChangeListener = Callable[
@@ -273,7 +276,9 @@ class StorageCollection[_ItemT, _StoreT: SerializedStorageCollection](
 
         await self.notify_changes(
             [
-                CollectionChange(CHANGE_ADDED, item[CONF_ID], item)
+                CollectionChange(
+                    CHANGE_ADDED, item[CONF_ID], item, self._hash_item(item)
+                )
                 for item in raw_storage["items"]
             ]
         )
@@ -313,7 +318,16 @@ class StorageCollection[_ItemT, _StoreT: SerializedStorageCollection](
         item = self._create_item(item_id, validated_data)
         self.data[item_id] = item
         self._async_schedule_save()
-        await self.notify_changes([CollectionChange(CHANGE_ADDED, item_id, item)])
+        await self.notify_changes(
+            [
+                CollectionChange(
+                    CHANGE_ADDED,
+                    item_id,
+                    item,
+                    self._hash_item(self._serialize_item(item_id, item)),
+                )
+            ]
+        )
         return item
 
     async def async_update_item(self, item_id: str, updates: dict) -> _ItemT:
@@ -331,7 +345,16 @@ class StorageCollection[_ItemT, _StoreT: SerializedStorageCollection](
         self.data[item_id] = updated
         self._async_schedule_save()
 
-        await self.notify_changes([CollectionChange(CHANGE_UPDATED, item_id, updated)])
+        await self.notify_changes(
+            [
+                CollectionChange(
+                    CHANGE_UPDATED,
+                    item_id,
+                    updated,
+                    self._hash_item(self._serialize_item(item_id, updated)),
+                )
+            ]
+        )
 
         return self.data[item_id]
 
@@ -364,6 +387,10 @@ class StorageCollection[_ItemT, _StoreT: SerializedStorageCollection](
     @callback
     def _data_to_save(self) -> _StoreT:
         """Return JSON-compatible date for storing to file."""
+
+    def _hash_item(self, item: dict) -> str:
+        """Return a hash of the item."""
+        return md5(json_bytes(item)).hexdigest()
 
 
 class DictStorageCollection(StorageCollection[dict, SerializedStorageCollection]):
@@ -464,6 +491,10 @@ class _CollectionLifeCycle(Generic[_EntityT]):
 
     async def _update_entity(self, change_set: CollectionChange) -> None:
         if entity := self.entities.get(change_set.item_id):
+            if change_set.item_hash:
+                self.ent_reg.async_update_entity_options(
+                    entity.entity_id, "collection", {"hash": change_set.item_hash}
+                )
             await entity.async_update_config(change_set.item)
 
     async def _collection_changed(self, change_set: Iterable[CollectionChange]) -> None:

--- a/tests/helpers/test_collection.py
+++ b/tests/helpers/test_collection.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
 import logging
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 import voluptuous as vol
 
@@ -15,6 +17,7 @@ from homeassistant.helpers import (
     storage,
 )
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.util.dt import utcnow
 
 from tests.common import flush_store
 from tests.typing import WebSocketGenerator
@@ -252,6 +255,84 @@ async def test_storage_collection(hass: HomeAssistant) -> None:
             {"id": "mock_3", "name": "Mock 3"},
         ]
     }
+
+
+async def test_storage_collection_update_modifiet_at(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that updating a storage collection will update the modified_at datetime in the entity registry."""
+
+    entities: dict[str, TestEntity] = {}
+
+    class TestEntity(MockEntity):
+        """Entity that is config based."""
+
+        def __init__(self, config: ConfigType) -> None:
+            """Initialize entity."""
+            super().__init__(config)
+            self._state = "initial"
+
+        @classmethod
+        def from_storage(cls, config: ConfigType) -> TestEntity:
+            """Create instance from storage."""
+            obj = super().from_storage(config)
+            entities[obj.unique_id] = obj
+            return obj
+
+        @property
+        def state(self) -> str:
+            """Return state of entity."""
+            return self._state
+
+        def set_state(self, value: str) -> None:
+            """Set value."""
+            self._state = value
+            self.async_write_ha_state()
+
+    store = storage.Store(hass, 1, "test-data")
+    data = {"id": "mock-1", "name": "Mock 1", "data": 1}
+    await store.async_save(
+        {
+            "items": [
+                data,
+            ]
+        }
+    )
+    id_manager = collection.IDManager()
+    ent_comp = entity_component.EntityComponent(_LOGGER, "test", hass)
+    await ent_comp.async_setup({})
+    coll = MockStorageCollection(store, id_manager)
+    collection.sync_entity_lifecycle(hass, "test", "test", ent_comp, coll, TestEntity)
+    changes = track_changes(coll)
+
+    await coll.async_load()
+    assert id_manager.has_id("mock-1")
+    assert len(changes) == 1
+    assert changes[0] == (collection.CHANGE_ADDED, "mock-1", data)
+
+    modified_1 = entity_registry.async_get("test.mock_1").modified_at
+    assert modified_1 == utcnow()
+
+    freezer.tick(timedelta(minutes=1))
+
+    updated_item = await coll.async_update_item("mock-1", {"data": 2})
+    assert id_manager.has_id("mock-1")
+    assert updated_item == {"id": "mock-1", "name": "Mock 1", "data": 2}
+    assert len(changes) == 2
+    assert changes[1] == (collection.CHANGE_UPDATED, "mock-1", updated_item)
+
+    modified_2 = entity_registry.async_get("test.mock_1").modified_at
+    assert modified_2 > modified_1
+    assert modified_2 == utcnow()
+
+    freezer.tick(timedelta(minutes=1))
+
+    entities["mock-1"].set_state("second")
+
+    modified_3 = entity_registry.async_get("test.mock_1").modified_at
+    assert modified_3 == modified_2
 
 
 async def test_attach_entity_component_collection(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes the issue where the modified_at was not updated if a user changed some data of the storage helper (will be used for all UI input helpers) 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/123421
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
