### PR TITLE
Allow one reusable proxy URL per ESPHome device

### DIFF
--- a/homeassistant/components/esphome/ffmpeg_proxy.py
+++ b/homeassistant/components/esphome/ffmpeg_proxy.py
@@ -229,7 +229,7 @@ class FFmpegProxyView(HomeAssistantView):
         """Start a get request."""
         if (convert_info := self.proxy_data.conversions.get(device_id)) is None:
             return web.Response(
-                body="No proxy URL for device", status=HTTPStatus.BAD_REQUEST
+                body="No proxy URL for device", status=HTTPStatus.NOT_FOUND
             )
 
         # {id}.mp3 -> id, mp3

--- a/tests/components/esphome/test_ffmpeg_proxy.py
+++ b/tests/components/esphome/test_ffmpeg_proxy.py
@@ -61,7 +61,7 @@ async def test_proxy_view(
 
         # Should fail because we haven't allowed the URL yet
         req = await client.get(url)
-        assert req.status == HTTPStatus.BAD_REQUEST
+        assert req.status == HTTPStatus.NOT_FOUND
 
         # Allow the URL
         with patch(

--- a/tests/components/esphome/test_ffmpeg_proxy.py
+++ b/tests/components/esphome/test_ffmpeg_proxy.py
@@ -75,6 +75,12 @@ async def test_proxy_view(
                 == url
             )
 
+        # Requesting the wrong media format should fail
+        wrong_url = f"/api/esphome/ffmpeg_proxy/{device_id}/{convert_id}.flac"
+        req = await client.get(wrong_url)
+        assert req.status == HTTPStatus.BAD_REQUEST
+
+        # Correct URL
         req = await client.get(url)
         assert req.status == HTTPStatus.OK
 
@@ -109,3 +115,78 @@ async def test_ffmpeg_error(
     assert req.status == HTTPStatus.OK
     mp3_data = await req.content.read()
     assert not mp3_data
+
+
+async def test_lingering_process(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test that a new request stops the old ffmpeg process."""
+    device_id = "1234"
+
+    await async_setup_component(hass, esphome.DOMAIN, {esphome.DOMAIN: {}})
+    client = await hass_client()
+
+    with tempfile.NamedTemporaryFile(mode="wb+", suffix=".wav") as temp_file:
+        with wave.open(temp_file.name, "wb") as wav_file:
+            wav_file.setframerate(16000)
+            wav_file.setsampwidth(2)
+            wav_file.setnchannels(1)
+            wav_file.writeframes(bytes(16000 * 2))  # 1s
+
+        temp_file.seek(0)
+        wav_url = pathname2url(temp_file.name)
+        convert_id = "test-id"
+        url1 = f"/api/esphome/ffmpeg_proxy/{device_id}/{convert_id}.wav"
+
+        # Allow the URL
+        with patch(
+            "homeassistant.components.esphome.ffmpeg_proxy.secrets.token_urlsafe",
+            return_value=convert_id,
+        ):
+            assert (
+                async_create_proxy_url(
+                    hass, device_id, wav_url, media_format="wav", rate=22050, channels=2
+                )
+                == url1
+            )
+
+        # First request will start ffmpeg
+        req1 = await client.get(url1)
+        assert req1.status == HTTPStatus.OK
+
+        # Only read part of the data
+        await req1.content.readexactly(100)
+
+        # Allow another URL
+        convert_id = "test-id-2"
+        url2 = f"/api/esphome/ffmpeg_proxy/{device_id}/{convert_id}.wav"
+
+        with patch(
+            "homeassistant.components.esphome.ffmpeg_proxy.secrets.token_urlsafe",
+            return_value=convert_id,
+        ):
+            assert (
+                async_create_proxy_url(
+                    hass, device_id, wav_url, media_format="wav", rate=22050, channels=2
+                )
+                == url2
+            )
+
+        req2 = await client.get(url2)
+        assert req2.status == HTTPStatus.OK
+
+        wav_data = await req2.content.read()
+
+    # All of the data should be there because this is a new ffmpeg process
+    with io.BytesIO(wav_data) as wav_io, wave.open(wav_io, "rb") as wav_file:
+        # We can't use getnframes() here because the WAV header will be incorrect.
+        # WAV encoders usually go back and update the WAV header after all of
+        # the frames are written, but ffmpeg can't do that because we're
+        # streaming the data.
+        # So instead, we just read and count frames until we run out.
+        num_frames = 0
+        while chunk := wav_file.readframes(1024):
+            num_frames += len(chunk) // (2 * 2)  # 2 channels, 16-bit samples
+
+        assert num_frames == 22050  # 1s

--- a/tests/components/esphome/test_ffmpeg_proxy.py
+++ b/tests/components/esphome/test_ffmpeg_proxy.py
@@ -96,11 +96,11 @@ async def test_proxy_view(
         assert round(mp3_file.info.length, 0) == 1
 
 
-async def test_ffmpeg_error(
+async def test_ffmpeg_file_doesnt_exist(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
 ) -> None:
-    """Test proxy HTTP view with an ffmpeg error."""
+    """Test ffmpeg conversion with a file that doesn't exist."""
     device_id = "1234"
 
     await async_setup_component(hass, esphome.DOMAIN, {esphome.DOMAIN: {}})
@@ -136,20 +136,15 @@ async def test_lingering_process(
 
         temp_file.seek(0)
         wav_url = pathname2url(temp_file.name)
-        convert_id = "test-id"
-        url1 = f"/api/esphome/ffmpeg_proxy/{device_id}/{convert_id}.wav"
-
-        # Allow the URL
-        with patch(
-            "homeassistant.components.esphome.ffmpeg_proxy.secrets.token_urlsafe",
-            return_value=convert_id,
-        ):
-            assert (
-                async_create_proxy_url(
-                    hass, device_id, wav_url, media_format="wav", rate=22050, channels=2
-                )
-                == url1
-            )
+        url1 = async_create_proxy_url(
+            hass,
+            device_id,
+            wav_url,
+            media_format="wav",
+            rate=22050,
+            channels=2,
+            width=2,
+        )
 
         # First request will start ffmpeg
         req1 = await client.get(url1)
@@ -159,19 +154,15 @@ async def test_lingering_process(
         await req1.content.readexactly(100)
 
         # Allow another URL
-        convert_id = "test-id-2"
-        url2 = f"/api/esphome/ffmpeg_proxy/{device_id}/{convert_id}.wav"
-
-        with patch(
-            "homeassistant.components.esphome.ffmpeg_proxy.secrets.token_urlsafe",
-            return_value=convert_id,
-        ):
-            assert (
-                async_create_proxy_url(
-                    hass, device_id, wav_url, media_format="wav", rate=22050, channels=2
-                )
-                == url2
-            )
+        url2 = async_create_proxy_url(
+            hass,
+            device_id,
+            wav_url,
+            media_format="wav",
+            rate=22050,
+            channels=2,
+            width=2,
+        )
 
         req2 = await client.get(url2)
         assert req2.status == HTTPStatus.OK
@@ -190,3 +181,54 @@ async def test_lingering_process(
             num_frames += len(chunk) // (2 * 2)  # 2 channels, 16-bit samples
 
         assert num_frames == 22050  # 1s
+
+
+async def test_request_same_url_multiple_times(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test that the ffmpeg process is restarted if the same URL is requested multiple times."""
+    device_id = "1234"
+
+    await async_setup_component(hass, esphome.DOMAIN, {esphome.DOMAIN: {}})
+    client = await hass_client()
+
+    with tempfile.NamedTemporaryFile(mode="wb+", suffix=".wav") as temp_file:
+        with wave.open(temp_file.name, "wb") as wav_file:
+            wav_file.setframerate(16000)
+            wav_file.setsampwidth(2)
+            wav_file.setnchannels(1)
+            wav_file.writeframes(bytes(16000 * 2 * 10))  # 10s
+
+        temp_file.seek(0)
+        wav_url = pathname2url(temp_file.name)
+        url = async_create_proxy_url(
+            hass,
+            device_id,
+            wav_url,
+            media_format="wav",
+            rate=22050,
+            channels=2,
+            width=2,
+        )
+
+        # First request will start ffmpeg
+        req1 = await client.get(url)
+        assert req1.status == HTTPStatus.OK
+
+        # Only read part of the data
+        await req1.content.readexactly(100)
+
+        # Second request should restart ffmpeg
+        req2 = await client.get(url)
+        assert req2.status == HTTPStatus.OK
+
+        wav_data = await req2.content.read()
+
+    # All of the data should be there because this is a new ffmpeg process
+    with io.BytesIO(wav_data) as wav_io, wave.open(wav_io, "rb") as wav_file:
+        num_frames = 0
+        while chunk := wav_file.readframes(1024):
+            num_frames += len(chunk) // (2 * 2)  # 2 channels, 16-bit samples
+
+        assert num_frames == 22050 * 10  # 10s


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The ESPHome media proxy swaps media player URLs when a device requests a specific format. The swapped URL points to HA, and automatically converts the media using ffmpeg.

Previously, the media proxy URLs were one-time use and multiple URLs were kept for a device. Now, only a single proxy URL is kept per device, and it is reusable in case the device is restarted.

When the URL can be reused, there is some ambiguity in what should happen when it's requested the second time. One possibility is for the stream to be resumed at the exact point it stopped. The problem is that the media header was already sent, so the device would have to know it was in the middle of decoding a stream (possibly mid-frame).
Instead, we simply restart the conversion process from the beginning.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
