### PR TITLE
Add event platform to ring

### DIFF
--- a/homeassistant/components/ring/const.py
+++ b/homeassistant/components/ring/const.py
@@ -18,6 +18,7 @@ PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
     Platform.CAMERA,
+    Platform.EVENT,
     Platform.LIGHT,
     Platform.SENSOR,
     Platform.SIREN,

--- a/homeassistant/components/ring/event.py
+++ b/homeassistant/components/ring/event.py
@@ -1,0 +1,109 @@
+"""Component providing support for ring events."""
+
+from dataclasses import dataclass
+from typing import Generic
+
+from ring_doorbell import RingCapability, RingEvent as RingAlert
+from ring_doorbell.const import KIND_DING, KIND_INTERCOM_UNLOCK, KIND_MOTION
+
+from homeassistant.components.event import (
+    EventDeviceClass,
+    EventEntity,
+    EventEntityDescription,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import RingConfigEntry
+from .coordinator import RingListenCoordinator
+from .entity import RingBaseEntity, RingDeviceT
+
+
+@dataclass(frozen=True, kw_only=True)
+class RingEventEntityDescription(EventEntityDescription, Generic[RingDeviceT]):
+    """Base class for event entity description."""
+
+    capability: RingCapability
+
+
+EVENT_DESCRIPTIONS: tuple[RingEventEntityDescription, ...] = (
+    RingEventEntityDescription(
+        key=KIND_DING,
+        translation_key=KIND_DING,
+        device_class=EventDeviceClass.DOORBELL,
+        event_types=[KIND_DING],
+        capability=RingCapability.DING,
+    ),
+    RingEventEntityDescription(
+        key=KIND_MOTION,
+        translation_key=KIND_MOTION,
+        device_class=EventDeviceClass.MOTION,
+        event_types=[KIND_MOTION],
+        capability=RingCapability.MOTION_DETECTION,
+    ),
+    RingEventEntityDescription(
+        key=KIND_INTERCOM_UNLOCK,
+        translation_key=KIND_INTERCOM_UNLOCK,
+        device_class=EventDeviceClass.BUTTON,
+        event_types=[KIND_INTERCOM_UNLOCK],
+        capability=RingCapability.OPEN,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: RingConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up events for a Ring device."""
+    ring_data = entry.runtime_data
+    listen_coordinator = ring_data.listen_coordinator
+
+    async_add_entities(
+        RingEvent(device, listen_coordinator, description)
+        for description in EVENT_DESCRIPTIONS
+        for device in ring_data.devices.all_devices
+        if device.has_capability(description.capability)
+    )
+
+
+class RingEvent(RingBaseEntity[RingListenCoordinator, RingDeviceT], EventEntity):
+    """An event implementation for Ring device."""
+
+    entity_description: RingEventEntityDescription[RingDeviceT]
+
+    def __init__(
+        self,
+        device: RingDeviceT,
+        coordinator: RingListenCoordinator,
+        description: RingEventEntityDescription[RingDeviceT],
+    ) -> None:
+        """Initialize a event entity for Ring device."""
+        super().__init__(device, coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{device.id}-{description.key}"
+
+    @callback
+    def _async_handle_event(self, event: str) -> None:
+        """Handle the event."""
+        self._trigger_event(event)
+
+    def _get_coordinator_alert(self) -> RingAlert | None:
+        return self.coordinator.alerts.get(
+            (self._device.device_api_id, self.entity_description.key)
+        )
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        if alert := self._get_coordinator_alert():
+            self._async_handle_event(alert.kind)
+        super()._handle_coordinator_update()
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self.coordinator.event_listener.started
+
+    async def async_update(self) -> None:
+        """All updates are passive."""

--- a/tests/components/ring/test_event.py
+++ b/tests/components/ring/test_event.py
@@ -1,0 +1,80 @@
+"""The tests for the Ring event platform."""
+
+from datetime import datetime
+import time
+
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+from ring_doorbell import Ring
+
+from homeassistant.components.ring.binary_sensor import RingEvent
+from homeassistant.components.ring.coordinator import RingEventListener
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from .common import setup_platform
+from .device_mocks import FRONT_DOOR_DEVICE_ID, INGRESS_DEVICE_ID
+
+
+@pytest.mark.parametrize(
+    ("device_id", "device_name", "alert_kind", "device_class"),
+    [
+        pytest.param(
+            FRONT_DOOR_DEVICE_ID,
+            "front_door",
+            "motion",
+            "motion",
+            id="front_door_motion",
+        ),
+        pytest.param(
+            FRONT_DOOR_DEVICE_ID, "front_door", "ding", "doorbell", id="front_door_ding"
+        ),
+        pytest.param(
+            INGRESS_DEVICE_ID, "ingress", "ding", "doorbell", id="ingress_ding"
+        ),
+        pytest.param(
+            INGRESS_DEVICE_ID,
+            "ingress",
+            "intercom_unlock",
+            "button",
+            id="ingress_unlock",
+        ),
+    ],
+)
+async def test_event(
+    hass: HomeAssistant,
+    mock_ring_client: Ring,
+    mock_ring_event_listener_class: RingEventListener,
+    freezer: FrozenDateTimeFactory,
+    device_id: int,
+    device_name: str,
+    alert_kind: str,
+    device_class: str,
+) -> None:
+    """Test the Ring event platforms."""
+
+    await setup_platform(hass, Platform.EVENT)
+
+    start_time_str = "2024-09-04T15:32:53.892+00:00"
+    start_time = datetime.strptime(start_time_str, "%Y-%m-%dT%H:%M:%S.%f%z")
+    freezer.move_to(start_time)
+    on_event_cb = mock_ring_event_listener_class.return_value.add_notification_callback.call_args.args[
+        0
+    ]
+
+    # Default state is unknown
+    entity_id = f"event.{device_name}_{alert_kind}"
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "unknown"
+    assert state.attributes["device_class"] == device_class
+
+    # A new alert sets to on
+    event = RingEvent(
+        1234546, device_id, "Foo", "Bar", time.time(), 180, kind=alert_kind, state=None
+    )
+    mock_ring_client.active_alerts.return_value = [event]
+    on_event_cb(event)
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == start_time_str


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

This PR deprecates the ring `binary_sensor` and `sensor` for motion and dings and replaces them with an `event` entity.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `binary_sensor` and `sensor` for these push events will start to be deprecated in favour of the `event` entity which is the correct entity for these kinds of alerts.

Depends on https://github.com/home-assistant/core/pull/124879, will be rebased after 124879 merged to dev

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/34581


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
