### PR TITLE
Migrate wolflink config_entry unique_id to string

### DIFF
--- a/homeassistant/components/wolflink/__init__.py
+++ b/homeassistant/components/wolflink/__init__.py
@@ -31,7 +31,7 @@ PLATFORMS = [Platform.SENSOR]
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Wolf SmartSet Service from a config entry."""
 
-    if type(entry.unique_id) is int:  # type: ignore[comparison-overlap]
+    if isinstance(entry.unique_id, int):
         hass.config_entries.async_update_entry(entry, unique_id=str(entry.unique_id))
 
     username = entry.data[CONF_USERNAME]

--- a/homeassistant/components/wolflink/__init__.py
+++ b/homeassistant/components/wolflink/__init__.py
@@ -32,22 +32,6 @@ PLATFORMS = [Platform.SENSOR]
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Wolf SmartSet Service from a config entry."""
 
-    if isinstance(entry.unique_id, int):
-        hass.config_entries.async_update_entry(entry, unique_id=str(entry.unique_id))
-        device_registry = dr.async_get(hass)
-        for device in dr.async_entries_for_config_entry(
-            device_registry, entry.entry_id
-        ):
-            new_identifiers = set()
-            for identifier in device.identifiers:
-                if identifier[0] == DOMAIN:
-                    new_identifiers.add((DOMAIN, str(identifier[1])))
-                else:
-                    new_identifiers.add(identifier)
-            device_registry.async_update_device(
-                device.id, new_identifiers=new_identifiers
-            )
-
     username = entry.data[CONF_USERNAME]
     password = entry.data[CONF_PASSWORD]
     device_name = entry.data[DEVICE_NAME]
@@ -141,6 +125,32 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate old entry."""
+    # convert unique_id to string
+    if entry.version == 1 and entry.minor_version == 1:
+        if isinstance(entry.unique_id, int):
+            hass.config_entries.async_update_entry(
+                entry, unique_id=str(entry.unique_id)
+            )
+            device_registry = dr.async_get(hass)
+            for device in dr.async_entries_for_config_entry(
+                device_registry, entry.entry_id
+            ):
+                new_identifiers = set()
+                for identifier in device.identifiers:
+                    if identifier[0] == DOMAIN:
+                        new_identifiers.add((DOMAIN, str(identifier[1])))
+                    else:
+                        new_identifiers.add(identifier)
+                device_registry.async_update_device(
+                    device.id, new_identifiers=new_identifiers
+                )
+        hass.config_entries.async_update_entry(entry, minor_version=2)
+
+    return True
 
 
 async def fetch_parameters(client: WolfClient, gateway_id: int, device_id: int):

--- a/homeassistant/components/wolflink/__init__.py
+++ b/homeassistant/components/wolflink/__init__.py
@@ -11,6 +11,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -33,6 +34,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if isinstance(entry.unique_id, int):
         hass.config_entries.async_update_entry(entry, unique_id=str(entry.unique_id))
+        device_registry = dr.async_get(hass)
+        for device in dr.async_entries_for_config_entry(
+            device_registry, entry.entry_id
+        ):
+            new_identifiers = set()
+            for identifier in device.identifiers:
+                if identifier[0] == DOMAIN:
+                    new_identifiers.add((DOMAIN, str(identifier[1])))
+                else:
+                    new_identifiers.add(identifier)
+            device_registry.async_update_device(
+                device.id, new_identifiers=new_identifiers
+            )
 
     username = entry.data[CONF_USERNAME]
     password = entry.data[CONF_PASSWORD]

--- a/homeassistant/components/wolflink/__init__.py
+++ b/homeassistant/components/wolflink/__init__.py
@@ -30,6 +30,10 @@ PLATFORMS = [Platform.SENSOR]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Wolf SmartSet Service from a config entry."""
+
+    if type(entry.unique_id) is int:  # type: ignore[comparison-overlap]
+        hass.config_entries.async_update_entry(entry, unique_id=str(entry.unique_id))
+
     username = entry.data[CONF_USERNAME]
     password = entry.data[CONF_PASSWORD]
     device_name = entry.data[DEVICE_NAME]

--- a/homeassistant/components/wolflink/config_flow.py
+++ b/homeassistant/components/wolflink/config_flow.py
@@ -24,6 +24,7 @@ class WolfLinkConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Wolf SmartSet Service."""
 
     VERSION = 1
+    MINOR_VERSION = 2
 
     def __init__(self) -> None:
         """Initialize with empty username and password."""

--- a/homeassistant/components/wolflink/config_flow.py
+++ b/homeassistant/components/wolflink/config_flow.py
@@ -66,7 +66,7 @@ class WolfLinkConfigFlow(ConfigFlow, domain=DOMAIN):
                 device for device in self.fetched_systems if device.name == device_name
             ]
             device_id = system[0].id
-            await self.async_set_unique_id(device_id)
+            await self.async_set_unique_id(str(device_id))
             self._abort_if_unique_id_configured()
             return self.async_create_entry(
                 title=user_input[DEVICE_NAME],

--- a/homeassistant/components/wolflink/sensor.py
+++ b/homeassistant/components/wolflink/sensor.py
@@ -63,7 +63,7 @@ class WolfLinkSensor(CoordinatorEntity, SensorEntity):
         self._attr_unique_id = f"{device_id}:{wolf_object.parameter_id}"
         self._state = None
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, device_id)},
+            identifiers={(DOMAIN, str(device_id))},
             configuration_url="https://www.wolf-smartset.com/",
             manufacturer=MANUFACTURER,
         )

--- a/tests/components/wolflink/const.py
+++ b/tests/components/wolflink/const.py
@@ -1,0 +1,16 @@
+"""Constants for the Wolf SmartSet Service tests."""
+
+from homeassistant.components.wolflink.const import (
+    DEVICE_GATEWAY,
+    DEVICE_ID,
+    DEVICE_NAME,
+)
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+
+CONFIG = {
+    DEVICE_NAME: "test-device",
+    DEVICE_ID: 1234,
+    DEVICE_GATEWAY: 5678,
+    CONF_USERNAME: "test-username",
+    CONF_PASSWORD: "test-password",
+}

--- a/tests/components/wolflink/test_config_flow.py
+++ b/tests/components/wolflink/test_config_flow.py
@@ -134,7 +134,7 @@ async def test_already_configured_error(hass: HomeAssistant) -> None:
         patch("homeassistant.components.wolflink.async_setup_entry", return_value=True),
     ):
         MockConfigEntry(
-            domain=DOMAIN, unique_id=CONFIG[DEVICE_ID], data=CONFIG
+            domain=DOMAIN, unique_id=str(CONFIG[DEVICE_ID]), data=CONFIG
         ).add_to_hass(hass)
 
         result = await hass.config_entries.flow.async_init(

--- a/tests/components/wolflink/test_config_flow.py
+++ b/tests/components/wolflink/test_config_flow.py
@@ -17,15 +17,9 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from tests.common import MockConfigEntry
+from .const import CONFIG
 
-CONFIG = {
-    DEVICE_NAME: "test-device",
-    DEVICE_ID: 1234,
-    DEVICE_GATEWAY: 5678,
-    CONF_USERNAME: "test-username",
-    CONF_PASSWORD: "test-password",
-}
+from tests.common import MockConfigEntry
 
 INPUT_CONFIG = {
     CONF_USERNAME: CONFIG[CONF_USERNAME],

--- a/tests/components/wolflink/test_init.py
+++ b/tests/components/wolflink/test_init.py
@@ -1,30 +1,15 @@
-"""Test the Wolf SmartSet Service config flow."""
+"""Test the Wolf SmartSet Service."""
 
 from unittest.mock import patch
 
 from httpx import RequestError
-from wolf_comm.models import Device
 
-from homeassistant.components.wolflink.const import (
-    DEVICE_GATEWAY,
-    DEVICE_ID,
-    DEVICE_NAME,
-    DOMAIN,
-)
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.components.wolflink.const import DEVICE_ID, DOMAIN
 from homeassistant.core import HomeAssistant
 
+from .const import CONFIG
+
 from tests.common import MockConfigEntry
-
-CONFIG = {
-    DEVICE_NAME: "test-device",
-    DEVICE_ID: 1234,
-    DEVICE_GATEWAY: 5678,
-    CONF_USERNAME: "test-username",
-    CONF_PASSWORD: "test-password",
-}
-
-DEVICE = Device(CONFIG[DEVICE_ID], CONFIG[DEVICE_GATEWAY], CONFIG[DEVICE_NAME])
 
 
 async def test_unique_id_migration(hass: HomeAssistant) -> None:

--- a/tests/components/wolflink/test_init.py
+++ b/tests/components/wolflink/test_init.py
@@ -29,6 +29,8 @@ async def test_unique_id_migration(
         manufacturer=MANUFACTURER,
     ).id
 
+    assert config_entry.version == 1
+    assert config_entry.minor_version == 1
     assert config_entry.unique_id == 1234
     assert (
         hass.config_entries.async_entry_for_domain_unique_id(DOMAIN, 1234)
@@ -45,6 +47,8 @@ async def test_unique_id_migration(
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
 
+    assert config_entry.version == 1
+    assert config_entry.minor_version == 2
     assert config_entry.unique_id == "1234"
     assert (
         hass.config_entries.async_entry_for_domain_unique_id(DOMAIN, "1234")

--- a/tests/components/wolflink/test_init.py
+++ b/tests/components/wolflink/test_init.py
@@ -4,20 +4,30 @@ from unittest.mock import patch
 
 from httpx import RequestError
 
-from homeassistant.components.wolflink.const import DEVICE_ID, DOMAIN
+from homeassistant.components.wolflink.const import DEVICE_ID, DOMAIN, MANUFACTURER
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
 from .const import CONFIG
 
 from tests.common import MockConfigEntry
 
 
-async def test_unique_id_migration(hass: HomeAssistant) -> None:
+async def test_unique_id_migration(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test already configured while creating entry."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, unique_id=CONFIG[DEVICE_ID], data=CONFIG
     )
     config_entry.add_to_hass(hass)
+
+    device_id = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, CONFIG[DEVICE_ID])},
+        configuration_url="https://www.wolf-smartset.com/",
+        manufacturer=MANUFACTURER,
+    ).id
 
     assert config_entry.unique_id == 1234
     assert (
@@ -25,6 +35,7 @@ async def test_unique_id_migration(hass: HomeAssistant) -> None:
         is config_entry
     )
     assert hass.config_entries.async_entry_for_domain_unique_id(DOMAIN, "1234") is None
+    assert device_registry.async_get(device_id).identifiers == {(DOMAIN, 1234)}
 
     with (
         patch(
@@ -40,3 +51,5 @@ async def test_unique_id_migration(hass: HomeAssistant) -> None:
         is config_entry
     )
     assert hass.config_entries.async_entry_for_domain_unique_id(DOMAIN, 1234) is None
+
+    assert device_registry.async_get(device_id).identifiers == {(DOMAIN, "1234")}

--- a/tests/components/wolflink/test_init.py
+++ b/tests/components/wolflink/test_init.py
@@ -1,0 +1,57 @@
+"""Test the Wolf SmartSet Service config flow."""
+
+from unittest.mock import patch
+
+from httpx import RequestError
+from wolf_comm.models import Device
+
+from homeassistant.components.wolflink.const import (
+    DEVICE_GATEWAY,
+    DEVICE_ID,
+    DEVICE_NAME,
+    DOMAIN,
+)
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+CONFIG = {
+    DEVICE_NAME: "test-device",
+    DEVICE_ID: 1234,
+    DEVICE_GATEWAY: 5678,
+    CONF_USERNAME: "test-username",
+    CONF_PASSWORD: "test-password",
+}
+
+DEVICE = Device(CONFIG[DEVICE_ID], CONFIG[DEVICE_GATEWAY], CONFIG[DEVICE_NAME])
+
+
+async def test_unique_id_migration(hass: HomeAssistant) -> None:
+    """Test already configured while creating entry."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, unique_id=CONFIG[DEVICE_ID], data=CONFIG
+    )
+    config_entry.add_to_hass(hass)
+
+    assert config_entry.unique_id == 1234
+    assert (
+        hass.config_entries.async_entry_for_domain_unique_id(DOMAIN, 1234)
+        is config_entry
+    )
+    assert hass.config_entries.async_entry_for_domain_unique_id(DOMAIN, "1234") is None
+
+    with (
+        patch(
+            "homeassistant.components.wolflink.fetch_parameters",
+            side_effect=RequestError("Unable to fetch parameters"),
+        ),
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+
+    assert config_entry.unique_id == "1234"
+    assert (
+        hass.config_entries.async_entry_for_domain_unique_id(DOMAIN, "1234")
+        is config_entry
+    )
+    assert hass.config_entries.async_entry_for_domain_unique_id(DOMAIN, 1234) is None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #125313 and #125602

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
