### PR TITLE
Add storage settings for enphase_envoy batteries without enpower device

### DIFF
--- a/homeassistant/components/enphase_envoy/number.py
+++ b/homeassistant/components/enphase_envoy/number.py
@@ -88,7 +88,6 @@ async def async_setup_entry(
         envoy_data.tariff
         and envoy_data.tariff.storage_settings
         and coordinator.envoy.supported_features & SupportedFeatures.ENCHARGE
-        and coordinator.envoy.supported_features & SupportedFeatures.ENPOWER
     ):
         entities.append(
             EnvoyStorageSettingsNumberEntity(coordinator, STORAGE_RESERVE_SOC_ENTITY)
@@ -152,18 +151,30 @@ class EnvoyStorageSettingsNumberEntity(EnvoyBaseEntity, NumberEntity):
         """Initialize the Enphase relay number entity."""
         super().__init__(coordinator, description)
         self.envoy = coordinator.envoy
-        assert self.data.enpower is not None
-        enpower = self.data.enpower
-        self._serial_number = enpower.serial_number
-        self._attr_unique_id = f"{self._serial_number}_{description.key}"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self._serial_number)},
-            manufacturer="Enphase",
-            model="Enpower",
-            name=f"Enpower {self._serial_number}",
-            sw_version=str(enpower.firmware_version),
-            via_device=(DOMAIN, self.envoy_serial_num),
-        )
+        assert self.data is not None
+        if enpower := self.data.enpower:
+            self._serial_number = enpower.serial_number
+            self._attr_unique_id = f"{self._serial_number}_{description.key}"
+            self._attr_device_info = DeviceInfo(
+                identifiers={(DOMAIN, self._serial_number)},
+                manufacturer="Enphase",
+                model="Enpower",
+                name=f"Enpower {self._serial_number}",
+                sw_version=str(enpower.firmware_version),
+                via_device=(DOMAIN, self.envoy_serial_num),
+            )
+        else:
+            # If no enpower device assign numbers to Envoy itself
+            self._attr_unique_id = f"{self.envoy_serial_num}_{description.key}"
+            self._attr_device_info = DeviceInfo(
+                identifiers={(DOMAIN, self.envoy_serial_num)},
+                manufacturer="Enphase",
+                model=coordinator.envoy.envoy_model,
+                name=coordinator.name,
+                sw_version=str(coordinator.envoy.firmware),
+                hw_version=coordinator.envoy.part_number,
+                serial_number=self.envoy_serial_num,
+            )
 
     @property
     def native_value(self) -> float:

--- a/homeassistant/components/enphase_envoy/select.py
+++ b/homeassistant/components/enphase_envoy/select.py
@@ -143,7 +143,6 @@ async def async_setup_entry(
         envoy_data.tariff
         and envoy_data.tariff.storage_settings
         and coordinator.envoy.supported_features & SupportedFeatures.ENCHARGE
-        and coordinator.envoy.supported_features & SupportedFeatures.ENPOWER
     ):
         entities.append(
             EnvoyStorageSettingsSelectEntity(coordinator, STORAGE_MODE_ENTITY)
@@ -209,18 +208,29 @@ class EnvoyStorageSettingsSelectEntity(EnvoyBaseEntity, SelectEntity):
         super().__init__(coordinator, description)
         self.envoy = coordinator.envoy
         assert coordinator.envoy.data is not None
-        assert coordinator.envoy.data.enpower is not None
-        enpower = coordinator.envoy.data.enpower
-        self._serial_number = enpower.serial_number
-        self._attr_unique_id = f"{self._serial_number}_{description.key}"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self._serial_number)},
-            manufacturer="Enphase",
-            model="Enpower",
-            name=f"Enpower {self._serial_number}",
-            sw_version=str(enpower.firmware_version),
-            via_device=(DOMAIN, self.envoy_serial_num),
-        )
+        if enpower := coordinator.envoy.data.enpower:
+            self._serial_number = enpower.serial_number
+            self._attr_unique_id = f"{self._serial_number}_{description.key}"
+            self._attr_device_info = DeviceInfo(
+                identifiers={(DOMAIN, self._serial_number)},
+                manufacturer="Enphase",
+                model="Enpower",
+                name=f"Enpower {self._serial_number}",
+                sw_version=str(enpower.firmware_version),
+                via_device=(DOMAIN, self.envoy_serial_num),
+            )
+        else:
+            # If no enpower device assign selects to Envoy itself
+            self._attr_unique_id = f"{self.envoy_serial_num}_{description.key}"
+            self._attr_device_info = DeviceInfo(
+                identifiers={(DOMAIN, self.envoy_serial_num)},
+                manufacturer="Enphase",
+                model=coordinator.envoy.envoy_model,
+                name=coordinator.name,
+                sw_version=str(coordinator.envoy.firmware),
+                hw_version=coordinator.envoy.part_number,
+                serial_number=self.envoy_serial_num,
+            )
 
     @property
     def current_option(self) -> str:

--- a/tests/components/enphase_envoy/fixtures/envoy_eu_batt.json
+++ b/tests/components/enphase_envoy/fixtures/envoy_eu_batt.json
@@ -1,0 +1,874 @@
+{
+  "serial_number": "123456789012",
+  "firmware": "7.6.358",
+  "part_number": "800-00654-r08",
+  "envoy_model": "Envoy, phases: 3, phase mode: three, net-consumption CT, production CT",
+  "supported_features": 1759,
+  "phase_mode": "three",
+  "phase_count": 3,
+  "active_phase_count": 0,
+  "ct_meter_count": 2,
+  "consumption_meter_type": "net-consumption",
+  "production_meter_type": "production",
+  "storage_meter_type": null,
+  "data": {
+    "encharge_inventory": {
+      "122327081322": {
+        "admin_state": 6,
+        "admin_state_str": "ENCHG_STATE_READY",
+        "bmu_firmware_version": "2.1.16",
+        "comm_level_2_4_ghz": 4,
+        "comm_level_sub_ghz": 4,
+        "communicating": true,
+        "dc_switch_off": false,
+        "encharge_capacity": 3500,
+        "encharge_revision": 2,
+        "firmware_loaded_date": 1714736645,
+        "firmware_version": "2.6.6618_rel/22.11",
+        "installed_date": 1714736645,
+        "last_report_date": 1714804173,
+        "led_status": 17,
+        "max_cell_temp": 16,
+        "operating": true,
+        "part_number": "830-01760-r46",
+        "percent_full": 4,
+        "serial_number": "122327081322",
+        "temperature": 16,
+        "temperature_unit": "C",
+        "zigbee_dongle_fw_version": "100F"
+      }
+    },
+    "encharge_power": {
+      "122327081322": {
+        "apparent_power_mva": 0,
+        "real_power_mw": 0,
+        "soc": 4
+      }
+    },
+    "encharge_aggregate": {
+      "available_energy": 140,
+      "backup_reserve": 0,
+      "state_of_charge": 4,
+      "reserve_state_of_charge": 0,
+      "configured_reserve_state_of_charge": 0,
+      "max_available_capacity": 3500
+    },
+    "enpower": null,
+    "system_consumption": {
+      "watt_hours_lifetime": 11230297,
+      "watt_hours_last_7_days": 60488,
+      "watt_hours_today": 11220,
+      "watts_now": 267
+    },
+    "system_production": {
+      "watt_hours_lifetime": 3264161,
+      "watt_hours_last_7_days": 70188,
+      "watt_hours_today": 105,
+      "watts_now": 119
+    },
+    "system_consumption_phases": null,
+    "system_production_phases": null,
+    "system_net_consumption": {
+      "watt_hours_lifetime": 7967021,
+      "watt_hours_last_7_days": 0,
+      "watt_hours_today": 0,
+      "watts_now": 148
+    },
+    "system_net_consumption_phases": null,
+    "ctmeter_production": {
+      "eid": 704643328,
+      "timestamp": 1714804347,
+      "energy_delivered": 3264161,
+      "energy_received": 2600,
+      "active_power": 119,
+      "power_factor": 0.666,
+      "voltage": 717.827,
+      "current": 0.727,
+      "frequency": 50.0,
+      "state": "enabled",
+      "measurement_type": "production",
+      "metering_status": "normal",
+      "status_flags": []
+    },
+    "ctmeter_consumption": {
+      "eid": 704643584,
+      "timestamp": 1714804347,
+      "energy_delivered": 9671362,
+      "energy_received": 1704783,
+      "active_power": 148,
+      "power_factor": 0.318,
+      "voltage": 717.603,
+      "current": 1.918,
+      "frequency": 50.0,
+      "state": "enabled",
+      "measurement_type": "net-consumption",
+      "metering_status": "normal",
+      "status_flags": []
+    },
+    "ctmeter_storage": null,
+    "ctmeter_production_phases": {
+      "L1": {
+        "eid": 1778385169,
+        "timestamp": 1714804347,
+        "energy_delivered": 1064047,
+        "energy_received": 19,
+        "active_power": 38,
+        "power_factor": 0.636,
+        "voltage": 240.455,
+        "current": 0.238,
+        "frequency": 50.0,
+        "state": "enabled",
+        "measurement_type": "production",
+        "metering_status": "normal",
+        "status_flags": []
+      },
+      "L2": {
+        "eid": 1778385170,
+        "timestamp": 1714804347,
+        "energy_delivered": 1105921,
+        "energy_received": 518,
+        "active_power": 42,
+        "power_factor": 0.615,
+        "voltage": 239.646,
+        "current": 0.3,
+        "frequency": 50.0,
+        "state": "enabled",
+        "measurement_type": "production",
+        "metering_status": "normal",
+        "status_flags": []
+      },
+      "L3": {
+        "eid": 1778385171,
+        "timestamp": 1714804347,
+        "energy_delivered": 1094193,
+        "energy_received": 2062,
+        "active_power": 39,
+        "power_factor": 0.778,
+        "voltage": 237.725,
+        "current": 0.189,
+        "frequency": 50.0,
+        "state": "enabled",
+        "measurement_type": "production",
+        "metering_status": "normal",
+        "status_flags": []
+      }
+    },
+    "ctmeter_consumption_phases": {
+      "L1": {
+        "eid": 1778385425,
+        "timestamp": 1714804347,
+        "energy_delivered": 3066805,
+        "energy_received": 309331,
+        "active_power": 186,
+        "power_factor": 0.493,
+        "voltage": 240.294,
+        "current": 1.566,
+        "frequency": 50.0,
+        "state": "enabled",
+        "measurement_type": "net-consumption",
+        "metering_status": "normal",
+        "status_flags": []
+      },
+      "L2": {
+        "eid": 1778385426,
+        "timestamp": 1714804347,
+        "energy_delivered": 2426811,
+        "energy_received": 678824,
+        "active_power": -17,
+        "power_factor": -0.375,
+        "voltage": 239.513,
+        "current": 0.194,
+        "frequency": 50.0,
+        "state": "enabled",
+        "measurement_type": "net-consumption",
+        "metering_status": "normal",
+        "status_flags": []
+      },
+      "L3": {
+        "eid": 1778385427,
+        "timestamp": 1714804347,
+        "energy_delivered": 4177747,
+        "energy_received": 716628,
+        "active_power": -21,
+        "power_factor": -0.571,
+        "voltage": 237.796,
+        "current": 0.159,
+        "frequency": 50.0,
+        "state": "enabled",
+        "measurement_type": "net-consumption",
+        "metering_status": "normal",
+        "status_flags": []
+      }
+    },
+    "ctmeter_storage_phases": null,
+    "dry_contact_status": {},
+    "dry_contact_settings": {},
+    "inverters": {
+      "482312083761": {
+        "serial_number": "482312083761",
+        "last_report_date": 1714804246,
+        "last_report_watts": 11,
+        "max_report_watts": 341
+      },
+      "482312084840": {
+        "serial_number": "482312084840",
+        "last_report_date": 1714803976,
+        "last_report_watts": 9,
+        "max_report_watts": 336
+      },
+      "482312087202": {
+        "serial_number": "482312087202",
+        "last_report_date": 1714804186,
+        "last_report_watts": 12,
+        "max_report_watts": 343
+      },
+      "482312084298": {
+        "serial_number": "482312084298",
+        "last_report_date": 1714804187,
+        "last_report_watts": 11,
+        "max_report_watts": 343
+      },
+      "482312087222": {
+        "serial_number": "482312087222",
+        "last_report_date": 1714803404,
+        "last_report_watts": 13,
+        "max_report_watts": 342
+      },
+      "482312083708": {
+        "serial_number": "482312083708",
+        "last_report_date": 1714803465,
+        "last_report_watts": 14,
+        "max_report_watts": 342
+      },
+      "482312086604": {
+        "serial_number": "482312086604",
+        "last_report_date": 1714803495,
+        "last_report_watts": 14,
+        "max_report_watts": 340
+      },
+      "482312087072": {
+        "serial_number": "482312087072",
+        "last_report_date": 1714803435,
+        "last_report_watts": 13,
+        "max_report_watts": 340
+      },
+      "482312082644": {
+        "serial_number": "482312082644",
+        "last_report_date": 1714803585,
+        "last_report_watts": 13,
+        "max_report_watts": 341
+      }
+    },
+    "tariff": {
+      "currency": {
+        "code": "EUR"
+      },
+      "logger": "mylogger",
+      "date": "1714749724",
+      "storage_settings": {
+        "mode": "self-consumption",
+        "operation_mode_sub_type": "",
+        "reserved_soc": 0.0,
+        "very_low_soc": 5,
+        "charge_from_grid": true,
+        "date": "1714749724"
+      },
+      "single_rate": {
+        "rate": 0.0,
+        "sell": 0.0
+      },
+      "seasons": [
+        {
+          "id": "all_year_long",
+          "start": "1/1",
+          "days": [
+            {
+              "id": "all_days",
+              "days": "Mon,Tue,Wed,Thu,Fri,Sat,Sun",
+              "must_charge_start": 0,
+              "must_charge_duration": 0,
+              "must_charge_mode": "CP",
+              "enable_discharge_to_grid": false,
+              "periods": [
+                {
+                  "id": "period_1",
+                  "start": 0,
+                  "rate": 0.0
+                }
+              ]
+            }
+          ],
+          "tiers": []
+        }
+      ],
+      "seasons_sell": []
+    },
+    "raw": {
+      "/ivp/meters": [
+        {
+          "eid": 704643328,
+          "state": "enabled",
+          "measurementType": "production",
+          "phaseMode": "three",
+          "phaseCount": 3,
+          "meteringStatus": "normal",
+          "statusFlags": []
+        },
+        {
+          "eid": 704643584,
+          "state": "enabled",
+          "measurementType": "net-consumption",
+          "phaseMode": "three",
+          "phaseCount": 3,
+          "meteringStatus": "normal",
+          "statusFlags": []
+        }
+      ],
+      "/ivp/meters/readings": [
+        {
+          "eid": 704643328,
+          "timestamp": 1714804347,
+          "actEnergyDlvd": 3264160.793,
+          "actEnergyRcvd": 2599.885,
+          "apparentEnergy": 4225140.177,
+          "reactEnergyLagg": 943620.773,
+          "reactEnergyLead": 58691.262,
+          "instantaneousDemand": 119.065,
+          "activePower": 119.065,
+          "apparentPower": 173.94,
+          "reactivePower": 4.114,
+          "pwrFactor": 0.666,
+          "voltage": 717.827,
+          "current": 0.727,
+          "freq": 50.0,
+          "channels": [
+            {
+              "eid": 1778385169,
+              "timestamp": 1714804347,
+              "actEnergyDlvd": 1064046.936,
+              "actEnergyRcvd": 19.428,
+              "apparentEnergy": 1375000.058,
+              "reactEnergyLagg": 314247.281,
+              "reactEnergyLead": 21768.496,
+              "instantaneousDemand": 38.313,
+              "activePower": 38.313,
+              "apparentPower": 57.367,
+              "reactivePower": 1.403,
+              "pwrFactor": 0.636,
+              "voltage": 240.455,
+              "current": 0.238,
+              "freq": 50.0
+            },
+            {
+              "eid": 1778385170,
+              "timestamp": 1714804347,
+              "actEnergyDlvd": 1105920.676,
+              "actEnergyRcvd": 518.282,
+              "apparentEnergy": 1501914.525,
+              "reactEnergyLagg": 310307.761,
+              "reactEnergyLead": 20407.466,
+              "instantaneousDemand": 41.683,
+              "activePower": 41.683,
+              "apparentPower": 71.693,
+              "reactivePower": 0.94,
+              "pwrFactor": 0.615,
+              "voltage": 239.646,
+              "current": 0.3,
+              "freq": 50.0
+            },
+            {
+              "eid": 1778385171,
+              "timestamp": 1714804347,
+              "actEnergyDlvd": 1094193.182,
+              "actEnergyRcvd": 2062.175,
+              "apparentEnergy": 1348225.594,
+              "reactEnergyLagg": 319065.731,
+              "reactEnergyLead": 16515.3,
+              "instantaneousDemand": 39.07,
+              "activePower": 39.07,
+              "apparentPower": 44.88,
+              "reactivePower": 1.771,
+              "pwrFactor": 0.778,
+              "voltage": 237.725,
+              "current": 0.189,
+              "freq": 50.0
+            }
+          ]
+        },
+        {
+          "eid": 704643584,
+          "timestamp": 1714804347,
+          "actEnergyDlvd": 9671361.96,
+          "actEnergyRcvd": 1704783.419,
+          "apparentEnergy": 13673800.457,
+          "reactEnergyLagg": 494494.97,
+          "reactEnergyLead": 3015382.102,
+          "instantaneousDemand": 148.165,
+          "activePower": 148.165,
+          "apparentPower": 460.673,
+          "reactivePower": -300.949,
+          "pwrFactor": 0.318,
+          "voltage": 717.603,
+          "current": 1.918,
+          "freq": 50.0,
+          "channels": [
+            {
+              "eid": 1778385425,
+              "timestamp": 1714804347,
+              "actEnergyDlvd": 3066804.679,
+              "actEnergyRcvd": 309330.838,
+              "apparentEnergy": 4951108.353,
+              "reactEnergyLagg": 24517.912,
+              "reactEnergyLead": 2377508.453,
+              "instantaneousDemand": 185.511,
+              "activePower": 185.511,
+              "apparentPower": 376.511,
+              "reactivePower": -298.049,
+              "pwrFactor": 0.493,
+              "voltage": 240.294,
+              "current": 1.566,
+              "freq": 50.0
+            },
+            {
+              "eid": 1778385426,
+              "timestamp": 1714804347,
+              "actEnergyDlvd": 2426810.597,
+              "actEnergyRcvd": 678824.485,
+              "apparentEnergy": 3566049.507,
+              "reactEnergyLagg": 366590.771,
+              "reactEnergyLead": 368314.783,
+              "instantaneousDemand": -16.627,
+              "activePower": -16.627,
+              "apparentPower": 46.326,
+              "reactivePower": -25.535,
+              "pwrFactor": -0.375,
+              "voltage": 239.513,
+              "current": 0.194,
+              "freq": 50.0
+            },
+            {
+              "eid": 1778385427,
+              "timestamp": 1714804347,
+              "actEnergyDlvd": 4177746.684,
+              "actEnergyRcvd": 716628.097,
+              "apparentEnergy": 5156642.597,
+              "reactEnergyLagg": 103386.286,
+              "reactEnergyLead": 269558.867,
+              "instantaneousDemand": -20.719,
+              "activePower": -20.719,
+              "apparentPower": 37.835,
+              "reactivePower": 22.635,
+              "pwrFactor": -0.571,
+              "voltage": 237.796,
+              "current": 0.159,
+              "freq": 50.0
+            }
+          ]
+        }
+      ],
+      "/production": {
+        "production": [
+          {
+            "type": "inverters",
+            "activeCount": 9,
+            "readingTime": 1714804306,
+            "wNow": 107,
+            "whLifetime": 920667
+          },
+          {
+            "type": "eim",
+            "activeCount": 1,
+            "measurementType": "production",
+            "readingTime": 1714804348,
+            "wNow": 119.065,
+            "whLifetime": 3264160.793,
+            "varhLeadLifetime": 58691.262,
+            "varhLagLifetime": 943620.773,
+            "vahLifetime": 4225140.177,
+            "rmsCurrent": 0.727,
+            "rmsVoltage": 717.827,
+            "reactPwr": 4.114,
+            "apprntPwr": 173.94,
+            "pwrFactor": 0.67,
+            "whToday": 104.793,
+            "whLastSevenDays": 70187.793,
+            "vahToday": 1331.177,
+            "varhLeadToday": 1.262,
+            "varhLagToday": 1054.773
+          }
+        ],
+        "consumption": [
+          {
+            "type": "eim",
+            "activeCount": 1,
+            "measurementType": "total-consumption",
+            "readingTime": 1714804348,
+            "wNow": 267.23,
+            "whLifetime": 11230296.56,
+            "varhLeadLifetime": 2956690.84,
+            "varhLagLifetime": -449125.804,
+            "vahLifetime": 13673800.457,
+            "rmsCurrent": 1.941,
+            "rmsVoltage": 717.603,
+            "reactPwr": -296.835,
+            "apprntPwr": 466.217,
+            "pwrFactor": 0.56,
+            "whToday": 11219.56,
+            "whLastSevenDays": 60487.56,
+            "vahToday": 14520.457,
+            "varhLeadToday": 3820.84,
+            "varhLagToday": 0.0
+          },
+          {
+            "type": "eim",
+            "activeCount": 1,
+            "measurementType": "net-consumption",
+            "readingTime": 1714804348,
+            "wNow": 148.165,
+            "whLifetime": 7967021.314,
+            "varhLeadLifetime": 3015382.102,
+            "varhLagLifetime": 494494.97,
+            "vahLifetime": 13673800.457,
+            "rmsCurrent": 1.214,
+            "rmsVoltage": 717.603,
+            "reactPwr": -300.949,
+            "apprntPwr": 292.209,
+            "pwrFactor": 0.5,
+            "whToday": 0,
+            "whLastSevenDays": 0,
+            "vahToday": 0,
+            "varhLeadToday": 0,
+            "varhLagToday": 0
+          }
+        ],
+        "storage": [
+          {
+            "type": "acb",
+            "activeCount": 0,
+            "readingTime": 0,
+            "wNow": 0,
+            "whNow": 0,
+            "state": "idle"
+          }
+        ]
+      },
+      "/api/v1/production/inverters": [
+        {
+          "serialNumber": "482312083761",
+          "lastReportDate": 1714804246,
+          "devType": 1,
+          "lastReportWatts": 11,
+          "maxReportWatts": 341
+        },
+        {
+          "serialNumber": "482312084840",
+          "lastReportDate": 1714803976,
+          "devType": 1,
+          "lastReportWatts": 9,
+          "maxReportWatts": 336
+        },
+        {
+          "serialNumber": "482312087202",
+          "lastReportDate": 1714804186,
+          "devType": 1,
+          "lastReportWatts": 12,
+          "maxReportWatts": 343
+        },
+        {
+          "serialNumber": "482312084298",
+          "lastReportDate": 1714804187,
+          "devType": 1,
+          "lastReportWatts": 11,
+          "maxReportWatts": 343
+        },
+        {
+          "serialNumber": "482312087222",
+          "lastReportDate": 1714803404,
+          "devType": 1,
+          "lastReportWatts": 13,
+          "maxReportWatts": 342
+        },
+        {
+          "serialNumber": "482312083708",
+          "lastReportDate": 1714803465,
+          "devType": 1,
+          "lastReportWatts": 14,
+          "maxReportWatts": 342
+        },
+        {
+          "serialNumber": "482312086604",
+          "lastReportDate": 1714803495,
+          "devType": 1,
+          "lastReportWatts": 14,
+          "maxReportWatts": 340
+        },
+        {
+          "serialNumber": "482312087072",
+          "lastReportDate": 1714803435,
+          "devType": 1,
+          "lastReportWatts": 13,
+          "maxReportWatts": 340
+        },
+        {
+          "serialNumber": "482312082644",
+          "lastReportDate": 1714803585,
+          "devType": 1,
+          "lastReportWatts": 13,
+          "maxReportWatts": 341
+        }
+      ],
+      "/ivp/ensemble/inventory": [
+        {
+          "type": "ENCHARGE",
+          "devices": [
+            {
+              "part_num": "830-01760-r46",
+              "installed": 1714736645,
+              "serial_num": "122327081322",
+              "device_status": ["envoy.global.ok", "prop.done"],
+              "last_rpt_date": 1714804173,
+              "admin_state": 6,
+              "admin_state_str": "ENCHG_STATE_READY",
+              "created_date": 1714736645,
+              "img_load_date": 1714736645,
+              "img_pnum_running": "2.6.6618_rel/22.11",
+              "zigbee_dongle_fw_version": "100F",
+              "bmu_fw_version": "2.1.16",
+              "operating": true,
+              "communicating": true,
+              "sleep_enabled": false,
+              "percentFull": 4,
+              "temperature": 16,
+              "maxCellTemp": 16,
+              "comm_level_sub_ghz": 4,
+              "comm_level_2_4_ghz": 4,
+              "led_status": 17,
+              "dc_switch_off": false,
+              "encharge_rev": 2,
+              "encharge_capacity": 3500
+            }
+          ]
+        }
+      ],
+      "/ivp/ensemble/secctrl": {
+        "shutdown": false,
+        "freq_bias_hz": 1.3899999856948853,
+        "voltage_bias_v": 16.899999618530273,
+        "freq_bias_hz_q8": 2235,
+        "voltage_bias_v_q5": 540,
+        "freq_bias_hz_phaseb": 0.0,
+        "voltage_bias_v_phaseb": 0.0,
+        "freq_bias_hz_q8_phaseb": 0,
+        "voltage_bias_v_q5_phaseb": 0,
+        "freq_bias_hz_phasec": 0.0,
+        "voltage_bias_v_phasec": 0.0,
+        "freq_bias_hz_q8_phasec": 0,
+        "voltage_bias_v_q5_phasec": 0,
+        "configured_backup_soc": 0,
+        "adjusted_backup_soc": 0,
+        "agg_soc": 4,
+        "Max_energy": 3500,
+        "ENC_agg_soc": 4,
+        "ENC_agg_soh": 100,
+        "ENC_agg_backup_energy": 0,
+        "ENC_agg_avail_energy": 140,
+        "Enc_commissioned_capacity": 3500,
+        "Enc_max_available_capacity": 3500,
+        "ACB_agg_soc": 0,
+        "ACB_agg_energy": 0
+      },
+      "/ivp/ensemble/power": {
+        "devices:": [
+          {
+            "serial_num": "122327081322",
+            "real_power_mw": 0,
+            "apparent_power_mva": 0,
+            "soc": 4
+          }
+        ]
+      },
+      "/admin/lib/tariff": {
+        "tariff": {
+          "currency": {
+            "code": "EUR"
+          },
+          "logger": "mylogger",
+          "date": "1714749724",
+          "storage_settings": {
+            "mode": "self-consumption",
+            "operation_mode_sub_type": "",
+            "reserved_soc": 0.0,
+            "very_low_soc": 5,
+            "charge_from_grid": false,
+            "date": "1714749724"
+          },
+          "single_rate": {
+            "rate": 0.0,
+            "sell": 0.0
+          },
+          "seasons": [
+            {
+              "id": "all_year_long",
+              "start": "1/1",
+              "days": [
+                {
+                  "id": "all_days",
+                  "days": "Mon,Tue,Wed,Thu,Fri,Sat,Sun",
+                  "must_charge_start": 0,
+                  "must_charge_duration": 0,
+                  "must_charge_mode": "CP",
+                  "enable_discharge_to_grid": false,
+                  "periods": [
+                    {
+                      "id": "period_1",
+                      "start": 0,
+                      "rate": 0.0
+                    }
+                  ]
+                }
+              ],
+              "tiers": []
+            }
+          ],
+          "seasons_sell": []
+        },
+        "schedule": {
+          "source": "Tariff",
+          "date": "2024-05-03 15:28:15 UTC",
+          "version": "00.00.02",
+          "reserved_soc": 0.0,
+          "operation_mode_sub_type": "",
+          "very_low_soc": 5,
+          "charge_from_grid": false,
+          "battery_mode": "self-consumption",
+          "schedule": {
+            "Disable": [
+              {
+                "Sun": [
+                  {
+                    "start": 0,
+                    "duration": 1440,
+                    "setting": "ID"
+                  }
+                ]
+              },
+              {
+                "Mon": [
+                  {
+                    "start": 0,
+                    "duration": 1440,
+                    "setting": "ID"
+                  }
+                ]
+              },
+              {
+                "Tue": [
+                  {
+                    "start": 0,
+                    "duration": 1440,
+                    "setting": "ID"
+                  }
+                ]
+              },
+              {
+                "Wed": [
+                  {
+                    "start": 0,
+                    "duration": 1440,
+                    "setting": "ID"
+                  }
+                ]
+              },
+              {
+                "Thu": [
+                  {
+                    "start": 0,
+                    "duration": 1440,
+                    "setting": "ID"
+                  }
+                ]
+              },
+              {
+                "Fri": [
+                  {
+                    "start": 0,
+                    "duration": 1440,
+                    "setting": "ID"
+                  }
+                ]
+              },
+              {
+                "Sat": [
+                  {
+                    "start": 0,
+                    "duration": 1440,
+                    "setting": "ID"
+                  }
+                ]
+              }
+            ],
+            "tariff": [
+              {
+                "start": "1/1",
+                "end": "1/1",
+                "Sun": [
+                  {
+                    "start": 0,
+                    "duration": 1440,
+                    "setting": "ZN"
+                  }
+                ],
+                "Mon": [
+                  {
+                    "start": 0,
+                    "duration": 1440,
+                    "setting": "ZN"
+                  }
+                ],
+                "Tue": [
+                  {
+                    "start": 0,
+                    "duration": 1440,
+                    "setting": "ZN"
+                  }
+                ],
+                "Wed": [
+                  {
+                    "start": 0,
+                    "duration": 1440,
+                    "setting": "ZN"
+                  }
+                ],
+                "Thu": [
+                  {
+                    "start": 0,
+                    "duration": 1440,
+                    "setting": "ZN"
+                  }
+                ],
+                "Fri": [
+                  {
+                    "start": 0,
+                    "duration": 1440,
+                    "setting": "ZN"
+                  }
+                ],
+                "Sat": [
+                  {
+                    "start": 0,
+                    "duration": 1440,
+                    "setting": "ZN"
+                  }
+                ]
+              }
+            ]
+          },
+          "override": false,
+          "override_backup_soc": 30.0,
+          "override_chg_dischg_rate": 0.0,
+          "override_tou_mode": "StorageTouMode_DEFAULT_TOU_MODE"
+        }
+      }
+    }
+  }
+}

--- a/tests/components/enphase_envoy/fixtures/envoy_eu_batt.json
+++ b/tests/components/enphase_envoy/fixtures/envoy_eu_batt.json
@@ -1,5 +1,5 @@
 {
-  "serial_number": "123456789012",
+  "serial_number": "1234",
   "firmware": "7.6.358",
   "part_number": "800-00654-r08",
   "envoy_model": "Envoy, phases: 3, phase mode: three, net-consumption CT, production CT",
@@ -13,7 +13,7 @@
   "storage_meter_type": null,
   "data": {
     "encharge_inventory": {
-      "122327081322": {
+      "123456": {
         "admin_state": 6,
         "admin_state_str": "ENCHG_STATE_READY",
         "bmu_firmware_version": "2.1.16",
@@ -39,7 +39,7 @@
       }
     },
     "encharge_power": {
-      "122327081322": {
+      "123456": {
         "apparent_power_mva": 0,
         "real_power_mw": 0,
         "soc": 4
@@ -55,51 +55,51 @@
     },
     "enpower": null,
     "system_consumption": {
-      "watt_hours_lifetime": 11230297,
-      "watt_hours_last_7_days": 60488,
-      "watt_hours_today": 11220,
-      "watts_now": 267
+      "watt_hours_lifetime": 1234,
+      "watt_hours_last_7_days": 1234,
+      "watt_hours_today": 1234,
+      "watts_now": 1234
     },
     "system_production": {
-      "watt_hours_lifetime": 3264161,
-      "watt_hours_last_7_days": 70188,
-      "watt_hours_today": 105,
-      "watts_now": 119
+      "watt_hours_lifetime": 1234,
+      "watt_hours_last_7_days": 1234,
+      "watt_hours_today": 1234,
+      "watts_now": 1234
     },
     "system_consumption_phases": null,
     "system_production_phases": null,
     "system_net_consumption": {
-      "watt_hours_lifetime": 7967021,
-      "watt_hours_last_7_days": 0,
-      "watt_hours_today": 0,
-      "watts_now": 148
+      "watt_hours_lifetime": 4321,
+      "watt_hours_last_7_days": -1,
+      "watt_hours_today": -1,
+      "watts_now": 2341
     },
     "system_net_consumption_phases": null,
     "ctmeter_production": {
-      "eid": 704643328,
-      "timestamp": 1714804347,
-      "energy_delivered": 3264161,
-      "energy_received": 2600,
-      "active_power": 119,
-      "power_factor": 0.666,
-      "voltage": 717.827,
-      "current": 0.727,
-      "frequency": 50.0,
+      "eid": "100000010",
+      "timestamp": 1708006110,
+      "energy_delivered": 11234,
+      "energy_received": 12345,
+      "active_power": 100,
+      "power_factor": 0.11,
+      "voltage": 111,
+      "current": 0.2,
+      "frequency": 50.1,
       "state": "enabled",
       "measurement_type": "production",
       "metering_status": "normal",
-      "status_flags": []
+      "status_flags": ["production-imbalance", "power-on-unused-phase"]
     },
     "ctmeter_consumption": {
-      "eid": 704643584,
-      "timestamp": 1714804347,
-      "energy_delivered": 9671362,
-      "energy_received": 1704783,
-      "active_power": 148,
-      "power_factor": 0.318,
-      "voltage": 717.603,
-      "current": 1.918,
-      "frequency": 50.0,
+      "eid": "100000020",
+      "timestamp": 1708006120,
+      "energy_delivered": 21234,
+      "energy_received": 22345,
+      "active_power": 101,
+      "power_factor": 0.21,
+      "voltage": 112,
+      "current": 0.3,
+      "frequency": 50.2,
       "state": "enabled",
       "measurement_type": "net-consumption",
       "metering_status": "normal",
@@ -108,45 +108,45 @@
     "ctmeter_storage": null,
     "ctmeter_production_phases": {
       "L1": {
-        "eid": 1778385169,
-        "timestamp": 1714804347,
-        "energy_delivered": 1064047,
-        "energy_received": 19,
-        "active_power": 38,
-        "power_factor": 0.636,
-        "voltage": 240.455,
-        "current": 0.238,
-        "frequency": 50.0,
+        "eid": "100000011",
+        "timestamp": 1708006111,
+        "energy_delivered": 112341,
+        "energy_received": 123451,
+        "active_power": 20,
+        "power_factor": 0.12,
+        "voltage": 111,
+        "current": 0.2,
+        "frequency": 50.1,
         "state": "enabled",
         "measurement_type": "production",
         "metering_status": "normal",
-        "status_flags": []
+        "status_flags": ["production-imbalance"]
       },
       "L2": {
-        "eid": 1778385170,
-        "timestamp": 1714804347,
-        "energy_delivered": 1105921,
-        "energy_received": 518,
-        "active_power": 42,
-        "power_factor": 0.615,
-        "voltage": 239.646,
-        "current": 0.3,
-        "frequency": 50.0,
+        "eid": "100000012",
+        "timestamp": 1708006112,
+        "energy_delivered": 112342,
+        "energy_received": 123452,
+        "active_power": 30,
+        "power_factor": 0.13,
+        "voltage": 111,
+        "current": 0.2,
+        "frequency": 50.1,
         "state": "enabled",
         "measurement_type": "production",
         "metering_status": "normal",
-        "status_flags": []
+        "status_flags": ["power-on-unused-phase"]
       },
       "L3": {
-        "eid": 1778385171,
-        "timestamp": 1714804347,
-        "energy_delivered": 1094193,
-        "energy_received": 2062,
-        "active_power": 39,
-        "power_factor": 0.778,
-        "voltage": 237.725,
-        "current": 0.189,
-        "frequency": 50.0,
+        "eid": "100000013",
+        "timestamp": 1708006113,
+        "energy_delivered": 112343,
+        "energy_received": 123453,
+        "active_power": 50,
+        "power_factor": 0.14,
+        "voltage": 111,
+        "current": 0.2,
+        "frequency": 50.1,
         "state": "enabled",
         "measurement_type": "production",
         "metering_status": "normal",
@@ -155,45 +155,45 @@
     },
     "ctmeter_consumption_phases": {
       "L1": {
-        "eid": 1778385425,
-        "timestamp": 1714804347,
-        "energy_delivered": 3066805,
-        "energy_received": 309331,
-        "active_power": 186,
-        "power_factor": 0.493,
-        "voltage": 240.294,
-        "current": 1.566,
-        "frequency": 50.0,
+        "eid": "100000021",
+        "timestamp": 1708006121,
+        "energy_delivered": 212341,
+        "energy_received": 223451,
+        "active_power": 21,
+        "power_factor": 0.22,
+        "voltage": 112,
+        "current": 0.3,
+        "frequency": 50.2,
         "state": "enabled",
         "measurement_type": "net-consumption",
         "metering_status": "normal",
         "status_flags": []
       },
       "L2": {
-        "eid": 1778385426,
-        "timestamp": 1714804347,
-        "energy_delivered": 2426811,
-        "energy_received": 678824,
-        "active_power": -17,
-        "power_factor": -0.375,
-        "voltage": 239.513,
-        "current": 0.194,
-        "frequency": 50.0,
+        "eid": "100000022",
+        "timestamp": 1708006122,
+        "energy_delivered": 212342,
+        "energy_received": 223452,
+        "active_power": 31,
+        "power_factor": 0.23,
+        "voltage": 112,
+        "current": 0.3,
+        "frequency": 50.2,
         "state": "enabled",
         "measurement_type": "net-consumption",
         "metering_status": "normal",
         "status_flags": []
       },
       "L3": {
-        "eid": 1778385427,
-        "timestamp": 1714804347,
-        "energy_delivered": 4177747,
-        "energy_received": 716628,
-        "active_power": -21,
-        "power_factor": -0.571,
-        "voltage": 237.796,
-        "current": 0.159,
-        "frequency": 50.0,
+        "eid": "100000023",
+        "timestamp": 1708006123,
+        "energy_delivered": 212343,
+        "energy_received": 223453,
+        "active_power": 51,
+        "power_factor": 0.24,
+        "voltage": 112,
+        "current": 0.3,
+        "frequency": 50.2,
         "state": "enabled",
         "measurement_type": "net-consumption",
         "metering_status": "normal",
@@ -204,59 +204,11 @@
     "dry_contact_status": {},
     "dry_contact_settings": {},
     "inverters": {
-      "482312083761": {
-        "serial_number": "482312083761",
-        "last_report_date": 1714804246,
-        "last_report_watts": 11,
-        "max_report_watts": 341
-      },
-      "482312084840": {
-        "serial_number": "482312084840",
-        "last_report_date": 1714803976,
-        "last_report_watts": 9,
-        "max_report_watts": 336
-      },
-      "482312087202": {
-        "serial_number": "482312087202",
-        "last_report_date": 1714804186,
-        "last_report_watts": 12,
-        "max_report_watts": 343
-      },
-      "482312084298": {
-        "serial_number": "482312084298",
-        "last_report_date": 1714804187,
-        "last_report_watts": 11,
-        "max_report_watts": 343
-      },
-      "482312087222": {
-        "serial_number": "482312087222",
-        "last_report_date": 1714803404,
-        "last_report_watts": 13,
-        "max_report_watts": 342
-      },
-      "482312083708": {
-        "serial_number": "482312083708",
-        "last_report_date": 1714803465,
-        "last_report_watts": 14,
-        "max_report_watts": 342
-      },
-      "482312086604": {
-        "serial_number": "482312086604",
-        "last_report_date": 1714803495,
-        "last_report_watts": 14,
-        "max_report_watts": 340
-      },
-      "482312087072": {
-        "serial_number": "482312087072",
-        "last_report_date": 1714803435,
-        "last_report_watts": 13,
-        "max_report_watts": 340
-      },
-      "482312082644": {
-        "serial_number": "482312082644",
-        "last_report_date": 1714803585,
-        "last_report_watts": 13,
-        "max_report_watts": 341
+      "1": {
+        "serial_number": "1",
+        "last_report_date": 1,
+        "last_report_watts": 1,
+        "max_report_watts": 1
       }
     },
     "tariff": {
@@ -304,571 +256,7 @@
       "seasons_sell": []
     },
     "raw": {
-      "/ivp/meters": [
-        {
-          "eid": 704643328,
-          "state": "enabled",
-          "measurementType": "production",
-          "phaseMode": "three",
-          "phaseCount": 3,
-          "meteringStatus": "normal",
-          "statusFlags": []
-        },
-        {
-          "eid": 704643584,
-          "state": "enabled",
-          "measurementType": "net-consumption",
-          "phaseMode": "three",
-          "phaseCount": 3,
-          "meteringStatus": "normal",
-          "statusFlags": []
-        }
-      ],
-      "/ivp/meters/readings": [
-        {
-          "eid": 704643328,
-          "timestamp": 1714804347,
-          "actEnergyDlvd": 3264160.793,
-          "actEnergyRcvd": 2599.885,
-          "apparentEnergy": 4225140.177,
-          "reactEnergyLagg": 943620.773,
-          "reactEnergyLead": 58691.262,
-          "instantaneousDemand": 119.065,
-          "activePower": 119.065,
-          "apparentPower": 173.94,
-          "reactivePower": 4.114,
-          "pwrFactor": 0.666,
-          "voltage": 717.827,
-          "current": 0.727,
-          "freq": 50.0,
-          "channels": [
-            {
-              "eid": 1778385169,
-              "timestamp": 1714804347,
-              "actEnergyDlvd": 1064046.936,
-              "actEnergyRcvd": 19.428,
-              "apparentEnergy": 1375000.058,
-              "reactEnergyLagg": 314247.281,
-              "reactEnergyLead": 21768.496,
-              "instantaneousDemand": 38.313,
-              "activePower": 38.313,
-              "apparentPower": 57.367,
-              "reactivePower": 1.403,
-              "pwrFactor": 0.636,
-              "voltage": 240.455,
-              "current": 0.238,
-              "freq": 50.0
-            },
-            {
-              "eid": 1778385170,
-              "timestamp": 1714804347,
-              "actEnergyDlvd": 1105920.676,
-              "actEnergyRcvd": 518.282,
-              "apparentEnergy": 1501914.525,
-              "reactEnergyLagg": 310307.761,
-              "reactEnergyLead": 20407.466,
-              "instantaneousDemand": 41.683,
-              "activePower": 41.683,
-              "apparentPower": 71.693,
-              "reactivePower": 0.94,
-              "pwrFactor": 0.615,
-              "voltage": 239.646,
-              "current": 0.3,
-              "freq": 50.0
-            },
-            {
-              "eid": 1778385171,
-              "timestamp": 1714804347,
-              "actEnergyDlvd": 1094193.182,
-              "actEnergyRcvd": 2062.175,
-              "apparentEnergy": 1348225.594,
-              "reactEnergyLagg": 319065.731,
-              "reactEnergyLead": 16515.3,
-              "instantaneousDemand": 39.07,
-              "activePower": 39.07,
-              "apparentPower": 44.88,
-              "reactivePower": 1.771,
-              "pwrFactor": 0.778,
-              "voltage": 237.725,
-              "current": 0.189,
-              "freq": 50.0
-            }
-          ]
-        },
-        {
-          "eid": 704643584,
-          "timestamp": 1714804347,
-          "actEnergyDlvd": 9671361.96,
-          "actEnergyRcvd": 1704783.419,
-          "apparentEnergy": 13673800.457,
-          "reactEnergyLagg": 494494.97,
-          "reactEnergyLead": 3015382.102,
-          "instantaneousDemand": 148.165,
-          "activePower": 148.165,
-          "apparentPower": 460.673,
-          "reactivePower": -300.949,
-          "pwrFactor": 0.318,
-          "voltage": 717.603,
-          "current": 1.918,
-          "freq": 50.0,
-          "channels": [
-            {
-              "eid": 1778385425,
-              "timestamp": 1714804347,
-              "actEnergyDlvd": 3066804.679,
-              "actEnergyRcvd": 309330.838,
-              "apparentEnergy": 4951108.353,
-              "reactEnergyLagg": 24517.912,
-              "reactEnergyLead": 2377508.453,
-              "instantaneousDemand": 185.511,
-              "activePower": 185.511,
-              "apparentPower": 376.511,
-              "reactivePower": -298.049,
-              "pwrFactor": 0.493,
-              "voltage": 240.294,
-              "current": 1.566,
-              "freq": 50.0
-            },
-            {
-              "eid": 1778385426,
-              "timestamp": 1714804347,
-              "actEnergyDlvd": 2426810.597,
-              "actEnergyRcvd": 678824.485,
-              "apparentEnergy": 3566049.507,
-              "reactEnergyLagg": 366590.771,
-              "reactEnergyLead": 368314.783,
-              "instantaneousDemand": -16.627,
-              "activePower": -16.627,
-              "apparentPower": 46.326,
-              "reactivePower": -25.535,
-              "pwrFactor": -0.375,
-              "voltage": 239.513,
-              "current": 0.194,
-              "freq": 50.0
-            },
-            {
-              "eid": 1778385427,
-              "timestamp": 1714804347,
-              "actEnergyDlvd": 4177746.684,
-              "actEnergyRcvd": 716628.097,
-              "apparentEnergy": 5156642.597,
-              "reactEnergyLagg": 103386.286,
-              "reactEnergyLead": 269558.867,
-              "instantaneousDemand": -20.719,
-              "activePower": -20.719,
-              "apparentPower": 37.835,
-              "reactivePower": 22.635,
-              "pwrFactor": -0.571,
-              "voltage": 237.796,
-              "current": 0.159,
-              "freq": 50.0
-            }
-          ]
-        }
-      ],
-      "/production": {
-        "production": [
-          {
-            "type": "inverters",
-            "activeCount": 9,
-            "readingTime": 1714804306,
-            "wNow": 107,
-            "whLifetime": 920667
-          },
-          {
-            "type": "eim",
-            "activeCount": 1,
-            "measurementType": "production",
-            "readingTime": 1714804348,
-            "wNow": 119.065,
-            "whLifetime": 3264160.793,
-            "varhLeadLifetime": 58691.262,
-            "varhLagLifetime": 943620.773,
-            "vahLifetime": 4225140.177,
-            "rmsCurrent": 0.727,
-            "rmsVoltage": 717.827,
-            "reactPwr": 4.114,
-            "apprntPwr": 173.94,
-            "pwrFactor": 0.67,
-            "whToday": 104.793,
-            "whLastSevenDays": 70187.793,
-            "vahToday": 1331.177,
-            "varhLeadToday": 1.262,
-            "varhLagToday": 1054.773
-          }
-        ],
-        "consumption": [
-          {
-            "type": "eim",
-            "activeCount": 1,
-            "measurementType": "total-consumption",
-            "readingTime": 1714804348,
-            "wNow": 267.23,
-            "whLifetime": 11230296.56,
-            "varhLeadLifetime": 2956690.84,
-            "varhLagLifetime": -449125.804,
-            "vahLifetime": 13673800.457,
-            "rmsCurrent": 1.941,
-            "rmsVoltage": 717.603,
-            "reactPwr": -296.835,
-            "apprntPwr": 466.217,
-            "pwrFactor": 0.56,
-            "whToday": 11219.56,
-            "whLastSevenDays": 60487.56,
-            "vahToday": 14520.457,
-            "varhLeadToday": 3820.84,
-            "varhLagToday": 0.0
-          },
-          {
-            "type": "eim",
-            "activeCount": 1,
-            "measurementType": "net-consumption",
-            "readingTime": 1714804348,
-            "wNow": 148.165,
-            "whLifetime": 7967021.314,
-            "varhLeadLifetime": 3015382.102,
-            "varhLagLifetime": 494494.97,
-            "vahLifetime": 13673800.457,
-            "rmsCurrent": 1.214,
-            "rmsVoltage": 717.603,
-            "reactPwr": -300.949,
-            "apprntPwr": 292.209,
-            "pwrFactor": 0.5,
-            "whToday": 0,
-            "whLastSevenDays": 0,
-            "vahToday": 0,
-            "varhLeadToday": 0,
-            "varhLagToday": 0
-          }
-        ],
-        "storage": [
-          {
-            "type": "acb",
-            "activeCount": 0,
-            "readingTime": 0,
-            "wNow": 0,
-            "whNow": 0,
-            "state": "idle"
-          }
-        ]
-      },
-      "/api/v1/production/inverters": [
-        {
-          "serialNumber": "482312083761",
-          "lastReportDate": 1714804246,
-          "devType": 1,
-          "lastReportWatts": 11,
-          "maxReportWatts": 341
-        },
-        {
-          "serialNumber": "482312084840",
-          "lastReportDate": 1714803976,
-          "devType": 1,
-          "lastReportWatts": 9,
-          "maxReportWatts": 336
-        },
-        {
-          "serialNumber": "482312087202",
-          "lastReportDate": 1714804186,
-          "devType": 1,
-          "lastReportWatts": 12,
-          "maxReportWatts": 343
-        },
-        {
-          "serialNumber": "482312084298",
-          "lastReportDate": 1714804187,
-          "devType": 1,
-          "lastReportWatts": 11,
-          "maxReportWatts": 343
-        },
-        {
-          "serialNumber": "482312087222",
-          "lastReportDate": 1714803404,
-          "devType": 1,
-          "lastReportWatts": 13,
-          "maxReportWatts": 342
-        },
-        {
-          "serialNumber": "482312083708",
-          "lastReportDate": 1714803465,
-          "devType": 1,
-          "lastReportWatts": 14,
-          "maxReportWatts": 342
-        },
-        {
-          "serialNumber": "482312086604",
-          "lastReportDate": 1714803495,
-          "devType": 1,
-          "lastReportWatts": 14,
-          "maxReportWatts": 340
-        },
-        {
-          "serialNumber": "482312087072",
-          "lastReportDate": 1714803435,
-          "devType": 1,
-          "lastReportWatts": 13,
-          "maxReportWatts": 340
-        },
-        {
-          "serialNumber": "482312082644",
-          "lastReportDate": 1714803585,
-          "devType": 1,
-          "lastReportWatts": 13,
-          "maxReportWatts": 341
-        }
-      ],
-      "/ivp/ensemble/inventory": [
-        {
-          "type": "ENCHARGE",
-          "devices": [
-            {
-              "part_num": "830-01760-r46",
-              "installed": 1714736645,
-              "serial_num": "122327081322",
-              "device_status": ["envoy.global.ok", "prop.done"],
-              "last_rpt_date": 1714804173,
-              "admin_state": 6,
-              "admin_state_str": "ENCHG_STATE_READY",
-              "created_date": 1714736645,
-              "img_load_date": 1714736645,
-              "img_pnum_running": "2.6.6618_rel/22.11",
-              "zigbee_dongle_fw_version": "100F",
-              "bmu_fw_version": "2.1.16",
-              "operating": true,
-              "communicating": true,
-              "sleep_enabled": false,
-              "percentFull": 4,
-              "temperature": 16,
-              "maxCellTemp": 16,
-              "comm_level_sub_ghz": 4,
-              "comm_level_2_4_ghz": 4,
-              "led_status": 17,
-              "dc_switch_off": false,
-              "encharge_rev": 2,
-              "encharge_capacity": 3500
-            }
-          ]
-        }
-      ],
-      "/ivp/ensemble/secctrl": {
-        "shutdown": false,
-        "freq_bias_hz": 1.3899999856948853,
-        "voltage_bias_v": 16.899999618530273,
-        "freq_bias_hz_q8": 2235,
-        "voltage_bias_v_q5": 540,
-        "freq_bias_hz_phaseb": 0.0,
-        "voltage_bias_v_phaseb": 0.0,
-        "freq_bias_hz_q8_phaseb": 0,
-        "voltage_bias_v_q5_phaseb": 0,
-        "freq_bias_hz_phasec": 0.0,
-        "voltage_bias_v_phasec": 0.0,
-        "freq_bias_hz_q8_phasec": 0,
-        "voltage_bias_v_q5_phasec": 0,
-        "configured_backup_soc": 0,
-        "adjusted_backup_soc": 0,
-        "agg_soc": 4,
-        "Max_energy": 3500,
-        "ENC_agg_soc": 4,
-        "ENC_agg_soh": 100,
-        "ENC_agg_backup_energy": 0,
-        "ENC_agg_avail_energy": 140,
-        "Enc_commissioned_capacity": 3500,
-        "Enc_max_available_capacity": 3500,
-        "ACB_agg_soc": 0,
-        "ACB_agg_energy": 0
-      },
-      "/ivp/ensemble/power": {
-        "devices:": [
-          {
-            "serial_num": "122327081322",
-            "real_power_mw": 0,
-            "apparent_power_mva": 0,
-            "soc": 4
-          }
-        ]
-      },
-      "/admin/lib/tariff": {
-        "tariff": {
-          "currency": {
-            "code": "EUR"
-          },
-          "logger": "mylogger",
-          "date": "1714749724",
-          "storage_settings": {
-            "mode": "self-consumption",
-            "operation_mode_sub_type": "",
-            "reserved_soc": 0.0,
-            "very_low_soc": 5,
-            "charge_from_grid": false,
-            "date": "1714749724"
-          },
-          "single_rate": {
-            "rate": 0.0,
-            "sell": 0.0
-          },
-          "seasons": [
-            {
-              "id": "all_year_long",
-              "start": "1/1",
-              "days": [
-                {
-                  "id": "all_days",
-                  "days": "Mon,Tue,Wed,Thu,Fri,Sat,Sun",
-                  "must_charge_start": 0,
-                  "must_charge_duration": 0,
-                  "must_charge_mode": "CP",
-                  "enable_discharge_to_grid": false,
-                  "periods": [
-                    {
-                      "id": "period_1",
-                      "start": 0,
-                      "rate": 0.0
-                    }
-                  ]
-                }
-              ],
-              "tiers": []
-            }
-          ],
-          "seasons_sell": []
-        },
-        "schedule": {
-          "source": "Tariff",
-          "date": "2024-05-03 15:28:15 UTC",
-          "version": "00.00.02",
-          "reserved_soc": 0.0,
-          "operation_mode_sub_type": "",
-          "very_low_soc": 5,
-          "charge_from_grid": false,
-          "battery_mode": "self-consumption",
-          "schedule": {
-            "Disable": [
-              {
-                "Sun": [
-                  {
-                    "start": 0,
-                    "duration": 1440,
-                    "setting": "ID"
-                  }
-                ]
-              },
-              {
-                "Mon": [
-                  {
-                    "start": 0,
-                    "duration": 1440,
-                    "setting": "ID"
-                  }
-                ]
-              },
-              {
-                "Tue": [
-                  {
-                    "start": 0,
-                    "duration": 1440,
-                    "setting": "ID"
-                  }
-                ]
-              },
-              {
-                "Wed": [
-                  {
-                    "start": 0,
-                    "duration": 1440,
-                    "setting": "ID"
-                  }
-                ]
-              },
-              {
-                "Thu": [
-                  {
-                    "start": 0,
-                    "duration": 1440,
-                    "setting": "ID"
-                  }
-                ]
-              },
-              {
-                "Fri": [
-                  {
-                    "start": 0,
-                    "duration": 1440,
-                    "setting": "ID"
-                  }
-                ]
-              },
-              {
-                "Sat": [
-                  {
-                    "start": 0,
-                    "duration": 1440,
-                    "setting": "ID"
-                  }
-                ]
-              }
-            ],
-            "tariff": [
-              {
-                "start": "1/1",
-                "end": "1/1",
-                "Sun": [
-                  {
-                    "start": 0,
-                    "duration": 1440,
-                    "setting": "ZN"
-                  }
-                ],
-                "Mon": [
-                  {
-                    "start": 0,
-                    "duration": 1440,
-                    "setting": "ZN"
-                  }
-                ],
-                "Tue": [
-                  {
-                    "start": 0,
-                    "duration": 1440,
-                    "setting": "ZN"
-                  }
-                ],
-                "Wed": [
-                  {
-                    "start": 0,
-                    "duration": 1440,
-                    "setting": "ZN"
-                  }
-                ],
-                "Thu": [
-                  {
-                    "start": 0,
-                    "duration": 1440,
-                    "setting": "ZN"
-                  }
-                ],
-                "Fri": [
-                  {
-                    "start": 0,
-                    "duration": 1440,
-                    "setting": "ZN"
-                  }
-                ],
-                "Sat": [
-                  {
-                    "start": 0,
-                    "duration": 1440,
-                    "setting": "ZN"
-                  }
-                ]
-              }
-            ]
-          },
-          "override": false,
-          "override_backup_soc": 30.0,
-          "override_chg_dischg_rate": 0.0,
-          "override_tou_mode": "StorageTouMode_DEFAULT_TOU_MODE"
-        }
-      }
+      "varies_by": "firmware_version"
     }
   }
 }

--- a/tests/components/enphase_envoy/snapshots/test_binary_sensor.ambr
+++ b/tests/components/enphase_envoy/snapshots/test_binary_sensor.ambr
@@ -1,4 +1,97 @@
 # serializer version: 1
+# name: test_binary_sensor[envoy_eu_batt][binary_sensor.encharge_122327081322_communicating-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.encharge_122327081322_communicating',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': 'Communicating',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'communicating',
+    'unique_id': '122327081322_communicating',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensor[envoy_eu_batt][binary_sensor.encharge_122327081322_communicating-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'connectivity',
+      'friendly_name': 'Encharge 122327081322 Communicating',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.encharge_122327081322_communicating',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_binary_sensor[envoy_eu_batt][binary_sensor.encharge_122327081322_dc_switch-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.encharge_122327081322_dc_switch',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'DC switch',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'dc_switch',
+    'unique_id': '122327081322_dc_switch',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensor[envoy_eu_batt][binary_sensor.encharge_122327081322_dc_switch-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Encharge 122327081322 DC switch',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.encharge_122327081322_dc_switch',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_binary_sensor[envoy_metered_batt_relay][binary_sensor.encharge_123456_communicating-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/enphase_envoy/snapshots/test_binary_sensor.ambr
+++ b/tests/components/enphase_envoy/snapshots/test_binary_sensor.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_binary_sensor[envoy_eu_batt][binary_sensor.encharge_122327081322_communicating-entry]
+# name: test_binary_sensor[envoy_eu_batt][binary_sensor.encharge_123456_communicating-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -11,7 +11,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.encharge_122327081322_communicating',
+    'entity_id': 'binary_sensor.encharge_123456_communicating',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -28,25 +28,25 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'communicating',
-    'unique_id': '122327081322_communicating',
+    'unique_id': '123456_communicating',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_binary_sensor[envoy_eu_batt][binary_sensor.encharge_122327081322_communicating-state]
+# name: test_binary_sensor[envoy_eu_batt][binary_sensor.encharge_123456_communicating-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'connectivity',
-      'friendly_name': 'Encharge 122327081322 Communicating',
+      'friendly_name': 'Encharge 123456 Communicating',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.encharge_122327081322_communicating',
+    'entity_id': 'binary_sensor.encharge_123456_communicating',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_binary_sensor[envoy_eu_batt][binary_sensor.encharge_122327081322_dc_switch-entry]
+# name: test_binary_sensor[envoy_eu_batt][binary_sensor.encharge_123456_dc_switch-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -58,7 +58,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.encharge_122327081322_dc_switch',
+    'entity_id': 'binary_sensor.encharge_123456_dc_switch',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -75,17 +75,17 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'dc_switch',
-    'unique_id': '122327081322_dc_switch',
+    'unique_id': '123456_dc_switch',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_binary_sensor[envoy_eu_batt][binary_sensor.encharge_122327081322_dc_switch-state]
+# name: test_binary_sensor[envoy_eu_batt][binary_sensor.encharge_123456_dc_switch-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Encharge 122327081322 DC switch',
+      'friendly_name': 'Encharge 123456 DC switch',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.encharge_122327081322_dc_switch',
+    'entity_id': 'binary_sensor.encharge_123456_dc_switch',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/enphase_envoy/snapshots/test_number.ambr
+++ b/tests/components/enphase_envoy/snapshots/test_number.ambr
@@ -1,4 +1,61 @@
 # serializer version: 1
+# name: test_number[envoy_eu_batt][number.envoy_1234_reserve_battery_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 100.0,
+      'min': 0.0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': None,
+    'entity_id': 'number.envoy_1234_reserve_battery_level',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <NumberDeviceClass.BATTERY: 'battery'>,
+    'original_icon': None,
+    'original_name': 'Reserve battery level',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'reserve_soc',
+    'unique_id': '1234_reserve_soc',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_number[envoy_eu_batt][number.envoy_1234_reserve_battery_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'Envoy 1234 Reserve battery level',
+      'max': 100.0,
+      'min': 0.0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1.0,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.envoy_1234_reserve_battery_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
 # name: test_number[envoy_metered_batt_relay][number.enpower_654321_reserve_battery_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/enphase_envoy/snapshots/test_select.ambr
+++ b/tests/components/enphase_envoy/snapshots/test_select.ambr
@@ -1,4 +1,61 @@
 # serializer version: 1
+# name: test_select[envoy_eu_batt][select.envoy_1234_storage_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'backup',
+        'self_consumption',
+        'savings',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.envoy_1234_storage_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Storage mode',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'storage_mode',
+    'unique_id': '1234_storage_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_select[envoy_eu_batt][select.envoy_1234_storage_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Envoy 1234 Storage mode',
+      'options': list([
+        'backup',
+        'self_consumption',
+        'savings',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.envoy_1234_storage_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'self_consumption',
+  })
+# ---
 # name: test_select[envoy_metered_batt_relay][select.enpower_654321_storage_mode-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/enphase_envoy/snapshots/test_sensor.ambr
+++ b/tests/components/enphase_envoy/snapshots/test_sensor.ambr
@@ -1838,7 +1838,7 @@
     'state': '1970-01-01T00:00:01+00:00',
   })
 # ---
-# name: test_sensor[envoy_eu_batt][sensor.encharge_122327081322_apparent_power-entry]
+# name: test_sensor[envoy_eu_batt][sensor.encharge_123456_apparent_power-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1850,7 +1850,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.encharge_122327081322_apparent_power',
+    'entity_id': 'sensor.encharge_123456_apparent_power',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1867,26 +1867,26 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': '122327081322_apparent_power_mva',
+    'unique_id': '123456_apparent_power_mva',
     'unit_of_measurement': <UnitOfApparentPower.VOLT_AMPERE: 'VA'>,
   })
 # ---
-# name: test_sensor[envoy_eu_batt][sensor.encharge_122327081322_apparent_power-state]
+# name: test_sensor[envoy_eu_batt][sensor.encharge_123456_apparent_power-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'apparent_power',
-      'friendly_name': 'Encharge 122327081322 Apparent power',
+      'friendly_name': 'Encharge 123456 Apparent power',
       'unit_of_measurement': <UnitOfApparentPower.VOLT_AMPERE: 'VA'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.encharge_122327081322_apparent_power',
+    'entity_id': 'sensor.encharge_123456_apparent_power',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0.0',
   })
 # ---
-# name: test_sensor[envoy_eu_batt][sensor.encharge_122327081322_battery-entry]
+# name: test_sensor[envoy_eu_batt][sensor.encharge_123456_battery-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1898,7 +1898,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.encharge_122327081322_battery',
+    'entity_id': 'sensor.encharge_123456_battery',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1915,26 +1915,26 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': '122327081322_soc',
+    'unique_id': '123456_soc',
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensor[envoy_eu_batt][sensor.encharge_122327081322_battery-state]
+# name: test_sensor[envoy_eu_batt][sensor.encharge_123456_battery-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'battery',
-      'friendly_name': 'Encharge 122327081322 Battery',
+      'friendly_name': 'Encharge 123456 Battery',
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.encharge_122327081322_battery',
+    'entity_id': 'sensor.encharge_123456_battery',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '4',
   })
 # ---
-# name: test_sensor[envoy_eu_batt][sensor.encharge_122327081322_last_reported-entry]
+# name: test_sensor[envoy_eu_batt][sensor.encharge_123456_last_reported-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1946,7 +1946,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.encharge_122327081322_last_reported',
+    'entity_id': 'sensor.encharge_123456_last_reported',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1963,25 +1963,25 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'last_reported',
-    'unique_id': '122327081322_last_reported',
+    'unique_id': '123456_last_reported',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor[envoy_eu_batt][sensor.encharge_122327081322_last_reported-state]
+# name: test_sensor[envoy_eu_batt][sensor.encharge_123456_last_reported-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'timestamp',
-      'friendly_name': 'Encharge 122327081322 Last reported',
+      'friendly_name': 'Encharge 123456 Last reported',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.encharge_122327081322_last_reported',
+    'entity_id': 'sensor.encharge_123456_last_reported',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2024-05-04T06:29:33+00:00',
   })
 # ---
-# name: test_sensor[envoy_eu_batt][sensor.encharge_122327081322_power-entry]
+# name: test_sensor[envoy_eu_batt][sensor.encharge_123456_power-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1993,7 +1993,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.encharge_122327081322_power',
+    'entity_id': 'sensor.encharge_123456_power',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2010,26 +2010,26 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': '122327081322_real_power_mw',
+    'unique_id': '123456_real_power_mw',
     'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
   })
 # ---
-# name: test_sensor[envoy_eu_batt][sensor.encharge_122327081322_power-state]
+# name: test_sensor[envoy_eu_batt][sensor.encharge_123456_power-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'power',
-      'friendly_name': 'Encharge 122327081322 Power',
+      'friendly_name': 'Encharge 123456 Power',
       'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.encharge_122327081322_power',
+    'entity_id': 'sensor.encharge_123456_power',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0.0',
   })
 # ---
-# name: test_sensor[envoy_eu_batt][sensor.encharge_122327081322_temperature-entry]
+# name: test_sensor[envoy_eu_batt][sensor.encharge_123456_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -2041,7 +2041,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.encharge_122327081322_temperature',
+    'entity_id': 'sensor.encharge_123456_temperature',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2058,19 +2058,19 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': '122327081322_temperature',
+    'unique_id': '123456_temperature',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_sensor[envoy_eu_batt][sensor.encharge_122327081322_temperature-state]
+# name: test_sensor[envoy_eu_batt][sensor.encharge_123456_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
-      'friendly_name': 'Encharge 122327081322 Temperature',
+      'friendly_name': 'Encharge 123456 Temperature',
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.encharge_122327081322_temperature',
+    'entity_id': 'sensor.encharge_123456_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -2181,7 +2181,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.148',
+    'state': '2.341',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_battery-entry]
@@ -2337,7 +2337,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.148',
+    'state': '0.101',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_current_net_power_consumption_l1-entry]
@@ -2395,7 +2395,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.186',
+    'state': '0.021',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_current_net_power_consumption_l2-entry]
@@ -2453,7 +2453,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '-0.017',
+    'state': '0.031',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_current_net_power_consumption_l3-entry]
@@ -2511,7 +2511,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '-0.021',
+    'state': '0.051',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_current_power_consumption-entry]
@@ -2569,7 +2569,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.267',
+    'state': '1.234',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_current_power_production-entry]
@@ -2627,7 +2627,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.119',
+    'state': '1.234',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_energy_consumption_last_seven_days-entry]
@@ -2682,7 +2682,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '60.488',
+    'state': '1.234',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_energy_consumption_today-entry]
@@ -2740,7 +2740,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '11.22',
+    'state': '1.234',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_energy_production_last_seven_days-entry]
@@ -2795,7 +2795,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '70.188',
+    'state': '1.234',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_energy_production_today-entry]
@@ -2853,7 +2853,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.105',
+    'state': '1.234',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_frequency_net_consumption_ct-entry]
@@ -2908,7 +2908,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '50.0',
+    'state': '50.2',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_frequency_net_consumption_ct_l1-entry]
@@ -2963,7 +2963,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '50.0',
+    'state': '50.2',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_frequency_net_consumption_ct_l2-entry]
@@ -3018,7 +3018,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '50.0',
+    'state': '50.2',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_frequency_net_consumption_ct_l3-entry]
@@ -3073,7 +3073,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '50.0',
+    'state': '50.2',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_frequency_production_ct-entry]
@@ -3128,7 +3128,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '50.0',
+    'state': '50.1',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_frequency_production_ct_l1-entry]
@@ -3183,7 +3183,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '50.0',
+    'state': '50.1',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_frequency_production_ct_l2-entry]
@@ -3238,7 +3238,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '50.0',
+    'state': '50.1',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_frequency_production_ct_l3-entry]
@@ -3293,7 +3293,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '50.0',
+    'state': '50.1',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_balanced_net_energy_consumption-entry]
@@ -3351,7 +3351,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '7967.021',
+    'state': '4.321',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_energy_consumption-entry]
@@ -3409,7 +3409,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '11.230297',
+    'state': '0.001234',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_energy_production-entry]
@@ -3467,7 +3467,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '3.264161',
+    'state': '0.001234',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_net_energy_consumption-entry]
@@ -3525,7 +3525,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '9.671362',
+    'state': '0.021234',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_net_energy_consumption_l1-entry]
@@ -3583,7 +3583,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '3.066805',
+    'state': '0.212341',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_net_energy_consumption_l2-entry]
@@ -3641,7 +3641,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '2.426811',
+    'state': '0.212342',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_net_energy_consumption_l3-entry]
@@ -3699,7 +3699,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '4.177747',
+    'state': '0.212343',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_net_energy_production-entry]
@@ -3757,7 +3757,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '1.704783',
+    'state': '0.022345',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_net_energy_production_l1-entry]
@@ -3815,7 +3815,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.309331',
+    'state': '0.223451',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_net_energy_production_l2-entry]
@@ -3873,7 +3873,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.678824',
+    'state': '0.223452',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_net_energy_production_l3-entry]
@@ -3931,7 +3931,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.716628',
+    'state': '0.223453',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_meter_status_flags_active_net_consumption_ct-entry]
@@ -4166,7 +4166,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0',
+    'state': '2',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_meter_status_flags_active_production_ct_l1-entry]
@@ -4213,7 +4213,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0',
+    'state': '1',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_meter_status_flags_active_production_ct_l2-entry]
@@ -4260,7 +4260,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0',
+    'state': '1',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_meter_status_flags_active_production_ct_l3-entry]
@@ -4837,7 +4837,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '1.918',
+    'state': '0.3',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_net_consumption_ct_current_l1-entry]
@@ -4895,7 +4895,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '1.566',
+    'state': '0.3',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_net_consumption_ct_current_l2-entry]
@@ -4953,7 +4953,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.194',
+    'state': '0.3',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_net_consumption_ct_current_l3-entry]
@@ -5011,7 +5011,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.159',
+    'state': '0.3',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_powerfactor_net_consumption_ct-entry]
@@ -5065,7 +5065,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.318',
+    'state': '0.21',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_powerfactor_net_consumption_ct_l1-entry]
@@ -5119,7 +5119,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.493',
+    'state': '0.22',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_powerfactor_net_consumption_ct_l2-entry]
@@ -5173,7 +5173,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '-0.375',
+    'state': '0.23',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_powerfactor_net_consumption_ct_l3-entry]
@@ -5227,7 +5227,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '-0.571',
+    'state': '0.24',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_powerfactor_production_ct-entry]
@@ -5281,7 +5281,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.666',
+    'state': '0.11',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_powerfactor_production_ct_l1-entry]
@@ -5335,7 +5335,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.636',
+    'state': '0.12',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_powerfactor_production_ct_l2-entry]
@@ -5389,7 +5389,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.615',
+    'state': '0.13',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_powerfactor_production_ct_l3-entry]
@@ -5443,7 +5443,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.778',
+    'state': '0.14',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_production_ct_current-entry]
@@ -5501,7 +5501,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.727',
+    'state': '0.2',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_production_ct_current_l1-entry]
@@ -5559,7 +5559,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.238',
+    'state': '0.2',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_production_ct_current_l2-entry]
@@ -5617,7 +5617,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.3',
+    'state': '0.2',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_production_ct_current_l3-entry]
@@ -5675,7 +5675,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.189',
+    'state': '0.2',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_reserve_battery_energy-entry]
@@ -5831,7 +5831,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '717.603',
+    'state': '112',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_voltage_net_consumption_ct_l1-entry]
@@ -5889,7 +5889,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '240.294',
+    'state': '112',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_voltage_net_consumption_ct_l2-entry]
@@ -5947,7 +5947,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '239.513',
+    'state': '112',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_voltage_net_consumption_ct_l3-entry]
@@ -6005,7 +6005,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '237.796',
+    'state': '112',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_voltage_production_ct-entry]
@@ -6063,7 +6063,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '717.827',
+    'state': '111',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_voltage_production_ct_l1-entry]
@@ -6121,7 +6121,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '240.455',
+    'state': '111',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_voltage_production_ct_l2-entry]
@@ -6179,7 +6179,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '239.646',
+    'state': '111',
   })
 # ---
 # name: test_sensor[envoy_eu_batt][sensor.envoy_1234_voltage_production_ct_l3-entry]
@@ -6237,10 +6237,10 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '237.725',
+    'state': '111',
   })
 # ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312082644-entry]
+# name: test_sensor[envoy_eu_batt][sensor.inverter_1-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -6254,7 +6254,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.inverter_482312082644',
+    'entity_id': 'sensor.inverter_1',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -6271,28 +6271,28 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': '482312082644',
+    'unique_id': '1',
     'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
   })
 # ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312082644-state]
+# name: test_sensor[envoy_eu_batt][sensor.inverter_1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'power',
-      'friendly_name': 'Inverter 482312082644',
+      'friendly_name': 'Inverter 1',
       'icon': 'mdi:flash',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.inverter_482312082644',
+    'entity_id': 'sensor.inverter_1',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '13',
+    'state': '1',
   })
 # ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312082644_last_reported-entry]
+# name: test_sensor[envoy_eu_batt][sensor.inverter_1_last_reported-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -6304,7 +6304,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.inverter_482312082644_last_reported',
+    'entity_id': 'sensor.inverter_1_last_reported',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -6321,823 +6321,23 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'last_reported',
-    'unique_id': '482312082644_last_reported',
+    'unique_id': '1_last_reported',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312082644_last_reported-state]
+# name: test_sensor[envoy_eu_batt][sensor.inverter_1_last_reported-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'timestamp',
-      'friendly_name': 'Inverter 482312082644 Last reported',
+      'friendly_name': 'Inverter 1 Last reported',
       'icon': 'mdi:flash',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.inverter_482312082644_last_reported',
+    'entity_id': 'sensor.inverter_1_last_reported',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '2024-05-04T06:19:45+00:00',
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312083708-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.inverter_482312083708',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
-    'original_icon': 'mdi:flash',
-    'original_name': None,
-    'platform': 'enphase_envoy',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': '482312083708',
-    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312083708-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'Inverter 482312083708',
-      'icon': 'mdi:flash',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.inverter_482312083708',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '14',
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312083708_last_reported-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.inverter_482312083708_last_reported',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
-    'original_icon': 'mdi:flash',
-    'original_name': 'Last reported',
-    'platform': 'enphase_envoy',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': 'last_reported',
-    'unique_id': '482312083708_last_reported',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312083708_last_reported-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'Inverter 482312083708 Last reported',
-      'icon': 'mdi:flash',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.inverter_482312083708_last_reported',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2024-05-04T06:17:45+00:00',
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312083761-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.inverter_482312083761',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
-    'original_icon': 'mdi:flash',
-    'original_name': None,
-    'platform': 'enphase_envoy',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': '482312083761',
-    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312083761-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'Inverter 482312083761',
-      'icon': 'mdi:flash',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.inverter_482312083761',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '11',
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312083761_last_reported-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.inverter_482312083761_last_reported',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
-    'original_icon': 'mdi:flash',
-    'original_name': 'Last reported',
-    'platform': 'enphase_envoy',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': 'last_reported',
-    'unique_id': '482312083761_last_reported',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312083761_last_reported-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'Inverter 482312083761 Last reported',
-      'icon': 'mdi:flash',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.inverter_482312083761_last_reported',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2024-05-04T06:30:46+00:00',
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312084298-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.inverter_482312084298',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
-    'original_icon': 'mdi:flash',
-    'original_name': None,
-    'platform': 'enphase_envoy',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': '482312084298',
-    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312084298-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'Inverter 482312084298',
-      'icon': 'mdi:flash',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.inverter_482312084298',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '11',
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312084298_last_reported-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.inverter_482312084298_last_reported',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
-    'original_icon': 'mdi:flash',
-    'original_name': 'Last reported',
-    'platform': 'enphase_envoy',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': 'last_reported',
-    'unique_id': '482312084298_last_reported',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312084298_last_reported-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'Inverter 482312084298 Last reported',
-      'icon': 'mdi:flash',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.inverter_482312084298_last_reported',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2024-05-04T06:29:47+00:00',
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312084840-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.inverter_482312084840',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
-    'original_icon': 'mdi:flash',
-    'original_name': None,
-    'platform': 'enphase_envoy',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': '482312084840',
-    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312084840-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'Inverter 482312084840',
-      'icon': 'mdi:flash',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.inverter_482312084840',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '9',
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312084840_last_reported-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.inverter_482312084840_last_reported',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
-    'original_icon': 'mdi:flash',
-    'original_name': 'Last reported',
-    'platform': 'enphase_envoy',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': 'last_reported',
-    'unique_id': '482312084840_last_reported',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312084840_last_reported-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'Inverter 482312084840 Last reported',
-      'icon': 'mdi:flash',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.inverter_482312084840_last_reported',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2024-05-04T06:26:16+00:00',
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312086604-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.inverter_482312086604',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
-    'original_icon': 'mdi:flash',
-    'original_name': None,
-    'platform': 'enphase_envoy',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': '482312086604',
-    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312086604-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'Inverter 482312086604',
-      'icon': 'mdi:flash',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.inverter_482312086604',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '14',
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312086604_last_reported-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.inverter_482312086604_last_reported',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
-    'original_icon': 'mdi:flash',
-    'original_name': 'Last reported',
-    'platform': 'enphase_envoy',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': 'last_reported',
-    'unique_id': '482312086604_last_reported',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312086604_last_reported-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'Inverter 482312086604 Last reported',
-      'icon': 'mdi:flash',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.inverter_482312086604_last_reported',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2024-05-04T06:18:15+00:00',
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312087072-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.inverter_482312087072',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
-    'original_icon': 'mdi:flash',
-    'original_name': None,
-    'platform': 'enphase_envoy',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': '482312087072',
-    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312087072-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'Inverter 482312087072',
-      'icon': 'mdi:flash',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.inverter_482312087072',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '13',
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312087072_last_reported-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.inverter_482312087072_last_reported',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
-    'original_icon': 'mdi:flash',
-    'original_name': 'Last reported',
-    'platform': 'enphase_envoy',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': 'last_reported',
-    'unique_id': '482312087072_last_reported',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312087072_last_reported-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'Inverter 482312087072 Last reported',
-      'icon': 'mdi:flash',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.inverter_482312087072_last_reported',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2024-05-04T06:17:15+00:00',
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312087202-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.inverter_482312087202',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
-    'original_icon': 'mdi:flash',
-    'original_name': None,
-    'platform': 'enphase_envoy',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': '482312087202',
-    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312087202-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'Inverter 482312087202',
-      'icon': 'mdi:flash',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.inverter_482312087202',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '12',
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312087202_last_reported-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.inverter_482312087202_last_reported',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
-    'original_icon': 'mdi:flash',
-    'original_name': 'Last reported',
-    'platform': 'enphase_envoy',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': 'last_reported',
-    'unique_id': '482312087202_last_reported',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312087202_last_reported-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'Inverter 482312087202 Last reported',
-      'icon': 'mdi:flash',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.inverter_482312087202_last_reported',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2024-05-04T06:29:46+00:00',
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312087222-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.inverter_482312087222',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
-    'original_icon': 'mdi:flash',
-    'original_name': None,
-    'platform': 'enphase_envoy',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': '482312087222',
-    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312087222-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'Inverter 482312087222',
-      'icon': 'mdi:flash',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.inverter_482312087222',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '13',
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312087222_last_reported-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.inverter_482312087222_last_reported',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
-    'original_icon': 'mdi:flash',
-    'original_name': 'Last reported',
-    'platform': 'enphase_envoy',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': 'last_reported',
-    'unique_id': '482312087222_last_reported',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensor[envoy_eu_batt][sensor.inverter_482312087222_last_reported-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'Inverter 482312087222 Last reported',
-      'icon': 'mdi:flash',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.inverter_482312087222_last_reported',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2024-05-04T06:16:44+00:00',
+    'state': '1970-01-01T00:00:01+00:00',
   })
 # ---
 # name: test_sensor[envoy_metered_batt_relay][sensor.encharge_123456_apparent_power-entry]

--- a/tests/components/enphase_envoy/snapshots/test_sensor.ambr
+++ b/tests/components/enphase_envoy/snapshots/test_sensor.ambr
@@ -1838,6 +1838,5308 @@
     'state': '1970-01-01T00:00:01+00:00',
   })
 # ---
+# name: test_sensor[envoy_eu_batt][sensor.encharge_122327081322_apparent_power-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.encharge_122327081322_apparent_power',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.APPARENT_POWER: 'apparent_power'>,
+    'original_icon': None,
+    'original_name': 'Apparent power',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '122327081322_apparent_power_mva',
+    'unit_of_measurement': <UnitOfApparentPower.VOLT_AMPERE: 'VA'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.encharge_122327081322_apparent_power-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'apparent_power',
+      'friendly_name': 'Encharge 122327081322 Apparent power',
+      'unit_of_measurement': <UnitOfApparentPower.VOLT_AMPERE: 'VA'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.encharge_122327081322_apparent_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.encharge_122327081322_battery-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.encharge_122327081322_battery',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+    'original_icon': None,
+    'original_name': 'Battery',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '122327081322_soc',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.encharge_122327081322_battery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'Encharge 122327081322 Battery',
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.encharge_122327081322_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '4',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.encharge_122327081322_last_reported-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.encharge_122327081322_last_reported',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Last reported',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'last_reported',
+    'unique_id': '122327081322_last_reported',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.encharge_122327081322_last_reported-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Encharge 122327081322 Last reported',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.encharge_122327081322_last_reported',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-05-04T06:29:33+00:00',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.encharge_122327081322_power-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.encharge_122327081322_power',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Power',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '122327081322_real_power_mw',
+    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.encharge_122327081322_power-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Encharge 122327081322 Power',
+      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.encharge_122327081322_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.encharge_122327081322_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.encharge_122327081322_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Temperature',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '122327081322_temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.encharge_122327081322_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'Encharge 122327081322 Temperature',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.encharge_122327081322_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '16',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_available_battery_energy-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_available_battery_energy',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Available battery energy',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'available_energy',
+    'unique_id': '1234_available_energy',
+    'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_available_battery_energy-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Envoy 1234 Available battery energy',
+      'icon': 'mdi:flash',
+      'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_available_battery_energy',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '140',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_balanced_net_power_consumption-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_balanced_net_power_consumption',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'balanced net power consumption',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'balanced_net_consumption',
+    'unique_id': '1234_balanced_net_consumption',
+    'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_balanced_net_power_consumption-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Envoy 1234 balanced net power consumption',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_balanced_net_power_consumption',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.148',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_battery-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_battery',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Battery',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1234_battery_level',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_battery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'Envoy 1234 Battery',
+      'icon': 'mdi:flash',
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '4',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_battery_capacity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_battery_capacity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Battery capacity',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'max_capacity',
+    'unique_id': '1234_max_capacity',
+    'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_battery_capacity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Envoy 1234 Battery capacity',
+      'icon': 'mdi:flash',
+      'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '3500',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_current_net_power_consumption-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_current_net_power_consumption',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Current net power consumption',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'net_consumption',
+    'unique_id': '1234_net_consumption',
+    'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_current_net_power_consumption-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Envoy 1234 Current net power consumption',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_current_net_power_consumption',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.148',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_current_net_power_consumption_l1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_current_net_power_consumption_l1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Current net power consumption l1',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'net_consumption_phase',
+    'unique_id': '1234_net_consumption_l1',
+    'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_current_net_power_consumption_l1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Envoy 1234 Current net power consumption l1',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_current_net_power_consumption_l1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.186',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_current_net_power_consumption_l2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_current_net_power_consumption_l2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Current net power consumption l2',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'net_consumption_phase',
+    'unique_id': '1234_net_consumption_l2',
+    'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_current_net_power_consumption_l2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Envoy 1234 Current net power consumption l2',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_current_net_power_consumption_l2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-0.017',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_current_net_power_consumption_l3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_current_net_power_consumption_l3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Current net power consumption l3',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'net_consumption_phase',
+    'unique_id': '1234_net_consumption_l3',
+    'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_current_net_power_consumption_l3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Envoy 1234 Current net power consumption l3',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_current_net_power_consumption_l3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-0.021',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_current_power_consumption-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_current_power_consumption',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Current power consumption',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'current_power_consumption',
+    'unique_id': '1234_consumption',
+    'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_current_power_consumption-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Envoy 1234 Current power consumption',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_current_power_consumption',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.267',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_current_power_production-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_current_power_production',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Current power production',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'current_power_production',
+    'unique_id': '1234_production',
+    'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_current_power_production-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Envoy 1234 Current power production',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_current_power_production',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.119',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_energy_consumption_last_seven_days-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_energy_consumption_last_seven_days',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Energy consumption last seven days',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'seven_days_consumption',
+    'unique_id': '1234_seven_days_consumption',
+    'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_energy_consumption_last_seven_days-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Envoy 1234 Energy consumption last seven days',
+      'icon': 'mdi:flash',
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_energy_consumption_last_seven_days',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '60.488',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_energy_consumption_today-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_energy_consumption_today',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Energy consumption today',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'daily_consumption',
+    'unique_id': '1234_daily_consumption',
+    'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_energy_consumption_today-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Envoy 1234 Energy consumption today',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_energy_consumption_today',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '11.22',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_energy_production_last_seven_days-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_energy_production_last_seven_days',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Energy production last seven days',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'seven_days_production',
+    'unique_id': '1234_seven_days_production',
+    'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_energy_production_last_seven_days-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Envoy 1234 Energy production last seven days',
+      'icon': 'mdi:flash',
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_energy_production_last_seven_days',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '70.188',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_energy_production_today-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_energy_production_today',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Energy production today',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'daily_production',
+    'unique_id': '1234_daily_production',
+    'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_energy_production_today-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Envoy 1234 Energy production today',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_energy_production_today',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.105',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_frequency_net_consumption_ct-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_frequency_net_consumption_ct',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.FREQUENCY: 'frequency'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Frequency net consumption CT',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'net_ct_frequency',
+    'unique_id': '1234_frequency',
+    'unit_of_measurement': <UnitOfFrequency.HERTZ: 'Hz'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_frequency_net_consumption_ct-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'frequency',
+      'friendly_name': 'Envoy 1234 Frequency net consumption CT',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfFrequency.HERTZ: 'Hz'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_frequency_net_consumption_ct',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '50.0',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_frequency_net_consumption_ct_l1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_frequency_net_consumption_ct_l1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.FREQUENCY: 'frequency'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Frequency net consumption CT l1',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'net_ct_frequency_phase',
+    'unique_id': '1234_frequency_l1',
+    'unit_of_measurement': <UnitOfFrequency.HERTZ: 'Hz'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_frequency_net_consumption_ct_l1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'frequency',
+      'friendly_name': 'Envoy 1234 Frequency net consumption CT l1',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfFrequency.HERTZ: 'Hz'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_frequency_net_consumption_ct_l1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '50.0',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_frequency_net_consumption_ct_l2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_frequency_net_consumption_ct_l2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.FREQUENCY: 'frequency'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Frequency net consumption CT l2',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'net_ct_frequency_phase',
+    'unique_id': '1234_frequency_l2',
+    'unit_of_measurement': <UnitOfFrequency.HERTZ: 'Hz'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_frequency_net_consumption_ct_l2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'frequency',
+      'friendly_name': 'Envoy 1234 Frequency net consumption CT l2',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfFrequency.HERTZ: 'Hz'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_frequency_net_consumption_ct_l2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '50.0',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_frequency_net_consumption_ct_l3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_frequency_net_consumption_ct_l3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.FREQUENCY: 'frequency'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Frequency net consumption CT l3',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'net_ct_frequency_phase',
+    'unique_id': '1234_frequency_l3',
+    'unit_of_measurement': <UnitOfFrequency.HERTZ: 'Hz'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_frequency_net_consumption_ct_l3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'frequency',
+      'friendly_name': 'Envoy 1234 Frequency net consumption CT l3',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfFrequency.HERTZ: 'Hz'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_frequency_net_consumption_ct_l3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '50.0',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_frequency_production_ct-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_frequency_production_ct',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.FREQUENCY: 'frequency'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Frequency production CT',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'production_ct_frequency',
+    'unique_id': '1234_production_ct_frequency',
+    'unit_of_measurement': <UnitOfFrequency.HERTZ: 'Hz'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_frequency_production_ct-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'frequency',
+      'friendly_name': 'Envoy 1234 Frequency production CT',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfFrequency.HERTZ: 'Hz'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_frequency_production_ct',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '50.0',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_frequency_production_ct_l1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_frequency_production_ct_l1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.FREQUENCY: 'frequency'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Frequency production CT l1',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'production_ct_frequency_phase',
+    'unique_id': '1234_production_ct_frequency_l1',
+    'unit_of_measurement': <UnitOfFrequency.HERTZ: 'Hz'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_frequency_production_ct_l1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'frequency',
+      'friendly_name': 'Envoy 1234 Frequency production CT l1',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfFrequency.HERTZ: 'Hz'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_frequency_production_ct_l1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '50.0',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_frequency_production_ct_l2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_frequency_production_ct_l2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.FREQUENCY: 'frequency'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Frequency production CT l2',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'production_ct_frequency_phase',
+    'unique_id': '1234_production_ct_frequency_l2',
+    'unit_of_measurement': <UnitOfFrequency.HERTZ: 'Hz'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_frequency_production_ct_l2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'frequency',
+      'friendly_name': 'Envoy 1234 Frequency production CT l2',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfFrequency.HERTZ: 'Hz'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_frequency_production_ct_l2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '50.0',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_frequency_production_ct_l3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_frequency_production_ct_l3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.FREQUENCY: 'frequency'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Frequency production CT l3',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'production_ct_frequency_phase',
+    'unique_id': '1234_production_ct_frequency_l3',
+    'unit_of_measurement': <UnitOfFrequency.HERTZ: 'Hz'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_frequency_production_ct_l3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'frequency',
+      'friendly_name': 'Envoy 1234 Frequency production CT l3',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfFrequency.HERTZ: 'Hz'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_frequency_production_ct_l3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '50.0',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_balanced_net_energy_consumption-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL: 'total'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_lifetime_balanced_net_energy_consumption',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Lifetime balanced net energy consumption',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'lifetime_balanced_net_consumption',
+    'unique_id': '1234_lifetime_balanced_net_consumption',
+    'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_balanced_net_energy_consumption-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Envoy 1234 Lifetime balanced net energy consumption',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.TOTAL: 'total'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_lifetime_balanced_net_energy_consumption',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '7967.021',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_energy_consumption-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_lifetime_energy_consumption',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Lifetime energy consumption',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'lifetime_consumption',
+    'unique_id': '1234_lifetime_consumption',
+    'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_energy_consumption-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Envoy 1234 Lifetime energy consumption',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_lifetime_energy_consumption',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '11.230297',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_energy_production-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_lifetime_energy_production',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Lifetime energy production',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'lifetime_production',
+    'unique_id': '1234_lifetime_production',
+    'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_energy_production-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Envoy 1234 Lifetime energy production',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_lifetime_energy_production',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '3.264161',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_net_energy_consumption-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_lifetime_net_energy_consumption',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Lifetime net energy consumption',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'lifetime_net_consumption',
+    'unique_id': '1234_lifetime_net_consumption',
+    'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_net_energy_consumption-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Envoy 1234 Lifetime net energy consumption',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_lifetime_net_energy_consumption',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '9.671362',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_net_energy_consumption_l1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_lifetime_net_energy_consumption_l1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Lifetime net energy consumption l1',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'lifetime_net_consumption_phase',
+    'unique_id': '1234_lifetime_net_consumption_l1',
+    'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_net_energy_consumption_l1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Envoy 1234 Lifetime net energy consumption l1',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_lifetime_net_energy_consumption_l1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '3.066805',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_net_energy_consumption_l2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_lifetime_net_energy_consumption_l2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Lifetime net energy consumption l2',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'lifetime_net_consumption_phase',
+    'unique_id': '1234_lifetime_net_consumption_l2',
+    'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_net_energy_consumption_l2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Envoy 1234 Lifetime net energy consumption l2',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_lifetime_net_energy_consumption_l2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2.426811',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_net_energy_consumption_l3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_lifetime_net_energy_consumption_l3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Lifetime net energy consumption l3',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'lifetime_net_consumption_phase',
+    'unique_id': '1234_lifetime_net_consumption_l3',
+    'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_net_energy_consumption_l3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Envoy 1234 Lifetime net energy consumption l3',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_lifetime_net_energy_consumption_l3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '4.177747',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_net_energy_production-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_lifetime_net_energy_production',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Lifetime net energy production',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'lifetime_net_production',
+    'unique_id': '1234_lifetime_net_production',
+    'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_net_energy_production-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Envoy 1234 Lifetime net energy production',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_lifetime_net_energy_production',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1.704783',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_net_energy_production_l1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_lifetime_net_energy_production_l1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Lifetime net energy production l1',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'lifetime_net_production_phase',
+    'unique_id': '1234_lifetime_net_production_l1',
+    'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_net_energy_production_l1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Envoy 1234 Lifetime net energy production l1',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_lifetime_net_energy_production_l1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.309331',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_net_energy_production_l2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_lifetime_net_energy_production_l2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Lifetime net energy production l2',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'lifetime_net_production_phase',
+    'unique_id': '1234_lifetime_net_production_l2',
+    'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_net_energy_production_l2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Envoy 1234 Lifetime net energy production l2',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_lifetime_net_energy_production_l2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.678824',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_net_energy_production_l3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_lifetime_net_energy_production_l3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Lifetime net energy production l3',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'lifetime_net_production_phase',
+    'unique_id': '1234_lifetime_net_production_l3',
+    'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_lifetime_net_energy_production_l3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Envoy 1234 Lifetime net energy production l3',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_lifetime_net_energy_production_l3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.716628',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_meter_status_flags_active_net_consumption_ct-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_meter_status_flags_active_net_consumption_ct',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Meter status flags active net consumption CT',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'net_ct_status_flags',
+    'unique_id': '1234_net_consumption_ct_status_flags',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_meter_status_flags_active_net_consumption_ct-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Envoy 1234 Meter status flags active net consumption CT',
+      'icon': 'mdi:flash',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_meter_status_flags_active_net_consumption_ct',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_meter_status_flags_active_net_consumption_ct_l1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_meter_status_flags_active_net_consumption_ct_l1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Meter status flags active net consumption CT l1',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'net_ct_status_flags_phase',
+    'unique_id': '1234_net_consumption_ct_status_flags_l1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_meter_status_flags_active_net_consumption_ct_l1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Envoy 1234 Meter status flags active net consumption CT l1',
+      'icon': 'mdi:flash',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_meter_status_flags_active_net_consumption_ct_l1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_meter_status_flags_active_net_consumption_ct_l2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_meter_status_flags_active_net_consumption_ct_l2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Meter status flags active net consumption CT l2',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'net_ct_status_flags_phase',
+    'unique_id': '1234_net_consumption_ct_status_flags_l2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_meter_status_flags_active_net_consumption_ct_l2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Envoy 1234 Meter status flags active net consumption CT l2',
+      'icon': 'mdi:flash',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_meter_status_flags_active_net_consumption_ct_l2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_meter_status_flags_active_net_consumption_ct_l3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_meter_status_flags_active_net_consumption_ct_l3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Meter status flags active net consumption CT l3',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'net_ct_status_flags_phase',
+    'unique_id': '1234_net_consumption_ct_status_flags_l3',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_meter_status_flags_active_net_consumption_ct_l3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Envoy 1234 Meter status flags active net consumption CT l3',
+      'icon': 'mdi:flash',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_meter_status_flags_active_net_consumption_ct_l3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_meter_status_flags_active_production_ct-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_meter_status_flags_active_production_ct',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Meter status flags active production CT',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'production_ct_status_flags',
+    'unique_id': '1234_production_ct_status_flags',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_meter_status_flags_active_production_ct-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Envoy 1234 Meter status flags active production CT',
+      'icon': 'mdi:flash',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_meter_status_flags_active_production_ct',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_meter_status_flags_active_production_ct_l1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_meter_status_flags_active_production_ct_l1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Meter status flags active production CT l1',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'production_ct_status_flags_phase',
+    'unique_id': '1234_production_ct_status_flags_l1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_meter_status_flags_active_production_ct_l1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Envoy 1234 Meter status flags active production CT l1',
+      'icon': 'mdi:flash',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_meter_status_flags_active_production_ct_l1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_meter_status_flags_active_production_ct_l2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_meter_status_flags_active_production_ct_l2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Meter status flags active production CT l2',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'production_ct_status_flags_phase',
+    'unique_id': '1234_production_ct_status_flags_l2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_meter_status_flags_active_production_ct_l2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Envoy 1234 Meter status flags active production CT l2',
+      'icon': 'mdi:flash',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_meter_status_flags_active_production_ct_l2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_meter_status_flags_active_production_ct_l3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_meter_status_flags_active_production_ct_l3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Meter status flags active production CT l3',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'production_ct_status_flags_phase',
+    'unique_id': '1234_production_ct_status_flags_l3',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_meter_status_flags_active_production_ct_l3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Envoy 1234 Meter status flags active production CT l3',
+      'icon': 'mdi:flash',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_meter_status_flags_active_production_ct_l3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_metering_status_net_consumption_ct-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        <CtMeterStatus.NORMAL: 'normal'>,
+        <CtMeterStatus.NOT_METERING: 'not-metering'>,
+        <CtMeterStatus.CHECK_WIRING: 'check-wiring'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_metering_status_net_consumption_ct',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Metering status net consumption CT',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'net_ct_metering_status',
+    'unique_id': '1234_net_consumption_ct_metering_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_metering_status_net_consumption_ct-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Envoy 1234 Metering status net consumption CT',
+      'icon': 'mdi:flash',
+      'options': list([
+        <CtMeterStatus.NORMAL: 'normal'>,
+        <CtMeterStatus.NOT_METERING: 'not-metering'>,
+        <CtMeterStatus.CHECK_WIRING: 'check-wiring'>,
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_metering_status_net_consumption_ct',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'normal',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_metering_status_net_consumption_ct_l1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        <CtMeterStatus.NORMAL: 'normal'>,
+        <CtMeterStatus.NOT_METERING: 'not-metering'>,
+        <CtMeterStatus.CHECK_WIRING: 'check-wiring'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_metering_status_net_consumption_ct_l1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Metering status net consumption CT l1',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'net_ct_metering_status_phase',
+    'unique_id': '1234_net_consumption_ct_metering_status_l1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_metering_status_net_consumption_ct_l1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Envoy 1234 Metering status net consumption CT l1',
+      'icon': 'mdi:flash',
+      'options': list([
+        <CtMeterStatus.NORMAL: 'normal'>,
+        <CtMeterStatus.NOT_METERING: 'not-metering'>,
+        <CtMeterStatus.CHECK_WIRING: 'check-wiring'>,
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_metering_status_net_consumption_ct_l1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'normal',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_metering_status_net_consumption_ct_l2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        <CtMeterStatus.NORMAL: 'normal'>,
+        <CtMeterStatus.NOT_METERING: 'not-metering'>,
+        <CtMeterStatus.CHECK_WIRING: 'check-wiring'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_metering_status_net_consumption_ct_l2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Metering status net consumption CT l2',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'net_ct_metering_status_phase',
+    'unique_id': '1234_net_consumption_ct_metering_status_l2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_metering_status_net_consumption_ct_l2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Envoy 1234 Metering status net consumption CT l2',
+      'icon': 'mdi:flash',
+      'options': list([
+        <CtMeterStatus.NORMAL: 'normal'>,
+        <CtMeterStatus.NOT_METERING: 'not-metering'>,
+        <CtMeterStatus.CHECK_WIRING: 'check-wiring'>,
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_metering_status_net_consumption_ct_l2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'normal',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_metering_status_net_consumption_ct_l3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        <CtMeterStatus.NORMAL: 'normal'>,
+        <CtMeterStatus.NOT_METERING: 'not-metering'>,
+        <CtMeterStatus.CHECK_WIRING: 'check-wiring'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_metering_status_net_consumption_ct_l3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Metering status net consumption CT l3',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'net_ct_metering_status_phase',
+    'unique_id': '1234_net_consumption_ct_metering_status_l3',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_metering_status_net_consumption_ct_l3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Envoy 1234 Metering status net consumption CT l3',
+      'icon': 'mdi:flash',
+      'options': list([
+        <CtMeterStatus.NORMAL: 'normal'>,
+        <CtMeterStatus.NOT_METERING: 'not-metering'>,
+        <CtMeterStatus.CHECK_WIRING: 'check-wiring'>,
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_metering_status_net_consumption_ct_l3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'normal',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_metering_status_production_ct-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        <CtMeterStatus.NORMAL: 'normal'>,
+        <CtMeterStatus.NOT_METERING: 'not-metering'>,
+        <CtMeterStatus.CHECK_WIRING: 'check-wiring'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_metering_status_production_ct',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Metering status production CT',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'production_ct_metering_status',
+    'unique_id': '1234_production_ct_metering_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_metering_status_production_ct-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Envoy 1234 Metering status production CT',
+      'icon': 'mdi:flash',
+      'options': list([
+        <CtMeterStatus.NORMAL: 'normal'>,
+        <CtMeterStatus.NOT_METERING: 'not-metering'>,
+        <CtMeterStatus.CHECK_WIRING: 'check-wiring'>,
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_metering_status_production_ct',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'normal',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_metering_status_production_ct_l1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        <CtMeterStatus.NORMAL: 'normal'>,
+        <CtMeterStatus.NOT_METERING: 'not-metering'>,
+        <CtMeterStatus.CHECK_WIRING: 'check-wiring'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_metering_status_production_ct_l1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Metering status production CT l1',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'production_ct_metering_status_phase',
+    'unique_id': '1234_production_ct_metering_status_l1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_metering_status_production_ct_l1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Envoy 1234 Metering status production CT l1',
+      'icon': 'mdi:flash',
+      'options': list([
+        <CtMeterStatus.NORMAL: 'normal'>,
+        <CtMeterStatus.NOT_METERING: 'not-metering'>,
+        <CtMeterStatus.CHECK_WIRING: 'check-wiring'>,
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_metering_status_production_ct_l1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'normal',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_metering_status_production_ct_l2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        <CtMeterStatus.NORMAL: 'normal'>,
+        <CtMeterStatus.NOT_METERING: 'not-metering'>,
+        <CtMeterStatus.CHECK_WIRING: 'check-wiring'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_metering_status_production_ct_l2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Metering status production CT l2',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'production_ct_metering_status_phase',
+    'unique_id': '1234_production_ct_metering_status_l2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_metering_status_production_ct_l2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Envoy 1234 Metering status production CT l2',
+      'icon': 'mdi:flash',
+      'options': list([
+        <CtMeterStatus.NORMAL: 'normal'>,
+        <CtMeterStatus.NOT_METERING: 'not-metering'>,
+        <CtMeterStatus.CHECK_WIRING: 'check-wiring'>,
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_metering_status_production_ct_l2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'normal',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_metering_status_production_ct_l3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        <CtMeterStatus.NORMAL: 'normal'>,
+        <CtMeterStatus.NOT_METERING: 'not-metering'>,
+        <CtMeterStatus.CHECK_WIRING: 'check-wiring'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_metering_status_production_ct_l3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Metering status production CT l3',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'production_ct_metering_status_phase',
+    'unique_id': '1234_production_ct_metering_status_l3',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_metering_status_production_ct_l3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Envoy 1234 Metering status production CT l3',
+      'icon': 'mdi:flash',
+      'options': list([
+        <CtMeterStatus.NORMAL: 'normal'>,
+        <CtMeterStatus.NOT_METERING: 'not-metering'>,
+        <CtMeterStatus.CHECK_WIRING: 'check-wiring'>,
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_metering_status_production_ct_l3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'normal',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_net_consumption_ct_current-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_net_consumption_ct_current',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Net consumption CT current',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'net_ct_current',
+    'unique_id': '1234_net_ct_current',
+    'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_net_consumption_ct_current-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'Envoy 1234 Net consumption CT current',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_net_consumption_ct_current',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1.918',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_net_consumption_ct_current_l1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_net_consumption_ct_current_l1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Net consumption CT current l1',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'net_ct_current_phase',
+    'unique_id': '1234_net_ct_current_l1',
+    'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_net_consumption_ct_current_l1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'Envoy 1234 Net consumption CT current l1',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_net_consumption_ct_current_l1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1.566',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_net_consumption_ct_current_l2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_net_consumption_ct_current_l2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Net consumption CT current l2',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'net_ct_current_phase',
+    'unique_id': '1234_net_ct_current_l2',
+    'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_net_consumption_ct_current_l2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'Envoy 1234 Net consumption CT current l2',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_net_consumption_ct_current_l2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.194',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_net_consumption_ct_current_l3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_net_consumption_ct_current_l3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Net consumption CT current l3',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'net_ct_current_phase',
+    'unique_id': '1234_net_ct_current_l3',
+    'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_net_consumption_ct_current_l3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'Envoy 1234 Net consumption CT current l3',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_net_consumption_ct_current_l3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.159',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_powerfactor_net_consumption_ct-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_powerfactor_net_consumption_ct',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER_FACTOR: 'power_factor'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Powerfactor net consumption CT',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'net_ct_powerfactor',
+    'unique_id': '1234_net_ct_powerfactor',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_powerfactor_net_consumption_ct-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power_factor',
+      'friendly_name': 'Envoy 1234 Powerfactor net consumption CT',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_powerfactor_net_consumption_ct',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.318',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_powerfactor_net_consumption_ct_l1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_powerfactor_net_consumption_ct_l1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER_FACTOR: 'power_factor'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Powerfactor net consumption CT l1',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'net_ct_powerfactor_phase',
+    'unique_id': '1234_net_ct_powerfactor_l1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_powerfactor_net_consumption_ct_l1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power_factor',
+      'friendly_name': 'Envoy 1234 Powerfactor net consumption CT l1',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_powerfactor_net_consumption_ct_l1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.493',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_powerfactor_net_consumption_ct_l2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_powerfactor_net_consumption_ct_l2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER_FACTOR: 'power_factor'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Powerfactor net consumption CT l2',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'net_ct_powerfactor_phase',
+    'unique_id': '1234_net_ct_powerfactor_l2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_powerfactor_net_consumption_ct_l2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power_factor',
+      'friendly_name': 'Envoy 1234 Powerfactor net consumption CT l2',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_powerfactor_net_consumption_ct_l2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-0.375',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_powerfactor_net_consumption_ct_l3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_powerfactor_net_consumption_ct_l3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER_FACTOR: 'power_factor'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Powerfactor net consumption CT l3',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'net_ct_powerfactor_phase',
+    'unique_id': '1234_net_ct_powerfactor_l3',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_powerfactor_net_consumption_ct_l3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power_factor',
+      'friendly_name': 'Envoy 1234 Powerfactor net consumption CT l3',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_powerfactor_net_consumption_ct_l3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-0.571',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_powerfactor_production_ct-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_powerfactor_production_ct',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER_FACTOR: 'power_factor'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'powerfactor production CT',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'production_ct_powerfactor',
+    'unique_id': '1234_production_ct_powerfactor',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_powerfactor_production_ct-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power_factor',
+      'friendly_name': 'Envoy 1234 powerfactor production CT',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_powerfactor_production_ct',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.666',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_powerfactor_production_ct_l1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_powerfactor_production_ct_l1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER_FACTOR: 'power_factor'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Powerfactor production CT l1',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'production_ct_powerfactor_phase',
+    'unique_id': '1234_production_ct_powerfactor_l1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_powerfactor_production_ct_l1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power_factor',
+      'friendly_name': 'Envoy 1234 Powerfactor production CT l1',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_powerfactor_production_ct_l1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.636',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_powerfactor_production_ct_l2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_powerfactor_production_ct_l2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER_FACTOR: 'power_factor'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Powerfactor production CT l2',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'production_ct_powerfactor_phase',
+    'unique_id': '1234_production_ct_powerfactor_l2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_powerfactor_production_ct_l2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power_factor',
+      'friendly_name': 'Envoy 1234 Powerfactor production CT l2',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_powerfactor_production_ct_l2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.615',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_powerfactor_production_ct_l3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_powerfactor_production_ct_l3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER_FACTOR: 'power_factor'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Powerfactor production CT l3',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'production_ct_powerfactor_phase',
+    'unique_id': '1234_production_ct_powerfactor_l3',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_powerfactor_production_ct_l3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power_factor',
+      'friendly_name': 'Envoy 1234 Powerfactor production CT l3',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_powerfactor_production_ct_l3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.778',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_production_ct_current-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_production_ct_current',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Production CT current',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'production_ct_current',
+    'unique_id': '1234_production_ct_current',
+    'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_production_ct_current-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'Envoy 1234 Production CT current',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_production_ct_current',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.727',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_production_ct_current_l1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_production_ct_current_l1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Production CT current l1',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'production_ct_current_phase',
+    'unique_id': '1234_production_ct_current_l1',
+    'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_production_ct_current_l1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'Envoy 1234 Production CT current l1',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_production_ct_current_l1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.238',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_production_ct_current_l2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_production_ct_current_l2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Production CT current l2',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'production_ct_current_phase',
+    'unique_id': '1234_production_ct_current_l2',
+    'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_production_ct_current_l2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'Envoy 1234 Production CT current l2',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_production_ct_current_l2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.3',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_production_ct_current_l3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_production_ct_current_l3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Production CT current l3',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'production_ct_current_phase',
+    'unique_id': '1234_production_ct_current_l3',
+    'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_production_ct_current_l3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'Envoy 1234 Production CT current l3',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_production_ct_current_l3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.189',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_reserve_battery_energy-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_reserve_battery_energy',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Reserve battery energy',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'reserve_energy',
+    'unique_id': '1234_reserve_energy',
+    'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_reserve_battery_energy-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Envoy 1234 Reserve battery energy',
+      'icon': 'mdi:flash',
+      'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_reserve_battery_energy',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_reserve_battery_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_reserve_battery_level',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Reserve battery level',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'reserve_soc',
+    'unique_id': '1234_reserve_soc',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_reserve_battery_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'Envoy 1234 Reserve battery level',
+      'icon': 'mdi:flash',
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_reserve_battery_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_voltage_net_consumption_ct-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_voltage_net_consumption_ct',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Voltage net consumption CT',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'net_ct_voltage',
+    'unique_id': '1234_voltage',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_voltage_net_consumption_ct-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'Envoy 1234 Voltage net consumption CT',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_voltage_net_consumption_ct',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '717.603',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_voltage_net_consumption_ct_l1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_voltage_net_consumption_ct_l1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Voltage net consumption CT l1',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'net_ct_voltage_phase',
+    'unique_id': '1234_voltage_l1',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_voltage_net_consumption_ct_l1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'Envoy 1234 Voltage net consumption CT l1',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_voltage_net_consumption_ct_l1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '240.294',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_voltage_net_consumption_ct_l2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_voltage_net_consumption_ct_l2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Voltage net consumption CT l2',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'net_ct_voltage_phase',
+    'unique_id': '1234_voltage_l2',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_voltage_net_consumption_ct_l2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'Envoy 1234 Voltage net consumption CT l2',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_voltage_net_consumption_ct_l2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '239.513',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_voltage_net_consumption_ct_l3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_voltage_net_consumption_ct_l3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Voltage net consumption CT l3',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'net_ct_voltage_phase',
+    'unique_id': '1234_voltage_l3',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_voltage_net_consumption_ct_l3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'Envoy 1234 Voltage net consumption CT l3',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_voltage_net_consumption_ct_l3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '237.796',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_voltage_production_ct-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_voltage_production_ct',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Voltage production CT',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'production_ct_voltage',
+    'unique_id': '1234_production_ct_voltage',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_voltage_production_ct-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'Envoy 1234 Voltage production CT',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_voltage_production_ct',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '717.827',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_voltage_production_ct_l1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_voltage_production_ct_l1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Voltage production CT l1',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'production_ct_voltage_phase',
+    'unique_id': '1234_production_ct_voltage_l1',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_voltage_production_ct_l1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'Envoy 1234 Voltage production CT l1',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_voltage_production_ct_l1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '240.455',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_voltage_production_ct_l2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_voltage_production_ct_l2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Voltage production CT l2',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'production_ct_voltage_phase',
+    'unique_id': '1234_production_ct_voltage_l2',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_voltage_production_ct_l2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'Envoy 1234 Voltage production CT l2',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_voltage_production_ct_l2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '239.646',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_voltage_production_ct_l3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.envoy_1234_voltage_production_ct_l3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Voltage production CT l3',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'production_ct_voltage_phase',
+    'unique_id': '1234_production_ct_voltage_l3',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.envoy_1234_voltage_production_ct_l3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'Envoy 1234 Voltage production CT l3',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_voltage_production_ct_l3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '237.725',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312082644-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.inverter_482312082644',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': 'mdi:flash',
+    'original_name': None,
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '482312082644',
+    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312082644-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Inverter 482312082644',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.inverter_482312082644',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '13',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312082644_last_reported-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.inverter_482312082644_last_reported',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Last reported',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'last_reported',
+    'unique_id': '482312082644_last_reported',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312082644_last_reported-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Inverter 482312082644 Last reported',
+      'icon': 'mdi:flash',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.inverter_482312082644_last_reported',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-05-04T06:19:45+00:00',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312083708-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.inverter_482312083708',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': 'mdi:flash',
+    'original_name': None,
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '482312083708',
+    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312083708-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Inverter 482312083708',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.inverter_482312083708',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '14',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312083708_last_reported-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.inverter_482312083708_last_reported',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Last reported',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'last_reported',
+    'unique_id': '482312083708_last_reported',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312083708_last_reported-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Inverter 482312083708 Last reported',
+      'icon': 'mdi:flash',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.inverter_482312083708_last_reported',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-05-04T06:17:45+00:00',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312083761-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.inverter_482312083761',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': 'mdi:flash',
+    'original_name': None,
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '482312083761',
+    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312083761-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Inverter 482312083761',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.inverter_482312083761',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '11',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312083761_last_reported-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.inverter_482312083761_last_reported',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Last reported',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'last_reported',
+    'unique_id': '482312083761_last_reported',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312083761_last_reported-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Inverter 482312083761 Last reported',
+      'icon': 'mdi:flash',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.inverter_482312083761_last_reported',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-05-04T06:30:46+00:00',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312084298-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.inverter_482312084298',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': 'mdi:flash',
+    'original_name': None,
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '482312084298',
+    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312084298-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Inverter 482312084298',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.inverter_482312084298',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '11',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312084298_last_reported-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.inverter_482312084298_last_reported',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Last reported',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'last_reported',
+    'unique_id': '482312084298_last_reported',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312084298_last_reported-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Inverter 482312084298 Last reported',
+      'icon': 'mdi:flash',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.inverter_482312084298_last_reported',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-05-04T06:29:47+00:00',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312084840-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.inverter_482312084840',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': 'mdi:flash',
+    'original_name': None,
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '482312084840',
+    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312084840-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Inverter 482312084840',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.inverter_482312084840',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '9',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312084840_last_reported-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.inverter_482312084840_last_reported',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Last reported',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'last_reported',
+    'unique_id': '482312084840_last_reported',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312084840_last_reported-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Inverter 482312084840 Last reported',
+      'icon': 'mdi:flash',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.inverter_482312084840_last_reported',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-05-04T06:26:16+00:00',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312086604-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.inverter_482312086604',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': 'mdi:flash',
+    'original_name': None,
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '482312086604',
+    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312086604-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Inverter 482312086604',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.inverter_482312086604',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '14',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312086604_last_reported-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.inverter_482312086604_last_reported',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Last reported',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'last_reported',
+    'unique_id': '482312086604_last_reported',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312086604_last_reported-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Inverter 482312086604 Last reported',
+      'icon': 'mdi:flash',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.inverter_482312086604_last_reported',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-05-04T06:18:15+00:00',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312087072-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.inverter_482312087072',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': 'mdi:flash',
+    'original_name': None,
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '482312087072',
+    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312087072-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Inverter 482312087072',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.inverter_482312087072',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '13',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312087072_last_reported-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.inverter_482312087072_last_reported',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Last reported',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'last_reported',
+    'unique_id': '482312087072_last_reported',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312087072_last_reported-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Inverter 482312087072 Last reported',
+      'icon': 'mdi:flash',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.inverter_482312087072_last_reported',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-05-04T06:17:15+00:00',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312087202-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.inverter_482312087202',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': 'mdi:flash',
+    'original_name': None,
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '482312087202',
+    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312087202-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Inverter 482312087202',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.inverter_482312087202',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '12',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312087202_last_reported-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.inverter_482312087202_last_reported',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Last reported',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'last_reported',
+    'unique_id': '482312087202_last_reported',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312087202_last_reported-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Inverter 482312087202 Last reported',
+      'icon': 'mdi:flash',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.inverter_482312087202_last_reported',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-05-04T06:29:46+00:00',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312087222-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.inverter_482312087222',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': 'mdi:flash',
+    'original_name': None,
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '482312087222',
+    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312087222-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Inverter 482312087222',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.inverter_482312087222',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '13',
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312087222_last_reported-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.inverter_482312087222_last_reported',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': 'mdi:flash',
+    'original_name': 'Last reported',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'last_reported',
+    'unique_id': '482312087222_last_reported',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor[envoy_eu_batt][sensor.inverter_482312087222_last_reported-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Inverter 482312087222 Last reported',
+      'icon': 'mdi:flash',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.inverter_482312087222_last_reported',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-05-04T06:16:44+00:00',
+  })
+# ---
 # name: test_sensor[envoy_metered_batt_relay][sensor.encharge_123456_apparent_power-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/enphase_envoy/snapshots/test_switch.ambr
+++ b/tests/components/enphase_envoy/snapshots/test_switch.ambr
@@ -1,4 +1,50 @@
 # serializer version: 1
+# name: test_switch[envoy_eu_batt][switch.envoy_1234_charge_from_grid-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.envoy_1234_charge_from_grid',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Charge from grid',
+    'platform': 'enphase_envoy',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'charge_from_grid',
+    'unique_id': '1234_charge_from_grid',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch[envoy_eu_batt][switch.envoy_1234_charge_from_grid-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Envoy 1234 Charge from grid',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.envoy_1234_charge_from_grid',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_switch[envoy_metered_batt_relay][switch.enpower_654321_charge_from_grid-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/enphase_envoy/test_binary_sensor.py
+++ b/tests/components/enphase_envoy/test_binary_sensor.py
@@ -16,7 +16,9 @@ from tests.common import MockConfigEntry, snapshot_platform
 
 
 @pytest.mark.parametrize(
-    ("mock_envoy"), ["envoy_metered_batt_relay"], indirect=["mock_envoy"]
+    ("mock_envoy"),
+    ["envoy_eu_batt", "envoy_metered_batt_relay"],
+    indirect=["mock_envoy"],
 )
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_binary_sensor(

--- a/tests/components/enphase_envoy/test_number.py
+++ b/tests/components/enphase_envoy/test_number.py
@@ -21,7 +21,9 @@ from tests.common import MockConfigEntry, snapshot_platform
 
 
 @pytest.mark.parametrize(
-    ("mock_envoy"), ["envoy_metered_batt_relay"], indirect=["mock_envoy"]
+    ("mock_envoy"),
+    ["envoy_metered_batt_relay", "envoy_eu_batt"],
+    indirect=["mock_envoy"],
 )
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_number(
@@ -60,19 +62,29 @@ async def test_no_number(
 
 
 @pytest.mark.parametrize(
-    ("mock_envoy"), ["envoy_metered_batt_relay"], indirect=["mock_envoy"]
+    ("mock_envoy", "use_envoy_serial"),
+    [
+        ("envoy_metered_batt_relay", False),
+        ("envoy_eu_batt", True),
+    ],
+    indirect=["mock_envoy"],
 )
 async def test_number_operation_storage(
     hass: HomeAssistant,
     mock_envoy: AsyncMock,
     config_entry: MockConfigEntry,
+    use_envoy_serial: bool,
 ) -> None:
     """Test enphase_envoy number storage entities operation."""
     with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.NUMBER]):
         await setup_integration(hass, config_entry)
 
-    sn = mock_envoy.data.enpower.serial_number
-    test_entity = f"{Platform.NUMBER}.enpower_{sn}_reserve_battery_level"
+    sn = (
+        f"envoy_{mock_envoy.serial_number}"
+        if use_envoy_serial
+        else f"enpower_{mock_envoy.data.enpower.serial_number}"
+    )
+    test_entity = f"{Platform.NUMBER}.{sn}_reserve_battery_level"
 
     assert (entity_state := hass.states.get(test_entity))
     assert mock_envoy.data.tariff.storage_settings.reserved_soc == float(

--- a/tests/components/enphase_envoy/test_number.py
+++ b/tests/components/enphase_envoy/test_number.py
@@ -62,10 +62,10 @@ async def test_no_number(
 
 
 @pytest.mark.parametrize(
-    ("mock_envoy", "use_envoy_serial"),
+    ("mock_envoy", "use_serial"),
     [
-        ("envoy_metered_batt_relay", False),
-        ("envoy_eu_batt", True),
+        ("envoy_metered_batt_relay", "enpower_654321"),
+        ("envoy_eu_batt", "envoy_1234"),
     ],
     indirect=["mock_envoy"],
 )
@@ -73,18 +73,13 @@ async def test_number_operation_storage(
     hass: HomeAssistant,
     mock_envoy: AsyncMock,
     config_entry: MockConfigEntry,
-    use_envoy_serial: bool,
+    use_serial: bool,
 ) -> None:
     """Test enphase_envoy number storage entities operation."""
     with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.NUMBER]):
         await setup_integration(hass, config_entry)
 
-    sn = (
-        f"envoy_{mock_envoy.serial_number}"
-        if use_envoy_serial
-        else f"enpower_{mock_envoy.data.enpower.serial_number}"
-    )
-    test_entity = f"{Platform.NUMBER}.{sn}_reserve_battery_level"
+    test_entity = f"{Platform.NUMBER}.{use_serial}_reserve_battery_level"
 
     assert (entity_state := hass.states.get(test_entity))
     assert mock_envoy.data.tariff.storage_settings.reserved_soc == float(

--- a/tests/components/enphase_envoy/test_select.py
+++ b/tests/components/enphase_envoy/test_select.py
@@ -174,10 +174,10 @@ async def test_select_relay_modes(
 
 
 @pytest.mark.parametrize(
-    ("mock_envoy", "use_envoy_serial"),
+    ("mock_envoy", "use_serial"),
     [
-        ("envoy_metered_batt_relay", False),
-        ("envoy_eu_batt", True),
+        ("envoy_metered_batt_relay", "enpower_654321"),
+        ("envoy_eu_batt", "envoy_1234"),
     ],
     indirect=["mock_envoy"],
 )
@@ -185,18 +185,13 @@ async def test_select_storage_modes(
     hass: HomeAssistant,
     mock_envoy: AsyncMock,
     config_entry: MockConfigEntry,
-    use_envoy_serial: bool,
+    use_serial: str,
 ) -> None:
     """Test select platform entities storage mode changes."""
     with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SELECT]):
         await setup_integration(hass, config_entry)
 
-    sn = (
-        f"envoy_{mock_envoy.serial_number}"
-        if use_envoy_serial
-        else f"enpower_{mock_envoy.data.enpower.serial_number}"
-    )
-    test_entity = f"{Platform.SELECT}.{sn}_storage_mode"
+    test_entity = f"{Platform.SELECT}.{use_serial}_storage_mode"
 
     assert (entity_state := hass.states.get(test_entity))
     assert STORAGE_MODE_MAP[mock_envoy.data.tariff.storage_settings.mode] == (

--- a/tests/components/enphase_envoy/test_sensor.py
+++ b/tests/components/enphase_envoy/test_sensor.py
@@ -26,6 +26,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_plat
     [
         "envoy",
         "envoy_1p_metered",
+        "envoy_eu_batt",
         "envoy_metered_batt_relay",
         "envoy_nobatt_metered_3p",
         "envoy_tot_cons_metered",
@@ -59,6 +60,7 @@ PRODUCTION_NAMES: tuple[str, ...] = (
     [
         "envoy",
         "envoy_1p_metered",
+        "envoy_eu_batt",
         "envoy_metered_batt_relay",
         "envoy_nobatt_metered_3p",
         "envoy_tot_cons_metered",
@@ -148,6 +150,7 @@ CONSUMPTION_NAMES: tuple[str, ...] = (
     ("mock_envoy"),
     [
         "envoy_1p_metered",
+        "envoy_eu_batt",
         "envoy_metered_batt_relay",
         "envoy_nobatt_metered_3p",
     ],
@@ -189,6 +192,7 @@ NET_CONSUMPTION_NAMES: tuple[str, ...] = (
     ("mock_envoy"),
     [
         "envoy_1p_metered",
+        "envoy_eu_batt",
         "envoy_metered_batt_relay",
         "envoy_nobatt_metered_3p",
         "envoy_tot_cons_metered",
@@ -735,6 +739,7 @@ async def test_sensor_storage_phase_disabled_by_integration(
     [
         "envoy",
         "envoy_1p_metered",
+        "envoy_eu_batt",
         "envoy_metered_batt_relay",
         "envoy_nobatt_metered_3p",
         "envoy_tot_cons_metered",
@@ -767,6 +772,7 @@ async def test_sensor_inverter_data(
     [
         "envoy",
         "envoy_1p_metered",
+        "envoy_eu_batt",
         "envoy_metered_batt_relay",
         "envoy_nobatt_metered_3p",
         "envoy_tot_cons_metered",

--- a/tests/components/enphase_envoy/test_switch.py
+++ b/tests/components/enphase_envoy/test_switch.py
@@ -113,10 +113,10 @@ async def test_switch_grid_operation(
 
 
 @pytest.mark.parametrize(
-    ("mock_envoy", "use_envoy_serial"),
+    ("mock_envoy", "use_serial"),
     [
-        ("envoy_metered_batt_relay", False),
-        ("envoy_eu_batt", True),
+        ("envoy_metered_batt_relay", "enpower_654321"),
+        ("envoy_eu_batt", "envoy_1234"),
     ],
     indirect=["mock_envoy"],
 )
@@ -124,19 +124,13 @@ async def test_switch_charge_from_grid_operation(
     hass: HomeAssistant,
     mock_envoy: AsyncMock,
     config_entry: MockConfigEntry,
-    use_envoy_serial: bool,
+    use_serial: str,
 ) -> None:
     """Test switch platform operation for charge from grid switches."""
     with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SWITCH]):
         await setup_integration(hass, config_entry)
 
-    sn = (
-        f"envoy_{mock_envoy.serial_number}"
-        if use_envoy_serial
-        else f"enpower_{mock_envoy.data.enpower.serial_number}"
-    )
-
-    test_entity = f"{Platform.SWITCH}.{sn}_charge_from_grid"
+    test_entity = f"{Platform.SWITCH}.{use_serial}_charge_from_grid"
 
     # validate envoy value is reflected in entity
     assert (entity_state := hass.states.get(test_entity))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When using batteries with the Enphase Envoy, the enphase_envoy integration supports changing battery storage settings `charge from grid`, `Storage mode` and `Reserve battery level`, provided an Enpower device is present in the configuration.

The Enpower device is available when using an Enphase IQ System Controller. This device is not available in many EU countries and in these countries the batteries are installed without it providing no Enpower device. 

Changing the actual settings is however done in the Envoy and not in the Enpower device and can be done without the Enpower device being present. The needed entities are currently only created if an Enpower device is present in the configuration.

This PR:

- Does not change behavior if Enpower device is present, entities remain connected to the Enpower device
- Will create the needed entities also if batteries are present but no Enpower device is found
  - Connects these entities to the Envoy device in this case
  - Allows changing these setting similar as when connected to the Enpower device
- Adds a new test fixture with the EU battery configuration
- Adds new tests and updated snapshot files for this case

Note: This may not work with latest released Enphase Envoy firmware release >= 8.2.42nn as this seems to break with installed Enpower device.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:   #121159 and #125217
- Link to documentation pull request: [34647](https://github.com/home-assistant/home-assistant.io/pull/34647)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
