### PR TITLE
Add server side events to Smlight integration

### DIFF
--- a/homeassistant/components/smlight/coordinator.py
+++ b/homeassistant/components/smlight/coordinator.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 
 from pysmlight import Api2, Info, Sensors
+from pysmlight.const import Settings, SettingsProp
 from pysmlight.exceptions import SmlightAuthError, SmlightConnectionError
 
 from homeassistant.config_entries import ConfigEntry
@@ -81,6 +82,13 @@ class SmDataUpdateCoordinator(DataUpdateCoordinator[SmData]):
                 severity=IssueSeverity.ERROR,
                 translation_key="unsupported_firmware",
             )
+
+    def update_setting(self, setting: Settings, value: bool | int) -> None:
+        """Update the sensor value from event."""
+        prop = SettingsProp[setting.name].value
+        setattr(self.data.sensors, prop, value)
+
+        self.async_set_updated_data(self.data)
 
     async def _async_update_data(self) -> SmData:
         """Fetch data from the SMLIGHT device."""

--- a/homeassistant/components/smlight/coordinator.py
+++ b/homeassistant/components/smlight/coordinator.py
@@ -44,6 +44,10 @@ class SmDataUpdateCoordinator(DataUpdateCoordinator[SmData]):
         self.client = Api2(host=host, session=async_get_clientsession(hass))
         self.legacy_api: int = 0
 
+        self.config_entry.async_create_background_task(
+            hass, self.client.sse.client(), "smlight-sse-client"
+        )
+
     async def _async_setup(self) -> None:
         """Authenticate if needed during initial setup."""
         if await self.client.check_auth_needed():

--- a/tests/components/smlight/conftest.py
+++ b/tests/components/smlight/conftest.py
@@ -98,12 +98,10 @@ def mock_smlight_client(request: pytest.FixtureRequest) -> Generator[MagicMock]:
         def _mock_settings_cb(
             setting: Settings, callback: Callable
         ) -> Callable[[], None]:
-            if setting not in api._settings_callbacks:
-                api._settings_callbacks[setting] = callback
+            api._settings_callbacks.setdefault(setting, callback)
 
             def remove_callback():
-                if setting in api._settings_callbacks:
-                    del api._settings_callbacks[setting]
+                api._settings_callbacks.pop(setting, None)
 
             return remove_callback
 

--- a/tests/components/smlight/conftest.py
+++ b/tests/components/smlight/conftest.py
@@ -1,9 +1,8 @@
 """Common fixtures for the SMLIGHT Zigbee tests."""
 
-from collections.abc import AsyncGenerator, Callable, Generator
+from collections.abc import AsyncGenerator, Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from pysmlight.const import Settings
 from pysmlight.sse import sseClient
 from pysmlight.web import CmdWrapper, Info, Sensors
 import pytest
@@ -92,20 +91,6 @@ def mock_smlight_client(request: pytest.FixtureRequest) -> Generator[MagicMock]:
         api.cmds = AsyncMock(spec_set=CmdWrapper)
         api.set_toggle = AsyncMock()
         api.sse = MagicMock(spec_set=sseClient)
-        api.sse.client = AsyncMock()
-        api._settings_callbacks = {}
-
-        def _mock_settings_cb(
-            setting: Settings, callback: Callable
-        ) -> Callable[[], None]:
-            api._settings_callbacks.setdefault(setting, callback)
-
-            def remove_callback():
-                api._settings_callbacks.pop(setting, None)
-
-            return remove_callback
-
-        api.sse.register_settings_cb.side_effect = _mock_settings_cb
 
         yield api
 

--- a/tests/components/smlight/conftest.py
+++ b/tests/components/smlight/conftest.py
@@ -1,8 +1,10 @@
 """Common fixtures for the SMLIGHT Zigbee tests."""
 
-from collections.abc import AsyncGenerator, Generator
+from collections.abc import AsyncGenerator, Callable, Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from pysmlight.const import Settings
+from pysmlight.sse import sseClient
 from pysmlight.web import CmdWrapper, Info, Sensors
 import pytest
 
@@ -89,6 +91,23 @@ def mock_smlight_client(request: pytest.FixtureRequest) -> Generator[MagicMock]:
 
         api.cmds = AsyncMock(spec_set=CmdWrapper)
         api.set_toggle = AsyncMock()
+        api.sse = MagicMock(spec_set=sseClient)
+        api.sse.client = AsyncMock()
+        api._settings_callbacks = {}
+
+        def _mock_settings_cb(
+            setting: Settings, callback: Callable
+        ) -> Callable[[], None]:
+            if setting not in api._settings_callbacks:
+                api._settings_callbacks[setting] = callback
+
+            def remove_callback():
+                if setting in api._settings_callbacks:
+                    del api._settings_callbacks[setting]
+
+            return remove_callback
+
+        api.sse.register_settings_cb.side_effect = _mock_settings_cb
 
         yield api
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add server side events (SSE) client to Smlight integration and hook them up for switches platform. SSE events will also be used for update entities and a couple of other sensors later.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X]  The code change is tested and works locally.
- [X]  Local tests pass. **Your PR cannot be merged unless tests pass**
- [X]  There is no commented out code in this PR.
- [X]  I have followed the [development checklist][dev-checklist]
- [X]  I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
