### PR TITLE
Use TypeVar defaults for Generator

### DIFF
--- a/tests/components/fujitsu_fglair/conftest.py
+++ b/tests/components/fujitsu_fglair/conftest.py
@@ -30,7 +30,7 @@ TEST_PROPERTY_VALUES = {
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.fujitsu_fglair.async_setup_entry", return_value=True

--- a/tests/components/google_photos/conftest.py
+++ b/tests/components/google_photos/conftest.py
@@ -125,7 +125,7 @@ def mock_client_api(
     fixture_name: str,
     user_identifier: str,
     api_error: Exception,
-) -> Generator[Mock, None, None]:
+) -> Generator[Mock]:
     """Set up fake Google Photos API responses from fixtures."""
     mock_api = AsyncMock(GooglePhotosLibraryApi, autospec=True)
     mock_api.get_user_info.return_value = UserInfoResult(
@@ -136,9 +136,7 @@ def mock_client_api(
 
     responses = load_json_array_fixture(fixture_name, DOMAIN) if fixture_name else []
 
-    async def list_media_items(
-        *args: Any,
-    ) -> AsyncGenerator[ListMediaItemResult, None, None]:
+    async def list_media_items(*args: Any) -> AsyncGenerator[ListMediaItemResult]:
         for response in responses:
             mock_list_media_items = Mock(ListMediaItemResult)
             mock_list_media_items.media_items = [
@@ -163,9 +161,7 @@ def mock_client_api(
     # Emulate an async iterator for returning pages of response objects. We just
     # return a single page.
 
-    async def list_albums(
-        *args: Any, **kwargs: Any
-    ) -> AsyncGenerator[ListAlbumResult, None, None]:
+    async def list_albums(*args: Any, **kwargs: Any) -> AsyncGenerator[ListAlbumResult]:
         mock_list_album_result = Mock(ListAlbumResult)
         mock_list_album_result.albums = [
             Album.from_dict(album)

--- a/tests/components/google_photos/test_config_flow.py
+++ b/tests/components/google_photos/test_config_flow.py
@@ -28,7 +28,7 @@ CLIENT_SECRET = "5678"
 
 
 @pytest.fixture(name="mock_setup")
-def mock_setup_entry() -> Generator[Mock, None, None]:
+def mock_setup_entry() -> Generator[Mock]:
     """Fixture to mock out integration setup."""
     with patch(
         "homeassistant.components.google_photos.async_setup_entry", return_value=True
@@ -37,7 +37,7 @@ def mock_setup_entry() -> Generator[Mock, None, None]:
 
 
 @pytest.fixture(autouse=True)
-def mock_patch_api(mock_api: Mock) -> Generator[None, None, None]:
+def mock_patch_api(mock_api: Mock) -> Generator[None]:
     """Fixture to patch the config flow api."""
     with patch(
         "homeassistant.components.google_photos.config_flow.GooglePhotosLibraryApi",

--- a/tests/components/intellifire/conftest.py
+++ b/tests/components/intellifire/conftest.py
@@ -34,7 +34,7 @@ from tests.common import MockConfigEntry, load_json_object_fixture
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.intellifire.async_setup_entry", return_value=True
@@ -43,7 +43,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_fireplace_finder_none() -> Generator[None, MagicMock, None]:
+def mock_fireplace_finder_none() -> Generator[MagicMock]:
     """Mock fireplace finder."""
     mock_found_fireplaces = Mock()
     mock_found_fireplaces.ips = []
@@ -110,7 +110,7 @@ def mock_common_data_local() -> IntelliFireCommonFireplaceData:
 @pytest.fixture
 def mock_apis_multifp(
     mock_cloud_interface, mock_local_interface, mock_fp
-) -> Generator[tuple[AsyncMock, AsyncMock, MagicMock], None, None]:
+) -> Generator[tuple[AsyncMock, AsyncMock, MagicMock]]:
     """Multi fireplace version of mocks."""
     return mock_local_interface, mock_cloud_interface, mock_fp
 
@@ -118,7 +118,7 @@ def mock_apis_multifp(
 @pytest.fixture
 def mock_apis_single_fp(
     mock_cloud_interface, mock_local_interface, mock_fp
-) -> Generator[tuple[AsyncMock, AsyncMock, MagicMock], None, None]:
+) -> Generator[tuple[AsyncMock, AsyncMock, MagicMock]]:
     """Single fire place version of the mocks."""
     data_v1 = IntelliFireUserData(
         **load_json_object_fixture("user_data_1.json", DOMAIN)
@@ -131,7 +131,7 @@ def mock_apis_single_fp(
 
 
 @pytest.fixture
-def mock_cloud_interface() -> Generator[AsyncMock, None, None]:
+def mock_cloud_interface() -> Generator[AsyncMock]:
     """Mock cloud interface to use for testing."""
     user_data = IntelliFireUserData(
         **load_json_object_fixture("user_data_3.json", DOMAIN)
@@ -165,7 +165,7 @@ def mock_cloud_interface() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_local_interface() -> Generator[AsyncMock, None, None]:
+def mock_local_interface() -> Generator[AsyncMock]:
     """Mock version of IntelliFireAPILocal."""
     poll_data = IntelliFirePollData(
         **load_json_object_fixture("intellifire/local_poll.json")
@@ -181,7 +181,7 @@ def mock_local_interface() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_fp(mock_common_data_local) -> Generator[AsyncMock, None, None]:
+def mock_fp(mock_common_data_local) -> Generator[AsyncMock]:
     """Mock fireplace."""
 
     local_poll_data = IntelliFirePollData(

--- a/tests/components/smlight/conftest.py
+++ b/tests/components/smlight/conftest.py
@@ -39,14 +39,14 @@ def platforms() -> list[Platform]:
 
 
 @pytest.fixture(autouse=True)
-async def mock_patch_platforms(platforms: list[str]) -> AsyncGenerator[None, None]:
+async def mock_patch_platforms(platforms: list[str]) -> AsyncGenerator[None]:
     """Fixture to set up platforms for tests."""
     with patch(f"homeassistant.components.{DOMAIN}.PLATFORMS", platforms):
         yield
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.smlight.async_setup_entry", return_value=True

--- a/tests/components/yale/test_config_flow.py
+++ b/tests/components/yale/test_config_flow.py
@@ -25,7 +25,7 @@ CLIENT_ID = "1"
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[Mock, None, None]:
+def mock_setup_entry() -> Generator[Mock]:
     """Patch setup entry."""
     with patch(
         "homeassistant.components.yale.async_setup_entry", return_value=True


### PR DESCRIPTION
## Proposed change
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
