### PR TITLE
Add Duwi integrated switch platform

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -359,6 +359,7 @@ build.json @home-assistant/supervisor
 /tests/components/dsmr_reader/ @sorted-bits @glodenox @erwindouna
 /homeassistant/components/duotecno/ @cereal2nd
 /tests/components/duotecno/ @cereal2nd
+/homeassistant/components/duwi/ @duwi2024
 /homeassistant/components/dwd_weather_warnings/ @runningman84 @stephan192 @andarotajo
 /tests/components/dwd_weather_warnings/ @runningman84 @stephan192 @andarotajo
 /homeassistant/components/dynalite/ @ziv1234

--- a/homeassistant/components/duwi/__init__.py
+++ b/homeassistant/components/duwi/__init__.py
@@ -1,0 +1,356 @@
+"""Support for Duwi Smart devices."""
+
+import asyncio
+import functools
+import time
+from typing import Any, NamedTuple
+
+from duwi_open_sdk.base_api import CustomerApi, SharingTokenListener
+from duwi_open_sdk.device_scene_models import CustomerDevice, CustomerScene
+from duwi_open_sdk.manager import Manager, SharingDeviceListener
+from homeassistant import config_entries
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import __version__
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.dispatcher import dispatcher_send
+
+from .const import (
+    _LOGGER,
+    ACCESS_TOKEN,
+    ADDRESS,
+    APP_KEY,
+    APP_SECRET,
+    APP_VERSION,
+    CLIENT,
+    CLIENT_MODEL,
+    CLIENT_VERSION,
+    CONF_TOKEN_INFO,
+    DOMAIN,
+    DUWI_DISCOVERY_NEW,
+    DUWI_HA_ACCESS_TOKEN,
+    DUWI_HA_SIGNAL_UPDATE_ENTITY,
+    DUWI_SCENE_UPDATE,
+    HOUSE_KEY,
+    HOUSE_NAME,
+    HOUSE_NO,
+    MANUFACTURER,
+    PASSWORD,
+    PHONE,
+    REFRESH_TOKEN,
+    SUPPORTED_PLATFORMS,
+    WS_ADDRESS,
+)
+
+type DuwiConfigEntry = ConfigEntry[HomeAssistantDuwiData]
+
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(domain=DOMAIN)
+
+
+class HomeAssistantDuwiData(NamedTuple):
+    """Duwi data stored in the Home Assistant data object."""
+
+    manager: Manager
+    listener: SharingDeviceListener
+
+
+async def async_setup(hass: HomeAssistant, hass_config: dict) -> bool:
+    """Set up the Duwi Smart Devices integration."""
+
+    # Check for existing config entries for this integration
+    hass.data.setdefault(DOMAIN, {})
+    if not hass.config_entries.async_entries(DOMAIN):
+        # No entries found, initiate the configuration flow
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data={}
+            )
+        )
+
+    # Setup was successful
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: DuwiConfigEntry) -> bool:
+    """Set up a config entry for the Duwi Smart Devices integration."""
+
+    hass.data.setdefault(DOMAIN, {})
+
+    token_listener = TokenListener(hass, entry)
+    manager: Manager = Manager(
+        _id=entry.entry_id,
+        customer_api=CustomerApi(
+            address=entry.data[ADDRESS],
+            ws_address=entry.data[WS_ADDRESS],
+            app_key=entry.data[APP_KEY],
+            app_secret=entry.data[APP_SECRET],
+            house_no=entry.data[HOUSE_NO],
+            house_name=entry.data[HOUSE_NAME],
+            access_token=entry.data[ACCESS_TOKEN],
+            refresh_token=entry.data[REFRESH_TOKEN],
+            client_version=CLIENT_VERSION,
+            client_model=CLIENT_MODEL,
+            app_version=__version__,
+        ),
+        house_key=entry.data.get(HOUSE_KEY),
+        token_listener=token_listener,
+    )
+
+    login_status = await manager.init_manager(
+        entry.data["phone"], entry.data["password"]
+    )
+
+    if not login_status:
+        raise ConfigEntryAuthFailed(
+            "User authentication failed, please try reloading the integration or adding again."
+        )
+
+    # Fetch devices
+    is_online = await manager.update_device_cache()
+    listener = DeviceListener(hass, manager)
+    manager.add_device_listener(listener)
+
+    ids = []
+    if hass.data[DOMAIN].get(entry.entry_id) is not None:
+        old_manager = hass.data[DOMAIN].get(entry.entry_id, {}).manager
+        ids = await compare_manager(old_manager, manager, None)
+
+    hass.data[DOMAIN][entry.entry_id] = HomeAssistantDuwiData(
+        manager=manager, listener=listener
+    )
+
+    # Clean up inappropriate devices
+    await cleanup_device_registry(hass, ids)
+    hass.data[DOMAIN].setdefault("existing_house", []).append(entry.data[HOUSE_NO])
+
+    # Start global WebSocket listener
+    if is_online:
+        await hass.async_create_task(manager.ws.reconnect())
+    else:
+        hass.loop.create_task(manager.ws.reconnect())
+
+    hass.loop.create_task(manager.ws.listen())
+    hass.loop.create_task(manager.ws.keep_alive())
+
+    await hass.config_entries.async_forward_entry_setups(entry, SUPPORTED_PLATFORMS)
+
+    return True
+
+
+async def compare_manager(
+    old_manager: Manager | None, new_manager: Manager, devices: list | None
+) -> list:
+    """Compare old and new manager to find devices with different room or type."""
+
+    ids = []
+
+    if not old_manager:
+        # If there is no old manager, check for differences in the new manager
+        for d in devices:
+            d2 = new_manager.device_map.get(d.device_no)
+            if not d2:
+                # Device not found in new manager
+                continue
+
+            # Compare room and device type; if different, add device ID to the list
+            if d.room_no != d2.room_no or d.device_sub_type_no != d2.device_sub_type_no:
+                ids.append(d.device_no)
+        return ids
+
+    # Compare devices in both managers
+    for dev_id in old_manager.device_map:
+        d1 = old_manager.device_map.get(dev_id)
+        d2 = new_manager.device_map.get(dev_id)
+        if not d2:
+            # Device not found in new manager
+            continue
+
+        # Compare room and device type; if different, add device ID to the list
+        if d1.room_no != d2.room_no or d1.device_sub_type_no != d2.device_sub_type_no:
+            ids.append(dev_id)
+
+    return ids
+
+
+async def cleanup_device_registry(hass: HomeAssistant, device_ids: list) -> None:
+    """Remove deleted device registry entry if there are no remaining entities."""
+
+    device_registry = dr.async_get(hass)
+
+    for dev_id, device_entry in list(device_registry.devices.items()):
+        for item in device_entry.identifiers:
+            if item[0] == DOMAIN:
+                # Prepare to remove Duwi device
+                read_to_remove = True
+
+                for v in hass.data[DOMAIN].values():
+                    if hasattr(v, "manager"):
+                        # Check if device ID exists in the current manager's device map
+                        if item[1] in v.manager.device_map:
+                            read_to_remove = False
+                            break
+
+                # Remove the device if required
+                if read_to_remove or item[1] in device_ids:
+                    device_registry.async_remove_device(dev_id)
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: DuwiConfigEntry) -> bool:
+    """Unload the Duwi platforms associated with the provided config entry."""
+
+    # Attempt to unload all platforms associated with the entry.
+    await hass.data[DOMAIN][entry.entry_id].manager.unload()
+
+    house_no = entry.data.get(HOUSE_NO)
+    if house_no in hass.data[DOMAIN].get("existing_house"):
+        hass.data[DOMAIN]["existing_house"].remove(house_no)
+
+    if lp := hass.data[DOMAIN].get("lp"):
+        _LOGGER.info("Clearing hosts from async_unload_entry")
+        lp.clear_hosts(entry.entry_id)
+
+    return await hass.config_entries.async_unload_platforms(entry, SUPPORTED_PLATFORMS)
+
+
+async def async_remove_entry(hass: HomeAssistant, entry: DuwiConfigEntry) -> bool:
+    """Remove a config entry and revoke credentials from Duwi."""
+
+    manager = hass.data[DOMAIN][entry.entry_id].manager
+
+    # Cleanup device registry for the devices managed by this entry
+    await cleanup_device_registry(hass, manager.device_map.keys())
+
+    # Unload the manager and remove entry data
+    await manager.unload(True)
+    hass.data[DOMAIN].pop(entry.entry_id)
+
+    house_no_list: list = hass.data[DOMAIN].get("existing_house", [])
+
+    if lp := hass.data[DOMAIN].get("lp"):
+        _LOGGER.info("Clearing hosts from async_remove_entry")
+        lp.clear_hosts(entry.entry_id)
+
+        if not house_no_list:
+            # Last entry removed; stopping the lp service
+            _LOGGER.info("Last entry removed from async_remove_entry")
+            lp.stop()
+            hass.data[DOMAIN].pop("lp")
+
+    return await hass.config_entries.async_unload_platforms(entry, SUPPORTED_PLATFORMS)
+
+
+class DeviceListener(SharingDeviceListener):
+    """Device Update Listener."""
+
+    def __init__(self, hass: HomeAssistant, manager: Manager) -> None:
+        """Initialize the DeviceListener."""
+        self.hass = hass
+        self.manager = manager
+
+    def update_scene(self, scene: CustomerScene) -> None:
+        """Notify about scene update."""
+        dispatcher_send(self.hass, f"{DUWI_SCENE_UPDATE}_{scene.scene_no}")
+
+    def update_device(self, device: CustomerDevice) -> None:
+        """Update device status notification."""
+        dispatcher_send(self.hass, f"{DUWI_HA_SIGNAL_UPDATE_ENTITY}_{device.device_no}")
+
+    def add_device(self, device: CustomerDevice) -> None:
+        """Handle a new device being added."""
+        # Ensure the device isn't present stale
+        self.async_remove_device(device.device_no)
+        dispatcher_send(self.hass, DUWI_DISCOVERY_NEW, [device.device_no])
+
+    def remove_device(self, device_no: str) -> None:
+        """Schedule removal of a device."""
+        self.hass.add_job(self.async_remove_device, device_no)
+
+    def token_listener(self, token_info: dict[str, Any]) -> None:
+        """Handle token update notifications."""
+        # Implementation needed (if applicable)
+
+    @callback
+    def async_remove_device(self, device_no: str) -> None:
+        """Remove device from Home Assistant."""
+        device_registry = dr.async_get(self.hass)
+        _LOGGER.info("Removing device_no %s", device_no)
+
+        device_entry = device_registry.async_get_device(
+            identifiers={(DOMAIN, device_no)}
+        )
+
+        if device_entry is not None:
+            device_registry.async_remove_device(device_entry.id)
+
+
+class TokenListener(SharingTokenListener):
+    """Token listener for upstream token updates."""
+
+    def __init__(self, hass: HomeAssistant, entry: DuwiConfigEntry) -> None:
+        """Initialize the TokenListener."""
+        self.hass = hass
+        self.entry = entry
+
+    def update_token(self, is_refresh: bool, token_info: dict[str, Any] = None) -> None:
+        """Update token info in the config entry."""
+        _LOGGER.info("Updating token: %s %s", is_refresh, token_info)
+
+        if is_refresh:
+            # Prepare data for updating the config entry
+            data = {
+                PHONE: self.entry.data[PHONE],
+                PASSWORD: self.entry.data[PASSWORD],
+                HOUSE_KEY: self.entry.data[HOUSE_KEY],
+                ADDRESS: self.entry.data[ADDRESS],
+                WS_ADDRESS: self.entry.data[WS_ADDRESS],
+                APP_KEY: self.entry.data[APP_KEY],
+                APP_SECRET: self.entry.data[APP_SECRET],
+                HOUSE_NO: self.entry.data[HOUSE_NO],
+                ACCESS_TOKEN: token_info[ACCESS_TOKEN],
+                REFRESH_TOKEN: token_info[REFRESH_TOKEN],
+            }
+        else:
+            raise ConfigEntryAuthFailed(
+                "Failed to refresh token, please try reloading the integration or re-adding it."
+            )
+
+        @callback
+        def async_update_entry() -> None:
+            """Update the configuration entry with new token data."""
+            self.hass.config_entries.async_update_entry(self.entry, data=data)
+
+        # Schedule the asynchronous update job
+        self.hass.add_job(async_update_entry)
+
+
+def debounce(wait: float):
+    """Decorator to debounce a function, ensuring it is called after a specified wait time."""
+
+    def decorator(fn):
+        last_call = 0  # Timestamp of the last call
+        call_pending = None  # Task for the pending call
+
+        @functools.wraps(fn)
+        async def debounced(*args, **kwargs):
+            nonlocal last_call, call_pending
+
+            now = time.time()  # Get current time
+            if now - last_call < wait:
+                # If the function was called recently
+                if call_pending:
+                    # Cancel the previous pending call if it exists
+                    call_pending.cancel()
+                # Create a new task that waits for the remaining time
+                call_pending = asyncio.create_task(
+                    asyncio.sleep(wait - (now - last_call))
+                )
+                await call_pending
+
+            last_call = time.time()  # Update last call timestamp
+            return await fn(*args, **kwargs)  # Call the actual function
+
+        return debounced
+
+    return decorator

--- a/homeassistant/components/duwi/base.py
+++ b/homeassistant/components/duwi/base.py
@@ -1,0 +1,65 @@
+from typing import Any
+
+from duwi_open_sdk.device_scene_models import CustomerDevice
+from duwi_open_sdk.manager import Manager
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import Entity
+
+from .const import DOMAIN, DUWI_HA_SIGNAL_UPDATE_ENTITY, MANUFACTURER
+
+
+class DuwiEntity(Entity):
+    """Duwi base device."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    def __init__(self, device: CustomerDevice, device_manager: Manager) -> None:
+        """Initialize the Duwi entity."""
+        self._attr_unique_id = f"duwi.{device.device_no}"
+        self.device = device
+        self.entity_id = f"{DOMAIN}.{device.device_no}"
+        self.device_manager = device_manager
+        self.is_control = True
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return a device description for the device registry."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.device.device_no)},
+            manufacturer=MANUFACTURER,
+            name=f"{self.device.room_name + ' ' if self.device.room_name else '默认房间 '} {self.device.device_name}",
+            model=self.device.device_type,
+            suggested_area=f"{self.device.floor_name} {self.device.room_name}".strip(),
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Called when the entity is added to hass."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{DUWI_HA_SIGNAL_UPDATE_ENTITY}_{self.device.device_no}",
+                self.handle_signal,
+            )
+        )
+
+    async def handle_signal(self) -> None:
+        """Handle the signal and invoke the appropriate method based on is_control."""
+        if self.is_control:
+            self.async_write_ha_state()
+        else:
+            self.is_control = True
+
+    @property
+    def available(self) -> bool:
+        """Return if the device is available."""
+        return self.device.value.get("online", False)
+
+    async def _send_command(self, commands: dict[str, Any]) -> None:
+        """Send command to the device."""
+        self.device.value.update(commands)
+        self.is_control = False
+        await self.device_manager.send_commands(
+            self.device.device_no, self.device.is_group, commands
+        )

--- a/homeassistant/components/duwi/base.py
+++ b/homeassistant/components/duwi/base.py
@@ -59,7 +59,6 @@ class DuwiEntity(Entity):
     async def _send_command(self, commands: dict[str, Any]) -> None:
         """Send command to the device."""
         self.device.value.update(commands)
-        self.is_control = False
         await self.device_manager.send_commands(
             self.device.device_no, self.device.is_group, commands
         )

--- a/homeassistant/components/duwi/config_flow.py
+++ b/homeassistant/components/duwi/config_flow.py
@@ -1,0 +1,172 @@
+"""Config flow for Duwi Smart Devices integration."""
+
+import voluptuous as vol
+from duwi_open_sdk.base_api import CustomerApi
+from duwi_open_sdk.const import HTTP_ADDRESS, WEBSOCKET_ADDRESS, DuwiCode
+from duwi_open_sdk.customer_client import CustomerClient
+from homeassistant import config_entries
+
+from .const import (
+    ACCESS_TOKEN,
+    ADDRESS,
+    APP_KEY,
+    APP_SECRET,
+    APP_VERSION,
+    CLIENT_MODEL,
+    CLIENT_VERSION,
+    DOMAIN,
+    HOUSE_KEY,
+    HOUSE_NAME,
+    HOUSE_NO,
+    PASSWORD,
+    PHONE,
+    REFRESH_TOKEN,
+    WS_ADDRESS,
+)
+
+
+# Configuration class that handles flow initiated by the user for Duwi integration
+class DuwiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Duwi."""
+
+    async def async_step_user(self, user_input: dict = None) -> dict:
+        """Handle a flow initiated by the user."""
+
+        # Placeholder for error messages.
+        errors = {}
+
+        # Ensure DOMAIN data has been initialized in Home Assistant.
+        self.hass.data.setdefault(DOMAIN, {})
+        placeholders = {}
+
+        # Check if user has provided app_key and app_secret.
+        if user_input and all(
+            user_input.get(key) for key in (APP_KEY, APP_SECRET, PHONE, PASSWORD)
+        ):
+            self.client = CustomerApi(
+                address=HTTP_ADDRESS,
+                ws_address=WEBSOCKET_ADDRESS,
+                app_key=user_input[APP_KEY],
+                app_secret=user_input[APP_SECRET],
+                app_version=APP_VERSION,
+                client_version=CLIENT_VERSION,
+                client_model=CLIENT_MODEL,
+            )
+            lc = CustomerClient(self.client)
+
+            # Authenticate the developer.
+            auth_data = await lc.login(user_input[PHONE], user_input[PASSWORD])
+            status = auth_data.get("code")
+
+            # Handle status codes.
+            if status == DuwiCode.SUCCESS.value:
+                self.phone = user_input[PHONE]
+                self.password = user_input[PASSWORD]
+                self.access_token = auth_data.get("data", {}).get("accessToken")
+                self.refresh_token = auth_data.get("data", {}).get("refreshToken")
+                self.app_key = user_input[APP_KEY]
+                self.app_secret = user_input[APP_SECRET]
+                self.client.access_token = auth_data.get("data", {}).get("accessToken")
+                hic = CustomerClient(self.client)
+
+                # Fetch the house information.
+                house_infos_data = await hic.fetch_house_info()
+                house_infos_status = house_infos_data.get("code")
+
+                if house_infos_status != DuwiCode.SUCCESS.value:
+                    errors["base"] = "fetch_house_info_error"
+                    placeholders["code"] = house_infos_status
+                else:
+                    if len(house_infos_data.get("data", {}).get("houseInfos", [])) == 0:
+                        # Handle case where no houses are found.
+                        errors["base"] = "no_houses_found_error"
+
+                    self.houses = house_infos_data.get("data", {}).get("houseInfos", [])
+                    return await self.async_step_select_house()
+
+            if status != DuwiCode.SUCCESS.value:
+                errors["base"] = "auth_error"
+                placeholders["code"] = status
+            elif status == DuwiCode.LOGIN_ERROR.value:
+                errors["base"] = "invalid_auth"
+                placeholders["code"] = status
+            elif status == DuwiCode.SYS_ERROR.value:
+                errors["base"] = "sys_error"
+                placeholders["code"] = status
+
+        # Show user input form (with error messages if any).
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(APP_KEY): str,
+                    vol.Required(APP_SECRET): str,
+                    vol.Required(PHONE): str,
+                    vol.Required(PASSWORD): str,
+                }
+            ),
+            errors=errors,
+            description_placeholders=placeholders,
+        )
+
+    async def async_step_select_house(self, user_input: dict = None) -> dict:
+        """Handle the selection of a house by the user."""
+
+        # Placeholder for error messages.
+        errors = {}
+        # Placeholders for description placeholders.
+        placeholders = {}
+
+        # Retrieve the list of pre-existing self.houses to exclude.
+        existing_house = self.hass.data[DOMAIN].get("existing_house", {})
+
+        # Create a self.houses list excluding already existing ones.
+        houses_list = {
+            house["houseNo"]: house["houseName"]
+            for house in self.houses
+            if house["houseNo"] not in existing_house
+        }
+
+        houses_dict = {
+            house["houseNo"]: {
+                "house_name": house["houseName"],
+                "house_key": house["lanSecretKey"],
+            }
+            for house in self.houses
+            if house["houseNo"] not in existing_house
+        }
+
+        # If no self.houses remain, handle the error.
+        if len(houses_list) == 0:
+            errors["base"] = "no_houses_found_error"
+
+        # With user's house selection, create an entry for the selected house.
+        if user_input is not None:
+            return self.async_create_entry(
+                title=houses_dict[user_input["house_no"]].get("house_name"),
+                data={
+                    PHONE: self.phone,
+                    PASSWORD: self.password,
+                    ADDRESS: HTTP_ADDRESS,
+                    ACCESS_TOKEN: self.access_token,
+                    REFRESH_TOKEN: self.refresh_token,
+                    WS_ADDRESS: WEBSOCKET_ADDRESS,
+                    APP_KEY: self.app_key,
+                    APP_SECRET: self.app_secret,
+                    HOUSE_NO: user_input["house_no"],
+                    HOUSE_NAME: houses_dict[user_input["house_no"]].get("house_name"),
+                    HOUSE_KEY: houses_dict[user_input["house_no"]].get("house_key"),
+                },
+            )
+
+        # If no house has been selected yet, show the selection form.
+        return self.async_show_form(
+            step_id="select_house",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("house_no"): vol.In(houses_list),
+                }
+            ),
+            errors=errors,
+            description_placeholders=placeholders,
+        )

--- a/homeassistant/components/duwi/const.py
+++ b/homeassistant/components/duwi/const.py
@@ -1,0 +1,103 @@
+# Manufacturer of the product for identification purposes
+import logging
+from enum import StrEnum
+
+from homeassistant.components.climate import HVACMode
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import ILLUMINANCE, PERCENTAGE, Platform, UnitOfTemperature
+
+_LOGGER = logging.getLogger(__package__)
+
+MANUFACTURER = "duwi"
+
+DOMAIN = "duwi"
+
+APP_VERSION = "0.1.1"
+
+CLIENT_VERSION = "0.1.1"
+
+CLIENT_MODEL = "homeassistant"
+
+DUWI_DISCOVERY_NEW = "duwi_discovery_new"
+DUWI_SCENE_UPDATE = "duwi_scene_update"
+DUWI_HA_SIGNAL_UPDATE_ENTITY = "duwi_entry_update"
+DUWI_HA_ACCESS_TOKEN = "duwi_access_token"
+
+# API keys
+CLIENT = "client"
+ADDRESS = "address"
+WS_ADDRESS = "ws_address"
+APP_KEY = "app_key"
+APP_SECRET = "app_secret"
+ACCESS_TOKEN = "access_token"
+REFRESH_TOKEN = "refresh_token"
+PHONE = "phone"
+PASSWORD = "password"
+HOUSE_NO = "house_no"
+HOUSE_NAME = "house_name"
+HOUSE_KEY = "house_key"
+CONF_TOKEN_INFO = "token_info"
+
+# List of platforms that support config entry
+SUPPORTED_PLATFORMS = [
+    Platform.SWITCH,
+]
+
+
+class DPCode(StrEnum):
+    """Data Point Codes used by Duwi."""
+
+    # button
+    BUTTON = "button"
+
+    # switch
+    SWITCH = "switch"
+
+    # light
+    ON_OFF = "on_off"
+    LIGHT = "light"
+    COLOR_TEMP = "color_temp"
+    COLOR = "color"
+    RGB = "rgb"
+    RGBW = "rgbw"
+    RGBCW = "rgbcw"
+
+    # cover
+    ROLLER = "roller"
+    SHUTTER = "shutter"
+    SHUTTER_2 = "shutter-2"
+
+    # music
+    HUA_ERSI_MUSIC = "hua_ersi_music"
+    XIANG_WANG_MUSIC_S7_MINI_3S = "xiangwang_music_s7_mini_3s"
+    XIANG_WANG_MUSIC_S8 = "xiangwang_music_s8"
+    SHENG_BI_KE_MUSIC = "sheng_bike_music"
+    BO_SHENG_MUSIC = "bo_sheng_music"
+    YOU_DA_MUSIC = "youda_music"
+
+    # sensor
+    TEMP = "temp"
+    HUMIDITY = "humidity"
+    HCHO = "hcho"
+    PM25 = "pm25"
+    CO2 = "co2"
+    BRIGHT = "bright"
+    IQA = "iaq"
+    HUMAN = "human"
+    TRIGGER = "trigger"
+    MOISTURE = "moisture"
+    SMOKE = "smoke"
+    MOVING = "moving"
+    GAS = "gas"
+    DOOR = "door"
+    OPENING = "opening"
+    CO = "co"
+    TVOC = "tvoc"
+    PM10 = "pm10"
+
+    # climate
+    AC = "ac"
+    FA = "fa"
+    FH = "fh"
+    HP = "hp"
+    TC = "tc"

--- a/homeassistant/components/duwi/manifest.json
+++ b/homeassistant/components/duwi/manifest.json
@@ -8,5 +8,5 @@
   "loggers": ["duwi"],
   "integration_type": "hub",
   "issue_tracker": "https://github.com/home-assistant/core/issues",
-  "requirements": ["duwi-open-sdk==0.2.4"]
+  "requirements": ["duwi-smarthome-sdk == 0.6.2"]
 }

--- a/homeassistant/components/duwi/manifest.json
+++ b/homeassistant/components/duwi/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "duwi",
+  "name": "Duwi",
+  "codeowners": ["@duwi2024"],
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/duwi",
+  "iot_class": "cloud_push",
+  "loggers": ["duwi"],
+  "integration_type": "hub",
+  "issue_tracker": "https://github.com/home-assistant/core/issues",
+  "requirements": ["duwi-open-sdk==0.2.4"]
+}

--- a/homeassistant/components/duwi/string.json
+++ b/homeassistant/components/duwi/string.json
@@ -1,0 +1,95 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Developer Authentication",
+        "description": "Please enter\n your authentication information, your **App Key** and **App Secret**.\n Your Duwi Smart account information **Phone Number** and **Password**.",
+        "data": {
+          "app_key": "App Key",
+          "app_secret": "App Secret",
+          "phone": "Phone Number",
+          "password": "Password"
+        }
+      },
+      "select_house": {
+        "title": "Select Your House",
+        "description": "You can select the house you own (previously added houses have been excluded).",
+        "data": {
+          "house_no": "Your Owned House"
+        }
+      }
+    },
+    "error": {
+      "auth_error": "Exception occurred with App Key or App Secret error, status code: {code}",
+      "invalid_auth": "Invalid authentication {code}",
+      "fetch_house_info_error": "An exception occurred while fetching house information, status code: {code}",
+      "no_houses_found_error": "No addable houses found in this account",
+      "sys_error": "System error, status code: {code}",
+      "unknown_error": "Unknown error, status code: {code}"
+    }
+  },
+  "entity": {
+    "climate": {
+      "duwi_climate": {
+        "state_attributes": {
+          "fan_mode": {
+            "state": {
+              "auto": "Auto",
+              "extreme_strong": "Extreme Strong",
+              "super_strong": "Super Strong",
+              "strong": "Strong",
+              "super_high": "Super High",
+              "high": "High",
+              "mid_high": "Mid High",
+              "mid": "Mid",
+              "mid_low": "Mid Low",
+              "low": "Low",
+              "super_low": "Super Low",
+              "extreme_low": "Extreme Low",
+              "super_quiet": "Super Quiet",
+              "stop": "Stop"
+            }
+          },
+          "preset_mode": {
+            "state": {
+              "mode": "Lock Mode",
+              "mode_wind": "Lock Mode & Wind Speed",
+              "mode_wind_temp": "Lock Mode & Wind Speed & Temperature",
+              "child": "Child Lock",
+              "lock": "Full Lock",
+              "half_lock": "Half Lock",
+              "unlock": "Unlock",
+              "auto": "Auto",
+              "manual": "Manual",
+              "timing": "Timing",
+              "heat_exchange": "Heat Exchange",
+              "common": "Common",
+              "indoor_loop": "Indoor Loop",
+              "outdoor_loop": "Outdoor Loop",
+              "air": "Ventilation",
+              "wet": "Dehumidification",
+              "fresh": "Fresh Air",
+              "fresh_wet": "Fresh Air Dehumidification",
+              "program": "Program",
+              "ventilate": "Ventilate",
+              "exhaust": "Exhaust",
+              "smart": "Smart",
+              "powerful": "Powerful",
+              "cold_room": "Cold Room",
+              "heat_room": "Warm Room",
+              "energy_recycle": "Energy Saving",
+              "night": "Night",
+              "holiday": "Holiday",
+              "sleep": "Sleep",
+              "clean": "Purify",
+              "pass": "Bypass",
+              "pipeline_clean": "Pipeline Cleaning",
+              "frost": "Defrost",
+              "max": "MAX"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/duwi/switch.py
+++ b/homeassistant/components/duwi/switch.py
@@ -1,0 +1,119 @@
+"""Support for Duwi switches."""
+
+from typing import Any
+
+from duwi_open_sdk.device_scene_models import CustomerDevice
+from duwi_open_sdk.manager import Manager
+from homeassistant.components.switch import (
+    SwitchDeviceClass,
+    SwitchEntity,
+    SwitchEntityDescription,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import DuwiConfigEntry
+from .base import DuwiEntity
+from .const import _LOGGER, DOMAIN, DUWI_DISCOVERY_NEW, DPCode
+
+# List of Duwi switch types, each represented by a unique ID.
+DUWI_SWITCH_TYPES = [
+    ("1-002",),
+    ("1-003",),
+    ("1-005",),
+    ("1-006",),
+    ("107-001",),
+    ("107-002",),
+    ("107-003",),
+]
+
+# Map of switch type IDs to their SwitchEntityDescription objects.
+SWITCHES = {
+    key[0]: (
+        SwitchEntityDescription(
+            key=DPCode.SWITCH,
+            name=None,
+            device_class=SwitchDeviceClass.SWITCH,
+        ),
+    )
+    for key in DUWI_SWITCH_TYPES
+}
+
+# Grouped switches, allowing categorization of related entities.
+GROUP_SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
+    "Breaker": (
+        SwitchEntityDescription(
+            key=DPCode.SWITCH,
+            name=None,
+            device_class=SwitchDeviceClass.SWITCH,
+        ),
+    ),
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: DuwiConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up duwi sensors dynamically through duwi discovery."""
+    hass_data = hass.data[DOMAIN].get(entry.entry_id)
+
+    @callback
+    def async_discover_device(device_ids: list[str]) -> None:
+        """Discover and add a discovered Duwi sensor."""
+        entities: list[DuwiSwitchEntity] = []
+
+        for device_id in device_ids:
+            device = hass_data.manager.device_map.get(device_id)
+            if not device:
+                _LOGGER.warning("Device not found in device_map: %s", device_id)
+                continue
+
+            # Get the device descriptions from SWITCHES or GROUP_SWITCHES.
+            descriptions = SWITCHES.get(device.device_type_no) or GROUP_SWITCHES.get(
+                device.device_group_type
+            )
+
+            if descriptions:
+                entities.extend(
+                    DuwiSwitchEntity(device, hass_data.manager, description)
+                    for description in descriptions
+                )
+
+        async_add_entities(entities)
+
+    # Discover devices at setup time.
+    async_discover_device(list(hass_data.manager.device_map.keys()))
+
+    # Register the discovery callback.
+    entry.async_on_unload(
+        async_dispatcher_connect(hass, DUWI_DISCOVERY_NEW, async_discover_device)
+    )
+
+
+class DuwiSwitchEntity(DuwiEntity, SwitchEntity):
+    """Duwi Switch Device."""
+
+    def __init__(
+        self,
+        device: CustomerDevice,
+        device_manager: Manager,
+        description: SwitchEntityDescription,
+    ) -> None:
+        """Initialize the Duwi switch entity."""
+        super().__init__(device, device_manager)
+        self.entity_description = description
+        self._attr_unique_id = f"{super().unique_id}{description.key}"
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the switch is on."""
+        return self.device.value.get(self.entity_description.key, "off") == "on"
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the switch on."""
+        await self._send_command({self.entity_description.key: "on"})
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the switch off."""
+        await self._send_command({self.entity_description.key: "off"})

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -140,6 +140,7 @@ FLOWS = {
         "dsmr_reader",
         "dunehd",
         "duotecno",
+        "duwi",
         "dwd_weather_warnings",
         "dynalite",
         "eafm",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -1386,6 +1386,12 @@
       "integration_type": "virtual",
       "supported_by": "opower"
     },
+    "duwi": {
+      "name": "Duwi",
+      "integration_type": "hub",
+      "config_flow": true,
+      "iot_class": "cloud_push"
+    },
     "dwd_weather_warnings": {
       "name": "Deutscher Wetterdienst (DWD) Weather Warnings",
       "integration_type": "service",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -761,6 +761,9 @@ dropmqttapi==1.0.3
 # homeassistant.components.dsmr
 dsmr-parser==1.4.2
 
+# homeassistant.components.duwi
+duwi-open-sdk == 0.2.4
+
 # homeassistant.components.dwd_weather_warnings
 dwdwfsapi==1.0.7
 

--- a/tests/components/duwi/__init__.py
+++ b/tests/components/duwi/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Duwi component."""

--- a/tests/components/duwi/conftest.py
+++ b/tests/components/duwi/conftest.py
@@ -1,0 +1,65 @@
+"""Define common test fixtures for the Duwi integration."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from duwi_open_sdk.const import DuwiCode
+
+
+@pytest.fixture
+def mock_duwi_login_user() -> Generator[AsyncMock, None, None]:
+    """Mock the Duwi login authentication process."""
+
+    async def mock_auth_func(phone: str, password: str):
+        # Simulate successful authentication
+        if phone == "correct_phone" and password == "correct_password":
+            return {
+                "code": DuwiCode.SUCCESS.value,
+                "data": {
+                    "access_token": "mocked_access_token",
+                    "access_token_expire_time": "mocked_access_token_expire_time",
+                    "refresh_token": "mocked_refresh_token",
+                    "refresh_token_expire_time": "mocked_refresh_token_expire_time",
+                }
+            }
+        # Simulate failed authentication
+        return {
+            "code": DuwiCode.LOGIN_ERROR.value,
+            "data": {}
+        }
+
+    with patch("duwi_open_sdk.manager.CustomerClient.login", new_callable=AsyncMock) as mock_auth:
+        mock_auth.side_effect = mock_auth_func
+        yield mock_auth
+
+
+@pytest.fixture
+def mock_duwi_login_and_fetch_house() -> Generator[AsyncMock, None, None]:
+    """Mock the Duwi login authentication process and house info fetching."""
+
+    async def mock_fetch_house_info():
+        # Simulate successful house info fetching
+        return {
+            "code": DuwiCode.SUCCESS.value,
+            "data": {
+                "houseInfos": [
+                    {
+                        "houseNo": "mocked_house_no1",
+                        "houseName": "mocked_house_name1",
+                        "lanSecretKey": "mocked_lan_secret_key1",
+                    },
+                    {
+                        "houseNo": "mocked_house_no2",
+                        "houseName": "mocked_house_name2",
+                        "lanSecretKey": "mocked_lan_secret_key2",
+                    }
+                ]
+            }
+        }
+
+    with patch("duwi_open_sdk.manager.CustomerClient.fetch_house_info", new_callable=AsyncMock) as mock_fetch:
+        # Set side effects for mocks
+        mock_fetch.side_effect = mock_fetch_house_info
+
+        yield mock_fetch

--- a/tests/components/duwi/conftest.py
+++ b/tests/components/duwi/conftest.py
@@ -21,15 +21,14 @@ def mock_duwi_login_user() -> Generator[AsyncMock, None, None]:
                     "access_token_expire_time": "mocked_access_token_expire_time",
                     "refresh_token": "mocked_refresh_token",
                     "refresh_token_expire_time": "mocked_refresh_token_expire_time",
-                }
+                },
             }
         # Simulate failed authentication
-        return {
-            "code": DuwiCode.LOGIN_ERROR.value,
-            "data": {}
-        }
+        return {"code": DuwiCode.LOGIN_ERROR.value, "data": {}}
 
-    with patch("duwi_open_sdk.manager.CustomerClient.login", new_callable=AsyncMock) as mock_auth:
+    with patch(
+        "duwi_open_sdk.manager.CustomerClient.login", new_callable=AsyncMock
+    ) as mock_auth:
         mock_auth.side_effect = mock_auth_func
         yield mock_auth
 
@@ -53,12 +52,14 @@ def mock_duwi_login_and_fetch_house() -> Generator[AsyncMock, None, None]:
                         "houseNo": "mocked_house_no2",
                         "houseName": "mocked_house_name2",
                         "lanSecretKey": "mocked_lan_secret_key2",
-                    }
+                    },
                 ]
-            }
+            },
         }
 
-    with patch("duwi_open_sdk.manager.CustomerClient.fetch_house_info", new_callable=AsyncMock) as mock_fetch:
+    with patch(
+        "duwi_open_sdk.manager.CustomerClient.fetch_house_info", new_callable=AsyncMock
+    ) as mock_fetch:
         # Set side effects for mocks
         mock_fetch.side_effect = mock_fetch_house_info
 

--- a/tests/components/duwi/snapshots/test_config_flow.ambr
+++ b/tests/components/duwi/snapshots/test_config_flow.ambr
@@ -1,0 +1,163 @@
+# serializer version: 1
+# name: test_user_flow_failed_by_phone_auth
+  FlowResultSnapshot({
+    'data_schema': list([
+      dict({
+        'name': 'app_key',
+        'required': True,
+        'type': 'string',
+      }),
+      dict({
+        'name': 'app_secret',
+        'required': True,
+        'type': 'string',
+      }),
+      dict({
+        'name': 'phone',
+        'required': True,
+        'type': 'string',
+      }),
+      dict({
+        'name': 'password',
+        'required': True,
+        'type': 'string',
+      }),
+    ]),
+    'description_placeholders': dict({
+      'code': '11000',
+    }),
+    'errors': dict({
+      'base': 'auth_error',
+    }),
+    'flow_id': <ANY>,
+    'handler': 'duwi',
+    'last_step': None,
+    'preview': None,
+    'step_id': 'user',
+    'type': <FlowResultType.FORM: 'form'>,
+  })
+# ---
+# name: test_user_flow_success
+  FlowResultSnapshot({
+    'data_schema': list([
+      dict({
+        'name': 'app_key',
+        'required': True,
+        'type': 'string',
+      }),
+      dict({
+        'name': 'app_secret',
+        'required': True,
+        'type': 'string',
+      }),
+      dict({
+        'name': 'phone',
+        'required': True,
+        'type': 'string',
+      }),
+      dict({
+        'name': 'password',
+        'required': True,
+        'type': 'string',
+      }),
+    ]),
+    'description_placeholders': dict({
+    }),
+    'errors': dict({
+    }),
+    'flow_id': <ANY>,
+    'handler': 'duwi',
+    'last_step': None,
+    'preview': None,
+    'step_id': 'user',
+    'type': <FlowResultType.FORM: 'form'>,
+  })
+# ---
+# name: test_user_flow_success.1
+  FlowResultSnapshot({
+    'data_schema': list([
+      dict({
+        'name': 'house_no',
+        'options': list([
+          tuple(
+            'mocked_house_no1',
+            'mocked_house_name1',
+          ),
+          tuple(
+            'mocked_house_no2',
+            'mocked_house_name2',
+          ),
+        ]),
+        'required': True,
+        'type': 'select',
+      }),
+    ]),
+    'description_placeholders': dict({
+    }),
+    'errors': dict({
+    }),
+    'flow_id': <ANY>,
+    'handler': 'duwi',
+    'last_step': None,
+    'preview': None,
+    'step_id': 'select_house',
+    'type': <FlowResultType.FORM: 'form'>,
+  })
+# ---
+# name: test_user_flow_success.2
+  FlowResultSnapshot({
+    'context': dict({
+      'source': 'user',
+    }),
+    'data': dict({
+      'access_token': None,
+      'address': 'http://8.140.128.174:8019/homeApi/v1',
+      'app_key': 'correct_app_key',
+      'app_secret': 'correct_app_secret',
+      'house_key': 'mocked_lan_secret_key1',
+      'house_name': 'mocked_house_name1',
+      'house_no': 'mocked_house_no1',
+      'password': 'correct_password',
+      'phone': 'correct_phone',
+      'refresh_token': None,
+      'ws_address': 'ws://8.140.128.174:32002',
+    }),
+    'description': None,
+    'description_placeholders': None,
+    'flow_id': <ANY>,
+    'handler': 'duwi',
+    'minor_version': 1,
+    'options': dict({
+    }),
+    'result': ConfigEntrySnapshot({
+      'data': dict({
+        'access_token': None,
+        'address': 'http://8.140.128.174:8019/homeApi/v1',
+        'app_key': 'correct_app_key',
+        'app_secret': 'correct_app_secret',
+        'house_key': 'mocked_lan_secret_key1',
+        'house_name': 'mocked_house_name1',
+        'house_no': 'mocked_house_no1',
+        'password': 'correct_password',
+        'phone': 'correct_phone',
+        'refresh_token': None,
+        'ws_address': 'ws://8.140.128.174:32002',
+      }),
+      'disabled_by': None,
+      'domain': 'duwi',
+      'entry_id': <ANY>,
+      'minor_version': 1,
+      'options': dict({
+      }),
+      'pref_disable_new_entities': False,
+      'pref_disable_polling': False,
+      'source': 'user',
+      'title': 'mocked_house_name1',
+      'unique_id': None,
+      'version': 1,
+    }),
+    'title': 'mocked_house_name1',
+    'type': <FlowResultType.CREATE_ENTRY: 'create_entry'>,
+    'version': 1,
+  })
+# ---

--- a/tests/components/duwi/test_config_flow.py
+++ b/tests/components/duwi/test_config_flow.py
@@ -3,19 +3,16 @@
 from __future__ import annotations
 
 import pytest
-from syrupy.assertion import SnapshotAssertion
-
 from homeassistant.components.duwi.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from syrupy.assertion import SnapshotAssertion
 
 
-@pytest.mark.usefixtures(
-    "mock_duwi_login_user", "mock_duwi_login_and_fetch_house"
-)
+@pytest.mark.usefixtures("mock_duwi_login_user", "mock_duwi_login_and_fetch_house")
 async def test_user_flow_success(
-        hass: HomeAssistant,
-        snapshot: SnapshotAssertion,
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test the configuration flow: successful path.
 
@@ -36,8 +33,12 @@ async def test_user_flow_success(
     # Simulate submitting the app credentials step
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        user_input={"app_key": "correct_app_key", "app_secret": "correct_app_secret", "phone": "correct_phone",
-                    "password": "correct_password"},
+        user_input={
+            "app_key": "correct_app_key",
+            "app_secret": "correct_app_secret",
+            "phone": "correct_phone",
+            "password": "correct_password",
+        },
     )
 
     # Move to selecting a house
@@ -55,12 +56,10 @@ async def test_user_flow_success(
     snapshot.assert_match(result3)
 
 
-@pytest.mark.usefixtures(
-    "mock_duwi_login_user", "mock_duwi_login_and_fetch_house"
-)
+@pytest.mark.usefixtures("mock_duwi_login_user", "mock_duwi_login_and_fetch_house")
 async def test_user_flow_failed_by_phone_auth(
-        hass: HomeAssistant,
-        snapshot: SnapshotAssertion,
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test the configuration flow: successful path.
 
@@ -80,8 +79,12 @@ async def test_user_flow_failed_by_phone_auth(
     # Simulate submitting the app credentials step
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        user_input={"app_key": "correct_app_key", "app_secret": "correct_app_secret", "phone": "error_phone",
-                    "password": "correct_password"},
+        user_input={
+            "app_key": "correct_app_key",
+            "app_secret": "correct_app_secret",
+            "phone": "error_phone",
+            "password": "correct_password",
+        },
     )
 
     # Move to selecting a house

--- a/tests/components/duwi/test_config_flow.py
+++ b/tests/components/duwi/test_config_flow.py
@@ -1,0 +1,90 @@
+"""Define integration configuration flow tests for the Duwi integration."""
+
+from __future__ import annotations
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.duwi.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+
+@pytest.mark.usefixtures(
+    "mock_duwi_login_user", "mock_duwi_login_and_fetch_house"
+)
+async def test_user_flow_success(
+        hass: HomeAssistant,
+        snapshot: SnapshotAssertion,
+) -> None:
+    """Test the configuration flow: successful path.
+
+    This simulates a user going through the configuration flow, including
+    providing correct credentials and selecting a house, leading to a successful
+    creation of a config entry.
+    """
+    # Start by initializing the flow
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "user"},
+    )
+    # Ensure we're being prompted for initial information
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "user"
+    snapshot.assert_match(result)
+
+    # Simulate submitting the app credentials step
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"app_key": "correct_app_key", "app_secret": "correct_app_secret", "phone": "correct_phone",
+                    "password": "correct_password"},
+    )
+
+    # Move to selecting a house
+    assert result2.get("type") == FlowResultType.FORM
+    assert result2.get("step_id") == "select_house"
+    snapshot.assert_match(result2)
+
+    # Finally, simulate selecting a house
+    result3 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"house_no": "mocked_house_no1"},
+    )
+    # The flow should now complete with a CREATE_ENTRY result
+    assert result3.get("type") == FlowResultType.CREATE_ENTRY
+    snapshot.assert_match(result3)
+
+
+@pytest.mark.usefixtures(
+    "mock_duwi_login_user", "mock_duwi_login_and_fetch_house"
+)
+async def test_user_flow_failed_by_phone_auth(
+        hass: HomeAssistant,
+        snapshot: SnapshotAssertion,
+) -> None:
+    """Test the configuration flow: successful path.
+
+    This simulates a user going through the configuration flow, including
+    providing correct credentials and selecting a house, leading to a successful
+    creation of a config entry.
+    """
+    # Start by initializing the flow
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "user"},
+    )
+    # Ensure we're being prompted for initial information
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "user"
+
+    # Simulate submitting the app credentials step
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"app_key": "correct_app_key", "app_secret": "correct_app_secret", "phone": "error_phone",
+                    "password": "correct_password"},
+    )
+
+    # Move to selecting a house
+    assert result2.get("type") == FlowResultType.FORM
+    assert result2.get("step_id") == "user"
+    snapshot.assert_match(result2)

--- a/tests/components/duwi/test_switch.py
+++ b/tests/components/duwi/test_switch.py
@@ -1,0 +1,70 @@
+"""Tests for the Duwi switch entity in Home Assistant."""
+
+import logging
+from typing import Generator, Optional
+from unittest.mock import patch, MagicMock, AsyncMock
+
+import pytest
+from duwi_open_sdk.device_control import ControlDevice
+from duwi_open_sdk.device_scene_models import CustomerDevice
+from duwi_open_sdk.manager import Manager
+
+from homeassistant.components.duwi import DOMAIN
+from homeassistant.components.duwi.base import DuwiEntity
+from homeassistant.components.duwi.switch import DuwiSwitchEntity
+from homeassistant.components.switch import SwitchEntityDescription
+from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def mock_send_commands() -> Generator[AsyncMock, None, None]:
+    """Mock the send_commands method of the device manager."""
+
+    async def mock_send_commands(is_group: bool, body: Optional[ControlDevice]):
+        # Simulate sending commands and returning a response
+        return {"code": "10000"}
+
+    with patch("duwi_open_sdk.manager.CustomerClient.control", new_callable=AsyncMock) as mock_method:
+        mock_method.side_effect = mock_send_commands
+        yield mock_method
+
+
+@pytest.fixture
+def mock_switch(hass: HomeAssistant, mock_send_commands):
+    """Create and provide a mock Duwi switch entity."""
+    # Create mock instances for the parameters
+    mock_device = MagicMock(spec=CustomerDevice)
+    mock_device.device_no = "12345"
+    mock_device.is_group = False
+    mock_device.value = {
+        "switch": "on",
+        "online": True,
+    }
+    mock_manager = MagicMock(spec=Manager)
+    mock_description = MagicMock(spec=SwitchEntityDescription)
+
+    # Set expected attributes for mock objects (if needed)
+    mock_description.key = "mock_key"
+    return DuwiSwitchEntity(
+        device=mock_device,
+        device_manager=mock_manager,
+        description=mock_description,
+    )
+
+
+@pytest.mark.usefixtures
+async def test_turn_on(hass: HomeAssistant, mock_switch):
+    """Verify the switch turns on as expected."""
+    await mock_switch.async_turn_on()
+    await hass.async_block_till_done()
+    assert mock_switch.is_on, "Switch should be ON."
+
+
+@pytest.mark.usefixtures
+async def test_turn_off(hass: HomeAssistant, mock_switch):
+    """Ensure the switch turns off correctly."""
+    await mock_switch.async_turn_off()
+    await hass.async_block_till_done()
+    assert not mock_switch.is_on, "Switch should be OFF."

--- a/tests/components/duwi/test_switch.py
+++ b/tests/components/duwi/test_switch.py
@@ -2,13 +2,12 @@
 
 import logging
 from typing import Generator, Optional
-from unittest.mock import patch, MagicMock, AsyncMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from duwi_open_sdk.device_control import ControlDevice
 from duwi_open_sdk.device_scene_models import CustomerDevice
 from duwi_open_sdk.manager import Manager
-
 from homeassistant.components.duwi import DOMAIN
 from homeassistant.components.duwi.base import DuwiEntity
 from homeassistant.components.duwi.switch import DuwiSwitchEntity
@@ -26,7 +25,9 @@ def mock_send_commands() -> Generator[AsyncMock, None, None]:
         # Simulate sending commands and returning a response
         return {"code": "10000"}
 
-    with patch("duwi_open_sdk.manager.CustomerClient.control", new_callable=AsyncMock) as mock_method:
+    with patch(
+        "duwi_open_sdk.manager.CustomerClient.control", new_callable=AsyncMock
+    ) as mock_method:
         mock_method.side_effect = mock_send_commands
         yield mock_method
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds a new integration called "Duwi" to Home Assistant. The integration includes a switch platform that allows users to control and monitor Duwi devices through Home Assistant. Additionally, this PR includes a test suite for the new integration.

To enable communication with Duwi devices, this PR also requests the addition of the duwi-open-sdk package to PyPI. The source code for this package can be found at https://github.com/Ledgerbiggg/duwi-open-sdk.

This integration will provide users with a convenient way to manage their Duwi devices through Home Assistant, improving the overall user experience.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33089

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
