### PR TITLE
Fix for Hue sending effect None at turn_on command while no effect is active

### DIFF
--- a/homeassistant/components/hue/v2/light.py
+++ b/homeassistant/components/hue/v2/light.py
@@ -226,7 +226,11 @@ class HueLight(HueBaseEntity, LightEntity):
         flash = kwargs.get(ATTR_FLASH)
         effect = effect_str = kwargs.get(ATTR_EFFECT)
         if effect_str in (EFFECT_NONE, EFFECT_NONE.lower()):
-            effect = EffectStatus.NO_EFFECT
+            # ignore effect if set to "None" and we have no effect active
+            # the special effect "None" is only used to stop an active effect
+            # but sending it while no effect is active can actually result in issues
+            # https://github.com/home-assistant/core/issues/122165
+            effect = None if self.effect == EFFECT_NONE else EffectStatus.NO_EFFECT
         elif effect_str is not None:
             # work out if we got a regular effect or timed effect
             effect = EffectStatus(effect_str)

--- a/homeassistant/components/hue/v2/light.py
+++ b/homeassistant/components/hue/v2/light.py
@@ -230,7 +230,7 @@ class HueLight(HueBaseEntity, LightEntity):
             # the special effect "None" is only used to stop an active effect
             # but sending it while no effect is active can actually result in issues
             # https://github.com/home-assistant/core/issues/122165
-            effect = None if self.effect == EFFECT_NONE else EffectStatus.NO_EFFECT
+            effect = None if self.effect == EFFECT_NONE else effect
         elif effect_str is not None:
             # work out if we got a regular effect or timed effect
             effect = EffectStatus(effect_str)

--- a/homeassistant/components/hue/v2/light.py
+++ b/homeassistant/components/hue/v2/light.py
@@ -230,7 +230,7 @@ class HueLight(HueBaseEntity, LightEntity):
             # the special effect "None" is only used to stop an active effect
             # but sending it while no effect is active can actually result in issues
             # https://github.com/home-assistant/core/issues/122165
-            effect = None if self.effect == EFFECT_NONE else effect
+            effect = None if self.effect == EFFECT_NONE else EffectStatus.NO_EFFECT
         elif effect_str is not None:
             # work out if we got a regular effect or timed effect
             effect = EffectStatus(effect_str)

--- a/tests/components/hue/test_light_v2.py
+++ b/tests/components/hue/test_light_v2.py
@@ -175,7 +175,7 @@ async def test_light_turn_on_service(
     assert len(mock_bridge_v2.mock_requests) == 6
     assert mock_bridge_v2.mock_requests[5]["json"]["color_temperature"]["mirek"] == 500
 
-    # test enable effect
+    # test enable an effect
     await hass.services.async_call(
         "light",
         "turn_on",
@@ -184,8 +184,20 @@ async def test_light_turn_on_service(
     )
     assert len(mock_bridge_v2.mock_requests) == 7
     assert mock_bridge_v2.mock_requests[6]["json"]["effects"]["effect"] == "candle"
+    # fire event to update effect in HA state
+    event = {
+        "id": "3a6710fa-4474-4eba-b533-5e6e72968feb",
+        "type": "light",
+        "effects": {"status": "candle"},
+    }
+    mock_bridge_v2.api.emit_event("update", event)
+    await hass.async_block_till_done()
+    test_light = hass.states.get(test_light_id)
+    assert test_light is not None
+    assert test_light.attributes["effect"] == "candle"
 
     # test disable effect
+    # it should send a request with effect set to "no_effect"
     await hass.services.async_call(
         "light",
         "turn_on",
@@ -194,6 +206,28 @@ async def test_light_turn_on_service(
     )
     assert len(mock_bridge_v2.mock_requests) == 8
     assert mock_bridge_v2.mock_requests[7]["json"]["effects"]["effect"] == "no_effect"
+    # fire event to update effect in HA state
+    event = {
+        "id": "3a6710fa-4474-4eba-b533-5e6e72968feb",
+        "type": "light",
+        "effects": {"status": "no_effect"},
+    }
+    mock_bridge_v2.api.emit_event("update", event)
+    await hass.async_block_till_done()
+    test_light = hass.states.get(test_light_id)
+    assert test_light is not None
+    assert test_light.attributes["effect"] == "None"
+
+    # test turn on with useless effect
+    # it should send a effect in the request if the device has no effect active
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": test_light_id, "effect": "None"},
+        blocking=True,
+    )
+    assert len(mock_bridge_v2.mock_requests) == 9
+    assert "effects" not in mock_bridge_v2.mock_requests[8]["json"]
 
     # test timed effect
     await hass.services.async_call(
@@ -202,11 +236,11 @@ async def test_light_turn_on_service(
         {"entity_id": test_light_id, "effect": "sunrise", "transition": 6},
         blocking=True,
     )
-    assert len(mock_bridge_v2.mock_requests) == 9
+    assert len(mock_bridge_v2.mock_requests) == 10
     assert (
-        mock_bridge_v2.mock_requests[8]["json"]["timed_effects"]["effect"] == "sunrise"
+        mock_bridge_v2.mock_requests[9]["json"]["timed_effects"]["effect"] == "sunrise"
     )
-    assert mock_bridge_v2.mock_requests[8]["json"]["timed_effects"]["duration"] == 6000
+    assert mock_bridge_v2.mock_requests[9]["json"]["timed_effects"]["duration"] == 6000
 
     # test enabling effect should ignore color temperature
     await hass.services.async_call(
@@ -215,9 +249,9 @@ async def test_light_turn_on_service(
         {"entity_id": test_light_id, "effect": "candle", "color_temp": 500},
         blocking=True,
     )
-    assert len(mock_bridge_v2.mock_requests) == 10
-    assert mock_bridge_v2.mock_requests[9]["json"]["effects"]["effect"] == "candle"
-    assert "color_temperature" not in mock_bridge_v2.mock_requests[9]["json"]
+    assert len(mock_bridge_v2.mock_requests) == 11
+    assert mock_bridge_v2.mock_requests[10]["json"]["effects"]["effect"] == "candle"
+    assert "color_temperature" not in mock_bridge_v2.mock_requests[10]["json"]
 
     # test enabling effect should ignore xy color
     await hass.services.async_call(
@@ -226,9 +260,9 @@ async def test_light_turn_on_service(
         {"entity_id": test_light_id, "effect": "candle", "xy_color": [0.123, 0.123]},
         blocking=True,
     )
-    assert len(mock_bridge_v2.mock_requests) == 11
-    assert mock_bridge_v2.mock_requests[10]["json"]["effects"]["effect"] == "candle"
-    assert "xy_color" not in mock_bridge_v2.mock_requests[9]["json"]
+    assert len(mock_bridge_v2.mock_requests) == 12
+    assert mock_bridge_v2.mock_requests[11]["json"]["effects"]["effect"] == "candle"
+    assert "xy_color" not in mock_bridge_v2.mock_requests[11]["json"]
 
 
 async def test_light_turn_off_service(


### PR DESCRIPTION
## Proposed change

Fix a tiny (but annoying) bug that is introduced after a recent Hue Bridge update.
You can send a special "no effect" effect value to a light to make it stop its active effect but if you send that while no effect is active, it can cause weird behavior or the command might fail entirely. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #122165
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
