### PR TITLE
Remove deprecated attributes from ping binary sensor

### DIFF
--- a/homeassistant/components/ping/binary_sensor.py
+++ b/homeassistant/components/ping/binary_sensor.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -16,11 +14,6 @@ from . import PingConfigEntry
 from .const import CONF_IMPORTED_BY
 from .coordinator import PingUpdateCoordinator
 from .entity import PingEntity
-
-ATTR_ROUND_TRIP_TIME_AVG = "round_trip_time_avg"
-ATTR_ROUND_TRIP_TIME_MAX = "round_trip_time_max"
-ATTR_ROUND_TRIP_TIME_MDEV = "round_trip_time_mdev"
-ATTR_ROUND_TRIP_TIME_MIN = "round_trip_time_min"
 
 
 async def async_setup_entry(
@@ -53,13 +46,3 @@ class PingBinarySensor(PingEntity, BinarySensorEntity):
     def is_on(self) -> bool:
         """Return true if the binary sensor is on."""
         return self.coordinator.data.is_alive
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any] | None:
-        """Return the state attributes of the ICMP checo request."""
-        return {
-            ATTR_ROUND_TRIP_TIME_AVG: self.coordinator.data.data.get("avg"),
-            ATTR_ROUND_TRIP_TIME_MAX: self.coordinator.data.data.get("max"),
-            ATTR_ROUND_TRIP_TIME_MDEV: self.coordinator.data.data.get("mdev"),
-            ATTR_ROUND_TRIP_TIME_MIN: self.coordinator.data.data.get("min"),
-        }

--- a/tests/components/ping/snapshots/test_binary_sensor.ambr
+++ b/tests/components/ping/snapshots/test_binary_sensor.ambr
@@ -36,10 +36,6 @@
     'attributes': ReadOnlyDict({
       'device_class': 'connectivity',
       'friendly_name': '10.10.10.10',
-      'round_trip_time_avg': 4.8,
-      'round_trip_time_max': 10,
-      'round_trip_time_mdev': None,
-      'round_trip_time_min': 1,
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.10_10_10_10',
@@ -54,10 +50,6 @@
     'attributes': ReadOnlyDict({
       'device_class': 'connectivity',
       'friendly_name': '10.10.10.10',
-      'round_trip_time_avg': None,
-      'round_trip_time_max': None,
-      'round_trip_time_mdev': None,
-      'round_trip_time_min': None,
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.10_10_10_10',


### PR DESCRIPTION
## Breaking change
The binary sensor attributes were replaced with sensor entities in 2024.4. The deprecated attributes have now been removed.

## Proposed change
The attributes of the ping binary sensor were replaced with sensor entities in https://github.com/home-assistant/core/pull/112004. This PR removes the deprecated attributes now.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
