### PR TITLE
Remove deprecated hass.components

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -438,7 +438,6 @@ class HomeAssistant:
         self.states = StateMachine(self.bus, self.loop)
         self.config = Config(self, config_dir)
         self.config.async_initialize()
-        self.components = loader.Components(self)
         self.helpers = loader.Helpers(self)
         self.state: CoreState = CoreState.not_running
         self.exit_code: int = 0

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -1530,45 +1530,6 @@ class ModuleWrapper:
         return value
 
 
-class Components:
-    """Helper to load components."""
-
-    def __init__(self, hass: HomeAssistant) -> None:
-        """Initialize the Components class."""
-        self._hass = hass
-
-    def __getattr__(self, comp_name: str) -> ModuleWrapper:
-        """Fetch a component."""
-        # Test integration cache
-        integration = self._hass.data[DATA_INTEGRATIONS].get(comp_name)
-
-        if isinstance(integration, Integration):
-            component: ComponentProtocol | None = integration.get_component()
-        else:
-            # Fallback to importing old-school
-            component = _load_file(self._hass, comp_name, _lookup_path(self._hass))
-
-        if component is None:
-            raise ImportError(f"Unable to load {comp_name}")
-
-        # Local import to avoid circular dependencies
-        from .helpers.frame import report  # pylint: disable=import-outside-toplevel
-
-        report(
-            (
-                f"accesses hass.components.{comp_name}."
-                " This is deprecated and will stop working in Home Assistant 2024.9, it"
-                f" should be updated to import functions used from {comp_name} directly"
-            ),
-            error_if_core=False,
-            log_custom_component_only=True,
-        )
-
-        wrapped = ModuleWrapper(self._hass, component)
-        setattr(self, comp_name, wrapped)
-        return wrapped
-
-
 class Helpers:
     """Helper to load helpers."""
 

--- a/script/hassfest/dependencies.py
+++ b/script/hassfest/dependencies.py
@@ -74,37 +74,6 @@ class ImportCollector(ast.NodeVisitor):
             if name_node.name.startswith("homeassistant.components."):
                 self._add_reference(name_node.name.split(".")[2])
 
-    def visit_Attribute(self, node: ast.Attribute) -> None:
-        """Visit Attribute node."""
-        # hass.components.hue.async_create()
-        # Name(id=hass)
-        #   .Attribute(attr=hue)
-        #   .Attribute(attr=async_create)
-
-        # self.hass.components.hue.async_create()
-        # Name(id=self)
-        #   .Attribute(attr=hass) or .Attribute(attr=_hass)
-        #   .Attribute(attr=hue)
-        #   .Attribute(attr=async_create)
-        if (
-            isinstance(node.value, ast.Attribute)
-            and node.value.attr == "components"
-            and (
-                (
-                    isinstance(node.value.value, ast.Name)
-                    and node.value.value.id == "hass"
-                )
-                or (
-                    isinstance(node.value.value, ast.Attribute)
-                    and node.value.value.attr in ("hass", "_hass")
-                )
-            )
-        ):
-            self._add_reference(node.attr)
-        else:
-            # Have it visit other kids
-            self.generic_visit(node)
-
 
 ALLOWED_USED_COMPONENTS = {
     *{platform.value for platform in Platform},

--- a/tests/hassfest/test_dependencies.py
+++ b/tests/hassfest/test_dependencies.py
@@ -68,33 +68,6 @@ import homeassistant.components.renamed_absolute as hue
     assert mock_collector.unfiltered_referenced == {"renamed_absolute"}
 
 
-def test_hass_components_var(mock_collector) -> None:
-    """Test detecting a hass_components_var reference."""
-    mock_collector.visit(
-        ast.parse(
-            """
-def bla(hass):
-    hass.components.hass_components_var.async_do_something()
-"""
-        )
-    )
-    assert mock_collector.unfiltered_referenced == {"hass_components_var"}
-
-
-def test_hass_components_class(mock_collector) -> None:
-    """Test detecting a hass_components_class reference."""
-    mock_collector.visit(
-        ast.parse(
-            """
-class Hello:
-    def something(self):
-        self.hass.components.hass_components_class.async_yo()
-"""
-        )
-    )
-    assert mock_collector.unfiltered_referenced == {"hass_components_class"}
-
-
 def test_all_imports(mock_collector) -> None:
     """Test all imports together."""
     mock_collector.visit(
@@ -108,13 +81,6 @@ from homeassistant.components.subimport.smart_home import EVENT_ALEXA_SMART_HOME
 from homeassistant.components.child_import_field import bla
 
 import homeassistant.components.renamed_absolute as hue
-
-def bla(hass):
-    hass.components.hass_components_var.async_do_something()
-
-class Hello:
-    def something(self):
-        self.hass.components.hass_components_class.async_yo()
 """
         )
     )
@@ -123,6 +89,4 @@ class Hello:
         "subimport",
         "child_import_field",
         "renamed_absolute",
-        "hass_components_var",
-        "hass_components_class",
     }

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -12,14 +12,14 @@ from awesomeversion import AwesomeVersion
 import pytest
 
 from homeassistant import loader
-from homeassistant.components import http, hue
+from homeassistant.components import hue
 from homeassistant.components.hue import light as hue_light
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import frame
 from homeassistant.helpers.json import json_dumps
 from homeassistant.util.json import json_loads
 
-from .common import MockModule, async_get_persistent_notifications, mock_integration
+from .common import MockModule, mock_integration
 
 
 async def test_circular_component_dependencies(hass: HomeAssistant) -> None:
@@ -64,29 +64,6 @@ async def test_nonexistent_component_dependencies(hass: HomeAssistant) -> None:
         await loader._async_component_dependencies(hass, mod_1)
 
 
-def test_component_loader(hass: HomeAssistant) -> None:
-    """Test loading components."""
-    components = loader.Components(hass)
-    assert components.http.CONFIG_SCHEMA is http.CONFIG_SCHEMA
-    assert hass.components.http.CONFIG_SCHEMA is http.CONFIG_SCHEMA
-
-
-def test_component_loader_non_existing(hass: HomeAssistant) -> None:
-    """Test loading components."""
-    components = loader.Components(hass)
-    with pytest.raises(ImportError):
-        _ = components.non_existing
-
-
-async def test_component_wrapper(hass: HomeAssistant) -> None:
-    """Test component wrapper."""
-    components = loader.Components(hass)
-    components.persistent_notification.async_create("message")
-
-    notifications = async_get_persistent_notifications(hass)
-    assert len(notifications)
-
-
 async def test_helpers_wrapper(hass: HomeAssistant) -> None:
     """Test helpers wrapper."""
     helpers = loader.Helpers(hass)
@@ -117,10 +94,6 @@ async def test_custom_component_name(hass: HomeAssistant) -> None:
     int_comp = integration.get_component()
     assert int_comp.__name__ == "custom_components.test_package"
     assert int_comp.__package__ == "custom_components.test_package"
-
-    comp = hass.components.test_package
-    assert comp.__name__ == "custom_components.test_package"
-    assert comp.__package__ == "custom_components.test_package"
 
     integration = await loader.async_get_integration(hass, "test")
     platform = integration.get_platform("light")
@@ -1267,39 +1240,6 @@ async def test_config_folder_not_in_path() -> None:
     # Verify that we are able to load the file with absolute path
     # pylint: disable-next=import-outside-toplevel,hass-relative-import
     import tests.testing_config.check_config_not_in_path  # noqa: F401
-
-
-async def test_hass_components_use_reported(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, mock_integration_frame: Mock
-) -> None:
-    """Test that use of hass.components is reported."""
-    mock_integration_frame.filename = (
-        "/home/paulus/homeassistant/custom_components/demo/light.py"
-    )
-    integration_frame = frame.IntegrationFrame(
-        custom_integration=True,
-        frame=mock_integration_frame,
-        integration="test_integration_frame",
-        module="custom_components.test_integration_frame",
-        relative_filename="custom_components/test_integration_frame/__init__.py",
-    )
-
-    with (
-        patch(
-            "homeassistant.helpers.frame.get_integration_frame",
-            return_value=integration_frame,
-        ),
-        patch(
-            "homeassistant.components.http.start_http_server_and_save_config",
-            return_value=None,
-        ),
-    ):
-        await hass.components.http.start_http_server_and_save_config(hass, [], None)
-
-        assert (
-            "Detected that custom integration 'test_integration_frame'"
-            " accesses hass.components.http. This is deprecated"
-        ) in caplog.text
 
 
 async def test_async_get_component_preloads_config_and_config_flow(


### PR DESCRIPTION
## Breaking change
With Home Assistant version `2024.3` we deprecated the usage of `hass.components`. This has been removed now, custom component should be updated to import the desired components directly.

## Proposed change
With version `2024.3` we deprecate the usage of `hass.components` and scheduled the removal in version `2024.9`. Now it is time to remove the deprecated `hass.components`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
