### PR TITLE
Fix solarlog test RuntimeWarning

### DIFF
--- a/tests/components/solarlog/conftest.py
+++ b/tests/components/solarlog/conftest.py
@@ -1,7 +1,7 @@
 """Test helpers."""
 
 from collections.abc import Generator
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from solarlog_cli.solarlog_models import InverterData, SolarlogData
@@ -53,6 +53,7 @@ def mock_solarlog_connector():
     data.inverter_data = INVERTER_DATA
 
     mock_solarlog_api = AsyncMock()
+    mock_solarlog_api.set_enabled_devices = MagicMock()
     mock_solarlog_api.test_connection.return_value = True
     mock_solarlog_api.update_data.return_value = data
     mock_solarlog_api.update_device_list.return_value = INVERTER_DATA


### PR DESCRIPTION
## Proposed change
Fixes
```py
tests/components/solarlog/test_init.py::test_load_unload
tests/components/solarlog/test_init.py::test_raise_config_entry_not_ready_when_offline
tests/components/solarlog/test_sensor.py::test_all_entities
tests/components/solarlog/test_sensor.py::test_connection_error[SolarLogConnectionError]
tests/components/solarlog/test_sensor.py::test_connection_error[SolarLogUpdateError]
tests/components/solarlog/test_diagnostics.py::test_entry_diagnostics
  /home/runner/work/ha-core/ha-core/homeassistant/components/solarlog/coordinator.py:55:
      RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
  Coroutine created at (most recent call last)
    ...
    self.solarlog.set_enabled_devices({key: True for key in device_list})
```

`solarlog.set_enabled_devices` is a normal method, not a coroutine:
https://github.com/dontinelli/solarlog_cli/blob/v0.2.2/src/solarlog_cli/solarlog_connector.py#L138-L139

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
