### PR TITLE
Add LED mode select entities to opentherm_gw

### DIFF
--- a/homeassistant/components/opentherm_gw/select.py
+++ b/homeassistant/components/opentherm_gw/select.py
@@ -5,7 +5,16 @@ from dataclasses import dataclass
 from enum import IntEnum, StrEnum
 from functools import partial
 
-from pyotgw.vars import OTGW_GPIO_A, OTGW_GPIO_B
+from pyotgw.vars import (
+    OTGW_GPIO_A,
+    OTGW_GPIO_B,
+    OTGW_LED_A,
+    OTGW_LED_B,
+    OTGW_LED_C,
+    OTGW_LED_D,
+    OTGW_LED_E,
+    OTGW_LED_F,
+)
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -37,6 +46,23 @@ class OpenThermSelectGPIOMode(StrEnum):
     DHW_BLOCK = "dhw_block"
 
 
+class OpenThermSelectLEDMode(StrEnum):
+    """OpenThermGateway LED modes."""
+
+    RX_ANY = "receive_any"
+    TX_ANY = "transmit_any"
+    THERMOSTAT_TRAFFIC = "thermostat_traffic"
+    BOILER_TRAFFIC = "boiler_traffic"
+    SETPOINT_OVERRIDE_ACTIVE = "setpoint_override_active"
+    FLAME_ON = "flame_on"
+    CENTRAL_HEATING_ON = "central_heating_on"
+    HOT_WATER_ON = "hot_water_on"
+    COMFORT_MODE_ON = "comfort_mode_on"
+    TX_ERROR_DETECTED = "transmit_error_detected"
+    BOILER_MAINTENANCE_REQUIRED = "boiler_maintenance_required"
+    RAISED_POWER_MODE_ACTIVE = "raised_power_mode_active"
+
+
 class PyotgwGPIOMode(IntEnum):
     """pyotgw GPIO modes."""
 
@@ -51,6 +77,34 @@ class PyotgwGPIOMode(IntEnum):
     DHW_BLOCK = 8
 
 
+class PyotgwLEDMode(StrEnum):
+    """pyotgw LED modes."""
+
+    RX_ANY = "R"
+    TX_ANY = "X"
+    THERMOSTAT_TRAFFIC = "T"
+    BOILER_TRAFFIC = "B"
+    SETPOINT_OVERRIDE_ACTIVE = "O"
+    FLAME_ON = "F"
+    CENTRAL_HEATING_ON = "H"
+    HOT_WATER_ON = "W"
+    COMFORT_MODE_ON = "C"
+    TX_ERROR_DETECTED = "E"
+    BOILER_MAINTENANCE_REQUIRED = "M"
+    RAISED_POWER_MODE_ACTIVE = "P"
+
+
+def pyotgw_led_mode_to_ha_led_mode(
+    pyotgw_led_mode: PyotgwLEDMode,
+) -> OpenThermSelectLEDMode | None:
+    """Convert pyotgw LED mode to Home Assistant LED mode."""
+    return (
+        OpenThermSelectLEDMode[PyotgwLEDMode(pyotgw_led_mode).name]
+        if pyotgw_led_mode in PyotgwLEDMode
+        else None
+    )
+
+
 async def set_gpio_mode(
     gpio_id: str, gw_hub: OpenThermGatewayHub, mode: str
 ) -> OpenThermSelectGPIOMode | None:
@@ -61,6 +115,20 @@ async def set_gpio_mode(
     return (
         OpenThermSelectGPIOMode[PyotgwGPIOMode(value).name]
         if value in PyotgwGPIOMode
+        else None
+    )
+
+
+async def set_led_mode(
+    led_id: str, gw_hub: OpenThermGatewayHub, mode: str
+) -> OpenThermSelectLEDMode | None:
+    """Set gpio mode, return selected option or None."""
+    value = await gw_hub.gateway.set_led_mode(
+        led_id, PyotgwLEDMode[OpenThermSelectLEDMode(mode).name]
+    )
+    return (
+        OpenThermSelectLEDMode[PyotgwLEDMode(value).name]
+        if value in PyotgwLEDMode
         else None
     )
 
@@ -105,6 +173,60 @@ SELECT_DESCRIPTIONS: tuple[OpenThermSelectEntityDescription, ...] = (
             if state in PyotgwGPIOMode
             else None
         ),
+    ),
+    OpenThermSelectEntityDescription(
+        key=OTGW_LED_A,
+        translation_key="led_mode_n",
+        translation_placeholders={"led_id": "A"},
+        device_description=GATEWAY_DEVICE_DESCRIPTION,
+        options=list(OpenThermSelectLEDMode),
+        select_action=partial(set_led_mode, "A"),
+        convert_pyotgw_state_to_ha_state=pyotgw_led_mode_to_ha_led_mode,
+    ),
+    OpenThermSelectEntityDescription(
+        key=OTGW_LED_B,
+        translation_key="led_mode_n",
+        translation_placeholders={"led_id": "B"},
+        device_description=GATEWAY_DEVICE_DESCRIPTION,
+        options=list(OpenThermSelectLEDMode),
+        select_action=partial(set_led_mode, "B"),
+        convert_pyotgw_state_to_ha_state=pyotgw_led_mode_to_ha_led_mode,
+    ),
+    OpenThermSelectEntityDescription(
+        key=OTGW_LED_C,
+        translation_key="led_mode_n",
+        translation_placeholders={"led_id": "C"},
+        device_description=GATEWAY_DEVICE_DESCRIPTION,
+        options=list(OpenThermSelectLEDMode),
+        select_action=partial(set_led_mode, "C"),
+        convert_pyotgw_state_to_ha_state=pyotgw_led_mode_to_ha_led_mode,
+    ),
+    OpenThermSelectEntityDescription(
+        key=OTGW_LED_D,
+        translation_key="led_mode_n",
+        translation_placeholders={"led_id": "D"},
+        device_description=GATEWAY_DEVICE_DESCRIPTION,
+        options=list(OpenThermSelectLEDMode),
+        select_action=partial(set_led_mode, "D"),
+        convert_pyotgw_state_to_ha_state=pyotgw_led_mode_to_ha_led_mode,
+    ),
+    OpenThermSelectEntityDescription(
+        key=OTGW_LED_E,
+        translation_key="led_mode_n",
+        translation_placeholders={"led_id": "E"},
+        device_description=GATEWAY_DEVICE_DESCRIPTION,
+        options=list(OpenThermSelectLEDMode),
+        select_action=partial(set_led_mode, "E"),
+        convert_pyotgw_state_to_ha_state=pyotgw_led_mode_to_ha_led_mode,
+    ),
+    OpenThermSelectEntityDescription(
+        key=OTGW_LED_F,
+        translation_key="led_mode_n",
+        translation_placeholders={"led_id": "F"},
+        device_description=GATEWAY_DEVICE_DESCRIPTION,
+        options=list(OpenThermSelectLEDMode),
+        select_action=partial(set_led_mode, "F"),
+        convert_pyotgw_state_to_ha_state=pyotgw_led_mode_to_ha_led_mode,
     ),
 )
 

--- a/homeassistant/components/opentherm_gw/strings.json
+++ b/homeassistant/components/opentherm_gw/strings.json
@@ -172,6 +172,23 @@
           "ds1820": "DS1820",
           "dhw_block": "Block hot water"
         }
+      },
+      "led_mode_n": {
+        "name": "LED {led_id} mode",
+        "state": {
+          "receive_any": "Receiving on any interface",
+          "transmit_any": "Transmitting on any interface",
+          "thermostat_traffic": "Traffic on the thermostat interface",
+          "boiler_traffic": "Traffic on the boiler interface",
+          "setpoint_override_active": "Setpoint override is active",
+          "flame_on": "Boiler flame is on",
+          "central_heating_on": "Central heating is on",
+          "hot_water_on": "Hot water is on",
+          "comfort_mode_on": "Comfort mode is on",
+          "transmit_error_detected": "Transmit error detected",
+          "boiler_maintenance_required": "Boiler maintenance required",
+          "raised_power_mode_active": "Raised power mode active"
+        }
       }
     },
     "sensor": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
After adding LED mode `select` entities in #125585, we can now follow-up by adding more `select` entities to configure other settings on the OpenTherm Gateway.
This PR adds 6 new `select` entities to configure the modes on all LEDs of the gateway.
Existing tests have been generalized so we can parametrize them for the new entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#34669

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
