### PR TITLE
Improve Shelly RPC entity naming

### DIFF
--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -1066,7 +1066,7 @@ RPC_SENSORS: Final = {
     "analoginput": RpcSensorDescription(
         key="input",
         sub_key="percent",
-        name="Analog input",
+        name="analog",
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         removal_condition=lambda config, _, key: (
@@ -1076,7 +1076,7 @@ RPC_SENSORS: Final = {
     "analoginput_xpercent": RpcSensorDescription(
         key="input",
         sub_key="xpercent",
-        name="Analog value",
+        name="analog value",
         removal_condition=lambda config, status, key: (
             config[key]["type"] != "analog"
             or config[key]["enable"] is False
@@ -1087,7 +1087,7 @@ RPC_SENSORS: Final = {
     "pulse_counter": RpcSensorDescription(
         key="input",
         sub_key="counts",
-        name="Pulse counter",
+        name="pulse counter",
         native_unit_of_measurement="pulse",
         state_class=SensorStateClass.TOTAL,
         value=lambda status, _: status["total"],
@@ -1098,7 +1098,7 @@ RPC_SENSORS: Final = {
     "counter_value": RpcSensorDescription(
         key="input",
         sub_key="counts",
-        name="Counter value",
+        name="counter value",
         value=lambda status, _: status["xtotal"],
         removal_condition=lambda config, status, key: (
             config[key]["type"] != "count"
@@ -1110,7 +1110,7 @@ RPC_SENSORS: Final = {
     "counter_frequency": RpcSensorDescription(
         key="input",
         sub_key="freq",
-        name="Pulse counter frequency",
+        name="pulse counter frequency",
         native_unit_of_measurement=UnitOfFrequency.HERTZ,
         state_class=SensorStateClass.MEASUREMENT,
         removal_condition=lambda config, _, key: (
@@ -1120,7 +1120,7 @@ RPC_SENSORS: Final = {
     "counter_frequency_value": RpcSensorDescription(
         key="input",
         sub_key="xfreq",
-        name="Pulse counter frequency value",
+        name="pulse counter frequency value",
         removal_condition=lambda config, status, key: (
             config[key]["type"] != "count"
             or config[key]["enable"] is False

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -329,7 +329,7 @@ def get_rpc_channel_name(device: RpcDevice, key: str) -> str:
     if entity_name is None:
         component = key.split(":")[0]
         if key.startswith(
-            ("cover:", "input:", "light:", "rgb", "rgbw", "switch:", "thermostat:")
+            ("cover:", "input:", "light:", "rgb:", "rgbw:", "switch:", "thermostat:")
         ):
             if len(get_rpc_key_ids(device.config, component)) > 1:
                 return f"{device_name} {key.replace(':', ' ').title()}"

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -312,11 +312,6 @@ def get_model_name(info: dict[str, Any]) -> str:
     return cast(str, MODEL_NAMES.get(info["type"], info["type"]))
 
 
-def get_rpc_key_ids(keys_dict: dict[str, Any], key: str) -> list[int]:
-    """Return list of key ids for RPC device from a dict."""
-    return [int(k.split(":")[1]) for k in keys_dict if k.startswith(f"{key}:")]
-
-
 def get_rpc_channel_name(device: RpcDevice, key: str) -> str:
     """Get name based on device and channel name."""
     key = key.replace("emdata", "em")
@@ -327,13 +322,10 @@ def get_rpc_channel_name(device: RpcDevice, key: str) -> str:
         entity_name = device.config[key].get("name")
 
     if entity_name is None:
-        component = key.split(":")[0]
         if key.startswith(
             ("cover:", "input:", "light:", "rgb:", "rgbw:", "switch:", "thermostat:")
         ):
-            if len(get_rpc_key_ids(device.config, component)) > 1:
-                return f"{device_name} {key.replace(':', ' ').title()}"
-            return f"{device_name} {component.title()}"
+            return f"{device_name} {key.replace(':', ' ').title()}"
         if key.startswith("em1"):
             return f"{device_name} EM{key.split(':')[-1]}"
         if key.startswith(("boolean:", "enum:", "number:", "text:")):
@@ -369,6 +361,11 @@ def get_rpc_key_instances(keys_dict: dict[str, Any], key: str) -> list[str]:
         key = "cover"
 
     return [k for k in keys_dict if k.startswith(f"{key}:")]
+
+
+def get_rpc_key_ids(keys_dict: dict[str, Any], key: str) -> list[int]:
+    """Return list of key ids for RPC device from a dict."""
+    return [int(k.split(":")[1]) for k in keys_dict if k.startswith(f"{key}:")]
 
 
 def is_rpc_momentary_input(

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -322,14 +322,16 @@ def get_rpc_channel_name(device: RpcDevice, key: str) -> str:
         entity_name = device.config[key].get("name")
 
     if entity_name is None:
-        if key.startswith(
-            ("cover:", "input:", "light:", "rgb:", "rgbw:", "switch:", "thermostat:")
-        ):
-            return f"{device_name} {key.replace(':', ' ').title()}"
+        channel = key.split(":")[0]
+        channel_id = key.split(":")[-1]
+        if key.startswith(("cover:", "input:", "light:", "switch:", "thermostat:")):
+            return f"{device_name} {channel.title()} {channel_id}"
+        if key.startswith(("rgb:", "rgbw:")):
+            return f"{device_name} {channel.upper()} light {channel_id}"
         if key.startswith("em1"):
-            return f"{device_name} EM{key.split(':')[-1]}"
+            return f"{device_name} EM{channel_id}"
         if key.startswith(("boolean:", "enum:", "number:", "text:")):
-            return key.replace(":", " ").title()
+            return f"{channel.title()} {channel_id}"
         return device_name
 
     return entity_name

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -322,8 +322,8 @@ def get_rpc_channel_name(device: RpcDevice, key: str) -> str:
         entity_name = device.config[key].get("name", device_name)
 
     if entity_name is None:
-        if key.startswith(("input:", "light:", "switch:")):
-            return f"{device_name} {key.replace(':', '_')}"
+        if key.startswith(("cover:", "input:", "light:", "switch:")):
+            return f"{device_name} {key.replace(':', ' ').title()}"
         if key.startswith("em1"):
             return f"{device_name} EM{key.split(':')[-1]}"
         if key.startswith(("boolean:", "enum:", "number:", "text:")):

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -324,11 +324,13 @@ def get_rpc_channel_name(device: RpcDevice, key: str) -> str:
     device_name = device.name
     entity_name: str | None = None
     if key in device.config:
-        entity_name = device.config[key].get("name", device_name)
+        entity_name = device.config[key].get("name")
 
     if entity_name is None:
         component = key.split(":")[0]
-        if key.startswith(("cover:", "input:", "light:", "switch:")):
+        if key.startswith(
+            ("cover:", "input:", "light:", "rgb", "rgbw", "switch:", "thermostat:")
+        ):
             if len(get_rpc_key_ids(device.config, component)) > 1:
                 return f"{device_name} {key.replace(':', ' ').title()}"
             return f"{device_name} {component.title()}"

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -312,6 +312,11 @@ def get_model_name(info: dict[str, Any]) -> str:
     return cast(str, MODEL_NAMES.get(info["type"], info["type"]))
 
 
+def get_rpc_key_ids(keys_dict: dict[str, Any], key: str) -> list[int]:
+    """Return list of key ids for RPC device from a dict."""
+    return [int(k.split(":")[1]) for k in keys_dict if k.startswith(f"{key}:")]
+
+
 def get_rpc_channel_name(device: RpcDevice, key: str) -> str:
     """Get name based on device and channel name."""
     key = key.replace("emdata", "em")
@@ -322,8 +327,11 @@ def get_rpc_channel_name(device: RpcDevice, key: str) -> str:
         entity_name = device.config[key].get("name", device_name)
 
     if entity_name is None:
+        component = key.split(":")[0]
         if key.startswith(("cover:", "input:", "light:", "switch:")):
-            return f"{device_name} {key.replace(':', ' ').title()}"
+            if len(get_rpc_key_ids(device.config, component)) > 1:
+                return f"{device_name} {key.replace(':', ' ').title()}"
+            return f"{device_name} {component.title()}"
         if key.startswith("em1"):
             return f"{device_name} EM{key.split(':')[-1]}"
         if key.startswith(("boolean:", "enum:", "number:", "text:")):
@@ -359,11 +367,6 @@ def get_rpc_key_instances(keys_dict: dict[str, Any], key: str) -> list[str]:
         key = "cover"
 
     return [k for k in keys_dict if k.startswith(f"{key}:")]
-
-
-def get_rpc_key_ids(keys_dict: dict[str, Any], key: str) -> list[int]:
-    """Return list of key ids for RPC device from a dict."""
-    return [int(k.split(":")[1]) for k in keys_dict if k.startswith(f"{key}:")]
 
 
 def is_rpc_momentary_input(

--- a/tests/components/shelly/test_climate.py
+++ b/tests/components/shelly/test_climate.py
@@ -609,7 +609,7 @@ async def test_rpc_climate_hvac_mode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test climate hvac mode service."""
-    entity_id = "climate.test_name_thermostat"
+    entity_id = "climate.test_name_thermostat_0"
 
     await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)
 
@@ -654,7 +654,7 @@ async def test_rpc_climate_without_humidity(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test climate entity without the humidity value."""
-    entity_id = "climate.test_name_thermostat"
+    entity_id = "climate.test_name_thermostat_0"
     new_status = deepcopy(mock_rpc_device.status)
     new_status.pop("humidity:0")
     monkeypatch.setattr(mock_rpc_device, "status", new_status)
@@ -677,7 +677,7 @@ async def test_rpc_climate_set_temperature(
     hass: HomeAssistant, mock_rpc_device: Mock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test climate set target temperature."""
-    entity_id = "climate.test_name_thermostat"
+    entity_id = "climate.test_name_thermostat_0"
 
     await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)
 
@@ -717,7 +717,7 @@ async def test_rpc_climate_hvac_mode_cool(
     hass: HomeAssistant, mock_rpc_device: Mock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test climate with hvac mode cooling."""
-    entity_id = "climate.test_name_thermostat"
+    entity_id = "climate.test_name_thermostat_0"
     new_config = deepcopy(mock_rpc_device.config)
     new_config["thermostat:0"]["type"] = "cooling"
     monkeypatch.setattr(mock_rpc_device, "config", new_config)
@@ -736,7 +736,7 @@ async def test_wall_display_thermostat_mode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test Wall Display in thermostat mode."""
-    climate_entity_id = "climate.test_name_thermostat"
+    climate_entity_id = "climate.test_name_thermostat_0"
     switch_entity_id = "switch.test_switch_0"
 
     await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)
@@ -763,7 +763,7 @@ async def test_wall_display_thermostat_mode_external_actuator(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test Wall Display in thermostat mode with an external actuator."""
-    climate_entity_id = "climate.test_name_thermostat"
+    climate_entity_id = "climate.test_name_thermostat_0"
     switch_entity_id = "switch.test_switch_0"
 
     new_status = deepcopy(mock_rpc_device.status)

--- a/tests/components/shelly/test_climate.py
+++ b/tests/components/shelly/test_climate.py
@@ -609,23 +609,25 @@ async def test_rpc_climate_hvac_mode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test climate hvac mode service."""
+    entity_id = "climate.test_name_thermostat"
+
     await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)
 
-    state = hass.states.get(ENTITY_ID)
+    state = hass.states.get(entity_id)
     assert state.state == HVACMode.HEAT
     assert state.attributes[ATTR_TEMPERATURE] == 23
     assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 12.3
     assert state.attributes[ATTR_HVAC_ACTION] == HVACAction.HEATING
     assert state.attributes[ATTR_CURRENT_HUMIDITY] == 44.4
 
-    entry = entity_registry.async_get(ENTITY_ID)
+    entry = entity_registry.async_get(entity_id)
     assert entry
     assert entry.unique_id == "123456789ABC-thermostat:0"
 
     monkeypatch.setitem(mock_rpc_device.status["thermostat:0"], "output", False)
     mock_rpc_device.mock_update()
 
-    state = hass.states.get(ENTITY_ID)
+    state = hass.states.get(entity_id)
     assert state.attributes[ATTR_HVAC_ACTION] == HVACAction.IDLE
     assert state.attributes[ATTR_CURRENT_HUMIDITY] == 44.4
 
@@ -633,7 +635,7 @@ async def test_rpc_climate_hvac_mode(
     await hass.services.async_call(
         CLIMATE_DOMAIN,
         SERVICE_SET_HVAC_MODE,
-        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_HVAC_MODE: HVACMode.OFF},
+        {ATTR_ENTITY_ID: entity_id, ATTR_HVAC_MODE: HVACMode.OFF},
         blocking=True,
     )
     mock_rpc_device.mock_update()
@@ -641,7 +643,7 @@ async def test_rpc_climate_hvac_mode(
     mock_rpc_device.call_rpc.assert_called_once_with(
         "Thermostat.SetConfig", {"config": {"id": 0, "enable": False}}
     )
-    state = hass.states.get(ENTITY_ID)
+    state = hass.states.get(entity_id)
     assert state.state == HVACMode.OFF
 
 
@@ -652,20 +654,21 @@ async def test_rpc_climate_without_humidity(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test climate entity without the humidity value."""
+    entity_id = "climate.test_name_thermostat"
     new_status = deepcopy(mock_rpc_device.status)
     new_status.pop("humidity:0")
     monkeypatch.setattr(mock_rpc_device, "status", new_status)
 
     await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)
 
-    state = hass.states.get(ENTITY_ID)
+    state = hass.states.get(entity_id)
     assert state.state == HVACMode.HEAT
     assert state.attributes[ATTR_TEMPERATURE] == 23
     assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 12.3
     assert state.attributes[ATTR_HVAC_ACTION] == HVACAction.HEATING
     assert ATTR_CURRENT_HUMIDITY not in state.attributes
 
-    entry = entity_registry.async_get(ENTITY_ID)
+    entry = entity_registry.async_get(entity_id)
     assert entry
     assert entry.unique_id == "123456789ABC-thermostat:0"
 
@@ -674,9 +677,11 @@ async def test_rpc_climate_set_temperature(
     hass: HomeAssistant, mock_rpc_device: Mock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test climate set target temperature."""
+    entity_id = "climate.test_name_thermostat"
+
     await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)
 
-    state = hass.states.get(ENTITY_ID)
+    state = hass.states.get(entity_id)
     assert state.attributes[ATTR_TEMPERATURE] == 23
 
     # test set temperature without target temperature
@@ -684,7 +689,7 @@ async def test_rpc_climate_set_temperature(
         CLIMATE_DOMAIN,
         SERVICE_SET_TEMPERATURE,
         {
-            ATTR_ENTITY_ID: ENTITY_ID,
+            ATTR_ENTITY_ID: entity_id,
             ATTR_TARGET_TEMP_LOW: 20,
             ATTR_TARGET_TEMP_HIGH: 30,
         },
@@ -696,7 +701,7 @@ async def test_rpc_climate_set_temperature(
     await hass.services.async_call(
         CLIMATE_DOMAIN,
         SERVICE_SET_TEMPERATURE,
-        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_TEMPERATURE: 28},
+        {ATTR_ENTITY_ID: entity_id, ATTR_TEMPERATURE: 28},
         blocking=True,
     )
     mock_rpc_device.mock_update()
@@ -704,7 +709,7 @@ async def test_rpc_climate_set_temperature(
     mock_rpc_device.call_rpc.assert_called_once_with(
         "Thermostat.SetConfig", {"config": {"id": 0, "target_C": 28}}
     )
-    state = hass.states.get(ENTITY_ID)
+    state = hass.states.get(entity_id)
     assert state.attributes[ATTR_TEMPERATURE] == 28
 
 
@@ -712,13 +717,14 @@ async def test_rpc_climate_hvac_mode_cool(
     hass: HomeAssistant, mock_rpc_device: Mock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test climate with hvac mode cooling."""
+    entity_id = "climate.test_name_thermostat"
     new_config = deepcopy(mock_rpc_device.config)
     new_config["thermostat:0"]["type"] = "cooling"
     monkeypatch.setattr(mock_rpc_device, "config", new_config)
 
     await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)
 
-    state = hass.states.get(ENTITY_ID)
+    state = hass.states.get(entity_id)
     assert state.state == HVACMode.COOL
     assert state.attributes[ATTR_HVAC_ACTION] == HVACAction.COOLING
 
@@ -730,7 +736,7 @@ async def test_wall_display_thermostat_mode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test Wall Display in thermostat mode."""
-    climate_entity_id = "climate.test_name"
+    climate_entity_id = "climate.test_name_thermostat"
     switch_entity_id = "switch.test_switch_0"
 
     await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)
@@ -757,7 +763,7 @@ async def test_wall_display_thermostat_mode_external_actuator(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test Wall Display in thermostat mode with an external actuator."""
-    climate_entity_id = "climate.test_name"
+    climate_entity_id = "climate.test_name_thermostat"
     switch_entity_id = "switch.test_switch_0"
 
     new_status = deepcopy(mock_rpc_device.status)

--- a/tests/components/shelly/test_sensor.py
+++ b/tests/components/shelly/test_sensor.py
@@ -729,14 +729,14 @@ async def test_rpc_analog_input_sensors(
 
     await init_integration(hass, 2)
 
-    entity_id = f"{SENSOR_DOMAIN}.test_name_analog_input"
+    entity_id = f"{SENSOR_DOMAIN}.test_name_input_1_analog"
     assert hass.states.get(entity_id).state == "89"
 
     entry = entity_registry.async_get(entity_id)
     assert entry
     assert entry.unique_id == "123456789ABC-input:1-analoginput"
 
-    entity_id = f"{SENSOR_DOMAIN}.test_name_analog_value"
+    entity_id = f"{SENSOR_DOMAIN}.test_name_input_1_analog_value"
     state = hass.states.get(entity_id)
     assert state
     assert state.state == "8.9"
@@ -757,10 +757,10 @@ async def test_rpc_disabled_analog_input_sensors(
 
     await init_integration(hass, 2)
 
-    entity_id = f"{SENSOR_DOMAIN}.test_name_analog_input"
+    entity_id = f"{SENSOR_DOMAIN}.test_name_input_1_analog"
     assert hass.states.get(entity_id) is None
 
-    entity_id = f"{SENSOR_DOMAIN}.test_name_analog_value"
+    entity_id = f"{SENSOR_DOMAIN}.test_name_input_1_analog_value"
     assert hass.states.get(entity_id) is None
 
 
@@ -777,10 +777,10 @@ async def test_rpc_disabled_xpercent(
     )
     await init_integration(hass, 2)
 
-    entity_id = f"{SENSOR_DOMAIN}.test_name_analog_input"
+    entity_id = f"{SENSOR_DOMAIN}.test_name_input_1_analog"
     assert hass.states.get(entity_id).state == "89"
 
-    entity_id = f"{SENSOR_DOMAIN}.test_name_analog_value"
+    entity_id = f"{SENSOR_DOMAIN}.test_name_input_1_analog_value"
     assert hass.states.get(entity_id) is None
 
 
@@ -1293,7 +1293,7 @@ async def test_rpc_rgbw_sensors(
 
     await init_integration(hass, 2)
 
-    entity_id = "sensor.test_name_power"
+    entity_id = f"sensor.test_name_{light_type}_power"
 
     state = hass.states.get(entity_id)
     assert state
@@ -1304,7 +1304,7 @@ async def test_rpc_rgbw_sensors(
     assert entry
     assert entry.unique_id == f"123456789ABC-{light_type}:0-power_{light_type}"
 
-    entity_id = "sensor.test_name_energy"
+    entity_id = f"sensor.test_name_{light_type}_energy"
 
     state = hass.states.get(entity_id)
     assert state
@@ -1315,7 +1315,7 @@ async def test_rpc_rgbw_sensors(
     assert entry
     assert entry.unique_id == f"123456789ABC-{light_type}:0-energy_{light_type}"
 
-    entity_id = "sensor.test_name_current"
+    entity_id = f"sensor.test_name_{light_type}_current"
 
     state = hass.states.get(entity_id)
     assert state
@@ -1328,7 +1328,7 @@ async def test_rpc_rgbw_sensors(
     assert entry
     assert entry.unique_id == f"123456789ABC-{light_type}:0-current_{light_type}"
 
-    entity_id = "sensor.test_name_voltage"
+    entity_id = f"sensor.test_name_{light_type}_voltage"
 
     state = hass.states.get(entity_id)
     assert state
@@ -1341,7 +1341,7 @@ async def test_rpc_rgbw_sensors(
     assert entry
     assert entry.unique_id == f"123456789ABC-{light_type}:0-voltage_{light_type}"
 
-    entity_id = "sensor.test_name_device_temperature"
+    entity_id = f"sensor.test_name_{light_type}_device_temperature"
 
     state = hass.states.get(entity_id)
     assert state

--- a/tests/components/shelly/test_sensor.py
+++ b/tests/components/shelly/test_sensor.py
@@ -1293,7 +1293,7 @@ async def test_rpc_rgbw_sensors(
 
     await init_integration(hass, 2)
 
-    entity_id = f"sensor.test_name_{light_type}_power"
+    entity_id = f"sensor.test_name_{light_type}_0_power"
 
     state = hass.states.get(entity_id)
     assert state
@@ -1304,7 +1304,7 @@ async def test_rpc_rgbw_sensors(
     assert entry
     assert entry.unique_id == f"123456789ABC-{light_type}:0-power_{light_type}"
 
-    entity_id = f"sensor.test_name_{light_type}_energy"
+    entity_id = f"sensor.test_name_{light_type}_0_energy"
 
     state = hass.states.get(entity_id)
     assert state
@@ -1315,7 +1315,7 @@ async def test_rpc_rgbw_sensors(
     assert entry
     assert entry.unique_id == f"123456789ABC-{light_type}:0-energy_{light_type}"
 
-    entity_id = f"sensor.test_name_{light_type}_current"
+    entity_id = f"sensor.test_name_{light_type}_0_current"
 
     state = hass.states.get(entity_id)
     assert state
@@ -1328,7 +1328,7 @@ async def test_rpc_rgbw_sensors(
     assert entry
     assert entry.unique_id == f"123456789ABC-{light_type}:0-current_{light_type}"
 
-    entity_id = f"sensor.test_name_{light_type}_voltage"
+    entity_id = f"sensor.test_name_{light_type}_0_voltage"
 
     state = hass.states.get(entity_id)
     assert state
@@ -1341,7 +1341,7 @@ async def test_rpc_rgbw_sensors(
     assert entry
     assert entry.unique_id == f"123456789ABC-{light_type}:0-voltage_{light_type}"
 
-    entity_id = f"sensor.test_name_{light_type}_device_temperature"
+    entity_id = f"sensor.test_name_{light_type}_0_device_temperature"
 
     state = hass.states.get(entity_id)
     assert state

--- a/tests/components/shelly/test_sensor.py
+++ b/tests/components/shelly/test_sensor.py
@@ -1293,7 +1293,7 @@ async def test_rpc_rgbw_sensors(
 
     await init_integration(hass, 2)
 
-    entity_id = f"sensor.test_name_{light_type}_0_power"
+    entity_id = f"sensor.test_name_{light_type}_light_0_power"
 
     state = hass.states.get(entity_id)
     assert state
@@ -1304,7 +1304,7 @@ async def test_rpc_rgbw_sensors(
     assert entry
     assert entry.unique_id == f"123456789ABC-{light_type}:0-power_{light_type}"
 
-    entity_id = f"sensor.test_name_{light_type}_0_energy"
+    entity_id = f"sensor.test_name_{light_type}_light_0_energy"
 
     state = hass.states.get(entity_id)
     assert state
@@ -1315,7 +1315,7 @@ async def test_rpc_rgbw_sensors(
     assert entry
     assert entry.unique_id == f"123456789ABC-{light_type}:0-energy_{light_type}"
 
-    entity_id = f"sensor.test_name_{light_type}_0_current"
+    entity_id = f"sensor.test_name_{light_type}_light_0_current"
 
     state = hass.states.get(entity_id)
     assert state
@@ -1328,7 +1328,7 @@ async def test_rpc_rgbw_sensors(
     assert entry
     assert entry.unique_id == f"123456789ABC-{light_type}:0-current_{light_type}"
 
-    entity_id = f"sensor.test_name_{light_type}_0_voltage"
+    entity_id = f"sensor.test_name_{light_type}_light_0_voltage"
 
     state = hass.states.get(entity_id)
     assert state
@@ -1341,7 +1341,7 @@ async def test_rpc_rgbw_sensors(
     assert entry
     assert entry.unique_id == f"123456789ABC-{light_type}:0-voltage_{light_type}"
 
-    entity_id = f"sensor.test_name_{light_type}_0_device_temperature"
+    entity_id = f"sensor.test_name_{light_type}_light_0_device_temperature"
 
     state = hass.states.get(entity_id)
     assert state

--- a/tests/components/shelly/test_utils.py
+++ b/tests/components/shelly/test_utils.py
@@ -240,10 +240,22 @@ async def test_get_rpc_channel_name(mock_rpc_device: Mock) -> None:
 
 
 @pytest.mark.parametrize(
-    ("component"), ["cover", "input", "light", "rgb", "rgbw", "switch", "thermostat"]
+    ("component", "expected"),
+    [
+        ("cover", "Cover"),
+        ("input", "Input"),
+        ("light", "Light"),
+        ("rgb", "RGB light"),
+        ("rgbw", "RGBW light"),
+        ("switch", "Switch"),
+        ("thermostat", "Thermostat"),
+    ],
 )
 async def test_get_rpc_channel_name_multiple_components(
-    mock_rpc_device: Mock, monkeypatch: pytest.MonkeyPatch, component: str
+    mock_rpc_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+    component: str,
+    expected: str,
 ) -> None:
     """Test get RPC channel name when there is more components of the same type."""
     config = {
@@ -254,27 +266,11 @@ async def test_get_rpc_channel_name_multiple_components(
 
     assert (
         get_rpc_channel_name(mock_rpc_device, f"{component}:0")
-        == f"Test name {component.title()} 0"
+        == f"Test name {expected} 0"
     )
     assert (
         get_rpc_channel_name(mock_rpc_device, f"{component}:1")
-        == f"Test name {component.title()} 1"
-    )
-
-
-@pytest.mark.parametrize(
-    ("component"), ["cover", "input", "light", "rgb", "rgbw", "switch", "thermostat"]
-)
-async def test_get_rpc_channel_name_single_component(
-    mock_rpc_device: Mock, monkeypatch: pytest.MonkeyPatch, component: str
-) -> None:
-    """Test get RPC channel name when there is only one component of the same type."""
-    config = {f"{component}:0": {"name": None}}
-    monkeypatch.setattr(mock_rpc_device, "config", config)
-
-    assert (
-        get_rpc_channel_name(mock_rpc_device, f"{component}:0")
-        == f"Test name {component.title()} 0"
+        == f"Test name {expected} 1"
     )
 
 

--- a/tests/components/shelly/test_utils.py
+++ b/tests/components/shelly/test_utils.py
@@ -239,11 +239,11 @@ async def test_get_rpc_channel_name(mock_rpc_device: Mock) -> None:
     assert get_rpc_channel_name(mock_rpc_device, "input:3") == "Test name Input 3"
 
 
-@pytest.mark.parametrize(("component"), ["cover", "light", "switch", "input"])
+@pytest.mark.parametrize(("component"), ["cover", "input", "light", "switch"])
 async def test_get_rpc_channel_name_multiple_components(
     mock_rpc_device: Mock, monkeypatch: pytest.MonkeyPatch, component: str
 ) -> None:
-    """Test get RPC channel name."""
+    """Test get RPC channel name when there is more components of the same type."""
     config = {
         f"{component}:0": {"name": None},
         f"{component}:1": {"name": None},
@@ -260,11 +260,11 @@ async def test_get_rpc_channel_name_multiple_components(
     )
 
 
-@pytest.mark.parametrize(("component"), ["cover", "light", "switch", "input"])
+@pytest.mark.parametrize(("component"), ["cover", "input", "light", "switch"])
 async def test_get_rpc_channel_name_single_component(
     mock_rpc_device: Mock, monkeypatch: pytest.MonkeyPatch, component: str
 ) -> None:
-    """Test get RPC channel name."""
+    """Test get RPC channel name when there is only one component of the same type."""
     config = {f"{component}:0": {"name": None}}
     monkeypatch.setattr(mock_rpc_device, "config", config)
 

--- a/tests/components/shelly/test_utils.py
+++ b/tests/components/shelly/test_utils.py
@@ -239,6 +239,41 @@ async def test_get_rpc_channel_name(mock_rpc_device: Mock) -> None:
     assert get_rpc_channel_name(mock_rpc_device, "input:3") == "Test name Input 3"
 
 
+@pytest.mark.parametrize(("component"), ["cover", "light", "switch", "input"])
+async def test_get_rpc_channel_name_multiple_components(
+    mock_rpc_device: Mock, monkeypatch: pytest.MonkeyPatch, component: str
+) -> None:
+    """Test get RPC channel name."""
+    config = {
+        f"{component}:0": {"name": None},
+        f"{component}:1": {"name": None},
+    }
+    monkeypatch.setattr(mock_rpc_device, "config", config)
+
+    assert (
+        get_rpc_channel_name(mock_rpc_device, f"{component}:0")
+        == f"Test name {component.title()} 0"
+    )
+    assert (
+        get_rpc_channel_name(mock_rpc_device, f"{component}:1")
+        == f"Test name {component.title()} 1"
+    )
+
+
+@pytest.mark.parametrize(("component"), ["cover", "light", "switch", "input"])
+async def test_get_rpc_channel_name_single_component(
+    mock_rpc_device: Mock, monkeypatch: pytest.MonkeyPatch, component: str
+) -> None:
+    """Test get RPC channel name."""
+    config = {f"{component}:0": {"name": None}}
+    monkeypatch.setattr(mock_rpc_device, "config", config)
+
+    assert (
+        get_rpc_channel_name(mock_rpc_device, f"{component}:0")
+        == f"Test name {component.title()}"
+    )
+
+
 async def test_get_rpc_input_triggers(
     mock_rpc_device: Mock, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/components/shelly/test_utils.py
+++ b/tests/components/shelly/test_utils.py
@@ -239,7 +239,9 @@ async def test_get_rpc_channel_name(mock_rpc_device: Mock) -> None:
     assert get_rpc_channel_name(mock_rpc_device, "input:3") == "Test name Input 3"
 
 
-@pytest.mark.parametrize(("component"), ["cover", "input", "light", "switch"])
+@pytest.mark.parametrize(
+    ("component"), ["cover", "input", "light", "rgb", "rgbw", "switch", "thermostat"]
+)
 async def test_get_rpc_channel_name_multiple_components(
     mock_rpc_device: Mock, monkeypatch: pytest.MonkeyPatch, component: str
 ) -> None:
@@ -260,7 +262,9 @@ async def test_get_rpc_channel_name_multiple_components(
     )
 
 
-@pytest.mark.parametrize(("component"), ["cover", "input", "light", "switch"])
+@pytest.mark.parametrize(
+    ("component"), ["cover", "input", "light", "rgb", "rgbw", "switch", "thermostat"]
+)
 async def test_get_rpc_channel_name_single_component(
     mock_rpc_device: Mock, monkeypatch: pytest.MonkeyPatch, component: str
 ) -> None:

--- a/tests/components/shelly/test_utils.py
+++ b/tests/components/shelly/test_utils.py
@@ -236,7 +236,7 @@ async def test_get_block_input_triggers(
 async def test_get_rpc_channel_name(mock_rpc_device: Mock) -> None:
     """Test get RPC channel name."""
     assert get_rpc_channel_name(mock_rpc_device, "input:0") == "Test name input 0"
-    assert get_rpc_channel_name(mock_rpc_device, "input:3") == "Test name input_3"
+    assert get_rpc_channel_name(mock_rpc_device, "input:3") == "Test name Input 3"
 
 
 async def test_get_rpc_input_triggers(

--- a/tests/components/shelly/test_utils.py
+++ b/tests/components/shelly/test_utils.py
@@ -274,7 +274,7 @@ async def test_get_rpc_channel_name_single_component(
 
     assert (
         get_rpc_channel_name(mock_rpc_device, f"{component}:0")
-        == f"Test name {component.title()}"
+        == f"Test name {component.title()} 0"
     )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, entity names for different Shelly components are inconsistent. This PR changes the names to be consistent with the following scheme:
- for `cover`, `input`, `light`, `switch`, `thermostat` components: `<DEVICE_NAME> <COMPONENT> <COMPONENT_INDEX>` e.g. `Shelly Device Switch 1`
- for `rgb`, `rgbw` components: `<DEVICE_NAME> <COMPONENT> light <COMPONENT_INDEX>` e.g. `Shelly Device RGB light 0`

After discussion we decided not to drop the index 0 if the device has only one component to be consistent with the naming in the device interface.

![ha_rgb_0](https://github.com/user-attachments/assets/59a1303c-fa32-4fe4-9c0d-d1ec448b61ba)
![shelly_rgb_0](https://github.com/user-attachments/assets/b342da96-c27d-4cf5-8f7c-4bd6bfd6d138)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #125074
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/34679

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
