### PR TITLE
Migrate ring cam siren from switch to siren platform

### DIFF
--- a/homeassistant/components/ring/siren.py
+++ b/homeassistant/components/ring/siren.py
@@ -5,7 +5,13 @@ from dataclasses import dataclass
 import logging
 from typing import Any, Generic, cast
 
-from ring_doorbell import RingChime, RingEventKind, RingGeneric
+from ring_doorbell import (
+    RingCapability,
+    RingChime,
+    RingEventKind,
+    RingGeneric,
+    RingStickUpCam,
+)
 
 from homeassistant.components.siren import (
     ATTR_TONE,
@@ -60,6 +66,14 @@ SIRENS: tuple[RingSirenEntityDescription[Any], ...] = (
         turn_on_fn=lambda device, kwargs: device.async_test_sound(
             kind=str(kwargs.get(ATTR_TONE) or "") or RingEventKind.DING.value
         ),
+    ),
+    RingSirenEntityDescription[RingStickUpCam](
+        key="siren",
+        translation_key="siren",
+        exists_fn=lambda device: device.has_capability(RingCapability.SIREN),
+        is_on_fn=lambda device: device.siren > 0,
+        turn_on_fn=lambda device, _: device.async_set_siren(1),
+        turn_off_fn=lambda device: device.async_set_siren(0),
     ),
 )
 

--- a/homeassistant/components/ring/switch.py
+++ b/homeassistant/components/ring/switch.py
@@ -16,6 +16,7 @@ import homeassistant.util.dt as dt_util
 from . import RingConfigEntry
 from .coordinator import RingDataCoordinator
 from .entity import (
+    DeprecatedInfo,
     RingDeviceT,
     RingEntity,
     RingEntityDescription,
@@ -49,6 +50,9 @@ SWITCHES: Sequence[RingSwitchEntityDescription[Any]] = (
         is_on_fn=lambda device: device.siren > 0,
         turn_on_fn=lambda device: device.async_set_siren(1),
         turn_off_fn=lambda device: device.async_set_siren(0),
+        deprecated_info=DeprecatedInfo(
+            new_platform=Platform.SIREN, breaks_in_ha_version="2025.4.0"
+        ),
     ),
 )
 

--- a/tests/components/ring/snapshots/test_siren.ambr
+++ b/tests/components/ring/snapshots/test_siren.ambr
@@ -56,3 +56,99 @@
     'state': 'unknown',
   })
 # ---
+# name: test_states[siren.front_siren-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'siren',
+    'entity_category': None,
+    'entity_id': 'siren.front_siren',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Siren',
+    'platform': 'ring',
+    'previous_unique_id': None,
+    'supported_features': <SirenEntityFeature: 3>,
+    'translation_key': 'siren',
+    'unique_id': '765432',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[siren.front_siren-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by Ring.com',
+      'friendly_name': 'Front Siren',
+      'supported_features': <SirenEntityFeature: 3>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'siren.front_siren',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_states[siren.internal_siren-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'siren',
+    'entity_category': None,
+    'entity_id': 'siren.internal_siren',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Siren',
+    'platform': 'ring',
+    'previous_unique_id': None,
+    'supported_features': <SirenEntityFeature: 3>,
+    'translation_key': 'siren',
+    'unique_id': '345678',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[siren.internal_siren-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by Ring.com',
+      'friendly_name': 'Internal Siren',
+      'supported_features': <SirenEntityFeature: 3>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'siren.internal_siren',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The siren functionality on a ring camera is being migrated from the `switch` platform to the `siren` platform.
The `switch` siren functionality will be removed from Home Assistant in 2025.4.0

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Implement the ring cam siren functionality on the `siren` platform.
- Mark the siren `switch` platform for deprecation.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
