### PR TITLE
Bump python-MotionMount to 2.1.0

### DIFF
--- a/homeassistant/components/motionmount/manifest.json
+++ b/homeassistant/components/motionmount/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/motionmount",
   "integration_type": "device",
   "iot_class": "local_push",
-  "requirements": ["python-MotionMount==2.0.0"],
+  "requirements": ["python-MotionMount==2.1.0"],
   "zeroconf": ["_tvm._tcp.local."]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2274,7 +2274,7 @@ pytfiac==0.4
 pythinkingcleaner==0.0.3
 
 # homeassistant.components.motionmount
-python-MotionMount==2.0.0
+python-MotionMount==2.1.0
 
 # homeassistant.components.awair
 python-awair==0.2.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1819,7 +1819,7 @@ pytautulli==23.1.1
 pytedee-async==0.2.20
 
 # homeassistant.components.motionmount
-python-MotionMount==2.0.0
+python-MotionMount==2.1.0
 
 # homeassistant.components.awair
 python-awair==0.2.4


### PR DESCRIPTION
## Proposed change
Bump python-MotionMount to 2.1.0

Changelog:
2.1.0: - Add timeout (15 s) to connect()

[Full changelog](https://pypi.org/project/python-MotionMount/)

Diff:
```
-        reader, writer = await asyncio.open_connection(self.address, self.port)
+        connection_future = asyncio.open_connection(self.address, self.port)
+        reader, writer = await asyncio.wait_for(connection_future, timeout=15)
```
## Type of change
- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
