### PR TITLE
Websocket events

### DIFF
--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -78,31 +78,41 @@ def async_register_commands(
 ) -> None:
     """Register commands."""
     async_reg(hass, handle_call_service)
+    async_reg(hass, handle_connection_info)
     async_reg(hass, handle_entity_source)
     async_reg(hass, handle_execute_script)
     async_reg(hass, handle_fire_event)
     async_reg(hass, handle_get_config)
     async_reg(hass, handle_get_services)
     async_reg(hass, handle_get_states)
-    async_reg(hass, handle_manifest_get)
+    async_reg(hass, handle_integration_descriptions)
     async_reg(hass, handle_integration_setup_info)
+    async_reg(hass, handle_manifest_get)
     async_reg(hass, handle_manifest_list)
     async_reg(hass, handle_ping)
     async_reg(hass, handle_render_template)
     async_reg(hass, handle_subscribe_bootstrap_integrations)
+    async_reg(hass, handle_subscribe_entities)
     async_reg(hass, handle_subscribe_events)
     async_reg(hass, handle_subscribe_trigger)
+    async_reg(hass, handle_supported_features)
     async_reg(hass, handle_test_condition)
     async_reg(hass, handle_unsubscribe_events)
     async_reg(hass, handle_validate_config)
-    async_reg(hass, handle_subscribe_entities)
-    async_reg(hass, handle_supported_features)
-    async_reg(hass, handle_integration_descriptions)
 
 
 def pong_message(iden: int) -> dict[str, Any]:
     """Return a pong message."""
     return {"id": iden, "type": "pong"}
+
+
+def connection_info_message(iden: int, conn: ActiveConnection) -> dict[str, Any]:
+    """Return a connection information message."""
+    return {
+        "id": iden,
+        "type": "connection_info",
+        "connection_uuid": conn.get_uuid(),
+    }
 
 
 @callback
@@ -577,6 +587,15 @@ def handle_ping(
 ) -> None:
     """Handle ping command."""
     connection.send_message(pong_message(msg["id"]))
+
+
+@callback
+@decorators.websocket_command({vol.Required("type"): "connection_info"})
+def handle_connection_info(
+    hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
+) -> None:
+    """Handle connection_info command."""
+    connection.send_message(connection_info_message(msg["id"], connection))
 
 
 @lru_cache

--- a/homeassistant/components/websocket_api/connection.py
+++ b/homeassistant/components/websocket_api/connection.py
@@ -83,7 +83,7 @@ class ActiveConnection:
             const.EVENT_WEBSOCKET_CONNECTED,
             {
                 "connection_uuid": self.connection_uuid,
-                "remote": remote,
+                "remote_ip": remote,
                 "username": user.name,
                 "user_agent": user_agent,
             },
@@ -269,7 +269,7 @@ class ActiveConnection:
             const.EVENT_WEBSOCKET_DISCONNECTED,
             {
                 "connection_uuid": self.connection_uuid,
-                "remote": remote,
+                "remote_ip": remote,
                 "username": self.user.name,
                 "user_agent": user_agent,
             },

--- a/homeassistant/components/websocket_api/connection.py
+++ b/homeassistant/components/websocket_api/connection.py
@@ -84,7 +84,7 @@ class ActiveConnection:
             {
                 "connection_uuid": self.connection_uuid,
                 "remote": remote,
-                "user": user,
+                "username": user.name,
                 "user_agent": user_agent,
             },
         )
@@ -270,7 +270,7 @@ class ActiveConnection:
             {
                 "connection_uuid": self.connection_uuid,
                 "remote": remote,
-                "user": self.user,
+                "username": self.user.name,
                 "user_agent": user_agent,
             },
         )

--- a/homeassistant/components/websocket_api/const.py
+++ b/homeassistant/components/websocket_api/const.py
@@ -54,6 +54,9 @@ TYPE_RESULT: Final = "result"
 SIGNAL_WEBSOCKET_CONNECTED: Final = "websocket_connected"
 SIGNAL_WEBSOCKET_DISCONNECTED: Final = "websocket_disconnected"
 
+EVENT_WEBSOCKET_CONNECTED: Final = "websocket_connected"
+EVENT_WEBSOCKET_DISCONNECTED: Final = "websocket_disconnected"
+
 # Data used to store the current connection list
 DATA_CONNECTIONS: Final = f"{DOMAIN}.connections"
 

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -735,12 +735,26 @@ async def test_get_config(
 
 
 async def test_ping(websocket_client: MockHAClientWebSocket) -> None:
-    """Test get_panels command."""
+    """Test ping command."""
     await websocket_client.send_json({"id": 5, "type": "ping"})
 
     msg = await websocket_client.receive_json()
     assert msg["id"] == 5
     assert msg["type"] == "pong"
+
+
+async def test_connection_info(websocket_client: MockHAClientWebSocket) -> None:
+    """Test get_connection_info command."""
+    await websocket_client.send_json({"id": 5, "type": "connection_info"})
+
+    msg = await websocket_client.receive_json()
+    assert msg["id"] == 5
+    assert msg["type"] == "connection_info"
+
+    # consider connection uuid to be an opaque type (ie, don't assume any
+    # particular format)
+    assert msg["connection_uuid"] is not None
+    assert len(msg["connection_uuid"]) > 0
 
 
 async def test_call_service_context_with_user(

--- a/tests/components/websocket_api/test_connection.py
+++ b/tests/components/websocket_api/test_connection.py
@@ -147,19 +147,18 @@ async def test_event_bus_messages(hass: HomeAssistant) -> None:
 
     @callback
     def event_listener(event):
-        if event.type == EVENT_WEBSOCKET_CONNECTED:
+        if event.event_type == EVENT_WEBSOCKET_CONNECTED:
             connects.append(event)
-        elif event.type == EVENT_WEBSOCKET_DISCONNECTED:
+        elif event.event_type == EVENT_WEBSOCKET_DISCONNECTED:
             disconnects.append(event)
 
     hass.bus.async_listen(MATCH_ALL, event_listener)
 
-    connection = websocket_api.ActiveConnection(
-        hass, Mock(data={websocket_api.DOMAIN: None}), None, None, Mock()
-    )
+    hass.data = {**hass.data, websocket_api.DOMAIN: None}
+    connection = websocket_api.ActiveConnection(None, hass, None, None, Mock())
 
     assert len(connects) == 1
 
-    await connection.handle_close()
+    connection.async_handle_close()
 
     assert len(disconnects) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR makes the `websocket_api` integration fire an event to the event bus when a websocket client successfully connects (including successful authentication) and when the client disconnects. It also adds a `UUID` to each connection which is fired as part of those events, and a `connection_info` websocket command that allows a client to get its own UUID.

This allows automations and other integrations to track and respond to websocket clients. The events also include the user agent (if set) of the client. I see this mostly being useful for tracking the connection status of "satellite" devices like wall-mounted tablets or raspberry-pi-powered monitors, which might use the web interface (and get updates via websocket) or otherwise connect directly via websocket. Additionally, it could allow for the creation of integrations which use the websocket API directly (and thus don't require a separate open port) for "local-push"-style updates to track the connection status of their clients.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # n/a
- This PR is related to issue: n/a
- Link to documentation pull request: (will be added in a comment; creating this PR first)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ x] The code change is tested and works locally.
- [ x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ x] There is no commented out code in this PR.
- [ x] I have followed the [development checklist][dev-checklist]
- [ x] I have followed the [perfect PR recommendations][perfect-pr]
- [ x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ n/a] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [n/a ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ n/a] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
