### PR TITLE
Fix image content-type validation case sensitivity

### DIFF
--- a/homeassistant/components/image/__init__.py
+++ b/homeassistant/components/image/__init__.py
@@ -70,7 +70,7 @@ class ImageContentTypeError(HomeAssistantError):
 
 def valid_image_content_type(content_type: str | None) -> str:
     """Validate the assigned content type is one of an image."""
-    if content_type is None or content_type.split("/", 1)[0] != "image":
+    if content_type is None or content_type.split("/", 1)[0].lower() != "image":
         raise ImageContentTypeError
     return content_type
 

--- a/tests/components/image/conftest.py
+++ b/tests/components/image/conftest.py
@@ -52,6 +52,21 @@ class MockImageEntityInvalidContentType(image.ImageEntity):
         return b"Test"
 
 
+class MockImageEntityCapitalContentType(image.ImageEntity):
+    """Mock image entity with correct content type, but capitalized."""
+
+    _attr_name = "Test"
+
+    async def async_added_to_hass(self):
+        """Set the update time and assign and incorrect content type."""
+        self._attr_content_type = "Image/jpeg"
+        self._attr_image_last_updated = dt_util.utcnow()
+
+    async def async_image(self) -> bytes | None:
+        """Return bytes of image."""
+        return b"Test"
+
+
 class MockURLImageEntity(image.ImageEntity):
     """Mock image entity."""
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I have discovered that some online services that expose images don't always set lowercase Content Type header values.  For example, a service I want to interact with exposes images with the Content Type of "Image/jpeg", but the Image component explicitly checks for "image" in the first part of the Content Type.

This PR converts the received content type to lowercase before performing the comparison, so the Content Type of "Image/jpeg" and "image/jpeg" will work equally.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

I have written a quick HTTP server in python to test this change:

```
import http.server
import socketserver
import base64

base64_image = (
    "/9j/4AAQSkZJRgABAQAAAQABAAD//gAfQ29tcHJlc3NlZCBieSBqcGVnLXJlY29tcHJlc3P/2wCEAAQEBAQEBAQEBAQGBgUGBggHBwcHCAwJCQkJCQwTDA4MDA4MExEUEA8QFBEeFxUVFx4iHRsdIiolJSo0MjRERFwBBAQEBAQEBAQEBAYGBQYGCAcHBwcIDAkJCQkJDBMMDgwMDgwTERQQDxAUER4XFRUXHiIdGx0iKiUlKjQyNEREXP/CABEIAEAAQAMBIgACEQEDEQH/xAAbAAEAAgMBAQAAAAAAAAAAAAAABwgBAwUGBP/aAAgBAQAAAAC/wDFWefnDpWk8rEFivOa/T12l/q1jtiKnWd6kEa57QH9E6EAa9P3T2ELJpAD/xAAYAQEAAwEAAAAAAAAAAAAAAAAEAAMFAf/aAAgBAhAAAAAxYoenMxweuupl3//EABgBAQEBAQEAAAAAAAAAAAAAAAUEAAEG/9oACAEDEAAAAL0saoBvQDM8Glq0v//EADgQAAEDAgUBBAcFCQAAAAAAAAIBAwQFBgAHERIxQRATIVEUICIkYoGyCCNCQ5IlMDNSU2NxgtH/2gAIAQEAAT8A7N4/zJ27x43J2qqIiqq+CYvLMm4rqrZWzY5PDHVxWRcjeD0kk5JD/A3gckr8kNrNeqMJJK+1tckOk58yQF8cUi+74y2qwUe62pEmGi+LT5bzQON7DvVMVW+r3zIqh0e02X4sLo2wWw9nG993omFySvuOHpjFRhFKFN2xuQ6LnyJQTFl5mXHalbG2b4V446OIyZyfF6MS8Ep/jDCLqiKi4zDkPQbKuOSyqi4kF0B05HvE264+z7SYRRq5WnARZXfDFEuoAgoa/q7LysyjXhTBgVISEgPey+3ojrZddqqi89cWhZtJs6mrApoku897z7miuul03KmnHTs+0JSIYMUOsttoMrvSimvUwUVNP04y9lnNsy3JcglJxYLQFryuxNuq4r9LGtUWqUolQUmRXWEJeimOiF8sZQXEdpXLUrXrPu/pbqM+2vg3KaVR2/7+rm3cB3ldVOtaiIr6RHlY9jg5LioK/IMUGlt0Wj0yktluCHGaZ3cblAdFL59mb+Wx1cDumhMftBsPeo4cvgPBD5mOMrM026m3Ftq45OyeOjcaUfD6dBNf6n1duaeaIU4H7Ztt/fUT1bkyW/yPMA/ufTjKTLg6C2NyVtnSqPt6MMlzHbLqXxl6mamU/phP3JazHvn8SVEb/N83G/j8064ywzaR5Y9uXY9tlB91GmOrpv6bHdeDxmZmuQG7bNpPKcol7p+Wz47VXw7tnTk/MsZYZVJSlYuO5WUOoro5HjH4ox8Z+bn0+tmblM1cIPV2gMgzVuXGeAk/8cxlnlWxbYNVmutg7WSTUG+Qi/48z8y/ef/EACYRAAICAQIFBAMAAAAAAAAAAAECAwQAETEQFSFBYQUzQoFRkaH/2gAIAQIBAT8As2o6ygsCWY6Ko3JzmLoQbNV4kPy3H3nMWck1qskqD5DoPrK1qOypKghlOjKdwctEJ6hTkk9shlBOwbHRZFKOoZTuDiIsahEUBRsBlUh79ySP29FUnsWGWIEsxNFIOh2P4OQWJKzipcPiOTswyexJZc1aZ8SSdlHjIII68axRjoP6eE8EdiMxyrqD+xkEEdeMRxLoBw//xAAlEQACAgECBQUBAAAAAAAAAAABAgMEBQAxERIhUWEQM0FCcpH/2gAIAQMBAT8Ax+OnyMjJEVREXmkkfoqDzo4KOYOMfk4bMy7xgFSfzx30MFHCEGQycNaZtoyCxH64bayGOnx0ipKVZHHNHIh4qw8axwabB5aCD3g6SMBuYxvqKWSCRJYXKSKeKsNwdSyyTyPLM5eRjxLHcnWRDQ4PE15/fLPIAd1jO2qN2ahYSxAeo3B2YfIOrtCC/A2TxK9N56/2jPceNU6EGPhTJZUeYK/2c9z41duTX7D2Z24s2wGyj4A9KdyxRnWxWflYfwjsdXLli9O1iw/M5/gHYen/2Q=="
)

class RequestHandler(http.server.SimpleHTTPRequestHandler):
    def do_GET(self):
        # Decode the base64 string
        image_data = base64.b64decode(base64_image)
        
        # Set response headers
        self.send_response(200)
        self.send_header("Content-type", "Image/jpeg")
        self.send_header("Content-Length", str(len(image_data)))
        self.end_headers()
        
        # Send the image data
        self.wfile.write(image_data)

# Set up and start the server
PORT = 8000
with socketserver.TCPServer(("", PORT), RequestHandler) as httpd:
    print(f"Serving at port {PORT}")
    httpd.serve_forever()

```

A homeassistant image entity can be configured via configuration.yaml for testing:

```
template:
  - image:
      - name: "Test image"
        url: "http://[localIp]:8000"
        attributes:
          title: "This is a test of Image/jpeg content-type"
```

![image](https://github.com/user-attachments/assets/e77cea22-7ca0-4f75-b8fd-e6333a2ee581)


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
