### PR TITLE
Improve handling of old firmware versions

### DIFF
--- a/homeassistant/components/smlight/coordinator.py
+++ b/homeassistant/components/smlight/coordinator.py
@@ -9,8 +9,10 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.issue_registry import IssueSeverity
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, LOGGER, SCAN_INTERVAL
@@ -40,6 +42,7 @@ class SmDataUpdateCoordinator(DataUpdateCoordinator[SmData]):
 
         self.unique_id: str | None = None
         self.client = Api2(host=host, session=async_get_clientsession(hass))
+        self.legacy_api: int = 0
 
     async def _async_setup(self) -> None:
         """Authenticate if needed during initial setup."""
@@ -62,11 +65,28 @@ class SmDataUpdateCoordinator(DataUpdateCoordinator[SmData]):
         info = await self.client.get_info()
         self.unique_id = format_mac(info.MAC)
 
+        if info.legacy_api:
+            self.legacy_api = info.legacy_api
+            ir.async_create_issue(
+                self.hass,
+                DOMAIN,
+                "unsupported_firmware",
+                is_fixable=False,
+                is_persistent=False,
+                learn_more_url="https://smlight.tech/flasher/#SLZB-06",
+                severity=IssueSeverity.ERROR,
+                translation_key="unsupported_firmware",
+            )
+
     async def _async_update_data(self) -> SmData:
         """Fetch data from the SMLIGHT device."""
         try:
+            sensors = Sensors()
+            if not self.legacy_api:
+                sensors = await self.client.get_sensors()
+
             return SmData(
-                sensors=await self.client.get_sensors(),
+                sensors=sensors,
                 info=await self.client.get_info(),
             )
         except SmlightAuthError as err:

--- a/homeassistant/components/smlight/strings.json
+++ b/homeassistant/components/smlight/strings.json
@@ -81,5 +81,11 @@
         "name": "Zigbee flash mode"
       }
     }
+  },
+  "issues": {
+    "unsupported_firmware": {
+      "title": "SLZB core firmware update required",
+      "description": "Your SMLIGHT SLZB-06x device is running an unsupported core firmware version. Please update it to the latest version to enjoy all the features of this integration."
+    }
   }
 }

--- a/tests/components/smlight/fixtures/info.json
+++ b/tests/components/smlight/fixtures/info.json
@@ -3,6 +3,8 @@
   "device_ip": "192.168.1.161",
   "fs_total": 3456,
   "fw_channel": "dev",
+  "legacy_api": 0,
+  "hostname": "SLZB-06p7",
   "MAC": "AA:BB:CC:DD:EE:FF",
   "model": "SLZB-06p7",
   "ram_total": 296,

--- a/tests/components/smlight/fixtures/info.json
+++ b/tests/components/smlight/fixtures/info.json
@@ -8,7 +8,7 @@
   "MAC": "AA:BB:CC:DD:EE:FF",
   "model": "SLZB-06p7",
   "ram_total": 296,
-  "sw_version": "v2.3.1.dev",
+  "sw_version": "v2.3.6",
   "wifi_mode": 0,
   "zb_flash_size": 704,
   "zb_hw": "CC2652P7",

--- a/tests/components/smlight/snapshots/test_init.ambr
+++ b/tests/components/smlight/snapshots/test_init.ambr
@@ -27,7 +27,7 @@
     'primary_config_entry': <ANY>,
     'serial_number': None,
     'suggested_area': None,
-    'sw_version': 'core: v2.3.1.dev / zigbee: -1',
+    'sw_version': 'core: v2.3.6 / zigbee: -1',
     'via_device_id': None,
   })
 # ---


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SLZB-06 core (esp32) firmware introduced the API required for this integration in `v2.3.6`. If a user has an older version of the firmware than this, we can still get enough information from the device to setup device registry and create a repair advising to upgrade.

This PR will allow users to install the integration on unsupported firmware (currently this is crashing) and then a repair will be created advising to update.

* Users on `v0.9.9` core firmware will need to visit the SMLIGHT web flasher to update via USB (webpage linked by the `learn more` button).
* Users on `v2.x` < `v2.3.6` core firmware can upgrade from the SLZB-06 device SMLIGHT web UI, but eventually will be able to update from HA with the update entities to be introduced in a later PR

Perhaps this could also be applied to the stable branch, however it does also require dependency update per:
https://github.com/home-assistant/core/pull/125387

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #125244
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
