### PR TITLE
Add pylint check for DOMAIN alias

### DIFF
--- a/pylint/plugins/hass_imports.py
+++ b/pylint/plugins/hass_imports.py
@@ -552,19 +552,21 @@ class HassImportsFormatChecker(BaseChecker):
                 if node.modname.startswith(f"{root}.components.{current_component}."):
                     self.add_message("hass-relative-import", node=node)
                     return
-        if node.modname.startswith("homeassistant.components.") and (
-            node.modname.endswith(".const")
-            or "const" in {names[0] for names in node.names}
+        if node.modname.startswith("homeassistant.components.") and not (
+            self.current_package.startswith("tests.components.")
+            and self.current_package.split(".")[2] == node.modname.split(".")[2]
         ):
-            if (
-                self.current_package.startswith("tests.components.")
-                and self.current_package.split(".")[2] == node.modname.split(".")[2]
-            ):
-                # Ignore check if the component being tested matches
-                # the component being imported from
+            if node.modname.endswith(".const"):
+                self.add_message("hass-component-root-import", node=node)
                 return
-            self.add_message("hass-component-root-import", node=node)
-            return
+            for name, alias in node.names:
+                if name == "const":
+                    self.add_message("hass-component-root-import", node=node)
+                    return
+                if name == "DOMAIN" and (alias is None or alias == "DOMAIN"):
+                    self.add_message("hass-import-constant-alias", node=node)
+                    return
+
         if obsolete_imports := _OBSOLETE_IMPORT.get(node.modname):
             for name_tuple in node.names:
                 for obsolete_import in obsolete_imports:

--- a/pylint/plugins/hass_imports.py
+++ b/pylint/plugins/hass_imports.py
@@ -485,28 +485,21 @@ class HassImportsFormatChecker(BaseChecker):
         """Check for improper `import _` invocations."""
         if self.current_package is None:
             return
-        for module, alias in node.names:
+        for module, _alias in node.names:
             if module.startswith(f"{self.current_package}."):
                 self.add_message("hass-relative-import", node=node)
                 continue
-
-            if (
-                not module.startswith("homeassistant.components.")
-                or self.current_package.startswith("tests.components.")
-                and self.current_package.split(".")[2] == module.split(".")[2]
+            if module.startswith("homeassistant.components.") and module.endswith(
+                "const"
             ):
-                # Ignore check if the component being tested matches
-                # the component being imported from
-                continue
-
-            if module.endswith(".const"):
-                # Ensure constants are imported from the root module
+                if (
+                    self.current_package.startswith("tests.components.")
+                    and self.current_package.split(".")[2] == module.split(".")[2]
+                ):
+                    # Ignore check if the component being tested matches
+                    # the component being imported from
+                    continue
                 self.add_message("hass-component-root-import", node=node)
-                continue
-
-            if module.endswith(".DOMAIN") and (alias is None or alias == "DOMAIN"):
-                # Ensure alias is set for external domains
-                self.add_message("hass-import-constant-alias", node=node, args="DOMAIN")
 
     def _visit_importfrom_relative(
         self, current_package: str, node: nodes.ImportFrom

--- a/pylint/plugins/hass_imports.py
+++ b/pylint/plugins/hass_imports.py
@@ -461,7 +461,7 @@ class HassImportsFormatChecker(BaseChecker):
             "Used when a helper should be used via the namespace",
         ),
         "W7426": (
-            "`%s` should not be imported using an alias, such as `%s as %s`",
+            "`%s` should be imported using an alias, such as `%s as %s`",
             "hass-import-constant-alias",
             "Used when a constant should be imported as an alias",
         ),

--- a/pylint/plugins/hass_imports.py
+++ b/pylint/plugins/hass_imports.py
@@ -506,7 +506,7 @@ class HassImportsFormatChecker(BaseChecker):
 
             if module.endswith(".DOMAIN") and (alias is None or alias == "DOMAIN"):
                 # Ensure alias is set for external domains
-                self.add_message("hass-import-constant-alias", node=node)
+                self.add_message("hass-import-constant-alias", node=node, args="DOMAIN")
 
     def _visit_importfrom_relative(
         self, current_package: str, node: nodes.ImportFrom
@@ -564,7 +564,9 @@ class HassImportsFormatChecker(BaseChecker):
                     self.add_message("hass-component-root-import", node=node)
                     return
                 if name == "DOMAIN" and (alias is None or alias == "DOMAIN"):
-                    self.add_message("hass-import-constant-alias", node=node)
+                    self.add_message(
+                        "hass-import-constant-alias", node=node, args="DOMAIN"
+                    )
                     return
 
         if obsolete_imports := _OBSOLETE_IMPORT.get(node.modname):

--- a/pylint/plugins/hass_imports.py
+++ b/pylint/plugins/hass_imports.py
@@ -461,7 +461,7 @@ class HassImportsFormatChecker(BaseChecker):
             "Used when a helper should be used via the namespace",
         ),
         "W7426": (
-            "`%s` should not be imported directly. Please use an alias",
+            "`%s` should not be imported directly. Please use an alias like `%s`",
             "hass-import-constant-alias",
             "Used when a constant should be imported as an alias",
         ),
@@ -545,6 +545,7 @@ class HassImportsFormatChecker(BaseChecker):
                 if node.modname.startswith(f"{root}.components.{current_component}."):
                     self.add_message("hass-relative-import", node=node)
                     return
+
         if node.modname.startswith("homeassistant.components.") and not (
             self.current_package.startswith("tests.components.")
             and self.current_package.split(".")[2] == node.modname.split(".")[2]
@@ -558,7 +559,9 @@ class HassImportsFormatChecker(BaseChecker):
                     return
                 if name == "DOMAIN" and (alias is None or alias == "DOMAIN"):
                     self.add_message(
-                        "hass-import-constant-alias", node=node, args="DOMAIN"
+                        "hass-import-constant-alias",
+                        node=node,
+                        args=("DOMAIN", f"{node.modname.split(".")[2].upper()}_DOMAIN"),
                     )
                     return
 

--- a/pylint/plugins/hass_imports.py
+++ b/pylint/plugins/hass_imports.py
@@ -461,7 +461,7 @@ class HassImportsFormatChecker(BaseChecker):
             "Used when a helper should be used via the namespace",
         ),
         "W7426": (
-            "`%s` should not be imported directly. Please use an alias like `%s`",
+            "`%s` should not be imported using an alias, such as `%s as %s`",
             "hass-import-constant-alias",
             "Used when a constant should be imported as an alias",
         ),
@@ -561,7 +561,11 @@ class HassImportsFormatChecker(BaseChecker):
                     self.add_message(
                         "hass-import-constant-alias",
                         node=node,
-                        args=("DOMAIN", f"{node.modname.split(".")[2].upper()}_DOMAIN"),
+                        args=(
+                            "DOMAIN",
+                            "DOMAIN",
+                            f"{node.modname.split(".")[2].upper()}_DOMAIN",
+                        ),
                     )
                     return
 

--- a/tests/pylint/test_imports.py
+++ b/tests/pylint/test_imports.py
@@ -316,6 +316,16 @@ def test_bad_namespace_import(
     [
         (
             "homeassistant.components.pylint_test.sensor",
+            "from homeassistant.components.other import DOMAIN as OTHER_DOMAIN",
+            -1,
+        ),
+        (
+            "homeassistant.components.pylint_test.sensor",
+            "from homeassistant.components.other import DOMAIN",
+            49,
+        ),
+        (
+            "homeassistant.components.pylint_test.sensor",
             "import homeassistant.components.other.DOMAIN as OTHER_DOMAIN",
             -1,
         ),

--- a/tests/pylint/test_imports.py
+++ b/tests/pylint/test_imports.py
@@ -347,7 +347,7 @@ def test_domain_alias(
             pylint.testutils.MessageTest(
                 msg_id="hass-import-constant-alias",
                 node=import_node,
-                args=None,
+                args=("DOMAIN", "OTHER_DOMAIN"),
                 line=1,
                 col_offset=0,
                 end_line=1,

--- a/tests/pylint/test_imports.py
+++ b/tests/pylint/test_imports.py
@@ -324,16 +324,6 @@ def test_bad_namespace_import(
             "from homeassistant.components.other import DOMAIN",
             49,
         ),
-        (
-            "homeassistant.components.pylint_test.sensor",
-            "import homeassistant.components.other.DOMAIN as OTHER_DOMAIN",
-            -1,
-        ),
-        (
-            "homeassistant.components.pylint_test.sensor",
-            "import homeassistant.components.other.DOMAIN",
-            44,
-        ),
     ],
 )
 def test_domain_alias(

--- a/tests/pylint/test_imports.py
+++ b/tests/pylint/test_imports.py
@@ -347,7 +347,7 @@ def test_domain_alias(
             pylint.testutils.MessageTest(
                 msg_id="hass-import-constant-alias",
                 node=import_node,
-                args=("DOMAIN", "OTHER_DOMAIN"),
+                args=("DOMAIN", "DOMAIN", "OTHER_DOMAIN"),
                 line=1,
                 col_offset=0,
                 end_line=1,

--- a/tests/pylint/test_imports.py
+++ b/tests/pylint/test_imports.py
@@ -309,3 +309,54 @@ def test_bad_namespace_import(
         ),
     ):
         imports_checker.visit_importfrom(node)
+
+
+@pytest.mark.parametrize(
+    ("module_name", "import_string", "end_col_offset"),
+    [
+        (
+            "homeassistant.components.pylint_test.sensor",
+            "import homeassistant.components.other.DOMAIN as OTHER_DOMAIN",
+            -1,
+        ),
+        (
+            "homeassistant.components.pylint_test.sensor",
+            "import homeassistant.components.other.DOMAIN",
+            44,
+        ),
+    ],
+)
+def test_domain_alias(
+    linter: UnittestLinter,
+    imports_checker: BaseChecker,
+    module_name: str,
+    import_string: str,
+    end_col_offset: int,
+) -> None:
+    """Ensure good imports pass through ok."""
+
+    import_node = astroid.extract_node(
+        f"{import_string}  #@",
+        module_name,
+    )
+    imports_checker.visit_module(import_node.parent)
+
+    expected_messages = []
+    if end_col_offset > 0:
+        expected_messages.append(
+            pylint.testutils.MessageTest(
+                msg_id="hass-import-constant-alias",
+                node=import_node,
+                args=None,
+                line=1,
+                col_offset=0,
+                end_line=1,
+                end_col_offset=end_col_offset,
+            )
+        )
+
+    with assert_adds_messages(linter, *expected_messages):
+        if import_string.startswith("import"):
+            imports_checker.visit_import(import_node)
+        else:
+            imports_checker.visit_importfrom(import_node)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensure that an alias is used when import DOMAIN constant from another integration/platform

Sample run:
```console
************* Module tests.components.zha.test_button
tests/components/zha/test_button.py:12:0: W7426: `DOMAIN` should be imported using an alias, such as `DOMAIN as BUTTON_DOMAIN` (hass-import-constant-alias)
tests/components/zha/test_button.py:12:0: W7426: `DOMAIN` should be imported using an alias, such as `DOMAIN as BUTTON_DOMAIN` (hass-import-constant-alias)
************* Module tests.components.zwave_js.test_cover
tests/components/zwave_js/test_cover.py:13:0: W7426: `DOMAIN` should be imported using an alias, such as `DOMAIN as COVER_DOMAIN` (hass-import-constant-alias)
tests/components/zwave_js/test_cover.py:13:0: W7426: `DOMAIN` should be imported using an alias, such as `DOMAIN as COVER_DOMAIN` (hass-import-constant-alias)
************* Module tests.components.zwave_js.test_switch
tests/components/zwave_js/test_switch.py:9:0: W7426: `DOMAIN` should be imported using an alias, such as `DOMAIN as SWITCH_DOMAIN` (hass-import-constant-alias)
tests/components/zwave_js/test_switch.py:9:0: W7426: `DOMAIN` should be imported using an alias, such as `DOMAIN as SWITCH_DOMAIN` (hass-import-constant-alias)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
