### PR TITLE
Bump aioautomower to 2024.9.0

### DIFF
--- a/homeassistant/components/husqvarna_automower/manifest.json
+++ b/homeassistant/components/husqvarna_automower/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/husqvarna_automower",
   "iot_class": "cloud_push",
   "loggers": ["aioautomower"],
-  "requirements": ["aioautomower==2024.8.0"]
+  "requirements": ["aioautomower==2024.9.0"]
 }

--- a/homeassistant/components/husqvarna_automower/number.py
+++ b/homeassistant/components/husqvarna_automower/number.py
@@ -45,7 +45,7 @@ async def async_set_work_area_cutting_height(
     work_area_id: int,
 ) -> None:
     """Set cutting height for work area."""
-    await coordinator.api.commands.set_cutting_height_workarea(
+    await coordinator.api.commands.workarea_settings(
         mower_id, int(cheight), work_area_id
     )
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -198,7 +198,7 @@ aioaseko==0.2.0
 aioasuswrt==1.4.0
 
 # homeassistant.components.husqvarna_automower
-aioautomower==2024.8.0
+aioautomower==2024.9.0
 
 # homeassistant.components.azure_devops
 aioazuredevops==2.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -186,7 +186,7 @@ aioaseko==0.2.0
 aioasuswrt==1.4.0
 
 # homeassistant.components.husqvarna_automower
-aioautomower==2024.8.0
+aioautomower==2024.9.0
 
 # homeassistant.components.azure_devops
 aioazuredevops==2.2.1

--- a/tests/components/husqvarna_automower/fixtures/mower.json
+++ b/tests/components/husqvarna_automower/fixtures/mower.json
@@ -70,17 +70,26 @@
           {
             "workAreaId": 123456,
             "name": "Front lawn",
-            "cuttingHeight": 50
+            "cuttingHeight": 50,
+            "enabled": true,
+            "progress": 40,
+            "lastTimeCompleted": 1723449269
           },
           {
             "workAreaId": 654321,
             "name": "Back lawn",
-            "cuttingHeight": 25
+            "cuttingHeight": 25,
+            "enabled": true,
+            "progress": 30,
+            "lastTimeCompleted": 1722449269
           },
           {
             "workAreaId": 0,
             "name": "",
-            "cuttingHeight": 50
+            "cuttingHeight": 50,
+            "enabled": false,
+            "progress": 20,
+            "lastTimeCompleted": 1723439269
           }
         ],
         "positions": [

--- a/tests/components/husqvarna_automower/snapshots/test_diagnostics.ambr
+++ b/tests/components/husqvarna_automower/snapshots/test_diagnostics.ambr
@@ -5,26 +5,6 @@
       'battery_percent': 100,
     }),
     'calendar': dict({
-      'events': list([
-        dict({
-          'end': '2024-03-02T00:00:00',
-          'rrule': 'FREQ=WEEKLY;BYDAY=MO,WE,FR',
-          'schedule_no': 1,
-          'start': '2024-03-01T19:00:00',
-          'uid': '1140_300_MO,WE,FR',
-          'work_area_id': None,
-          'work_area_name': None,
-        }),
-        dict({
-          'end': '2024-03-02T08:00:00',
-          'rrule': 'FREQ=WEEKLY;BYDAY=TU,TH,SA',
-          'schedule_no': 2,
-          'start': '2024-03-02T00:00:00',
-          'uid': '0_480_TU,TH,SA',
-          'work_area_id': None,
-          'work_area_name': None,
-        }),
-      ]),
       'tasks': list([
         dict({
           'duration': 300,
@@ -135,15 +115,24 @@
     'work_areas': dict({
       '0': dict({
         'cutting_height': 50,
+        'enabled': False,
+        'last_time_completed_naive': '1970-01-20T22:43:59.269000',
         'name': 'my_lawn',
+        'progress': 20,
       }),
       '123456': dict({
         'cutting_height': 50,
+        'enabled': True,
+        'last_time_completed_naive': '1970-01-20T22:44:09.269000',
         'name': 'Front lawn',
+        'progress': 40,
       }),
       '654321': dict({
         'cutting_height': 25,
+        'enabled': True,
+        'last_time_completed_naive': '1970-01-20T22:27:29.269000',
         'name': 'Back lawn',
+        'progress': 30,
       }),
     }),
   })

--- a/tests/components/husqvarna_automower/test_number.py
+++ b/tests/components/husqvarna_automower/test_number.py
@@ -78,9 +78,7 @@ async def test_number_workarea_commands(
     values[TEST_MOWER_ID].work_areas[123456].cutting_height = 75
     mock_automower_client.get_status.return_value = values
     mocked_method = AsyncMock()
-    setattr(
-        mock_automower_client.commands, "set_cutting_height_workarea", mocked_method
-    )
+    setattr(mock_automower_client.commands, "workarea_settings", mocked_method)
     await hass.services.async_call(
         domain="number",
         service="set_value",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
bump aioautomower to 2024.9.0
RN: https://github.com/Thomas55555/aioautomower/releases/tag/2024.9.0
CL: https://github.com/Thomas55555/aioautomower/compare/2024.8.0...2024.9.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
