### PR TITLE
Bump aiolifx and aiolifx-themes to support more than 82 zones

### DIFF
--- a/homeassistant/components/lifx/manifest.json
+++ b/homeassistant/components/lifx/manifest.json
@@ -48,8 +48,8 @@
   "iot_class": "local_polling",
   "loggers": ["aiolifx", "aiolifx_effects", "bitstring"],
   "requirements": [
-    "aiolifx==1.0.9",
+    "aiolifx==1.1.1",
     "aiolifx-effects==0.3.2",
-    "aiolifx-themes==0.5.0"
+    "aiolifx-themes==0.5.5"
   ]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -273,10 +273,10 @@ aiokef==0.2.16
 aiolifx-effects==0.3.2
 
 # homeassistant.components.lifx
-aiolifx-themes==0.5.0
+aiolifx-themes==0.5.5
 
 # homeassistant.components.lifx
-aiolifx==1.0.9
+aiolifx==1.1.1
 
 # homeassistant.components.livisi
 aiolivisi==0.0.19

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -255,10 +255,10 @@ aiokafka==0.10.0
 aiolifx-effects==0.3.2
 
 # homeassistant.components.lifx
-aiolifx-themes==0.5.0
+aiolifx-themes==0.5.5
 
 # homeassistant.components.lifx
-aiolifx==1.0.9
+aiolifx==1.1.1
 
 # homeassistant.components.livisi
 aiolivisi==0.0.19

--- a/tests/components/lifx/test_diagnostics.py
+++ b/tests/components/lifx/test_diagnostics.py
@@ -9,6 +9,7 @@ from . import (
     DEFAULT_ENTRY_TITLE,
     IP_ADDRESS,
     SERIAL,
+    MockLifxCommand,
     _mocked_bulb,
     _mocked_clean_bulb,
     _mocked_infrared_bulb,
@@ -188,6 +189,22 @@ async def test_legacy_multizone_bulb_diagnostics(
     )
     config_entry.add_to_hass(hass)
     bulb = _mocked_light_strip()
+    bulb.get_color_zones = MockLifxCommand(
+        bulb,
+        msg_seq_num=0,
+        msg_count=8,
+        msg_color=[
+            (54612, 65535, 65535, 3500),
+            (54612, 65535, 65535, 3500),
+            (54612, 65535, 65535, 3500),
+            (54612, 65535, 65535, 3500),
+            (46420, 65535, 65535, 3500),
+            (46420, 65535, 65535, 3500),
+            (46420, 65535, 65535, 3500),
+            (46420, 65535, 65535, 3500),
+        ],
+        msg_index=0,
+    )
     bulb.zones_count = 8
     bulb.color_zones = [
         (54612, 65535, 65535, 3500),
@@ -302,6 +319,22 @@ async def test_multizone_bulb_diagnostics(
     config_entry.add_to_hass(hass)
     bulb = _mocked_light_strip()
     bulb.product = 38
+    bulb.get_color_zones = MockLifxCommand(
+        bulb,
+        msg_seq_num=0,
+        msg_count=8,
+        msg_color=[
+            (54612, 65535, 65535, 3500),
+            (54612, 65535, 65535, 3500),
+            (54612, 65535, 65535, 3500),
+            (54612, 65535, 65535, 3500),
+            (46420, 65535, 65535, 3500),
+            (46420, 65535, 65535, 3500),
+            (46420, 65535, 65535, 3500),
+            (46420, 65535, 65535, 3500),
+        ],
+        msg_index=0,
+    )
     bulb.zones_count = 8
     bulb.color_zones = [
         (54612, 65535, 65535, 3500),

--- a/tests/components/lifx/test_light.py
+++ b/tests/components/lifx/test_light.py
@@ -192,15 +192,7 @@ async def test_light_strip(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 100},
         blocking=True,
     )
-    call_dict = bulb.set_color_zones.calls[0][1]
-    call_dict.pop("callb")
-    assert call_dict == {
-        "apply": 0,
-        "color": [],
-        "duration": 0,
-        "end_index": 0,
-        "start_index": 0,
-    }
+    assert len(bulb.set_color_zones.calls) == 0
     bulb.set_color_zones.reset_mock()
 
     await hass.services.async_call(
@@ -209,15 +201,7 @@ async def test_light_strip(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: entity_id, ATTR_HS_COLOR: (10, 30)},
         blocking=True,
     )
-    call_dict = bulb.set_color_zones.calls[0][1]
-    call_dict.pop("callb")
-    assert call_dict == {
-        "apply": 0,
-        "color": [],
-        "duration": 0,
-        "end_index": 0,
-        "start_index": 0,
-    }
+    assert len(bulb.set_color_zones.calls) == 0
     bulb.set_color_zones.reset_mock()
 
     bulb.color_zones = [
@@ -238,7 +222,7 @@ async def test_light_strip(hass: HomeAssistant) -> None:
         blocking=True,
     )
     # Single color uses the fast path
-    assert bulb.set_color.calls[0][0][0] == [1820, 19660, 65535, 3500]
+    assert bulb.set_color.calls[1][0][0] == [1820, 19660, 65535, 3500]
     bulb.set_color.reset_mock()
     assert len(bulb.set_color_zones.calls) == 0
 
@@ -422,7 +406,9 @@ async def test_light_strip(hass: HomeAssistant) -> None:
             blocking=True,
         )
 
-    bulb.get_color_zones = MockLifxCommand(bulb)
+    bulb.get_color_zones = MockLifxCommand(
+        bulb, msg_seq_num=0, msg_color=[0, 0, 65535, 3500] * 3, msg_index=0, msg_count=3
+    )
     bulb.get_color = MockFailingLifxCommand(bulb)
 
     with pytest.raises(HomeAssistantError):
@@ -587,14 +573,14 @@ async def test_extended_multizone_messages(hass: HomeAssistant) -> None:
     bulb.set_extended_color_zones.reset_mock()
 
     bulb.color_zones = [
-        (0, 65535, 65535, 3500),
-        (54612, 65535, 65535, 3500),
-        (54612, 65535, 65535, 3500),
-        (54612, 65535, 65535, 3500),
-        (46420, 65535, 65535, 3500),
-        (46420, 65535, 65535, 3500),
-        (46420, 65535, 65535, 3500),
-        (46420, 65535, 65535, 3500),
+        [0, 65535, 65535, 3500],
+        [54612, 65535, 65535, 3500],
+        [54612, 65535, 65535, 3500],
+        [54612, 65535, 65535, 3500],
+        [46420, 65535, 65535, 3500],
+        [46420, 65535, 65535, 3500],
+        [46420, 65535, 65535, 3500],
+        [46420, 65535, 65535, 3500],
     ]
 
     await hass.services.async_call(
@@ -1308,7 +1294,11 @@ async def test_config_zoned_light_strip_fails(
         def __call__(self, callb=None, *args, **kwargs):
             """Call command."""
             self.call_count += 1
-            response = None if self.call_count >= 2 else MockMessage()
+            response = (
+                None
+                if self.call_count >= 2
+                else MockMessage(seq_num=0, color=[], index=0, count=0)
+            )
             if callb:
                 callb(self.bulb, response)
 
@@ -1349,7 +1339,15 @@ async def test_legacy_zoned_light_strip(
             self.call_count += 1
             self.bulb.color_zones = [None] * 12
             if callb:
-                callb(self.bulb, MockMessage())
+                callb(
+                    self.bulb,
+                    MockMessage(
+                        seq_num=0,
+                        index=0,
+                        count=self.bulb.zones_count,
+                        color=self.bulb.color_zones,
+                    ),
+                )
 
     get_color_zones_mock = MockPopulateLifxZonesCommand(light_strip)
     light_strip.get_color_zones = get_color_zones_mock
@@ -1946,6 +1944,33 @@ async def test_light_strip_zones_not_populated_yet(hass: HomeAssistant) -> None:
     bulb.power_level = 65535
     bulb.color_zones = None
     bulb.color = [65535, 65535, 65535, 65535]
+    bulb.get_color_zones = next(
+        iter(
+            [
+                MockLifxCommand(
+                    bulb,
+                    msg_seq_num=0,
+                    msg_color=[0, 0, 65535, 3500] * 8,
+                    msg_index=0,
+                    msg_count=16,
+                ),
+                MockLifxCommand(
+                    bulb,
+                    msg_seq_num=1,
+                    msg_color=[0, 0, 65535, 3500] * 8,
+                    msg_index=0,
+                    msg_count=16,
+                ),
+                MockLifxCommand(
+                    bulb,
+                    msg_seq_num=2,
+                    msg_color=[0, 0, 65535, 3500] * 8,
+                    msg_index=8,
+                    msg_count=16,
+                ),
+            ]
+        )
+    )
     assert bulb.get_color_zones.calls == []
 
     with (


### PR DESCRIPTION
## Proposed change

Bump `aiolifx` and `aiolifx-themes` to enable support for multizone lights with more than 82 zones (the previous limit). This required rewriting some of the tests to align with the underlying library changes. 

While this does resolve the linked issue, it does so pretty inefficiently. I'm working on updating the LIFX integration itself to remove a bunch of historical stuff that is no longer required. However, updating the tests for that is going to be time-consuming, so I don't have an ETA for it yet.

`aiolifx` release:  https://github.com/aiolifx/aiolifx/releases/tag/1.1.1
`aiolifx` changelog: https://github.com/aiolifx/aiolifx/compare/1.0.9...1.1.1

`aiolifx-themes` release: https://github.com/Djelibeybi/aiolifx-themes/releases/tag/v0.5.5
`aiolifx-themes` changelog: https://github.com/Djelibeybi/aiolifx-themes/compare/v0.5.0...v0.5.5

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #125149 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
