### PR TITLE
Improve test code coverage for enphase_envoy

### DIFF
--- a/tests/components/enphase_envoy/test_init.py
+++ b/tests/components/enphase_envoy/test_init.py
@@ -22,10 +22,13 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.setup import async_setup_component
 
 from . import setup_integration
 
 from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.typing import WebSocketGenerator
 
 
 async def test_with_pre_v7_firmware(
@@ -189,8 +192,7 @@ async def test_coordinator_token_refresh_error(
     hass: HomeAssistant,
     mock_envoy: AsyncMock,
 ) -> None:
-    """Test coordinator with token provided from config."""
-    # 63, 69-79  _async_try_refresh_token
+    """Test coordinator with expired token and failure to refresh."""
     token = encode(
         # some time in 2021
         payload={"name": "envoy", "exp": 1627314600},
@@ -210,12 +212,122 @@ async def test_coordinator_token_refresh_error(
             CONF_TOKEN: token,
         },
     )
-    # token refresh without username and password specified in
-    # EnvoyTokenAuthwill force token refresh error
+    # override fresh token in conftest mock_envoy.auth
     mock_envoy.auth = EnvoyTokenAuth("127.0.0.1", token=token, envoy_serial="1234")
-    await setup_integration(hass, entry)
+    # force token refresh to fail.
+    with patch(
+        "pyenphase.auth.EnvoyTokenAuth._obtain_token",
+        side_effect=EnvoyError,
+    ):
+        await setup_integration(hass, entry)
+
     await hass.async_block_till_done(wait_background_tasks=True)
     assert entry.state is ConfigEntryState.LOADED
 
     assert (entity_state := hass.states.get("sensor.inverter_1"))
     assert entity_state.state == "1"
+
+
+async def test_config_no_unique_id(
+    hass: HomeAssistant,
+    mock_envoy: AsyncMock,
+) -> None:
+    """Test enphase_envoy init if config entry has no unieuqe id."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="45a36e55aaddb2007c5f6602e0c38e72",
+        title="Envoy 1234",
+        unique_id=None,
+        data={
+            CONF_HOST: "1.1.1.1",
+            CONF_NAME: "Envoy 1234",
+            CONF_USERNAME: "test-username",
+            CONF_PASSWORD: "test-password",
+        },
+    )
+    await setup_integration(hass, entry)
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.unique_id == mock_envoy.serial_number
+
+
+async def test_config_different_unique_id(
+    hass: HomeAssistant,
+    mock_envoy: AsyncMock,
+) -> None:
+    """Test enphase_envoy init if config entry has different unique id."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="45a36e55aaddb2007c5f6602e0c38e72",
+        title="Envoy 1234",
+        unique_id=4321,
+        data={
+            CONF_HOST: "1.1.1.1",
+            CONF_NAME: "Envoy 1234",
+            CONF_USERNAME: "test-username",
+            CONF_PASSWORD: "test-password",
+        },
+    )
+    await setup_integration(hass, entry)
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
+@pytest.mark.parametrize(
+    ("mock_envoy"),
+    [
+        "envoy_metered_batt_relay",
+    ],
+    indirect=["mock_envoy"],
+)
+async def test_remove_config_entry_device(
+    hass: HomeAssistant,
+    mock_envoy: AsyncMock,
+    config_entry: MockConfigEntry,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test removing enphase_envoy config entry device."""
+    assert await async_setup_component(hass, "config", {})
+    await setup_integration(hass, config_entry)
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    # use client to send remove_device command
+    hass_client = await hass_ws_client(hass)
+
+    # add device that will pass remove test
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, "delete_this_device")},
+    )
+    response = await hass_client.remove_device(device_entry.id, config_entry.entry_id)
+    assert response["success"]
+
+    # inverters are not allowed to be removed
+    entity = entity_registry.entities["sensor.inverter_1"]
+    device_entry = device_registry.async_get(entity.device_id)
+    response = await hass_client.remove_device(device_entry.id, config_entry.entry_id)
+    assert not response["success"]
+
+    # envoy itself is not allowed to be removed
+    entity = entity_registry.entities["sensor.envoy_1234_current_power_production"]
+    device_entry = device_registry.async_get(entity.device_id)
+    response = await hass_client.remove_device(device_entry.id, config_entry.entry_id)
+    assert not response["success"]
+
+    # encharge can not be removed
+    entity = entity_registry.entities["sensor.encharge_123456_power"]
+    device_entry = device_registry.async_get(entity.device_id)
+    response = await hass_client.remove_device(device_entry.id, config_entry.entry_id)
+    assert not response["success"]
+
+    # enpower can not be removed
+    entity = entity_registry.entities["sensor.enpower_654321_temperature"]
+    device_entry = device_registry.async_get(entity.device_id)
+    response = await hass_client.remove_device(device_entry.id, config_entry.entry_id)
+    assert not response["success"]
+
+    # relays can be removed
+    entity = entity_registry.entities["switch.nc1_fixture"]
+    device_entry = device_registry.async_get(entity.device_id)
+    response = await hass_client.remove_device(device_entry.id, config_entry.entry_id)
+    assert response["success"]

--- a/tests/components/enphase_envoy/test_init.py
+++ b/tests/components/enphase_envoy/test_init.py
@@ -232,7 +232,7 @@ async def test_config_no_unique_id(
     hass: HomeAssistant,
     mock_envoy: AsyncMock,
 ) -> None:
-    """Test enphase_envoy init if config entry has no unieuqe id."""
+    """Test enphase_envoy init if config entry has no unique id."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         entry_id="45a36e55aaddb2007c5f6602e0c38e72",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add more tests to improve test code coverage to 100% for enphase_envoy integration. 

This PR:

- extends test_init.py to improve code coverage for \_\_init\_\_.py and coordinator.py to 100%
- results in 100% code coverage as of this PR, using local testing 
```txt
pytest tests/components/enphase_envoy/ --cov=homeassistant.components.enphase_envoy --cov-report term-missing

---------- coverage: platform linux, python 3.12.3-final-0 -----------
Name                                                      Stmts   Miss  Cover   Missing
---------------------------------------------------------------------------------------
homeassistant/components/enphase_envoy/__init__.py           45      0   100%
homeassistant/components/enphase_envoy/binary_sensor.py      59      0   100%
homeassistant/components/enphase_envoy/config_flow.py       142      0   100%
homeassistant/components/enphase_envoy/const.py               7      0   100%
homeassistant/components/enphase_envoy/coordinator.py        97      0   100%
homeassistant/components/enphase_envoy/diagnostics.py        55      0   100%
homeassistant/components/enphase_envoy/entity.py             18      0   100%
homeassistant/components/enphase_envoy/number.py             70      0   100%
homeassistant/components/enphase_envoy/select.py             83      0   100%
homeassistant/components/enphase_envoy/sensor.py            263      0   100%
homeassistant/components/enphase_envoy/switch.py            109      0   100%
---------------------------------------------------------------------------------------
TOTAL                                                       948      0   100%
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
