### PR TITLE
Add reconnect logic and proper reporting to MotionMount integration

### DIFF
--- a/homeassistant/components/motionmount/entity.py
+++ b/homeassistant/components/motionmount/entity.py
@@ -75,7 +75,7 @@ class MotionMountEntity(Entity):
         self.mm.remove_listener(self.update_name)
         await super().async_will_remove_from_hass()
 
-    async def _ensureConnected(self) -> bool:
+    async def _ensure_connected(self) -> bool:
         """Make sure there is a connection with the MotionMount.
 
         Returns false if the connection failed to be ensured.

--- a/homeassistant/components/motionmount/entity.py
+++ b/homeassistant/components/motionmount/entity.py
@@ -1,5 +1,7 @@
 """Support for MotionMount sensors."""
 
+import logging
+import socket
 from typing import TYPE_CHECKING
 
 import motionmount
@@ -11,6 +13,8 @@ from homeassistant.helpers.device_registry import DeviceInfo, format_mac
 from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN, EMPTY_MAC
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class MotionMountEntity(Entity):
@@ -70,3 +74,21 @@ class MotionMountEntity(Entity):
         self.mm.remove_listener(self.async_write_ha_state)
         self.mm.remove_listener(self.update_name)
         await super().async_will_remove_from_hass()
+
+    async def _ensureConnected(self) -> bool:
+        """Make sure there is a connection with the MotionMount.
+
+        Returns false if the connection failed to be ensured.
+        """
+
+        if self.mm.is_connected:
+            return True
+        try:
+            await self.mm.connect()
+        except (ConnectionError, TimeoutError, socket.gaierror):
+            # We're not interested in exceptions here. In case of a failed connection the try/except from the caller will report it
+            # The purpose of `ensureConnected()` is only to make sure we try to reconnect, where failures should not be logged each time
+            return False
+        else:
+            _LOGGER.info("Successfully reconnected to MotionMount")
+            return True

--- a/homeassistant/components/motionmount/entity.py
+++ b/homeassistant/components/motionmount/entity.py
@@ -90,5 +90,5 @@ class MotionMountEntity(Entity):
             # The purpose of `ensureConnected()` is only to make sure we try to reconnect, where failures should not be logged each time
             return False
         else:
-            _LOGGER.info("Successfully reconnected to MotionMount")
+            _LOGGER.warning("Successfully reconnected to MotionMount")
             return True

--- a/homeassistant/components/motionmount/entity.py
+++ b/homeassistant/components/motionmount/entity.py
@@ -86,8 +86,10 @@ class MotionMountEntity(Entity):
         try:
             await self.mm.connect()
         except (ConnectionError, TimeoutError, socket.gaierror):
-            # We're not interested in exceptions here. In case of a failed connection the try/except from the caller will report it
-            # The purpose of `ensureConnected()` is only to make sure we try to reconnect, where failures should not be logged each time
+            # We're not interested in exceptions here. In case of a failed connection
+            # the try/except from the caller will report it.
+            # The purpose of `_ensure_connected()` is only to make sure we try to
+            # reconnect, where failures should not be logged each time
             return False
         else:
             _LOGGER.warning("Successfully reconnected to MotionMount")

--- a/homeassistant/components/motionmount/number.py
+++ b/homeassistant/components/motionmount/number.py
@@ -1,11 +1,14 @@
 """Support for MotionMount numeric control."""
 
+import socket
+
 import motionmount
 
 from homeassistant.components.number import NumberEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -46,7 +49,13 @@ class MotionMountExtension(MotionMountEntity, NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the new value for extension."""
-        await self.mm.set_extension(int(value))
+        if not await self._ensureConnected():
+            return
+
+        try:
+            await self.mm.set_extension(int(value))
+        except (TimeoutError, socket.gaierror) as ex:
+            raise HomeAssistantError("Failed to communicate with MotionMount") from ex
 
 
 class MotionMountTurn(MotionMountEntity, NumberEntity):
@@ -69,4 +78,10 @@ class MotionMountTurn(MotionMountEntity, NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the new value for turn."""
-        await self.mm.set_turn(int(value * -1))
+        if not await self._ensureConnected():
+            return
+
+        try:
+            await self.mm.set_turn(int(value * -1))
+        except (TimeoutError, socket.gaierror) as ex:
+            raise HomeAssistantError("Failed to communicate with MotionMount") from ex

--- a/homeassistant/components/motionmount/number.py
+++ b/homeassistant/components/motionmount/number.py
@@ -49,7 +49,7 @@ class MotionMountExtension(MotionMountEntity, NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the new value for extension."""
-        if not await self._ensureConnected():
+        if not await self._ensure_connected():
             return
 
         try:
@@ -78,7 +78,7 @@ class MotionMountTurn(MotionMountEntity, NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the new value for turn."""
-        if not await self._ensureConnected():
+        if not await self._ensure_connected():
             return
 
         try:

--- a/homeassistant/components/motionmount/number.py
+++ b/homeassistant/components/motionmount/number.py
@@ -49,9 +49,6 @@ class MotionMountExtension(MotionMountEntity, NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the new value for extension."""
-        if not await self._ensure_connected():
-            return
-
         try:
             await self.mm.set_extension(int(value))
         except (TimeoutError, socket.gaierror) as ex:
@@ -78,9 +75,6 @@ class MotionMountTurn(MotionMountEntity, NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the new value for turn."""
-        if not await self._ensure_connected():
-            return
-
         try:
             await self.mm.set_turn(int(value * -1))
         except (TimeoutError, socket.gaierror) as ex:

--- a/homeassistant/components/motionmount/select.py
+++ b/homeassistant/components/motionmount/select.py
@@ -87,9 +87,6 @@ class MotionMountPresets(MotionMountEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Set the new option."""
-        if not await self._ensure_connected():
-            return
-
         index = int(option[:1])
         try:
             await self.mm.go_to_preset(index)

--- a/homeassistant/components/motionmount/select.py
+++ b/homeassistant/components/motionmount/select.py
@@ -53,7 +53,7 @@ class MotionMountPresets(MotionMountEntity, SelectEntity):
 
     async def async_update(self) -> None:
         """Get latest state from MotionMount."""
-        if not await self._ensureConnected():
+        if not await self._ensure_connected():
             return
 
         try:
@@ -86,7 +86,7 @@ class MotionMountPresets(MotionMountEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Set the new option."""
-        if not await self._ensureConnected():
+        if not await self._ensure_connected():
             return
 
         try:

--- a/homeassistant/components/motionmount/select.py
+++ b/homeassistant/components/motionmount/select.py
@@ -58,9 +58,10 @@ class MotionMountPresets(MotionMountEntity, SelectEntity):
 
         try:
             self._presets = await self.mm.get_presets()
-            self._update_options(self._presets)
         except (TimeoutError, socket.gaierror) as ex:
             _LOGGER.warning("Failed to communicate with MotionMount: %s", ex)
+        else:
+            self._update_options(self._presets)
 
     @property
     def current_option(self) -> str | None:
@@ -89,9 +90,10 @@ class MotionMountPresets(MotionMountEntity, SelectEntity):
         if not await self._ensure_connected():
             return
 
+        index = int(option[:1])
         try:
-            index = int(option[:1])
             await self.mm.go_to_preset(index)
-            self._attr_current_option = option
         except (TimeoutError, socket.gaierror) as ex:
             raise HomeAssistantError("Failed to communicate with MotionMount") from ex
+        else:
+            self._attr_current_option = option

--- a/homeassistant/components/motionmount/select.py
+++ b/homeassistant/components/motionmount/select.py
@@ -1,14 +1,22 @@
 """Support for MotionMount numeric control."""
 
+from datetime import timedelta
+import logging
+import socket
+
 import motionmount
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN, WALL_PRESET_NAME
 from .entity import MotionMountEntity
+
+_LOGGER = logging.getLogger(__name__)
+SCAN_INTERVAL = timedelta(seconds=60)
 
 
 async def async_setup_entry(
@@ -23,6 +31,7 @@ async def async_setup_entry(
 class MotionMountPresets(MotionMountEntity, SelectEntity):
     """The presets of a MotionMount."""
 
+    _attr_should_poll = True
     _attr_translation_key = "motionmount_preset"
 
     def __init__(
@@ -44,8 +53,14 @@ class MotionMountPresets(MotionMountEntity, SelectEntity):
 
     async def async_update(self) -> None:
         """Get latest state from MotionMount."""
-        self._presets = await self.mm.get_presets()
-        self._update_options(self._presets)
+        if not await self._ensureConnected():
+            return
+
+        try:
+            self._presets = await self.mm.get_presets()
+            self._update_options(self._presets)
+        except (TimeoutError, socket.gaierror) as ex:
+            _LOGGER.warning("Failed to communicate with MotionMount: %s", ex)
 
     @property
     def current_option(self) -> str | None:
@@ -71,9 +86,12 @@ class MotionMountPresets(MotionMountEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Set the new option."""
-        index = int(option[:1])
-        await self.mm.go_to_preset(index)
-        self._attr_current_option = option
+        if not await self._ensureConnected():
+            return
 
-        # Perform an update so we detect changes to the presets (changes are not pushed)
-        self.async_schedule_update_ha_state(True)
+        try:
+            index = int(option[:1])
+            await self.mm.go_to_preset(index)
+            self._attr_current_option = option
+        except (TimeoutError, socket.gaierror) as ex:
+            raise HomeAssistantError("Failed to communicate with MotionMount") from ex


### PR DESCRIPTION
## Proposed change
This PR adds reconnect logic to the MotionMount integration.
Before, the integration had to be manually reloaded when the connection was lost.
A lost connection is detected by (slowly) polling the device, or a user interaction. Changes still come in fast using a push model, as before.
When the connection is lost the polling will also make sure that the connection will be restored, when possible.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
