### PR TITLE
Change wake word interception to a subscription

### DIFF
--- a/homeassistant/components/assist_satellite/entity.py
+++ b/homeassistant/components/assist_satellite/entity.py
@@ -105,7 +105,9 @@ class AssistSatelliteEntity(entity.Entity):
         Returns the detected wake word phrase or None.
         """
         if self._wake_word_intercept_future is not None:
-            raise SatelliteBusyError("Wake word interception already in progress")
+            # Cancel existing interception
+            self._wake_word_intercept_future.set_result(None)
+            self._wake_word_intercept_future = None
 
         # Will cause next wake word to be intercepted in
         # async_accept_pipeline_from_satellite
@@ -116,6 +118,13 @@ class AssistSatelliteEntity(entity.Entity):
         try:
             return await self._wake_word_intercept_future
         finally:
+            self._wake_word_intercept_future = None
+
+    def async_stop_intercept_wake_word(self) -> None:
+        """Stop intercepting wake words."""
+        if self._wake_word_intercept_future is not None:
+            # Cancel existing interception
+            self._wake_word_intercept_future.set_result(None)
             self._wake_word_intercept_future = None
 
     async def async_internal_announce(

--- a/homeassistant/components/assist_satellite/entity.py
+++ b/homeassistant/components/assist_satellite/entity.py
@@ -25,13 +25,13 @@ from homeassistant.components.media_player import async_process_play_media_url
 from homeassistant.components.tts.media_source import (
     generate_media_source_id as tts_generate_media_source_id,
 )
-from homeassistant.core import Context, callback
+from homeassistant.core import CALLBACK_TYPE, Context, callback
 from homeassistant.helpers import entity
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.util import ulid
 
 from .const import AssistSatelliteEntityFeature
-from .errors import AssistSatelliteError, SatelliteBusyError
+from .errors import SatelliteBusyError
 
 _CONVERSATION_TIMEOUT_SEC: Final = 5 * 60  # 5 minutes
 
@@ -72,7 +72,7 @@ class AssistSatelliteEntity(entity.Entity):
 
     _run_has_tts: bool = False
     _is_announcing = False
-    _wake_word_intercept_future: asyncio.Future[str | None] | None = None
+    _wake_word_listener: Callable[[str | None, str], None] | None = None
     _attr_tts_options: dict[str, Any] | None = None
     _pipeline_task: asyncio.Task | None = None
 
@@ -99,33 +99,25 @@ class AssistSatelliteEntity(entity.Entity):
         """Options passed for text-to-speech."""
         return self._attr_tts_options
 
-    async def async_intercept_wake_word(self) -> str | None:
-        """Intercept the next wake word from the satellite.
+    def async_intercept_wake_word(
+        self, wake_word_listener: Callable[[str | None, str], None]
+    ) -> CALLBACK_TYPE:
+        """Set a listener to intercept the next wake word from the satellite.
 
-        Returns the detected wake word phrase or None.
+        Returns a callback to remove the listener.
         """
-        if self._wake_word_intercept_future is not None:
+        if self._wake_word_listener is not None:
             # Cancel existing interception
-            self._wake_word_intercept_future.set_result(None)
-            self._wake_word_intercept_future = None
+            self._wake_word_listener(None, "Only one interception is allowed")
 
-        # Will cause next wake word to be intercepted in
-        # async_accept_pipeline_from_satellite
-        self._wake_word_intercept_future = asyncio.Future()
+        self._wake_word_listener = wake_word_listener
 
-        _LOGGER.debug("Next wake word will be intercepted: %s", self.entity_id)
+        @callback
+        def unsubscribe() -> None:
+            if self._wake_word_listener == wake_word_listener:
+                self._wake_word_listener = None
 
-        try:
-            return await self._wake_word_intercept_future
-        finally:
-            self._wake_word_intercept_future = None
-
-    def async_stop_intercept_wake_word(self) -> None:
-        """Stop intercepting wake words."""
-        if self._wake_word_intercept_future is not None:
-            # Cancel existing interception
-            self._wake_word_intercept_future.set_result(None)
-            self._wake_word_intercept_future = None
+        return unsubscribe
 
     async def async_internal_announce(
         self,
@@ -213,11 +205,10 @@ class AssistSatelliteEntity(entity.Entity):
             PipelineStage.STT,
         ):
             if start_stage == PipelineStage.WAKE_WORD:
-                self._wake_word_intercept_future.set_exception(
-                    AssistSatelliteError(
-                        "Only on-device wake words currently supported"
-                    )
+                self._wake_word_listener(
+                    None, "Only on-device wake words currently supported"
                 )
+                self._wake_word_listener = None
                 return
 
             # Intercepting wake word and immediately end pipeline
@@ -227,12 +218,14 @@ class AssistSatelliteEntity(entity.Entity):
                 self.entity_id,
             )
 
-            if wake_word_phrase is None:
-                self._wake_word_intercept_future.set_exception(
-                    AssistSatelliteError("No wake word phrase provided")
-                )
-            else:
-                self._wake_word_intercept_future.set_result(wake_word_phrase)
+            try:
+                if wake_word_phrase is None:
+                    self._wake_word_listener(None, "No wake word phrase provided")
+                else:
+                    self._wake_word_listener(wake_word_phrase, "")
+            finally:
+                self._wake_word_listener = None
+
             self._internal_on_pipeline_event(PipelineEvent(PipelineEventType.RUN_END))
             return
 

--- a/homeassistant/components/assist_satellite/websocket_api.py
+++ b/homeassistant/components/assist_satellite/websocket_api.py
@@ -56,8 +56,6 @@ async def websocket_intercept_wake_word(
         except HomeAssistantError as err:
             connection.send_error(msg["id"], "home_assistant_error", str(err))
 
-    task = hass.async_create_background_task(
-        intercept_wake_word(), "intercept_wake_word"
-    )
+    task = hass.async_create_task(intercept_wake_word(), "intercept_wake_word")
     connection.subscriptions[msg["id"]] = task.cancel
     connection.send_message(websocket_api.result_message(msg["id"]))

--- a/tests/components/assist_satellite/test_websocket_api.py
+++ b/tests/components/assist_satellite/test_websocket_api.py
@@ -39,7 +39,9 @@ async def test_intercept_wake_word(
         wake_word_phrase="ok, nabu",
     )
 
-    msg = await ws_client.receive_json()
+    async with asyncio.timeout(1):
+        msg = await ws_client.receive_json()
+
     assert msg["id"] == subscription_id
     assert msg["type"] == "event"
     assert msg["event"] == {"wake_word_phrase": "ok, nabu"}
@@ -61,7 +63,9 @@ async def test_intercept_wake_word_requires_on_device_wake_word(
         }
     )
 
-    msg = await ws_client.receive_json()
+    async with asyncio.timeout(1):
+        msg = await ws_client.receive_json()
+
     assert msg["success"]
     assert msg["result"] is None
 
@@ -71,9 +75,11 @@ async def test_intercept_wake_word_requires_on_device_wake_word(
         start_stage=PipelineStage.WAKE_WORD,
     )
 
-    response = await ws_client.receive_json()
-    assert not response["success"]
-    assert response["error"] == {
+    async with asyncio.timeout(1):
+        msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"] == {
         "code": "home_assistant_error",
         "message": "Only on-device wake words currently supported",
     }
@@ -95,7 +101,9 @@ async def test_intercept_wake_word_requires_wake_word_phrase(
         }
     )
 
-    msg = await ws_client.receive_json()
+    async with asyncio.timeout(1):
+        msg = await ws_client.receive_json()
+
     assert msg["success"]
     assert msg["result"] is None
 
@@ -105,9 +113,11 @@ async def test_intercept_wake_word_requires_wake_word_phrase(
         # We are not passing wake word phrase
     )
 
-    response = await ws_client.receive_json()
-    assert not response["success"]
-    assert response["error"] == {
+    async with asyncio.timeout(1):
+        msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"] == {
         "code": "home_assistant_error",
         "message": "No wake word phrase provided",
     }
@@ -131,10 +141,12 @@ async def test_intercept_wake_word_require_admin(
             "entity_id": ENTITY_ID,
         }
     )
-    response = await ws_client.receive_json()
 
-    assert not response["success"]
-    assert response["error"] == {
+    async with asyncio.timeout(1):
+        msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"] == {
         "code": "unauthorized",
         "message": "Unauthorized",
     }
@@ -155,7 +167,8 @@ async def test_intercept_wake_word_invalid_satellite(
             "entity_id": "assist_satellite.invalid",
         }
     )
-    msg = await ws_client.receive_json()
+    async with asyncio.timeout(1):
+        msg = await ws_client.receive_json()
 
     assert not msg["success"]
     assert msg["error"] == {
@@ -180,7 +193,9 @@ async def test_intercept_wake_word_twice(
         }
     )
 
-    msg = await ws_client.receive_json()
+    async with asyncio.timeout(1):
+        msg = await ws_client.receive_json()
+
     assert msg["success"]
     assert msg["result"] is None
 
@@ -194,14 +209,18 @@ async def test_intercept_wake_word_twice(
     )
 
     # Should get an error from previous subscription
-    msg = await task
+    async with asyncio.timeout(1):
+        msg = await task
+
     assert not msg["success"]
     assert msg["error"] == {
         "code": "home_assistant_error",
-        "message": "Only one interception is allowed",
+        "message": "Wake word interception already in progress",
     }
 
     # Response to second subscription
-    msg = await ws_client.receive_json()
+    async with asyncio.timeout(1):
+        msg = await ws_client.receive_json()
+
     assert msg["success"]
     assert msg["result"] is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Modifies the `assist_satellite/intercept_wake_word` websocket command to be a subscription instead. This will allow it to be cancelled within the UI. Additionally, starting a second interception will cancel the first one.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
