### PR TITLE
Split opentherm_gw entity base class

### DIFF
--- a/homeassistant/components/opentherm_gw/binary_sensor.py
+++ b/homeassistant/components/opentherm_gw/binary_sensor.py
@@ -22,7 +22,7 @@ from .const import (
     THERMOSTAT_DEVICE_DESCRIPTION,
     OpenThermDataSource,
 )
-from .entity import OpenThermEntity, OpenThermEntityDescription
+from .entity import OpenThermEntityDescription, OpenThermStatusEntity
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -404,7 +404,7 @@ async def async_setup_entry(
     )
 
 
-class OpenThermBinarySensor(OpenThermEntity, BinarySensorEntity):
+class OpenThermBinarySensor(OpenThermStatusEntity, BinarySensorEntity):
     """Represent an OpenTherm Gateway binary sensor."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC

--- a/homeassistant/components/opentherm_gw/button.py
+++ b/homeassistant/components/opentherm_gw/button.py
@@ -12,16 +12,11 @@ from homeassistant.components.button import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ID, EntityCategory
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import OpenThermGatewayHub
-from .const import (
-    DATA_GATEWAYS,
-    DATA_OPENTHERM_GW,
-    GATEWAY_DEVICE_DESCRIPTION,
-    OpenThermDataSource,
-)
+from .const import DATA_GATEWAYS, DATA_OPENTHERM_GW, GATEWAY_DEVICE_DESCRIPTION
 from .entity import OpenThermEntity, OpenThermEntityDescription
 
 
@@ -62,11 +57,6 @@ class OpenThermButton(OpenThermEntity, ButtonEntity):
 
     _attr_entity_category = EntityCategory.CONFIG
     entity_description: OpenThermButtonEntityDescription
-
-    @callback
-    def receive_report(self, status: dict[OpenThermDataSource, dict]) -> None:
-        """Handle status updates from the component."""
-        # We don't need any information from the reports here
 
     async def async_press(self) -> None:
         """Perform button action."""

--- a/homeassistant/components/opentherm_gw/climate.py
+++ b/homeassistant/components/opentherm_gw/climate.py
@@ -34,7 +34,7 @@ from .const import (
     THERMOSTAT_DEVICE_DESCRIPTION,
     OpenThermDataSource,
 )
-from .entity import OpenThermEntity, OpenThermEntityDescription
+from .entity import OpenThermEntityDescription, OpenThermStatusEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -69,7 +69,7 @@ async def async_setup_entry(
     async_add_entities(ents)
 
 
-class OpenThermClimate(OpenThermEntity, ClimateEntity):
+class OpenThermClimate(OpenThermStatusEntity, ClimateEntity):
     """Representation of a climate device."""
 
     _attr_supported_features = (

--- a/homeassistant/components/opentherm_gw/entity.py
+++ b/homeassistant/components/opentherm_gw/entity.py
@@ -52,6 +52,15 @@ class OpenThermEntity(Entity):
             },
         )
 
+    @property
+    def available(self) -> bool:
+        """Return connection status of the hub to indicate availability."""
+        return self._gateway.connected
+
+
+class OpenThermStatusEntity(OpenThermEntity):
+    """Represent an OpenTherm entity that receives status updates."""
+
     async def async_added_to_hass(self) -> None:
         """Subscribe to updates from the component."""
         self.async_on_remove(
@@ -59,11 +68,6 @@ class OpenThermEntity(Entity):
                 self.hass, self._gateway.update_signal, self.receive_report
             )
         )
-
-    @property
-    def available(self) -> bool:
-        """Return connection status of the hub to indicate availability."""
-        return self._gateway.connected
 
     @callback
     def receive_report(self, status: dict[OpenThermDataSource, dict]) -> None:

--- a/homeassistant/components/opentherm_gw/sensor.py
+++ b/homeassistant/components/opentherm_gw/sensor.py
@@ -32,7 +32,7 @@ from .const import (
     THERMOSTAT_DEVICE_DESCRIPTION,
     OpenThermDataSource,
 )
-from .entity import OpenThermEntity, OpenThermEntityDescription
+from .entity import OpenThermEntityDescription, OpenThermStatusEntity
 
 SENSOR_FLOAT_SUGGESTED_DISPLAY_PRECISION = 1
 
@@ -889,7 +889,7 @@ async def async_setup_entry(
     )
 
 
-class OpenThermSensor(OpenThermEntity, SensorEntity):
+class OpenThermSensor(OpenThermStatusEntity, SensorEntity):
     """Representation of an OpenTherm sensor."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
While working on new platforms for the `opentherm_gw` integration, it became clear that several platforms have no use for the status updates from the hub (so far it's only the `button` platform).
With this PR, we differentiate between the base entity class `OpenThermEntity` which provides for that need and an `OpenThermStatusEntity` which subscribes to the status updates and expects its derived classes to handle them.
This way, we avoid implementing an empty `receive_report` function on every class that has no need for it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
