### PR TITLE
Remove attributes from Nuki entities

### DIFF
--- a/homeassistant/components/nuki/binary_sensor.py
+++ b/homeassistant/components/nuki/binary_sensor.py
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import NukiEntity, NukiEntryData
-from .const import ATTR_NUKI_ID, DOMAIN as NUKI_DOMAIN
+from .const import DOMAIN as NUKI_DOMAIN
 
 
 async def async_setup_entry(
@@ -51,14 +51,6 @@ class NukiDoorsensorEntity(NukiEntity[NukiDevice], BinarySensorEntity):
         """Return a unique ID."""
         return f"{self._nuki_device.nuki_id}_doorsensor"
 
-    # Deprecated, can be removed in 2024.10
-    @property
-    def extra_state_attributes(self):
-        """Return the device specific state attributes."""
-        return {
-            ATTR_NUKI_ID: self._nuki_device.nuki_id,
-        }
-
     @property
     def available(self) -> bool:
         """Return true if door sensor is present and activated."""
@@ -90,14 +82,6 @@ class NukiRingactionEntity(NukiEntity[NukiDevice], BinarySensorEntity):
     def unique_id(self) -> str:
         """Return a unique ID."""
         return f"{self._nuki_device.nuki_id}_ringaction"
-
-    # Deprecated, can be removed in 2024.10
-    @property
-    def extra_state_attributes(self):
-        """Return the device specific state attributes."""
-        return {
-            ATTR_NUKI_ID: self._nuki_device.nuki_id,
-        }
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/nuki/lock.py
+++ b/homeassistant/components/nuki/lock.py
@@ -18,14 +18,7 @@ from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import NukiEntity, NukiEntryData
-from .const import (
-    ATTR_BATTERY_CRITICAL,
-    ATTR_ENABLE,
-    ATTR_NUKI_ID,
-    ATTR_UNLATCH,
-    DOMAIN as NUKI_DOMAIN,
-    ERROR_STATES,
-)
+from .const import ATTR_ENABLE, ATTR_UNLATCH, DOMAIN as NUKI_DOMAIN, ERROR_STATES
 from .helpers import CannotConnect
 
 
@@ -74,15 +67,6 @@ class NukiDeviceEntity[_NukiDeviceT: NukiDevice](NukiEntity[_NukiDeviceT], LockE
     def unique_id(self) -> str | None:
         """Return a unique ID."""
         return self._nuki_device.nuki_id
-
-    # Deprecated, can be removed in 2024.10
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        """Return the device specific state attributes."""
-        return {
-            ATTR_BATTERY_CRITICAL: self._nuki_device.battery_critical,
-            ATTR_NUKI_ID: self._nuki_device.nuki_id,
-        }
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/nuki/sensor.py
+++ b/homeassistant/components/nuki/sensor.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import NukiEntity, NukiEntryData
-from .const import ATTR_NUKI_ID, DOMAIN as NUKI_DOMAIN
+from .const import DOMAIN as NUKI_DOMAIN
 
 
 async def async_setup_entry(
@@ -37,12 +37,6 @@ class NukiBatterySensor(NukiEntity[NukiDevice], SensorEntity):
     def unique_id(self) -> str:
         """Return a unique ID."""
         return f"{self._nuki_device.nuki_id}_battery_level"
-
-    # Deprecated, can be removed in 2024.10
-    @property
-    def extra_state_attributes(self):
-        """Return the device specific state attributes."""
-        return {ATTR_NUKI_ID: self._nuki_device.nuki_id}
 
     @property
     def native_value(self) -> float:

--- a/tests/components/nuki/snapshots/test_binary_sensor.ambr
+++ b/tests/components/nuki/snapshots/test_binary_sensor.ambr
@@ -83,7 +83,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Community door Ring Action',
-      'nuki_id': 2,
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.community_door_ring_action',
@@ -131,7 +130,6 @@
     'attributes': ReadOnlyDict({
       'device_class': 'door',
       'friendly_name': 'Home',
-      'nuki_id': 1,
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.home',

--- a/tests/components/nuki/snapshots/test_lock.ambr
+++ b/tests/components/nuki/snapshots/test_lock.ambr
@@ -35,9 +35,7 @@
 # name: test_locks[lock.community_door-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'battery_critical': False,
       'friendly_name': 'Community door',
-      'nuki_id': 2,
       'supported_features': <LockEntityFeature: 1>,
     }),
     'context': <ANY>,
@@ -84,9 +82,7 @@
 # name: test_locks[lock.home-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'battery_critical': False,
       'friendly_name': 'Home',
-      'nuki_id': 1,
       'supported_features': <LockEntityFeature: 1>,
     }),
     'context': <ANY>,

--- a/tests/components/nuki/snapshots/test_sensor.ambr
+++ b/tests/components/nuki/snapshots/test_sensor.ambr
@@ -37,7 +37,6 @@
     'attributes': ReadOnlyDict({
       'device_class': 'battery',
       'friendly_name': 'Home Battery',
-      'nuki_id': 1,
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
#111381 added the Nuki ID as serial number and #111285 added battery critical as a binary sensor. As announced in #111419 the corresponding state attributes will therefore be removed in 2024.10.

To avoid breakage when the attributes are removed, users should update any automations and scripts that use the concerned state attributes `nuki_id` or `battery_critical`.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
