### PR TITLE
Debug sfr_box diagnostic test

### DIFF
--- a/tests/components/sfr_box/__init__.py
+++ b/tests/components/sfr_box/__init__.py
@@ -1,1 +1,10 @@
 """Tests for the SFR Box integration."""
+
+from typing import Optional, Union
+
+
+class StupidClass:
+    """Blah."""
+
+    def __init__(self, connect_timeout: Optional[Union[int, float]]) -> None:  # noqa: UP007
+        """Blah."""

--- a/tests/components/sfr_box/conftest.py
+++ b/tests/components/sfr_box/conftest.py
@@ -83,7 +83,10 @@ def ftth_get_info() -> Generator[FtthInfo]:
 @pytest.fixture
 def system_get_info() -> Generator[SystemInfo]:
     """Fixture for SFRBox.system_get_info."""
-    info = SystemInfo(**json.loads(load_fixture("system_getInfo.json", DOMAIN)))
+    fixture_data = json.loads(load_fixture("system_getInfo.json", DOMAIN))
+    assert type(fixture_data["temperature"]) is int
+    info = SystemInfo(**fixture_data)
+    assert type(info.temperature) is float
     with patch(
         "homeassistant.components.sfr_box.coordinator.SFRBox.system_get_info",
         return_value=info,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Debug sfr_box diagnostic test

The class added to `sfr_box/__init__.py` makes tests fail. Some extra checks added to `sfr_box/conftest.py` to narrow down the problem.

`pytest -vvv tests/components/sfr_box/test_diagnostics.py`

With this change, the test passes:
```diff
diff --git a/tests/components/sfr_box/__init__.py b/tests/components/sfr_box/__init__.py
index e4b86709536..cbc8ce5e17f 100644
--- a/tests/components/sfr_box/__init__.py
+++ b/tests/components/sfr_box/__init__.py
@@ -6,5 +6,5 @@ from typing import Optional, Union
 class StupidClass:
     """Blah."""

-    def __init__(self, connect_timeout: Optional[Union[int, float]]) -> None:  # noqa: UP007
-        """Blah."""
+    #def __init__(self, connect_timeout: Optional[Union[int, float]]) -> None:  # noqa: UP007
+    #    """Blah."""
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
