### PR TITLE
Add test snapshots to ring switch and siren platforms

### DIFF
--- a/tests/components/ring/common.py
+++ b/tests/components/ring/common.py
@@ -13,9 +13,10 @@ from tests.common import MockConfigEntry
 
 async def setup_platform(hass: HomeAssistant, platform: Platform) -> None:
     """Set up the ring platform and prerequisites."""
-    MockConfigEntry(domain=DOMAIN, data={"username": "foo", "token": {}}).add_to_hass(
-        hass
-    )
+    if not hass.config_entries.async_has_entries(DOMAIN):
+        MockConfigEntry(
+            domain=DOMAIN, data={"username": "foo", "token": {}}
+        ).add_to_hass(hass)
     with patch("homeassistant.components.ring.PLATFORMS", [platform]):
         assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done(wait_background_tasks=True)

--- a/tests/components/ring/snapshots/test_siren.ambr
+++ b/tests/components/ring/snapshots/test_siren.ambr
@@ -1,0 +1,58 @@
+# serializer version: 1
+# name: test_states[siren.downstairs_siren-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'available_tones': list([
+        'ding',
+        'motion',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'siren',
+    'entity_category': None,
+    'entity_id': 'siren.downstairs_siren',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Siren',
+    'platform': 'ring',
+    'previous_unique_id': None,
+    'supported_features': <SirenEntityFeature: 5>,
+    'translation_key': 'siren',
+    'unique_id': '123456-siren',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[siren.downstairs_siren-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by Ring.com',
+      'available_tones': list([
+        'ding',
+        'motion',
+      ]),
+      'friendly_name': 'Downstairs Siren',
+      'supported_features': <SirenEntityFeature: 5>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'siren.downstairs_siren',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/ring/snapshots/test_switch.ambr
+++ b/tests/components/ring/snapshots/test_switch.ambr
@@ -1,0 +1,95 @@
+# serializer version: 1
+# name: test_states[switch.front_siren-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.front_siren',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Siren',
+    'platform': 'ring',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'siren',
+    'unique_id': '765432-siren',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[switch.front_siren-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by Ring.com',
+      'friendly_name': 'Front Siren',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.front_siren',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_states[switch.internal_siren-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.internal_siren',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Siren',
+    'platform': 'ring',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'siren',
+    'unique_id': '345678-siren',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_states[switch.internal_siren-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by Ring.com',
+      'friendly_name': 'Internal Siren',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.internal_siren',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/ring/test_siren.py
+++ b/tests/components/ring/test_siren.py
@@ -1,7 +1,10 @@
 """The tests for the Ring button platform."""
 
+from unittest.mock import Mock
+
 import pytest
 import ring_doorbell
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.config_entries import SOURCE_REAUTH
 from homeassistant.const import Platform
@@ -9,7 +12,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
-from .common import setup_platform
+from .common import MockConfigEntry, setup_platform
+
+from tests.common import snapshot_platform
 
 
 async def test_entity_registry(
@@ -22,6 +27,20 @@ async def test_entity_registry(
 
     entry = entity_registry.async_get("siren.downstairs_siren")
     assert entry.unique_id == "123456-siren"
+
+
+async def test_states(
+    hass: HomeAssistant,
+    mock_ring_client: Mock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test states."""
+
+    mock_config_entry.add_to_hass(hass)
+    await setup_platform(hass, Platform.SIREN)
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
 async def test_sirens_report_correctly(hass: HomeAssistant, mock_ring_client) -> None:

--- a/tests/components/ring/test_switch.py
+++ b/tests/components/ring/test_switch.py
@@ -1,7 +1,10 @@
 """The tests for the Ring switch platform."""
 
+from unittest.mock import Mock
+
 import pytest
 import ring_doorbell
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.config_entries import SOURCE_REAUTH
 from homeassistant.const import Platform
@@ -9,7 +12,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
-from .common import setup_platform
+from .common import MockConfigEntry, setup_platform
+
+from tests.common import snapshot_platform
 
 
 async def test_entity_registry(
@@ -25,6 +30,20 @@ async def test_entity_registry(
 
     entry = entity_registry.async_get("switch.internal_siren")
     assert entry.unique_id == "345678-siren"
+
+
+async def test_states(
+    hass: HomeAssistant,
+    mock_ring_client: Mock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test states."""
+
+    mock_config_entry.add_to_hass(hass)
+    await setup_platform(hass, Platform.SWITCH)
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
 async def test_siren_off_reports_correctly(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Probably a good idea to have snapshots in place before migrating these platforms to entity descriptions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
