### PR TITLE
Add new Plex sensors

### DIFF
--- a/homeassistant/components/plex/models.py
+++ b/homeassistant/components/plex/models.py
@@ -46,7 +46,7 @@ class PlexSession:
 
         # Metadata
         self.media_codec = None
-        self.media_codec_long = None
+        self.media_codec_extended = None
         self.media_filename = None
         self.media_tmdb_id = None
         self.media_tvdb_id = None
@@ -81,7 +81,7 @@ class PlexSession:
                 if stream.streamType == 2:  # 2 is the audio stream
                     # plex returns two forms of codecs, both are relevant and important
                     self.media_codec = stream.displayTitle
-                    self.media_codec_long = stream.extendedDisplayTitle
+                    self.media_codec_extended = stream.extendedDisplayTitle
                     break
 
     def update_item_ids(self, media):

--- a/homeassistant/components/plex/models.py
+++ b/homeassistant/components/plex/models.py
@@ -87,7 +87,12 @@ class PlexSession:
     def update_item_ids(self, media):
         """Update TMDB and TVDB ID."""
         # get the source object from the session
-        source = media.source()
+        try:
+            source = media.source()
+        except AttributeError:
+            # media object is different things in different contexts
+            _LOGGER.debug("No source object found")
+            return
         _LOGGER.debug(
             "Attempting to extract TMDB and TVDB IDs from source %s", source.guids
         )

--- a/homeassistant/components/plex/models.py
+++ b/homeassistant/components/plex/models.py
@@ -84,13 +84,16 @@ class PlexSession:
                     self.media_codec_long = stream.extendedDisplayTitle
                     break
 
-    def update_item_ids(self, source):
+    def update_item_ids(self, media):
         """Update TMDB and TVDB ID."""
+        # get the source object from the session
+        source = media.source()
         _LOGGER.debug(
             "Attempting to extract TMDB and TVDB IDs from source %s", source.guids
         )
         for guid in source.guids:
             _LOGGER.debug("Found GUID: %s", guid.id)
+            # search for tmdb:// or tvdb:// in the guid.id
             match guid.id:
                 case str(id_str) if (
                     tmdb_match := re.search(r"(?:tmdb)://(\d+)", id_str)
@@ -114,7 +117,7 @@ class PlexSession:
         if edition:
             _LOGGER.debug("Found edition title in metadata")
             return edition
-
+        # extract edition from filename
         if self.media_filename:
             _LOGGER.debug(
                 "Attempting to extract edition from filename %s", self.media_filename
@@ -141,8 +144,6 @@ class PlexSession:
         self.media_image_url = self.get_media_image_url(media)
         self.media_summary = media.summary
         self.media_title = media.title
-        self.source = media.source()
-        _LOGGER.debug("Media source: %s", self.source)
         if media.duration:
             self.media_duration = int(media.duration / 1000)
 
@@ -155,7 +156,7 @@ class PlexSession:
         self.media_edition_title = self.get_edition_name(media)
         self.update_audio_codec(media)
         # GUIDs are not present in session objects, only source
-        self.update_item_ids(self.source)
+        self.update_item_ids(media)
 
         if media.librarySectionID in SPECIAL_SECTIONS:
             self.media_library_title = SPECIAL_SECTIONS[media.librarySectionID]

--- a/homeassistant/components/plex/models.py
+++ b/homeassistant/components/plex/models.py
@@ -139,6 +139,7 @@ class PlexSession:
 
     def update_media(self, media):
         """Update attributes from a media object."""
+        _LOGGER.debug("media is type %s", type(media))
         self.media_content_id = media.ratingKey
         self.media_content_rating = getattr(media, "contentRating", None)
         self.media_image_url = self.get_media_image_url(media)

--- a/homeassistant/components/plex/sensor.py
+++ b/homeassistant/components/plex/sensor.py
@@ -155,6 +155,7 @@ class PlexMediaSensor(SensorEntity):
 
     entity_description: PlexSensorEntityDescription
     _attr_has_entity_name = True
+    _attr_entity_registry_enabled_default = False
 
     def __init__(
         self,

--- a/homeassistant/components/plex/sensor.py
+++ b/homeassistant/components/plex/sensor.py
@@ -2,18 +2,21 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
 import logging
 
 from plexapi.exceptions import NotFound
 import requests.exceptions
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import StateType
 
 from .const import (
     CONF_SERVER_IDENTIFIER,
@@ -51,6 +54,57 @@ LIBRARY_ICON_LOOKUP = {
 _LOGGER = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True)
+class PlexSensorEntityDescription(SensorEntityDescription):
+    """Describe Plex sensor entity."""
+
+    value_fn: Callable[[PlexMediaSensor], StateType] | None = None
+
+
+PLEX_SENSORS: tuple[PlexSensorEntityDescription, ...] = (
+    PlexSensorEntityDescription(
+        key="year",
+        translation_key="year",
+        value_fn=lambda sensor: sensor.get_attr("media_year"),
+    ),
+    PlexSensorEntityDescription(
+        key="title",
+        translation_key="title",
+        value_fn=lambda sensor: sensor.get_attr("media_title"),
+    ),
+    PlexSensorEntityDescription(
+        key="filename",
+        translation_key="filename",
+        value_fn=lambda sensor: sensor.get_attr("media_filename"),
+    ),
+    PlexSensorEntityDescription(
+        key="codec",
+        translation_key="codec",
+        value_fn=lambda sensor: sensor.get_attr("media_codec"),
+    ),
+    PlexSensorEntityDescription(
+        key="codec_long",
+        translation_key="codec_long",
+        value_fn=lambda sensor: sensor.get_attr("media_codec_long"),
+    ),
+    PlexSensorEntityDescription(
+        key="tmdb_id",
+        translation_key="tmdb_id",
+        value_fn=lambda sensor: sensor.get_attr("media_tmdb_id"),
+    ),
+    PlexSensorEntityDescription(
+        key="tvdb_id",
+        translation_key="tvdb_id",
+        value_fn=lambda sensor: sensor.get_attr("media_tvdb_id"),
+    ),
+    PlexSensorEntityDescription(
+        key="edition_title",
+        translation_key="edition_title",
+        value_fn=lambda sensor: sensor.get_attr("media_edition_title"),
+    ),
+)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -72,13 +126,8 @@ async def async_setup_entry(
             client = entity_params["device"]
             new_sensors.extend(
                 [
-                    PlexYearSensor(hass, plex_server, client),
-                    PlexTitleSensor(hass, plex_server, client),
-                    PlexFilenameSensor(hass, plex_server, client),
-                    PlexCodecSensor(hass, plex_server, client),
-                    PlexCodecLongSensor(hass, plex_server, client),
-                    PlexTmdbSensor(hass, plex_server, client),
-                    PlexEditionSensor(hass, plex_server, client),
+                    PlexMediaSensor(hass, plex_server, client, description)
+                    for description in PLEX_SENSORS
                 ]
             )
         async_add_entities(new_sensors, True)
@@ -96,158 +145,51 @@ async def async_setup_entry(
 class PlexMediaSensor(SensorEntity):
     """Base class for Plex media sensors."""
 
-    def __init__(self, hass, plex_server, client, attr_name):
-        """Initialize the class."""
+    entity_description: PlexSensorEntityDescription
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        plex_server,
+        client,
+        description: PlexSensorEntityDescription,
+    ) -> None:
+        """Initialize the sensor."""
+        self.entity_description = description
         self.hass = hass
         self._server = plex_server
         self._client = client
-        self._attr_name = f"Plex {attr_name.replace('_', ' ').title()}"
-        if client:
-            self._attr_unique_id = f"{plex_server.machine_identifier}:{client.machineIdentifier}_{attr_name}"
-            self._attr_device_info = DeviceInfo(
-                identifiers={(DOMAIN, client.machineIdentifier)},
-                manufacturer=client.device,
-                model=client.product,
-                name=client.title,
-                via_device=(DOMAIN, self._server.machine_identifier),
-            )
-        else:
-            self._attr_unique_id = f"{plex_server.machine_identifier}_{attr_name}"
-            self._attr_device_info = DeviceInfo(
-                identifiers={(DOMAIN, self._server.machine_identifier)},
-                manufacturer="Plex",
-                model="Plex Media Server",
-                name=self._server.friendly_name,
-                sw_version=self._server.version,
-                configuration_url=f"{self._server.url_in_use}/web",
-            )
+        self._attr_unique_id = f"{plex_server.machine_identifier}:{client.machineIdentifier}_{description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, client.machineIdentifier)},
+            manufacturer=client.device,
+            model=client.product,
+            name=client.title,
+            via_device=(DOMAIN, self._server.machine_identifier),
+        )
 
     @property
-    def available(self):
+    def available(self) -> bool:
         """Return sensor availability."""
-        if self._client:
-            return any(
-                session.player.machineIdentifier == self._client.machineIdentifier
-                for session in self._server.active_sessions.values()
-            )
-        return bool(self._server.active_sessions)
+        return any(
+            session.player.machineIdentifier == self._client.machineIdentifier
+            for session in self._server.active_sessions.values()
+        )
 
     @property
-    def native_value(self):
+    def native_value(self) -> StateType:
         """Return the state of the sensor."""
-        if self._client:
-            for session in self._server.active_sessions.values():
-                if session.player.machineIdentifier == self._client.machineIdentifier:
-                    return self._get_client_state(session)
-        else:
-            return self._get_server_state()
+        if self.entity_description.value_fn:
+            return self.entity_description.value_fn(self)
         return None
 
-    def _get_client_state(self, session):
-        """Get the state value when there is an active client session."""
-        raise NotImplementedError
-
-    def _get_server_state(self):
-        """Get the state value for the server-wide sensor."""
-        raise NotImplementedError
-
-
-class PlexYearSensor(PlexMediaSensor):
-    """Sensor for Plex media year."""
-
-    def __init__(self, hass, plex_server, client=None):
-        """Initialize the sensor."""
-        super().__init__(hass, plex_server, client, "year")
-
-    def _get_client_state(self, session):
-        return session.media_year
-
-    def _get_server_state(self):
-        return next(iter(self._server.active_sessions.values())).media_year
-
-
-class PlexTitleSensor(PlexMediaSensor):
-    """Sensor for Plex media title."""
-
-    def __init__(self, hass, plex_server, client=None):
-        """Initialize the sensor."""
-        super().__init__(hass, plex_server, client, "title")
-
-    def _get_client_state(self, session):
-        return session.media_title
-
-    def _get_server_state(self):
-        return next(iter(self._server.active_sessions.values())).media_title
-
-
-class PlexFilenameSensor(PlexMediaSensor):
-    """Sensor for Plex media filename."""
-
-    def __init__(self, hass, plex_server, client=None):
-        """Initialize the sensor."""
-        super().__init__(hass, plex_server, client, "filename")
-
-    def _get_client_state(self, session):
-        return session.media_filename
-
-    def _get_server_state(self):
-        return next(iter(self._server.active_sessions.values())).media_filename
-
-
-class PlexCodecSensor(PlexMediaSensor):
-    """Sensor for Plex media codec."""
-
-    def __init__(self, hass, plex_server, client=None):
-        """Initialize the sensor."""
-        super().__init__(hass, plex_server, client, "codec")
-
-    def _get_client_state(self, session):
-        return session.media_codec
-
-    def _get_server_state(self):
-        return next(iter(self._server.active_sessions.values())).media_codec
-
-
-class PlexCodecLongSensor(PlexMediaSensor):
-    """Sensor for Plex media codec (long version)."""
-
-    def __init__(self, hass, plex_server, client=None):
-        """Initialize the sensor."""
-        super().__init__(hass, plex_server, client, "codec_long")
-
-    def _get_client_state(self, session):
-        return session.media_codec_long
-
-    def _get_server_state(self):
-        return next(iter(self._server.active_sessions.values())).media_codec_long
-
-
-class PlexTmdbSensor(PlexMediaSensor):
-    """Sensor for Plex media TMDB ID."""
-
-    def __init__(self, hass, plex_server, client=None):
-        """Initialize the sensor."""
-        super().__init__(hass, plex_server, client, "tmdb_id")
-
-    def _get_client_state(self, session):
-        return session.media_tmdb_id
-
-    def _get_server_state(self):
-        return next(iter(self._server.active_sessions.values())).media_tmdb_id
-
-
-class PlexEditionSensor(PlexMediaSensor):
-    """Sensor for Plex media edition."""
-
-    def __init__(self, hass, plex_server, client=None):
-        """Initialize the sensor."""
-        super().__init__(hass, plex_server, client, "edition_title")
-
-    def _get_client_state(self, session):
-        return session.media_edition_title
-
-    def _get_server_state(self):
-        return next(iter(self._server.active_sessions.values())).media_edition_title
+    def get_attr(self, attr):
+        """Get the specified attribute from the current media session."""
+        for session in self._server.active_sessions.values():
+            if session.player.machineIdentifier == self._client.machineIdentifier:
+                return getattr(session, attr, None)
+        return None
 
 
 class PlexSensor(SensorEntity):

--- a/homeassistant/components/plex/sensor.py
+++ b/homeassistant/components/plex/sensor.py
@@ -83,9 +83,9 @@ PLEX_SENSORS: tuple[PlexSensorEntityDescription, ...] = (
         value_fn=lambda sensor: sensor.get_attr("media_codec"),
     ),
     PlexSensorEntityDescription(
-        key="codec_long",
-        translation_key="codec_long",
-        value_fn=lambda sensor: sensor.get_attr("media_codec_long"),
+        key="codec_extended",
+        translation_key="codec_extended",
+        value_fn=lambda sensor: sensor.get_attr("media_codec_extended"),
     ),
     PlexSensorEntityDescription(
         key="tmdb_id",
@@ -139,6 +139,14 @@ async def async_setup_entry(
     )
     get_plex_data(hass)[DISPATCHERS][server_id].append(unsub)
 
+    def create_library_sensors():
+        """Create Plex library sensors with sync calls."""
+        sensors.extend(
+            PlexLibrarySectionSensor(hass, plex_server, library)
+            for library in plex_server.library.sections()
+        )
+
+    await hass.async_add_executor_job(create_library_sensors)
     async_add_entities(sensors, True)
 
 

--- a/homeassistant/components/plex/strings.json
+++ b/homeassistant/components/plex/strings.json
@@ -62,6 +62,35 @@
       "scan_clients": {
         "name": "Scan clients"
       }
+    },
+    "sensor": {
+      "year": {
+        "name": "Year"
+      },
+      "title": {
+        "name": "Title"
+      },
+      "filename": {
+        "name": "Filename"
+      },
+      "codec": {
+        "name": "Codec"
+      },
+      "codec_long": {
+        "name": "Codec Extended"
+      },
+      "tmdb_id": {
+        "name": "TMDB ID"
+      },
+      "tvdb_id": {
+        "name": "TVDB ID"
+      },
+      "edition_title": {
+        "name": "Edition Title"
+      },
+      "plex": {
+        "name": "Plex"
+      }
     }
   },
   "services": {

--- a/homeassistant/components/plex/strings.json
+++ b/homeassistant/components/plex/strings.json
@@ -76,7 +76,7 @@
       "codec": {
         "name": "Codec"
       },
-      "codec_long": {
+      "codec_extended": {
         "name": "Codec Extended"
       },
       "tmdb_id": {

--- a/tests/components/plex/conftest.py
+++ b/tests/components/plex/conftest.py
@@ -1,6 +1,7 @@
 """Fixtures for Plex tests."""
 
 from collections.abc import Generator
+import re
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -534,6 +535,10 @@ def mock_plex_calls(
     requests_mock.get(f"{url}/library/metadata/30", text=media_30)
     requests_mock.get(f"{url}/library/metadata/100", text=media_100)
     requests_mock.get(f"{url}/library/metadata/200", text=media_200)
+    requests_mock.get(
+        re.compile(f"{url}/library/metadata/9876543210\\.*"), text=media_200
+    )
+    requests_mock.get(re.compile(f"{url}/library/metadata/203214\\.*"), text=media_200)
 
     requests_mock.get(f"{url}/library/metadata/20/children", text=children_20)
     requests_mock.get(f"{url}/library/metadata/30/children", text=children_30)

--- a/tests/components/plex/fixtures/session_base.xml
+++ b/tests/components/plex/fixtures/session_base.xml
@@ -1,11 +1,22 @@
-<MediaContainer size="1"><Video addedAt="1377829261" art="/library/metadata/1/art/1590245989" audienceRating="9.5" audienceRatingImage="rottentomatoes://image.rating.upright" chapterSource="agent" contentRating="R" duration="9000000" guid="com.plexapp.agents.imdb://tt0123456?lang=en" key="/library/metadata/1" lastViewedAt="1505969509" librarySectionID="1" librarySectionKey="/library/sections/1" librarySectionTitle="Movies" originallyAvailableAt="2000-01-01" primaryExtraKey="/library/metadata/195540" rating="9.0" ratingImage="rottentomatoes://image.rating.certified" ratingKey="1" sessionKey="1" studio="Studio Entertainment" summary="Some elaborate summary." tagline="Witty saying." thumb="/library/metadata/1/thumb/1590245989" title="Movie 1" type="movie" updatedAt="1590245989" viewCount="1" viewOffset="0" year="2000">
-<Genre count="119" filter="genre=25578" id="25578" tag="Sci-Fi" />
-<Genre count="197" filter="genre=87" id="87" tag="Action" />
-<Director count="4" filter="director=100" id="100" tag="Famous Director" />
-<Writer count="2" filter="writer=50000" id="50000" tag="A Writer" />
-<Producer count="3" filter="producer=2000" id="2000" tag="Dr. Producer" />
-<Country count="452" filter="country=1105" id="1105" tag="USA" />
-<Role count="25" filter="actor=1" id="1" role="Character 1" tag="Actor 1" thumb="http://4.3.2.1/t/p/original/1.jpg" />
-<Role count="2" filter="actor=2" id="2" role="Character 2" tag="Actor 2" thumb="http://4.3.2.1/t/p/original/2.jpg" />
-<Role filter="actor=3" id="3" role="Character 3" tag="Actor 3" thumb="http://4.3.2.1/t/p/original/3.jpg" />
-<Player address="1.2.3.11" device="SHIELD Android TV" deviceClass="stb" local="1" machineIdentifier="1234567890123456-com-plexapp-android" model="darcy" platform="Android" platformVersion="9" product="Plex for Android (TV)" profile="Android" protocolVersion="1" relayed="0" remotePublicAddress="10.20.30.40" secure="1" state="playing" title="SHIELD Android TV" userID="{user_id}" vendor="NVIDIA" version="8.9.2.21619" /><User id="{user_id}" thumb="https://plex.tv/users/1234567890abcdef/avatar?c=11111" title="User {user_id}" /><Session bandwidth="7000" id="session_id_1" location="lan" /><Media audioChannels="2" audioCodec="aac" audioProfile="dts" bitrate="6000" container="mp4" duration="9000000" height="544" id="2637" optimizedForStreaming="1" protocol="dash" selected="1" videoCodec="h264" videoFrameRate="24p" videoProfile="high" videoResolution="720p" width="1280"><Part audioProfile="dts" bitrate="6000" container="mp4" decision="transcode" duration="9000000" height="544" id="4631" optimizedForStreaming="1" protocol="dash" selected="1" videoProfile="high" width="1280"><Stream bitrate="6000" codec="h264" decision="copy" default="1" displayTitle="720p (H.264)" extendedDisplayTitle="x264 @ 6000 kbps (720p H.264)" frameRate="23.975999999999999" height="544" id="21428" language="English" languageCode="eng" location="segments-video" streamType="1" width="1280" /><Stream bitrate="256" bitrateMode="cbr" channels="2" codec="aac" decision="transcode" default="1" displayTitle="English (DTS 5.1)" extendedDisplayTitle="DTS 5.1 @ 1536 kbps (English)" id="21429" language="English" languageCode="eng" location="segments-audio" selected="1" streamType="2" /></Part></Media></Video></MediaContainer>
+<MediaContainer size="1">
+<Video addedAt="1377829261" art="/library/metadata/1/art/1590245989" audienceRating="9.5" audienceRatingImage="rottentomatoes://image.rating.upright" chapterSource="agent" contentRating="R" duration="9000000" guid="com.plexapp.agents.imdb://tt0123456?lang=en" key="/library/metadata/1" lastViewedAt="1505969509" librarySectionID="1" librarySectionKey="/library/sections/1" librarySectionTitle="Movies" originallyAvailableAt="2000-01-01" primaryExtraKey="/library/metadata/195540" rating="9.0" ratingImage="rottentomatoes://image.rating.certified" ratingKey="1" sessionKey="1" studio="Studio Entertainment" summary="Some elaborate summary." tagline="Witty saying." thumb="/library/metadata/1/thumb/1590245989" title="Movie 1" type="movie" updatedAt="1590245989" viewCount="1" viewOffset="0" year="2000">    <Genre count="119" filter="genre=25578" id="25578" tag="Sci-Fi" />
+    <Genre count="197" filter="genre=87" id="87" tag="Action" />
+    <Director count="4" filter="director=100" id="100" tag="Famous Director" />
+    <Writer count="2" filter="writer=50000" id="50000" tag="A Writer" />
+    <Producer count="3" filter="producer=2000" id="2000" tag="Dr. Producer" />
+    <Country count="452" filter="country=1105" id="1105" tag="USA" />
+    <Role count="25" filter="actor=1" id="1" role="Character 1" tag="Actor 1" thumb="http://4.3.2.1/t/p/original/1.jpg" />
+    <Role count="2" filter="actor=2" id="2" role="Character 2" tag="Actor 2" thumb="http://4.3.2.1/t/p/original/2.jpg" />
+    <Role filter="actor=3" id="3" role="Character 3" tag="Actor 3" thumb="http://4.3.2.1/t/p/original/3.jpg" />
+    <Guid id="tmdb://12345" />
+    <Player address="1.2.3.11" device="SHIELD Android TV" deviceClass="stb" local="1" machineIdentifier="1234567890123456-com-plexapp-android" model="darcy" platform="Android" platformVersion="9" product="Plex for Android (TV)" profile="Android" protocolVersion="1" relayed="0" remotePublicAddress="10.20.30.40" secure="1" state="playing" title="SHIELD Android TV" userID="{user_id}" vendor="NVIDIA" version="8.9.2.21619" />
+    <User id="{user_id}" thumb="https://plex.tv/users/1234567890abcdef/avatar?c=11111" title="User {user_id}" />
+    <Session bandwidth="7000" id="session_id_1" location="lan" />
+    <Media audioChannels="2" audioCodec="aac" audioProfile="dts" bitrate="6000" container="mp4" duration="9000000" height="544" id="2637" optimizedForStreaming="1" protocol="dash" selected="1" videoCodec="h264" videoFrameRate="24p" videoProfile="high" videoResolution="720p" width="1280">
+      <Part audioProfile="dts" bitrate="6000" container="mp4" decision="transcode" duration="9000000" height="544" id="4631" optimizedForStreaming="1" protocol="dash" selected="1" videoProfile="high" width="1280" file="Movie 1 (2000) - Extended.mp4">
+        <Stream bitrate="6000" codec="h264" decision="copy" default="1" displayTitle="720p (H.264)" extendedDisplayTitle="x264 @ 6000 kbps (720p H.264)" frameRate="23.975999999999999" height="544" id="21428" language="English" languageCode="eng" location="segments-video" streamType="1" width="1280" />
+        <Stream bitrate="256" bitrateMode="cbr" channels="2" codec="aac" decision="transcode" default="1" displayTitle="English (DTS 5.1)" extendedDisplayTitle="DTS 5.1 @ 1536 kbps (English)" id="21429" language="English" languageCode="eng" location="segments-audio" selected="1" streamType="2" />
+      </Part>
+    </Media>
+  </Video>
+</MediaContainer>

--- a/tests/components/plex/fixtures/session_base.xml
+++ b/tests/components/plex/fixtures/session_base.xml
@@ -5,10 +5,11 @@
     <Writer count="2" filter="writer=50000" id="50000" tag="A Writer" />
     <Producer count="3" filter="producer=2000" id="2000" tag="Dr. Producer" />
     <Country count="452" filter="country=1105" id="1105" tag="USA" />
+    <Guid id="tmdb://12345"/>
+<Guid id="tvdb://67890"/>
     <Role count="25" filter="actor=1" id="1" role="Character 1" tag="Actor 1" thumb="http://4.3.2.1/t/p/original/1.jpg" />
     <Role count="2" filter="actor=2" id="2" role="Character 2" tag="Actor 2" thumb="http://4.3.2.1/t/p/original/2.jpg" />
     <Role filter="actor=3" id="3" role="Character 3" tag="Actor 3" thumb="http://4.3.2.1/t/p/original/3.jpg" />
-    <Guid id="tmdb://12345" />
     <Player address="1.2.3.11" device="SHIELD Android TV" deviceClass="stb" local="1" machineIdentifier="1234567890123456-com-plexapp-android" model="darcy" platform="Android" platformVersion="9" product="Plex for Android (TV)" profile="Android" protocolVersion="1" relayed="0" remotePublicAddress="10.20.30.40" secure="1" state="playing" title="SHIELD Android TV" userID="{user_id}" vendor="NVIDIA" version="8.9.2.21619" />
     <User id="{user_id}" thumb="https://plex.tv/users/1234567890abcdef/avatar?c=11111" title="User {user_id}" />
     <Session bandwidth="7000" id="session_id_1" location="lan" />

--- a/tests/components/plex/helpers.py
+++ b/tests/components/plex/helpers.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 from typing import Any
+from unittest.mock import MagicMock
 
 from plexwebsocket import SIGNAL_CONNECTION_STATE, STATE_CONNECTED
 
@@ -45,3 +46,10 @@ async def wait_for_debouncer(hass: HomeAssistant) -> None:
     next_update = dt_util.utcnow() + timedelta(seconds=3)
     async_fire_time_changed(hass, next_update)
     await hass.async_block_till_done()
+
+
+def mock_source(self):
+    """Mock the plex source for TMDB. source() takes self as an argument."""
+    mock = MagicMock()
+    mock.guids = [MagicMock(id="tmdb://12345"), MagicMock(id="tvdb://67890")]
+    return mock

--- a/tests/components/plex/test_device_handling.py
+++ b/tests/components/plex/test_device_handling.py
@@ -120,10 +120,10 @@ async def test_migrate_transient_devices(
     plex_service_device = device_registry.async_get_device(
         identifiers=plex_client_service_device_id
     )
-
+    # there are 8 new sensors so these are all x+8 now
     assert (
         len(er.async_entries_for_device(entity_registry, device_id=plexweb_device.id))
-        == 0
+        == 8
     )
     assert (
         len(
@@ -131,7 +131,7 @@ async def test_migrate_transient_devices(
                 entity_registry, device_id=non_plexweb_device.id
             )
         )
-        == 1
+        == 9
     )
     assert (
         len(

--- a/tests/components/plex/test_device_handling.py
+++ b/tests/components/plex/test_device_handling.py
@@ -120,10 +120,9 @@ async def test_migrate_transient_devices(
     plex_service_device = device_registry.async_get_device(
         identifiers=plex_client_service_device_id
     )
-    # there are 8 new sensors so these are all x+8 now
     assert (
         len(er.async_entries_for_device(entity_registry, device_id=plexweb_device.id))
-        == 8
+        == 0
     )
     assert (
         len(
@@ -131,7 +130,7 @@ async def test_migrate_transient_devices(
                 entity_registry, device_id=non_plexweb_device.id
             )
         )
-        == 9
+        == 1
     )
     assert (
         len(

--- a/tests/components/plex/test_sensor.py
+++ b/tests/components/plex/test_sensor.py
@@ -271,6 +271,7 @@ async def test_library_sensor_values(
     assert library_music_sensor.attributes["last_added_timestamp"] == str(TIMESTAMP)
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 @pytest.mark.parametrize(
     "session_fixture",
     [
@@ -317,6 +318,7 @@ async def test_plex_sensors_special_sessions(
         assert sensor.state is not None
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_plex_sensors_values(
     hass: HomeAssistant,
     setup_plex_server,

--- a/tests/components/plex/test_sensor.py
+++ b/tests/components/plex/test_sensor.py
@@ -304,8 +304,8 @@ async def test_plex_sensors_no_sessions(
 
     # Test each sensor
     for sensor_name, expected_state in expected_states.items():
-        sensor = hass.states.get(f"sensor.plex_{sensor_name}")
-        assert sensor, f"Sensor 'sensor.plex_{sensor_name}' not found"
+        sensor = hass.states.get(f"sensor.shield_android_tv_{sensor_name}")
+        assert sensor, f"Sensor 'sensor.shield_android_tv_{sensor_name}' not found"
         assert (
             sensor.state == expected_state
         ), f"Expected {sensor_name} to be {expected_state}, but it was {sensor.state} with {requests_mock.last_request.text} and payload is {empty_payload}"
@@ -378,37 +378,42 @@ async def test_plex_sensors_values(
     await hass.async_block_till_done()
 
     # Test year sensor
-    year_sensor = hass.states.get("sensor.plex_year")
+    year_sensor = hass.states.get("sensor.shield_android_tv_year")
     assert year_sensor
     assert year_sensor.state == "2000"
 
     # Test title sensor
-    title_sensor = hass.states.get("sensor.plex_title")
+    title_sensor = hass.states.get("sensor.shield_android_tv_title")
     assert title_sensor
     assert title_sensor.state == "Movie 1"
 
     # Test filename sensor
-    filename_sensor = hass.states.get("sensor.plex_filename")
+    filename_sensor = hass.states.get("sensor.shield_android_tv_filename")
     assert filename_sensor
     assert filename_sensor.state is not None
 
     # Test codec sensor
-    codec_sensor = hass.states.get("sensor.plex_codec")
+    codec_sensor = hass.states.get("sensor.shield_android_tv_codec")
     assert codec_sensor
     assert codec_sensor.state == "English (DTS 5.1)"
 
     # Test codec long sensor
-    codec_long_sensor = hass.states.get("sensor.plex_codec_long")
+    codec_long_sensor = hass.states.get("sensor.shield_android_tv_codec_long")
     assert codec_long_sensor
     assert codec_long_sensor.state == "DTS 5.1 @ 1536 kbps (English)"
 
     # Test TMDB ID sensor
-    tmdb_sensor = hass.states.get("sensor.plex_tmdb_id")
+    tmdb_sensor = hass.states.get("sensor.shield_android_tv_tmdb_id")
+    assert tmdb_sensor
+    assert tmdb_sensor.state == "12345"
+
+    # Test TVDB ID sensor
+    tmdb_sensor = hass.states.get("sensor.shield_android_tv_tvdb_id")
     assert tmdb_sensor
     assert tmdb_sensor.state == "12345"
 
     # Test edition title sensor
-    edition_sensor = hass.states.get("sensor.plex_edition_title")
+    edition_sensor = hass.states.get("sensor.shield_android_tv_edition_title")
     assert edition_sensor
     assert (
         edition_sensor.state == "Extended"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds new sensors to the Plex integration

It adds the sensors per client device detected

I added tests for the new sensors as well

I also modified the title display so the media_player displays the title alone so the year can be on its own

The new sensors are (disabled by default)
1. Title
2. year
3. Codec
4. Codec extended
5. Edition (extended, theatrical, etc)
6. TMBD
7. TVDB
8. Filename

Why add these sensors?

1. This is useful info to have for any user. It makes it trivial to display rich dashboards for whats playing
2. This is a crucial step to enable theater automation with home assistant. I am working on a new integration that will require this info and getting it from an existing plex integration would be helpful
<img width="299" alt="image" src="https://github.com/user-attachments/assets/578084f7-8bf8-489a-8b06-d6b27b780803">

Please note, getting filenames does not work on iOS clients but does work on iPad and others. Seems to be a Plex issue.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/34737

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
