### PR TITLE
Bump zwave-js-server-python to 0.58.0

### DIFF
--- a/homeassistant/components/zwave_js/manifest.json
+++ b/homeassistant/components/zwave_js/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_push",
   "loggers": ["zwave_js_server"],
   "quality_scale": "platinum",
-  "requirements": ["pyserial==3.5", "zwave-js-server-python==0.57.0"],
+  "requirements": ["pyserial==3.5", "zwave-js-server-python==0.58.0"],
   "usb": [
     {
       "vid": "0658",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3053,7 +3053,7 @@ ziggo-mediabox-xl==1.1.0
 zm-py==0.5.4
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.57.0
+zwave-js-server-python==0.58.0
 
 # homeassistant.components.zwave_me
 zwave-me-ws==0.4.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2424,7 +2424,7 @@ zeversolar==0.3.1
 zha==0.0.32
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.57.0
+zwave-js-server-python==0.58.0
 
 # homeassistant.components.zwave_me
 zwave-me-ws==0.4.3

--- a/tests/components/zwave_js/test_lock.py
+++ b/tests/components/zwave_js/test_lock.py
@@ -95,7 +95,9 @@ async def test_door_lock(
     )
     node.receive_event(event)
 
-    assert hass.states.get(SCHLAGE_BE469_LOCK_ENTITY).state == STATE_LOCKED
+    state = hass.states.get(SCHLAGE_BE469_LOCK_ENTITY)
+    assert state
+    assert state.state == STATE_LOCKED
 
     client.async_send_command.reset_mock()
 
@@ -194,6 +196,7 @@ async def test_door_lock(
             "insideHandlesCanOpenDoorConfiguration": [True, True, True, True],
             "operationType": 2,
             "outsideHandlesCanOpenDoorConfiguration": [True, True, True, True],
+            "lockTimeoutConfiguration": 1,
         }
     ]
     assert args["commandClass"] == 98
@@ -239,6 +242,7 @@ async def test_door_lock(
             "insideHandlesCanOpenDoorConfiguration": [True, True, True, True],
             "operationType": 2,
             "outsideHandlesCanOpenDoorConfiguration": [True, True, True, True],
+            "lockTimeoutConfiguration": 1,
         }
     ]
     assert args["commandClass"] == 98
@@ -294,7 +298,9 @@ async def test_door_lock(
     node.receive_event(event)
 
     assert node.status == NodeStatus.DEAD
-    assert hass.states.get(SCHLAGE_BE469_LOCK_ENTITY).state == STATE_UNAVAILABLE
+    state = hass.states.get(SCHLAGE_BE469_LOCK_ENTITY)
+    assert state
+    assert state.state == STATE_UNAVAILABLE
 
 
 async def test_only_one_lock(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
With this release, you will need to update your `zwave-js-server` instance. You must use `zwave-js-server` 1.37.0 or greater (schema 37).
- If you use the Z-Wave JS add-on, you need at least version 0.7.0.
- If you use the Z-Wave JS UI add-on, you need at least version [3.9.0](https://github.com/hassio-addons/addon-zwave-js-ui/releases/tag/v3.9.0).
- If you use the Z-Wave JS UI Docker container, you need at least version [9.16.0](https://github.com/zwave-js/zwave-js-ui/releases/tag/v9.16.0).
- If you run your own Docker container or some other installation method, you will need to update your zwave-js-server instance to at least 1.37.0.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- https://github.com/home-assistant-libs/zwave-js-server-python/releases/tag/0.58.0
- fixes https://github.com/zwave-js/certification-backlog/issues/21

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
