### PR TITLE
Parameterize many of the threshold tests

### DIFF
--- a/tests/components/threshold/test_binary_sensor.py
+++ b/tests/components/threshold/test_binary_sensor.py
@@ -2,11 +2,23 @@
 
 import pytest
 
-from homeassistant.components.threshold.const import DOMAIN
+from homeassistant.components.threshold.const import (
+    CONF_HYSTERESIS,
+    CONF_LOWER,
+    CONF_UPPER,
+    DOMAIN,
+)
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
     ATTR_UNIT_OF_MEASUREMENT,
+    CONF_ENTITY_ID,
+    CONF_NAME,
+    CONF_PLATFORM,
+    STATE_OFF,
+    STATE_ON,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
+    Platform,
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
@@ -16,461 +28,318 @@ from homeassistant.setup import async_setup_component
 from tests.common import MockConfigEntry
 
 
-async def test_sensor_upper(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    ("from_val", "to_val", "expected_position", "expected_state"),
+    [
+        (None, 15, "below", STATE_OFF),  # at threshold
+        (15, 16, "above", STATE_ON),
+        (16, 14, "below", STATE_OFF),
+        (14, 15, "below", STATE_OFF),
+        (15, "cat", "unknown", STATE_UNKNOWN),
+        ("cat", 15, "below", STATE_OFF),
+        (15, None, "unknown", STATE_UNKNOWN),
+    ],
+)
+async def test_sensor_upper(
+    hass: HomeAssistant,
+    from_val: float | str | None,
+    to_val: float | str,
+    expected_position: str,
+    expected_state: str,
+) -> None:
     """Test if source is above threshold."""
     config = {
-        "binary_sensor": {
-            "platform": "threshold",
-            "upper": "15",
-            "entity_id": "sensor.test_monitored",
+        Platform.BINARY_SENSOR: {
+            CONF_PLATFORM: "threshold",
+            CONF_UPPER: "15",
+            CONF_ENTITY_ID: "sensor.test_monitored",
         }
     }
 
-    assert await async_setup_component(hass, "binary_sensor", config)
+    assert await async_setup_component(hass, Platform.BINARY_SENSOR, config)
     await hass.async_block_till_done()
 
-    # Set the monitored sensor's state to the threshold
-    hass.states.async_set("sensor.test_monitored", 15)
+    hass.states.async_set("sensor.test_monitored", from_val)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "below"
-    assert state.state == "off"
-
-    hass.states.async_set(
-        "sensor.test_monitored",
-        16,
-        {ATTR_UNIT_OF_MEASUREMENT: UnitOfTemperature.CELSIUS},
+    assert state.attributes[ATTR_ENTITY_ID] == "sensor.test_monitored"
+    assert state.attributes["upper"] == float(
+        config[Platform.BINARY_SENSOR][CONF_UPPER]
     )
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["entity_id"] == "sensor.test_monitored"
-    assert state.attributes["sensor_value"] == 16
-    assert state.attributes["position"] == "above"
-    assert state.attributes["upper"] == float(config["binary_sensor"]["upper"])
     assert state.attributes["hysteresis"] == 0.0
     assert state.attributes["type"] == "upper"
-    assert state.state == "on"
 
-    hass.states.async_set("sensor.test_monitored", 14)
+    hass.states.async_set("sensor.test_monitored", to_val)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "below"
-    assert state.state == "off"
-
-    hass.states.async_set("sensor.test_monitored", 15)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "below"
-    assert state.state == "off"
-
-    hass.states.async_set("sensor.test_monitored", "cat")
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "unknown"
-    assert state.state == "unknown"
-
-    hass.states.async_set("sensor.test_monitored", 15)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "below"
-    assert state.state == "off"
+    assert state.attributes["position"] == expected_position
+    assert state.state == expected_state
 
 
-async def test_sensor_lower(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    ("from_val", "to_val", "expected_position", "expected_state"),
+    [
+        (None, 15, "above", STATE_OFF),  # at threshold
+        (15, 16, "above", STATE_OFF),
+        (16, 14, "below", STATE_ON),
+        (14, 15, "below", STATE_ON),
+        (15, "cat", "unknown", STATE_UNKNOWN),
+        ("cat", 15, "above", STATE_OFF),
+        (15, None, "unknown", STATE_UNKNOWN),
+    ],
+)
+async def test_sensor_lower(
+    hass: HomeAssistant,
+    from_val: float | str | None,
+    to_val: float | str,
+    expected_position: str,
+    expected_state: str,
+) -> None:
     """Test if source is below threshold."""
     config = {
-        "binary_sensor": {
-            "platform": "threshold",
-            "lower": "15",
-            "entity_id": "sensor.test_monitored",
+        Platform.BINARY_SENSOR: {
+            CONF_PLATFORM: "threshold",
+            CONF_LOWER: "15",
+            CONF_ENTITY_ID: "sensor.test_monitored",
         }
     }
 
-    assert await async_setup_component(hass, "binary_sensor", config)
+    assert await async_setup_component(hass, Platform.BINARY_SENSOR, config)
     await hass.async_block_till_done()
 
-    # Set the monitored sensor's state to the threshold
-    hass.states.async_set("sensor.test_monitored", 15)
+    hass.states.async_set("sensor.test_monitored", from_val)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "above"
-    assert state.state == "off"
-
-    hass.states.async_set("sensor.test_monitored", 16)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "above"
-    assert state.attributes["lower"] == float(config["binary_sensor"]["lower"])
+    assert state.attributes[ATTR_ENTITY_ID] == "sensor.test_monitored"
+    assert state.attributes["lower"] == float(
+        config[Platform.BINARY_SENSOR][CONF_LOWER]
+    )
     assert state.attributes["hysteresis"] == 0.0
     assert state.attributes["type"] == "lower"
-    assert state.state == "off"
 
-    hass.states.async_set("sensor.test_monitored", 14)
+    hass.states.async_set("sensor.test_monitored", to_val)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "below"
-    assert state.state == "on"
-
-    hass.states.async_set("sensor.test_monitored", 15)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "below"
-    assert state.state == "on"
-
-    hass.states.async_set("sensor.test_monitored", "cat")
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "unknown"
-    assert state.state == "unknown"
-
-    hass.states.async_set("sensor.test_monitored", 15)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "above"
-    assert state.state == "off"
+    assert state.attributes["position"] == expected_position
+    assert state.state == expected_state
 
 
-async def test_sensor_upper_hysteresis(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    ("from_val", "to_val", "expected_position", "expected_state"),
+    [
+        (None, 17.5, "below", STATE_OFF),  # threshold + hysteresis
+        (17.5, 12.5, "below", STATE_OFF),  # threshold - hysteresis
+        (12.5, 20, "above", STATE_ON),
+        (20, 13, "above", STATE_ON),
+        (13, 12, "below", STATE_OFF),
+        (12, 17, "below", STATE_OFF),
+        (17, 18, "above", STATE_ON),
+        (18, "cat", "unknown", STATE_UNKNOWN),
+        ("cat", 18, "above", STATE_ON),
+        (18, None, "unknown", STATE_UNKNOWN),
+    ],
+)
+async def test_sensor_upper_hysteresis(
+    hass: HomeAssistant,
+    from_val: float | str | None,
+    to_val: float | str,
+    expected_position: str,
+    expected_state: str,
+) -> None:
     """Test if source is above threshold using hysteresis."""
     config = {
-        "binary_sensor": {
-            "platform": "threshold",
-            "upper": "15",
-            "hysteresis": "2.5",
-            "entity_id": "sensor.test_monitored",
+        Platform.BINARY_SENSOR: {
+            CONF_PLATFORM: "threshold",
+            CONF_UPPER: "15",
+            CONF_HYSTERESIS: "2.5",
+            CONF_ENTITY_ID: "sensor.test_monitored",
         }
     }
 
-    assert await async_setup_component(hass, "binary_sensor", config)
+    assert await async_setup_component(hass, Platform.BINARY_SENSOR, config)
     await hass.async_block_till_done()
 
-    # Set the monitored sensor's state to the threshold + hysteresis
-    hass.states.async_set("sensor.test_monitored", 17.5)
+    hass.states.async_set("sensor.test_monitored", from_val)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "below"
-    assert state.state == "off"
-
-    # Set the monitored sensor's state to the threshold - hysteresis
-    hass.states.async_set("sensor.test_monitored", 12.5)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "below"
-    assert state.state == "off"
-
-    hass.states.async_set("sensor.test_monitored", 20)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "above"
-    assert state.attributes["upper"] == float(config["binary_sensor"]["upper"])
+    assert state.attributes[ATTR_ENTITY_ID] == "sensor.test_monitored"
+    assert state.attributes["upper"] == float(
+        config[Platform.BINARY_SENSOR][CONF_UPPER]
+    )
     assert state.attributes["hysteresis"] == 2.5
     assert state.attributes["type"] == "upper"
-    assert state.attributes["position"] == "above"
-    assert state.state == "on"
 
-    hass.states.async_set("sensor.test_monitored", 13)
+    hass.states.async_set("sensor.test_monitored", to_val)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "above"
-    assert state.state == "on"
-
-    hass.states.async_set("sensor.test_monitored", 12)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "below"
-    assert state.state == "off"
-
-    hass.states.async_set("sensor.test_monitored", 17)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "below"
-    assert state.state == "off"
-
-    hass.states.async_set("sensor.test_monitored", 18)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "above"
-    assert state.state == "on"
-
-    hass.states.async_set("sensor.test_monitored", "cat")
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "unknown"
-    assert state.state == "unknown"
-
-    hass.states.async_set("sensor.test_monitored", 18)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "above"
-    assert state.state == "on"
+    assert state.attributes["position"] == expected_position
+    assert state.state == expected_state
 
 
-async def test_sensor_lower_hysteresis(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    ("from_val", "to_val", "expected_position", "expected_state"),
+    [
+        (None, 17.5, "above", STATE_OFF),  # threshold + hysteresis
+        (17.5, 12.5, "above", STATE_OFF),  # threshold - hysteresis
+        (12.5, 20, "above", STATE_OFF),
+        (20, 13, "above", STATE_OFF),
+        (13, 12, "below", STATE_ON),
+        (12, 17, "below", STATE_ON),
+        (17, 18, "above", STATE_OFF),
+        (18, "cat", "unknown", STATE_UNKNOWN),
+        ("cat", 18, "above", STATE_OFF),
+        (18, None, "unknown", STATE_UNKNOWN),
+    ],
+)
+async def test_sensor_lower_hysteresis(
+    hass: HomeAssistant,
+    from_val: float | str | None,
+    to_val: float | str,
+    expected_position: str,
+    expected_state: str,
+) -> None:
     """Test if source is below threshold using hysteresis."""
     config = {
-        "binary_sensor": {
-            "platform": "threshold",
-            "lower": "15",
-            "hysteresis": "2.5",
-            "entity_id": "sensor.test_monitored",
+        Platform.BINARY_SENSOR: {
+            CONF_PLATFORM: "threshold",
+            CONF_LOWER: "15",
+            CONF_HYSTERESIS: "2.5",
+            CONF_ENTITY_ID: "sensor.test_monitored",
         }
     }
 
-    assert await async_setup_component(hass, "binary_sensor", config)
+    assert await async_setup_component(hass, Platform.BINARY_SENSOR, config)
     await hass.async_block_till_done()
 
-    # Set the monitored sensor's state to the threshold + hysteresis
-    hass.states.async_set("sensor.test_monitored", 17.5)
+    hass.states.async_set("sensor.test_monitored", from_val)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "above"
-    assert state.state == "off"
-
-    # Set the monitored sensor's state to the threshold - hysteresis
-    hass.states.async_set("sensor.test_monitored", 12.5)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "above"
-    assert state.state == "off"
-
-    hass.states.async_set("sensor.test_monitored", 20)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "above"
-    assert state.attributes["lower"] == float(config["binary_sensor"]["lower"])
+    assert state.attributes[ATTR_ENTITY_ID] == "sensor.test_monitored"
+    assert state.attributes["lower"] == float(
+        config[Platform.BINARY_SENSOR][CONF_LOWER]
+    )
     assert state.attributes["hysteresis"] == 2.5
     assert state.attributes["type"] == "lower"
-    assert state.attributes["position"] == "above"
-    assert state.state == "off"
 
-    hass.states.async_set("sensor.test_monitored", 13)
+    hass.states.async_set("sensor.test_monitored", to_val)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "above"
-    assert state.state == "off"
-
-    hass.states.async_set("sensor.test_monitored", 12)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "below"
-    assert state.state == "on"
-
-    hass.states.async_set("sensor.test_monitored", 17)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "below"
-    assert state.state == "on"
-
-    hass.states.async_set("sensor.test_monitored", 18)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "above"
-    assert state.state == "off"
-
-    hass.states.async_set("sensor.test_monitored", "cat")
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "unknown"
-    assert state.state == "unknown"
-
-    hass.states.async_set("sensor.test_monitored", 18)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "above"
-    assert state.state == "off"
+    assert state.attributes["position"] == expected_position
+    assert state.state == expected_state
 
 
-async def test_sensor_in_range_no_hysteresis(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    ("from_val", "to_val", "expected_position", "expected_state"),
+    [
+        (None, 10, "in_range", STATE_ON),  # at lower threshold
+        (10, 20, "in_range", STATE_ON),  # at upper threshold
+        (20, 16, "in_range", STATE_ON),
+        (16, 9, "below", STATE_OFF),
+        (9, 21, "above", STATE_OFF),
+        (21, "cat", "unknown", STATE_UNKNOWN),
+        ("cat", 21, "above", STATE_OFF),
+        (21, None, "unknown", STATE_UNKNOWN),
+    ],
+)
+async def test_sensor_in_range_no_hysteresis(
+    hass: HomeAssistant,
+    from_val: float | str | None,
+    to_val: float | str,
+    expected_position: str,
+    expected_state: str,
+) -> None:
     """Test if source is within the range."""
     config = {
-        "binary_sensor": {
-            "platform": "threshold",
-            "lower": "10",
-            "upper": "20",
-            "entity_id": "sensor.test_monitored",
+        Platform.BINARY_SENSOR: {
+            CONF_PLATFORM: "threshold",
+            CONF_LOWER: "10",
+            CONF_UPPER: "20",
+            CONF_ENTITY_ID: "sensor.test_monitored",
         }
     }
 
-    assert await async_setup_component(hass, "binary_sensor", config)
+    assert await async_setup_component(hass, Platform.BINARY_SENSOR, config)
     await hass.async_block_till_done()
 
-    # Set the monitored sensor's state to the lower threshold
-    hass.states.async_set("sensor.test_monitored", 10)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "in_range"
-    assert state.state == "on"
-
-    # Set the monitored sensor's state to the upper threshold
-    hass.states.async_set("sensor.test_monitored", 20)
+    hass.states.async_set("sensor.test_monitored", from_val)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "in_range"
-    assert state.state == "on"
-
-    hass.states.async_set(
-        "sensor.test_monitored",
-        16,
-        {ATTR_UNIT_OF_MEASUREMENT: UnitOfTemperature.CELSIUS},
+    assert state.attributes[ATTR_ENTITY_ID] == "sensor.test_monitored"
+    assert state.attributes["lower"] == float(
+        config[Platform.BINARY_SENSOR][CONF_LOWER]
     )
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["entity_id"] == "sensor.test_monitored"
-    assert state.attributes["sensor_value"] == 16
-    assert state.attributes["position"] == "in_range"
-    assert state.attributes["lower"] == float(config["binary_sensor"]["lower"])
-    assert state.attributes["upper"] == float(config["binary_sensor"]["upper"])
+    assert state.attributes["upper"] == float(
+        config[Platform.BINARY_SENSOR][CONF_UPPER]
+    )
     assert state.attributes["hysteresis"] == 0.0
     assert state.attributes["type"] == "range"
-    assert state.state == "on"
 
-    hass.states.async_set("sensor.test_monitored", 9)
+    hass.states.async_set("sensor.test_monitored", to_val)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "below"
-    assert state.state == "off"
-
-    hass.states.async_set("sensor.test_monitored", 21)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "above"
-    assert state.state == "off"
-
-    hass.states.async_set("sensor.test_monitored", "cat")
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "unknown"
-    assert state.state == "unknown"
-
-    hass.states.async_set("sensor.test_monitored", 21)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "above"
-    assert state.state == "off"
+    assert state.attributes["position"] == expected_position
+    assert state.state == expected_state
 
 
-async def test_sensor_in_range_with_hysteresis(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    ("from_val", "to_val", "expected_position", "expected_state"),
+    [
+        (None, 12, "in_range", STATE_ON),  # lower threshold + hysteresis
+        (12, 22, "in_range", STATE_ON),  # upper threshold + hysteresis
+        (22, 18, "in_range", STATE_ON),  # upper threshold - hysteresis
+        (18, 16, "in_range", STATE_ON),
+        (16, 8, "in_range", STATE_ON),
+        (8, 7, "below", STATE_OFF),
+        (7, 12, "below", STATE_OFF),
+        (12, 13, "in_range", STATE_ON),
+        (13, 22, "in_range", STATE_ON),
+        (22, 23, "above", STATE_OFF),
+        (23, 18, "above", STATE_OFF),
+        (18, 17, "in_range", STATE_ON),
+        (17, "cat", "unknown", STATE_UNKNOWN),
+        ("cat", 17, "in_range", STATE_ON),
+        (17, None, "unknown", STATE_UNKNOWN),
+    ],
+)
+async def test_sensor_in_range_with_hysteresis(
+    hass: HomeAssistant,
+    from_val: float | str | None,
+    to_val: float | str,
+    expected_position: str,
+    expected_state: str,
+) -> None:
     """Test if source is within the range."""
     config = {
-        "binary_sensor": {
-            "platform": "threshold",
-            "lower": "10",
-            "upper": "20",
-            "hysteresis": "2",
-            "entity_id": "sensor.test_monitored",
+        Platform.BINARY_SENSOR: {
+            CONF_PLATFORM: "threshold",
+            CONF_LOWER: "10",
+            CONF_UPPER: "20",
+            CONF_HYSTERESIS: "2",
+            CONF_ENTITY_ID: "sensor.test_monitored",
         }
     }
 
-    assert await async_setup_component(hass, "binary_sensor", config)
+    assert await async_setup_component(hass, Platform.BINARY_SENSOR, config)
     await hass.async_block_till_done()
 
-    # Set the monitored sensor's state to the lower threshold - hysteresis
-    hass.states.async_set("sensor.test_monitored", 8)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "in_range"
-    assert state.state == "on"
-
-    # Set the monitored sensor's state to the lower threshold + hysteresis
-    hass.states.async_set("sensor.test_monitored", 12)
+    hass.states.async_set("sensor.test_monitored", from_val)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "in_range"
-    assert state.state == "on"
-
-    # Set the monitored sensor's state to the upper threshold + hysteresis
-    hass.states.async_set("sensor.test_monitored", 22)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "in_range"
-    assert state.state == "on"
-
-    # Set the monitored sensor's state to the upper threshold - hysteresis
-    hass.states.async_set("sensor.test_monitored", 18)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "in_range"
-    assert state.state == "on"
-
-    hass.states.async_set(
-        "sensor.test_monitored",
-        16,
-        {ATTR_UNIT_OF_MEASUREMENT: UnitOfTemperature.CELSIUS},
+    assert state.attributes[ATTR_ENTITY_ID] == "sensor.test_monitored"
+    assert state.attributes["lower"] == float(
+        config[Platform.BINARY_SENSOR][CONF_LOWER]
     )
-    await hass.async_block_till_done()
-
-    state = hass.states.get("binary_sensor.threshold")
-
-    assert state.attributes["entity_id"] == "sensor.test_monitored"
-    assert state.attributes["sensor_value"] == 16
-    assert state.attributes["position"] == "in_range"
-    assert state.attributes["lower"] == float(config["binary_sensor"]["lower"])
-    assert state.attributes["upper"] == float(config["binary_sensor"]["upper"])
-    assert state.attributes["hysteresis"] == float(
-        config["binary_sensor"]["hysteresis"]
+    assert state.attributes["upper"] == float(
+        config[Platform.BINARY_SENSOR][CONF_UPPER]
     )
+    assert state.attributes["hysteresis"] == 2.0
     assert state.attributes["type"] == "range"
-    assert state.state == "on"
 
-    hass.states.async_set("sensor.test_monitored", 8)
+    hass.states.async_set("sensor.test_monitored", to_val)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "in_range"
-    assert state.state == "on"
-
-    hass.states.async_set("sensor.test_monitored", 7)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "below"
-    assert state.state == "off"
-
-    hass.states.async_set("sensor.test_monitored", 12)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "below"
-    assert state.state == "off"
-
-    hass.states.async_set("sensor.test_monitored", 13)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "in_range"
-    assert state.state == "on"
-
-    hass.states.async_set("sensor.test_monitored", 22)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "in_range"
-    assert state.state == "on"
-
-    hass.states.async_set("sensor.test_monitored", 23)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "above"
-    assert state.state == "off"
-
-    hass.states.async_set("sensor.test_monitored", 18)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "above"
-    assert state.state == "off"
-
-    hass.states.async_set("sensor.test_monitored", 17)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "in_range"
-    assert state.state == "on"
-
-    hass.states.async_set("sensor.test_monitored", "cat")
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "unknown"
-    assert state.state == "unknown"
-
-    hass.states.async_set("sensor.test_monitored", 17)
-    await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.threshold")
-    assert state.attributes["position"] == "in_range"
-    assert state.state == "on"
+    assert state.attributes["position"] == expected_position
+    assert state.state == expected_state
 
 
 async def test_sensor_in_range_unknown_state(
@@ -478,15 +347,15 @@ async def test_sensor_in_range_unknown_state(
 ) -> None:
     """Test if source is within the range."""
     config = {
-        "binary_sensor": {
-            "platform": "threshold",
-            "lower": "10",
-            "upper": "20",
-            "entity_id": "sensor.test_monitored",
+        Platform.BINARY_SENSOR: {
+            CONF_PLATFORM: "threshold",
+            CONF_LOWER: "10",
+            CONF_UPPER: "20",
+            CONF_ENTITY_ID: "sensor.test_monitored",
         }
     }
 
-    assert await async_setup_component(hass, "binary_sensor", config)
+    assert await async_setup_component(hass, Platform.BINARY_SENSOR, config)
     await hass.async_block_till_done()
 
     hass.states.async_set(
@@ -498,26 +367,30 @@ async def test_sensor_in_range_unknown_state(
 
     state = hass.states.get("binary_sensor.threshold")
 
-    assert state.attributes["entity_id"] == "sensor.test_monitored"
+    assert state.attributes[ATTR_ENTITY_ID] == "sensor.test_monitored"
     assert state.attributes["sensor_value"] == 16
     assert state.attributes["position"] == "in_range"
-    assert state.attributes["lower"] == float(config["binary_sensor"]["lower"])
-    assert state.attributes["upper"] == float(config["binary_sensor"]["upper"])
+    assert state.attributes["lower"] == float(
+        config[Platform.BINARY_SENSOR][CONF_LOWER]
+    )
+    assert state.attributes["upper"] == float(
+        config[Platform.BINARY_SENSOR][CONF_UPPER]
+    )
     assert state.attributes["hysteresis"] == 0.0
     assert state.attributes["type"] == "range"
-    assert state.state == "on"
+    assert state.state == STATE_ON
 
     hass.states.async_set("sensor.test_monitored", STATE_UNKNOWN)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
     assert state.attributes["position"] == "unknown"
-    assert state.state == "unknown"
+    assert state.state == STATE_UNKNOWN
 
     hass.states.async_set("sensor.test_monitored", STATE_UNAVAILABLE)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
     assert state.attributes["position"] == "unknown"
-    assert state.state == "unknown"
+    assert state.state == STATE_UNKNOWN
 
     assert "State is not numerical" not in caplog.text
 
@@ -525,53 +398,57 @@ async def test_sensor_in_range_unknown_state(
 async def test_sensor_lower_zero_threshold(hass: HomeAssistant) -> None:
     """Test if a lower threshold of zero is set."""
     config = {
-        "binary_sensor": {
-            "platform": "threshold",
-            "lower": "0",
-            "entity_id": "sensor.test_monitored",
+        Platform.BINARY_SENSOR: {
+            CONF_PLATFORM: "threshold",
+            CONF_LOWER: "0",
+            CONF_ENTITY_ID: "sensor.test_monitored",
         }
     }
 
-    assert await async_setup_component(hass, "binary_sensor", config)
+    assert await async_setup_component(hass, Platform.BINARY_SENSOR, config)
     await hass.async_block_till_done()
 
     hass.states.async_set("sensor.test_monitored", 16)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
     assert state.attributes["type"] == "lower"
-    assert state.attributes["lower"] == float(config["binary_sensor"]["lower"])
-    assert state.state == "off"
+    assert state.attributes["lower"] == float(
+        config[Platform.BINARY_SENSOR][CONF_LOWER]
+    )
+    assert state.state == STATE_OFF
 
     hass.states.async_set("sensor.test_monitored", -3)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
-    assert state.state == "on"
+    assert state.state == STATE_ON
 
 
 async def test_sensor_upper_zero_threshold(hass: HomeAssistant) -> None:
     """Test if an upper threshold of zero is set."""
     config = {
-        "binary_sensor": {
-            "platform": "threshold",
-            "upper": "0",
-            "entity_id": "sensor.test_monitored",
+        Platform.BINARY_SENSOR: {
+            CONF_PLATFORM: "threshold",
+            CONF_UPPER: "0",
+            CONF_ENTITY_ID: "sensor.test_monitored",
         }
     }
 
-    assert await async_setup_component(hass, "binary_sensor", config)
+    assert await async_setup_component(hass, Platform.BINARY_SENSOR, config)
     await hass.async_block_till_done()
 
     hass.states.async_set("sensor.test_monitored", -10)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
     assert state.attributes["type"] == "upper"
-    assert state.attributes["upper"] == float(config["binary_sensor"]["upper"])
-    assert state.state == "off"
+    assert state.attributes["upper"] == float(
+        config[Platform.BINARY_SENSOR][CONF_UPPER]
+    )
+    assert state.state == STATE_OFF
 
     hass.states.async_set("sensor.test_monitored", 2)
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.threshold")
-    assert state.state == "on"
+    assert state.state == STATE_ON
 
 
 async def test_sensor_no_lower_upper(
@@ -579,13 +456,13 @@ async def test_sensor_no_lower_upper(
 ) -> None:
     """Test if no lower or upper has been provided."""
     config = {
-        "binary_sensor": {
-            "platform": "threshold",
-            "entity_id": "sensor.test_monitored",
+        Platform.BINARY_SENSOR: {
+            CONF_PLATFORM: "threshold",
+            CONF_ENTITY_ID: "sensor.test_monitored",
         }
     }
 
-    await async_setup_component(hass, "binary_sensor", config)
+    await async_setup_component(hass, Platform.BINARY_SENSOR, config)
     await hass.async_block_till_done()
 
     assert "Lower or Upper thresholds not provided" in caplog.text
@@ -618,11 +495,11 @@ async def test_device_id(
         data={},
         domain=DOMAIN,
         options={
-            "entity_id": "sensor.test_source",
-            "hysteresis": 0.0,
-            "lower": -2.0,
-            "name": "Threshold",
-            "upper": None,
+            CONF_ENTITY_ID: "sensor.test_source",
+            CONF_HYSTERESIS: 0.0,
+            CONF_LOWER: -2.0,
+            CONF_NAME: "Threshold",
+            CONF_UPPER: None,
         },
         title="Threshold",
     )


### PR DESCRIPTION
This simplfies the structure of the basic threshold tests, making it easier to subsequently update or add missing test cases.

Except for a few removals of an inconsistenly applied assertions on `state.attributes["sensor_value"]`, there are no changes to the existing tests intended. All previous tests are expected to run identically.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This is a refactoring to make the threshold tests easier to understand and update. I have found a few issues with the threshold integration that need clear tests to help debug and fix.

The previous code implicitly expressed `from` and `to` values, but not all cases were covered. For example, in `test_sensor_lower`, a transition from "below threshold" to "at threshold" was tested, but not "above threshold" to "at threshold". This missing case is more clearly visible now.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #110904

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
