### PR TITLE
Use smlight discovery hostname as device name

### DIFF
--- a/homeassistant/components/smlight/config_flow.py
+++ b/homeassistant/components/smlight/config_flow.py
@@ -139,10 +139,6 @@ class SmlightConfigFlow(ConfigFlow, domain=DOMAIN):
             self.context["entry_id"]
         )
         host = entry_data[CONF_HOST]
-        self.context["title_placeholders"] = {
-            "host": host,
-            "name": entry_data.get(CONF_USERNAME, "unknown"),
-        }
         self.client = Api2(host, session=async_get_clientsession(self.hass))
         self.host = host
 
@@ -166,7 +162,8 @@ class SmlightConfigFlow(ConfigFlow, domain=DOMAIN):
                 assert self._reauth_entry is not None
 
                 return self.async_update_reload_and_abort(
-                    self._reauth_entry, data={**user_input, CONF_HOST: self.host}
+                    self._reauth_entry,
+                    data={**self._reauth_entry.data, **user_input},
                 )
 
         return self.async_show_form(
@@ -197,4 +194,5 @@ class SmlightConfigFlow(ConfigFlow, domain=DOMAIN):
             user_input[CONF_HOST] = self.host
 
         assert info.model is not None
-        return self.async_create_entry(title=info.model, data=user_input)
+        title = self.context.get("title_placeholders", {}).get(CONF_NAME) or info.model
+        return self.async_create_entry(title=title, data=user_input)

--- a/homeassistant/components/smlight/strings.json
+++ b/homeassistant/components/smlight/strings.json
@@ -19,7 +19,7 @@
       },
       "reauth_confirm": {
         "title": "[%key:common::config_flow::title::reauth%]",
-        "description": "Please enter the correct username and password for {name}",
+        "description": "Please enter the correct username and password",
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]"

--- a/homeassistant/components/smlight/strings.json
+++ b/homeassistant/components/smlight/strings.json
@@ -19,7 +19,7 @@
       },
       "reauth_confirm": {
         "title": "[%key:common::config_flow::title::reauth%]",
-        "description": "Please enter the correct username and password for host: {host}",
+        "description": "Please enter the correct username and password for {name}",
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]"

--- a/tests/components/smlight/test_config_flow.py
+++ b/tests/components/smlight/test_config_flow.py
@@ -91,7 +91,7 @@ async def test_zeroconf_flow(
     assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["context"]["source"] == "zeroconf"
     assert result2["context"]["unique_id"] == "aa:bb:cc:dd:ee:ff"
-    assert result2["title"] == "SLZB-06p7"
+    assert result2["title"] == "slzb-06"
     assert result2["data"] == {
         CONF_HOST: MOCK_HOST,
     }
@@ -143,7 +143,7 @@ async def test_zeroconf_flow_auth(
     assert result3["type"] is FlowResultType.CREATE_ENTRY
     assert result3["context"]["source"] == "zeroconf"
     assert result3["context"]["unique_id"] == "aa:bb:cc:dd:ee:ff"
-    assert result3["title"] == "SLZB-06p7"
+    assert result3["title"] == "slzb-06"
     assert result3["data"] == {
         CONF_USERNAME: MOCK_USERNAME,
         CONF_PASSWORD: MOCK_PASSWORD,
@@ -356,7 +356,7 @@ async def test_zeroconf_legacy_mac(
     assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["context"]["source"] == "zeroconf"
     assert result2["context"]["unique_id"] == "aa:bb:cc:dd:ee:ff"
-    assert result2["title"] == "SLZB-06p7"
+    assert result2["title"] == "slzb-06"
     assert result2["data"] == {
         CONF_HOST: MOCK_HOST,
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently the device model is used as device name while the device has an option to set the hostname of the device. Using the device model is confusing since you can have multiple devices with the same model on the same network.

This change uses the discovery hostname as device name, for manual added devices the device model is still used as a fallback but in the future this can be improved by retrieving the hostname from the device for manually added devices using the `/ha_info` endpoint.

**Before:**
![devices](https://github.com/user-attachments/assets/49298464-4be3-49aa-b2b9-610f9e69b501)
![before](https://github.com/user-attachments/assets/e81ae3f2-b389-43fc-9e64-0682d00f147a)

**After:**
![devices-after](https://github.com/user-attachments/assets/ec9de762-622e-472f-9ab6-23c1dac45272)
![after](https://github.com/user-attachments/assets/00f3e0e6-0a18-4553-9d69-11c10999c080)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
