### PR TITLE
Deprecate aux_heat from Nexia climate entity, implement switch

### DIFF
--- a/homeassistant/components/nexia/climate.py
+++ b/homeassistant/components/nexia/climate.py
@@ -35,6 +35,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_platform
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.typing import VolDictType
 
 from .const import (
@@ -42,6 +43,7 @@ from .const import (
     ATTR_DEHUMIDIFY_SETPOINT,
     ATTR_HUMIDIFY_SETPOINT,
     ATTR_RUN_MODE,
+    DOMAIN,
 )
 from .coordinator import NexiaDataUpdateCoordinator
 from .entity import NexiaThermostatZoneEntity
@@ -378,11 +380,31 @@ class NexiaZone(NexiaThermostatZoneEntity, ClimateEntity):
 
     async def async_turn_aux_heat_off(self) -> None:
         """Turn Aux Heat off."""
+        async_create_issue(
+            self.hass,
+            DOMAIN,
+            "migrate_aux_heat",
+            breaks_in_ha_version="2025.4.0",
+            is_fixable=True,
+            is_persistent=True,
+            translation_key="migrate_aux_heat",
+            severity=IssueSeverity.WARNING,
+        )
         await self._thermostat.set_emergency_heat(False)
         self._signal_thermostat_update()
 
     async def async_turn_aux_heat_on(self) -> None:
         """Turn Aux Heat on."""
+        async_create_issue(
+            self.hass,
+            DOMAIN,
+            "migrate_aux_heat",
+            breaks_in_ha_version="2025.4.0",
+            is_fixable=True,
+            is_persistent=True,
+            translation_key="migrate_aux_heat",
+            severity=IssueSeverity.WARNING,
+        )
         await self._thermostat.set_emergency_heat(True)
         self._signal_thermostat_update()
 

--- a/homeassistant/components/nexia/climate.py
+++ b/homeassistant/components/nexia/climate.py
@@ -167,14 +167,11 @@ class NexiaZone(NexiaThermostatZoneEntity, ClimateEntity):
         # The has_* calls are stable for the life of the device
         # and do not do I/O
         self._has_relative_humidity = thermostat.has_relative_humidity()
-        self._has_emergency_heat = thermostat.has_emergency_heat()
         self._has_humidify_support = thermostat.has_humidify_support()
         self._has_dehumidify_support = thermostat.has_dehumidify_support()
         self._attr_supported_features = NEXIA_SUPPORTED
         if self._has_humidify_support or self._has_dehumidify_support:
             self._attr_supported_features |= ClimateEntityFeature.TARGET_HUMIDITY
-        if self._has_emergency_heat:
-            self._attr_supported_features |= ClimateEntityFeature.AUX_HEAT
         self._attr_preset_modes = zone.get_presets()
         self._attr_fan_modes = thermostat.get_fan_modes()
         self._attr_hvac_modes = HVAC_MODES
@@ -350,11 +347,6 @@ class NexiaZone(NexiaThermostatZoneEntity, ClimateEntity):
         self._signal_zone_update()
 
     @property
-    def is_aux_heat(self) -> bool:
-        """Emergency heat state."""
-        return self._thermostat.is_emergency_heat_active()
-
-    @property
     def extra_state_attributes(self) -> dict[str, str] | None:
         """Return the device specific state attributes."""
         if not self._has_relative_humidity:
@@ -375,16 +367,6 @@ class NexiaZone(NexiaThermostatZoneEntity, ClimateEntity):
         """Set the preset mode."""
         await self._zone.set_preset(preset_mode)
         self._signal_zone_update()
-
-    async def async_turn_aux_heat_off(self) -> None:
-        """Turn Aux Heat off."""
-        await self._thermostat.set_emergency_heat(False)
-        self._signal_thermostat_update()
-
-    async def async_turn_aux_heat_on(self) -> None:
-        """Turn Aux Heat on."""
-        await self._thermostat.set_emergency_heat(True)
-        self._signal_thermostat_update()
 
     async def async_turn_off(self) -> None:
         """Turn off the zone."""

--- a/homeassistant/components/nexia/strings.json
+++ b/homeassistant/components/nexia/strings.json
@@ -96,5 +96,18 @@
         }
       }
     }
+  },
+  "issues": {
+    "migrate_aux_heat": {
+      "title": "Migration of Nexia set_aux_heat action",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "description": "The Nexia `set_aux_heat` action has been migrated. A new `aux_heat_only` switch entity is available for each thermostat.\n\nUpdate any automations to use the new Emergency heat switch entity. When this is done, press submit to fix this issue.",
+            "title": "[%key:component::nexia::issues::migrate_aux_heat::title%]"
+          }
+        }
+      }
+    }
   }
 }

--- a/homeassistant/components/nexia/strings.json
+++ b/homeassistant/components/nexia/strings.json
@@ -58,6 +58,9 @@
     "switch": {
       "hold": {
         "name": "Hold"
+      },
+      "emergency_heat": {
+        "name": "Emergency heat"
       }
     }
   },

--- a/homeassistant/components/nexia/strings.json
+++ b/homeassistant/components/nexia/strings.json
@@ -58,9 +58,6 @@
     "switch": {
       "hold": {
         "name": "Hold"
-      },
-      "emergency_heat": {
-        "name": "Emergency heat"
       }
     }
   },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Start deprecation for `aux_heat` in `nexia` climate entity.

Creates switch for emergency heat but unfortunately there is nothing in the fixtures so can't add a test for it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 