### PR TITLE
Remove unneeded wrapping of URL in URL in network helper

### DIFF
--- a/homeassistant/helpers/network.py
+++ b/homeassistant/helpers/network.py
@@ -216,7 +216,7 @@ def _get_request_host() -> str | None:
     """Get the host address of the current request."""
     if (request := http.current_request.get()) is None:
         raise NoURLAvailableError
-    return yarl.URL(request.url).host
+    return request.url.host
 
 
 @bind_hass

--- a/tests/helpers/test_network.py
+++ b/tests/helpers/test_network.py
@@ -3,6 +3,7 @@
 from unittest.mock import Mock, patch
 
 import pytest
+from yarl import URL
 
 from homeassistant.components import cloud
 from homeassistant.config import async_process_ha_core_config
@@ -591,7 +592,7 @@ async def test_get_request_host(hass: HomeAssistant) -> None:
 
     with patch("homeassistant.components.http.current_request") as mock_request_context:
         mock_request = Mock()
-        mock_request.url = "http://example.com:8123/test/request"
+        mock_request.url = URL("http://example.com:8123/test/request")
         mock_request_context.get = Mock(return_value=mock_request)
 
         assert _get_request_host() == "example.com"
@@ -682,10 +683,12 @@ async def test_is_internal_request(hass: HomeAssistant, mock_current_request) ->
     mock_current_request.return_value = None
     assert not is_internal_request(hass)
 
-    mock_current_request.return_value = Mock(url="http://example.local:8123")
+    mock_current_request.return_value = Mock(url=URL("http://example.local:8123"))
     assert is_internal_request(hass)
 
-    mock_current_request.return_value = Mock(url="http://no_match.example.local:8123")
+    mock_current_request.return_value = Mock(
+        url=URL("http://no_match.example.local:8123")
+    )
     assert not is_internal_request(hass)
 
     # Test with internal URL: http://192.168.0.1:8123
@@ -697,18 +700,18 @@ async def test_is_internal_request(hass: HomeAssistant, mock_current_request) ->
     assert hass.config.internal_url == "http://192.168.0.1:8123"
     assert not is_internal_request(hass)
 
-    mock_current_request.return_value = Mock(url="http://192.168.0.1:8123")
+    mock_current_request.return_value = Mock(url=URL("http://192.168.0.1:8123"))
     assert is_internal_request(hass)
 
     # Test for matching against local IP
     hass.config.api = Mock(use_ssl=False, local_ip="192.168.123.123", port=8123)
     for allowed in ("127.0.0.1", "192.168.123.123"):
-        mock_current_request.return_value = Mock(url=f"http://{allowed}:8123")
+        mock_current_request.return_value = Mock(url=URL(f"http://{allowed}:8123"))
         assert is_internal_request(hass), mock_current_request.return_value.url
 
     # Test for matching against HassOS hostname
     for allowed in ("hellohost", "hellohost.local"):
-        mock_current_request.return_value = Mock(url=f"http://{allowed}:8123")
+        mock_current_request.return_value = Mock(url=URL(f"http://{allowed}:8123"))
         assert is_internal_request(hass), mock_current_request.return_value.url
 
 


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The URL object was being wrapped in another URL object

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
