### PR TITLE
Add switch platform to opentherm_gw

### DIFF
--- a/homeassistant/components/opentherm_gw/__init__.py
+++ b/homeassistant/components/opentherm_gw/__init__.py
@@ -90,7 +90,13 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.CLIMATE, Platform.SENSOR]
+PLATFORMS = [
+    Platform.BINARY_SENSOR,
+    Platform.BUTTON,
+    Platform.CLIMATE,
+    Platform.SENSOR,
+    Platform.SWITCH,
+]
 
 
 async def options_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/homeassistant/components/opentherm_gw/strings.json
+++ b/homeassistant/components/opentherm_gw/strings.json
@@ -309,6 +309,11 @@
       "outside_temperature": {
         "name": "Outside temperature"
       }
+    },
+    "switch": {
+      "central_heating_override_n": {
+        "name": "Central heating {circuit_number} override"
+      }
     }
   },
   "options": {

--- a/homeassistant/components/opentherm_gw/strings.json
+++ b/homeassistant/components/opentherm_gw/strings.json
@@ -312,7 +312,7 @@
     },
     "switch": {
       "central_heating_override_n": {
-        "name": "Central heating {circuit_number} override"
+        "name": "Force central heating {circuit_number} on"
       }
     }
   },

--- a/homeassistant/components/opentherm_gw/switch.py
+++ b/homeassistant/components/opentherm_gw/switch.py
@@ -1,0 +1,67 @@
+"""Support for OpenTherm Gateway switches."""
+
+from dataclasses import dataclass
+
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_ID, EntityCategory
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import (
+    DATA_GATEWAYS,
+    DATA_OPENTHERM_GW,
+    GATEWAY_DEVICE_DESCRIPTION,
+    OpenThermDataSource,
+)
+from .entity import OpenThermEntity, OpenThermEntityDescription
+
+
+@dataclass(frozen=True, kw_only=True)
+class OpenThermSwitchEntityDescription(
+    OpenThermEntityDescription, SwitchEntityDescription
+):
+    """Describes opentherm_gw switch entity."""
+
+
+SWITCH_DESCRIPTIONS: tuple[OpenThermSwitchEntityDescription, ...] = (
+    OpenThermSwitchEntityDescription(
+        key="central_heating_1_override",
+        translation_key="central_heating_override_n",
+        translation_placeholders={"circuit_number": "1"},
+        device_description=GATEWAY_DEVICE_DESCRIPTION,
+        entity_registry_enabled_default=False,
+    ),
+    OpenThermSwitchEntityDescription(
+        key="central_heating_1_override",
+        translation_key="central_heating_override_n",
+        translation_placeholders={"circuit_number": "2"},
+        device_description=GATEWAY_DEVICE_DESCRIPTION,
+        entity_registry_enabled_default=False,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the OpenTherm Gateway switches."""
+    gw_hub = hass.data[DATA_OPENTHERM_GW][DATA_GATEWAYS][config_entry.data[CONF_ID]]
+
+    async_add_entities(
+        OpenThermSwitch(gw_hub, description) for description in SWITCH_DESCRIPTIONS
+    )
+
+
+class OpenThermSwitch(OpenThermEntity, SwitchEntity):
+    """Represent an OpenTherm Gateway switch."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    entity_description: OpenThermSwitchEntityDescription
+
+    @callback
+    def receive_report(self, status: dict[OpenThermDataSource, dict]) -> None:
+        """Handle status updates from the component."""
+        # We don't need

--- a/homeassistant/components/opentherm_gw/switch.py
+++ b/homeassistant/components/opentherm_gw/switch.py
@@ -1,19 +1,17 @@
 """Support for OpenTherm Gateway switches."""
 
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import Any
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ID, EntityCategory
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import (
-    DATA_GATEWAYS,
-    DATA_OPENTHERM_GW,
-    GATEWAY_DEVICE_DESCRIPTION,
-    OpenThermDataSource,
-)
+from . import OpenThermGatewayHub
+from .const import DATA_GATEWAYS, DATA_OPENTHERM_GW, GATEWAY_DEVICE_DESCRIPTION
 from .entity import OpenThermEntity, OpenThermEntityDescription
 
 
@@ -23,6 +21,9 @@ class OpenThermSwitchEntityDescription(
 ):
     """Describes opentherm_gw switch entity."""
 
+    turn_off_action: Callable[[OpenThermGatewayHub], Awaitable[int | None]]
+    turn_on_action: Callable[[OpenThermGatewayHub], Awaitable[int | None]]
+
 
 SWITCH_DESCRIPTIONS: tuple[OpenThermSwitchEntityDescription, ...] = (
     OpenThermSwitchEntityDescription(
@@ -30,14 +31,16 @@ SWITCH_DESCRIPTIONS: tuple[OpenThermSwitchEntityDescription, ...] = (
         translation_key="central_heating_override_n",
         translation_placeholders={"circuit_number": "1"},
         device_description=GATEWAY_DEVICE_DESCRIPTION,
-        entity_registry_enabled_default=False,
+        turn_off_action=lambda hub: hub.gateway.set_ch_enable_bit(0),
+        turn_on_action=lambda hub: hub.gateway.set_ch_enable_bit(1),
     ),
     OpenThermSwitchEntityDescription(
-        key="central_heating_1_override",
+        key="central_heating_2_override",
         translation_key="central_heating_override_n",
         translation_placeholders={"circuit_number": "2"},
         device_description=GATEWAY_DEVICE_DESCRIPTION,
-        entity_registry_enabled_default=False,
+        turn_off_action=lambda hub: hub.gateway.set_ch2_enable_bit(0),
+        turn_on_action=lambda hub: hub.gateway.set_ch2_enable_bit(1),
     ),
 )
 
@@ -58,10 +61,19 @@ async def async_setup_entry(
 class OpenThermSwitch(OpenThermEntity, SwitchEntity):
     """Represent an OpenTherm Gateway switch."""
 
+    _attr_assumed_state = True
     _attr_entity_category = EntityCategory.CONFIG
+    _attr_entity_registry_enabled_default = False
     entity_description: OpenThermSwitchEntityDescription
 
-    @callback
-    def receive_report(self, status: dict[OpenThermDataSource, dict]) -> None:
-        """Handle status updates from the component."""
-        # We don't need
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn switch on."""
+        value = await self.entity_description.turn_off_action(self._gateway)
+        self._attr_is_on = bool(value) if value is not None else None
+        self.async_write_ha_state()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn switch on."""
+        value = await self.entity_description.turn_on_action(self._gateway)
+        self._attr_is_on = bool(value) if value is not None else None
+        self.async_write_ha_state()

--- a/tests/components/opentherm_gw/test_switch.py
+++ b/tests/components/opentherm_gw/test_switch.py
@@ -67,7 +67,6 @@ async def test_ch_override_switch(
         },
         blocking=True,
     )
-    await hass.async_block_till_done()
     assert hass.states.get(switch_entity_id).state == STATE_OFF
 
     await hass.services.async_call(
@@ -78,7 +77,6 @@ async def test_ch_override_switch(
         },
         blocking=True,
     )
-    await hass.async_block_till_done()
     assert hass.states.get(switch_entity_id).state == STATE_ON
 
     assert mock_pyotgw.return_value.set_ch_enable_bit.await_count == 2
@@ -138,7 +136,6 @@ async def test_ch2_override_switch(
         },
         blocking=True,
     )
-    await hass.async_block_till_done()
     assert hass.states.get(switch_entity_id).state == STATE_ON
 
     assert mock_pyotgw.return_value.set_ch2_enable_bit.await_count == 2

--- a/tests/components/opentherm_gw/test_switch.py
+++ b/tests/components/opentherm_gw/test_switch.py
@@ -1,0 +1,145 @@
+"""Test opentherm_gw switches."""
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock, call
+
+from homeassistant.components.opentherm_gw import DOMAIN as OPENTHERM_DOMAIN
+from homeassistant.components.opentherm_gw.const import OpenThermDeviceIdentifier
+from homeassistant.components.switch import (
+    DOMAIN as SWITCH_DOMAIN,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
+from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_ID,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+async def test_ch_override_switch(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_pyotgw: MagicMock,
+) -> None:
+    """Test central heating override switch."""
+
+    mock_pyotgw.return_value.set_ch_enable_bit = AsyncMock(side_effect=[0, 1])
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        switch_entity_id := entity_registry.async_get_entity_id(
+            SWITCH_DOMAIN,
+            OPENTHERM_DOMAIN,
+            f"{mock_config_entry.data[CONF_ID]}-{OpenThermDeviceIdentifier.GATEWAY}-central_heating_1_override",
+        )
+    ) is not None
+
+    assert (entity_entry := entity_registry.async_get(switch_entity_id)) is not None
+    assert entity_entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
+
+    entity_registry.async_update_entity(switch_entity_id, disabled_by=None)
+
+    async_fire_time_changed(
+        hass,
+        dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(switch_entity_id).state == STATE_UNKNOWN
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {
+            ATTR_ENTITY_ID: switch_entity_id,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(switch_entity_id).state == STATE_OFF
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {
+            ATTR_ENTITY_ID: switch_entity_id,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(switch_entity_id).state == STATE_ON
+
+    assert mock_pyotgw.return_value.set_ch_enable_bit.await_count == 2
+    mock_pyotgw.return_value.set_ch_enable_bit.assert_has_awaits([call(0), call(1)])
+
+
+async def test_ch2_override_switch(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_pyotgw: MagicMock,
+) -> None:
+    """Test central heating 2 override switch."""
+
+    mock_pyotgw.return_value.set_ch2_enable_bit = AsyncMock(side_effect=[0, 1])
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        switch_entity_id := entity_registry.async_get_entity_id(
+            SWITCH_DOMAIN,
+            OPENTHERM_DOMAIN,
+            f"{mock_config_entry.data[CONF_ID]}-{OpenThermDeviceIdentifier.GATEWAY}-central_heating_2_override",
+        )
+    ) is not None
+
+    assert (entity_entry := entity_registry.async_get(switch_entity_id)) is not None
+    assert entity_entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
+
+    entity_registry.async_update_entity(switch_entity_id, disabled_by=None)
+
+    async_fire_time_changed(
+        hass,
+        dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get(switch_entity_id).state == STATE_UNKNOWN
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {
+            ATTR_ENTITY_ID: switch_entity_id,
+        },
+        blocking=True,
+    )
+    assert hass.states.get(switch_entity_id).state == STATE_OFF
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {
+            ATTR_ENTITY_ID: switch_entity_id,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(switch_entity_id).state == STATE_ON
+
+    assert mock_pyotgw.return_value.set_ch2_enable_bit.await_count == 2
+    mock_pyotgw.return_value.set_ch2_enable_bit.assert_has_awaits([call(0), call(1)])

--- a/tests/components/opentherm_gw/test_switch.py
+++ b/tests/components/opentherm_gw/test_switch.py
@@ -56,15 +56,24 @@ async def test_switch_added_disabled(
     assert entity_entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
 
 
+@pytest.mark.parametrize(
+    ("entity_key", "target_func"),
+    [
+        ("central_heating_1_override", "set_ch_enable_bit"),
+        ("central_heating_2_override", "set_ch2_enable_bit"),
+    ],
+)
 async def test_ch_override_switch(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
     mock_pyotgw: MagicMock,
+    entity_key: str,
+    target_func: str,
 ) -> None:
     """Test central heating override switch."""
 
-    mock_pyotgw.return_value.set_ch_enable_bit = AsyncMock(side_effect=[0, 1])
+    setattr(mock_pyotgw.return_value, target_func, AsyncMock(side_effect=[0, 1]))
     mock_config_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
@@ -74,7 +83,7 @@ async def test_ch_override_switch(
         switch_entity_id := entity_registry.async_get_entity_id(
             SWITCH_DOMAIN,
             OPENTHERM_DOMAIN,
-            f"{mock_config_entry.data[CONF_ID]}-{OpenThermDeviceIdentifier.GATEWAY}-central_heating_1_override",
+            f"{mock_config_entry.data[CONF_ID]}-{OpenThermDeviceIdentifier.GATEWAY}-{entity_key}",
         )
     ) is not None
 
@@ -110,64 +119,6 @@ async def test_ch_override_switch(
     )
     assert hass.states.get(switch_entity_id).state == STATE_ON
 
-    assert mock_pyotgw.return_value.set_ch_enable_bit.await_count == 2
-    mock_pyotgw.return_value.set_ch_enable_bit.assert_has_awaits([call(0), call(1)])
-
-
-async def test_ch2_override_switch(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-    mock_config_entry: MockConfigEntry,
-    mock_pyotgw: MagicMock,
-) -> None:
-    """Test central heating 2 override switch."""
-
-    mock_pyotgw.return_value.set_ch2_enable_bit = AsyncMock(side_effect=[0, 1])
-    mock_config_entry.add_to_hass(hass)
-
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert (
-        switch_entity_id := entity_registry.async_get_entity_id(
-            SWITCH_DOMAIN,
-            OPENTHERM_DOMAIN,
-            f"{mock_config_entry.data[CONF_ID]}-{OpenThermDeviceIdentifier.GATEWAY}-central_heating_2_override",
-        )
-    ) is not None
-
-    assert (entity_entry := entity_registry.async_get(switch_entity_id)) is not None
-    assert entity_entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
-
-    entity_registry.async_update_entity(switch_entity_id, disabled_by=None)
-
-    async_fire_time_changed(
-        hass,
-        dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
-    )
-    await hass.async_block_till_done()
-
-    assert hass.states.get(switch_entity_id).state == STATE_UNKNOWN
-
-    await hass.services.async_call(
-        SWITCH_DOMAIN,
-        SERVICE_TURN_OFF,
-        {
-            ATTR_ENTITY_ID: switch_entity_id,
-        },
-        blocking=True,
-    )
-    assert hass.states.get(switch_entity_id).state == STATE_OFF
-
-    await hass.services.async_call(
-        SWITCH_DOMAIN,
-        SERVICE_TURN_ON,
-        {
-            ATTR_ENTITY_ID: switch_entity_id,
-        },
-        blocking=True,
-    )
-    assert hass.states.get(switch_entity_id).state == STATE_ON
-
-    assert mock_pyotgw.return_value.set_ch2_enable_bit.await_count == 2
-    mock_pyotgw.return_value.set_ch2_enable_bit.assert_has_awaits([call(0), call(1)])
+    mock_func = getattr(mock_pyotgw.return_value, target_func)
+    assert mock_func.await_count == 2
+    mock_func.assert_has_awaits([call(0), call(1)])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With this PR, we add switches to the OpenTherm Gateway integration. In the future, these switches will replace the `opentherm_gw.set_central_heating_ovrd` service.
As these switches control an advanced feature of the gateway that most people will not need, the switches are disabled by default.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#34615

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
