### PR TITLE
Remove aux_heat from ClimateEntity

### DIFF
--- a/homeassistant/components/climate/const.py
+++ b/homeassistant/components/climate/const.py
@@ -117,7 +117,6 @@ _DEPRECATED_CURRENT_HVAC_FAN = DeprecatedConstantEnum(HVACAction.FAN, "2025.1")
 CURRENT_HVAC_ACTIONS = [cls.value for cls in HVACAction]
 
 
-ATTR_AUX_HEAT = "aux_heat"
 ATTR_CURRENT_HUMIDITY = "current_humidity"
 ATTR_CURRENT_TEMPERATURE = "current_temperature"
 ATTR_FAN_MODES = "fan_modes"
@@ -145,7 +144,6 @@ DEFAULT_MAX_HUMIDITY = 99
 
 DOMAIN = "climate"
 
-SERVICE_SET_AUX_HEAT = "set_aux_heat"
 SERVICE_SET_FAN_MODE = "set_fan_mode"
 SERVICE_SET_PRESET_MODE = "set_preset_mode"
 SERVICE_SET_HUMIDITY = "set_humidity"
@@ -163,7 +161,6 @@ class ClimateEntityFeature(IntFlag):
     FAN_MODE = 8
     PRESET_MODE = 16
     SWING_MODE = 32
-    AUX_HEAT = 64
     TURN_OFF = 128
     TURN_ON = 256
 
@@ -187,9 +184,6 @@ _DEPRECATED_SUPPORT_PRESET_MODE = DeprecatedConstantEnum(
 )
 _DEPRECATED_SUPPORT_SWING_MODE = DeprecatedConstantEnum(
     ClimateEntityFeature.SWING_MODE, "2025.1"
-)
-_DEPRECATED_SUPPORT_AUX_HEAT = DeprecatedConstantEnum(
-    ClimateEntityFeature.AUX_HEAT, "2025.1"
 )
 
 # These can be removed if no deprecated constant are in this module anymore

--- a/homeassistant/components/climate/icons.json
+++ b/homeassistant/components/climate/icons.json
@@ -68,9 +68,6 @@
     "set_temperature": {
       "service": "mdi:thermometer"
     },
-    "set_aux_heat": {
-      "service": "mdi:radiator"
-    },
     "set_preset_mode": {
       "service": "mdi:sofa"
     },

--- a/homeassistant/components/climate/services.yaml
+++ b/homeassistant/components/climate/services.yaml
@@ -1,17 +1,5 @@
 # Describes the format for available climate services
 
-set_aux_heat:
-  target:
-    entity:
-      domain: climate
-      supported_features:
-        - climate.ClimateEntityFeature.AUX_HEAT
-  fields:
-    aux_heat:
-      required: true
-      selector:
-        boolean:
-
 set_preset_mode:
   target:
     entity:

--- a/homeassistant/components/climate/significant_change.py
+++ b/homeassistant/components/climate/significant_change.py
@@ -12,7 +12,6 @@ from homeassistant.helpers.significant_change import (
 )
 
 from . import (
-    ATTR_AUX_HEAT,
     ATTR_CURRENT_HUMIDITY,
     ATTR_CURRENT_TEMPERATURE,
     ATTR_FAN_MODE,
@@ -26,7 +25,6 @@ from . import (
 )
 
 SIGNIFICANT_ATTRIBUTES: set[str] = {
-    ATTR_AUX_HEAT,
     ATTR_CURRENT_HUMIDITY,
     ATTR_CURRENT_TEMPERATURE,
     ATTR_FAN_MODE,
@@ -65,7 +63,6 @@ def async_check_significant_change(
 
     for attr_name in changed_attrs:
         if attr_name in [
-            ATTR_AUX_HEAT,
             ATTR_FAN_MODE,
             ATTR_HVAC_ACTION,
             ATTR_PRESET_MODE,

--- a/homeassistant/components/climate/strings.json
+++ b/homeassistant/components/climate/strings.json
@@ -36,9 +36,6 @@
         "fan_only": "Fan only"
       },
       "state_attributes": {
-        "aux_heat": {
-          "name": "Aux heat"
-        },
         "current_humidity": {
           "name": "Current humidity"
         },
@@ -139,16 +136,6 @@
     }
   },
   "services": {
-    "set_aux_heat": {
-      "name": "Turn on/off auxiliary heater",
-      "description": "Turns auxiliary heater on/off.",
-      "fields": {
-        "aux_heat": {
-          "name": "Auxiliary heating",
-          "description": "New value of auxiliary heater."
-        }
-      }
-    },
     "set_preset_mode": {
       "name": "Set preset mode",
       "description": "Sets preset mode.",
@@ -245,16 +232,6 @@
         "heat_cool": "Heat/cool",
         "heat": "Heat"
       }
-    }
-  },
-  "issues": {
-    "deprecated_climate_aux_url_custom": {
-      "title": "The {platform} custom integration is using deprecated climate auxiliary heater",
-      "description": "The custom integration `{platform}` implements the `is_aux_heat` property or uses the auxiliary heater methods in a subclass of ClimateEntity.\n\nPlease create a bug report at {issue_tracker}.\n\nOnce an updated version of `{platform}` is available, install it and restart Home Assistant to fix this issue."
-    },
-    "deprecated_climate_aux_no_url": {
-      "title": "[%key:component::climate::issues::deprecated_climate_aux_url_custom::title%]",
-      "description": "The custom integration `{platform}` implements the `is_aux_heat` property or uses the auxiliary heater methods in a subclass of ClimateEntity.\n\nPlease report it to the author of the {platform} integration.\n\nOnce an updated version of `{platform}` is available, install it and restart Home Assistant to fix this issue."
     }
   },
   "exceptions": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
`ClimateEntity` has previously deprecated `aux_heat` and now it's removed. Integrations implementing the `aux_heat` property and service will break,

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove's deprecated `aux_heat` from `ClimateEntity`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 