### PR TITLE
Fix incomfort invalid setpoint if override is reported as 0.0

### DIFF
--- a/homeassistant/components/incomfort/climate.py
+++ b/homeassistant/components/incomfort/climate.py
@@ -90,8 +90,10 @@ class InComfortClimate(IncomfortEntity, ClimateEntity):
 
         As we set the override, we report back the override. The actual set point is
         is returned at a later time.
+        Some older thermostats return 0.0 as override, in that case we fallback to
+        the actual setpoint.
         """
-        return self._room.override
+        return self._room.override or self._room.setpoint
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set a new target temperature for this zone."""

--- a/tests/components/incomfort/snapshots/test_climate.ambr
+++ b/tests/components/incomfort/snapshots/test_climate.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_setup_platform[climate.thermostat_1-entry]
+# name: test_setup_platform[legacy_thermostat][climate.thermostat_1-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -38,7 +38,73 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_setup_platform[climate.thermostat_1-state]
+# name: test_setup_platform[legacy_thermostat][climate.thermostat_1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 21.4,
+      'friendly_name': 'Thermostat 1',
+      'hvac_action': <HVACAction.IDLE: 'idle'>,
+      'hvac_modes': list([
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 30.0,
+      'min_temp': 5.0,
+      'status': dict({
+        'override': 0.0,
+        'room_temp': 21.42,
+        'setpoint': 18.0,
+      }),
+      'supported_features': <ClimateEntityFeature: 1>,
+      'temperature': 18.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.thermostat_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat',
+  })
+# ---
+# name: test_setup_platform[new_thermostat][climate.thermostat_1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 30.0,
+      'min_temp': 5.0,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.thermostat_1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': <ClimateEntityFeature: 1>,
+    'translation_key': None,
+    'unique_id': 'c0ffeec0ffee_1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_platform[new_thermostat][climate.thermostat_1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 21.4,

--- a/tests/components/incomfort/test_climate.py
+++ b/tests/components/incomfort/test_climate.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from syrupy import SnapshotAssertion
 
 from homeassistant.config_entries import ConfigEntry
@@ -13,6 +14,14 @@ from tests.common import snapshot_platform
 
 
 @patch("homeassistant.components.incomfort.PLATFORMS", [Platform.CLIMATE])
+@pytest.mark.parametrize(
+    "mock_room_status",
+    [
+        {"room_temp": 21.42, "setpoint": 18.0, "override": 18.0},
+        {"room_temp": 21.42, "setpoint": 18.0, "override": 0.0},
+    ],
+    ids=["new_thermostat", "legacy_thermostat"],
+)
 async def test_setup_platform(
     hass: HomeAssistant,
     mock_incomfort: MagicMock,
@@ -20,6 +29,10 @@ async def test_setup_platform(
     snapshot: SnapshotAssertion,
     mock_config_entry: ConfigEntry,
 ) -> None:
-    """Test the incomfort entities are set up correctly."""
+    """Test the incomfort entities are set up correctly.
+
+    Legacy thermostats report 0.0 as override if no override is set,
+    but new thermostat sync the override with the actual setpoint instead.
+    """
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Older Intergas thermostats seem to report 0.0 in case no override temperature is set. In that case the actual setpoint should be reported instead.
The PR ensures the actual setpoint is returned in case the override setpoint is reported as 0.0 which is an invalid setpoint.

We changed the behavior in https://github.com/home-assistant/core/pull/119528, this fixed reporting the setpoint for newer thermostats, but caused a regression for older thermostats.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #125677
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
