### PR TITLE
Add validation to set_humidity action in humidifier

### DIFF
--- a/homeassistant/components/humidifier/strings.json
+++ b/homeassistant/components/humidifier/strings.json
@@ -115,5 +115,10 @@
       "name": "[%key:common::action::toggle%]",
       "description": "Toggles the humidifier on/off."
     }
+  },
+  "exceptions": {
+    "humidity_out_of_range": {
+      "message": "Provided humidity {humidity} is not valid. Accepted range is {min_humidity} to {max_humidity}."
+    }
   }
 }

--- a/tests/components/humidifier/conftest.py
+++ b/tests/components/humidifier/conftest.py
@@ -1,0 +1,69 @@
+"""Fixtures for Humidifier platform tests."""
+
+from collections.abc import Generator
+
+import pytest
+
+from homeassistant.components.humidifier import DOMAIN as HUMIDIFIER_DOMAIN
+from homeassistant.config_entries import ConfigEntry, ConfigFlow
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from tests.common import (
+    MockConfigEntry,
+    MockModule,
+    mock_config_flow,
+    mock_integration,
+    mock_platform,
+)
+
+
+class MockFlow(ConfigFlow):
+    """Test flow."""
+
+
+@pytest.fixture
+def config_flow_fixture(hass: HomeAssistant) -> Generator[None]:
+    """Mock config flow."""
+    mock_platform(hass, "test.config_flow")
+
+    with mock_config_flow("test", MockFlow):
+        yield
+
+
+@pytest.fixture
+def register_test_integration(
+    hass: HomeAssistant, config_flow_fixture: None
+) -> Generator:
+    """Provide a mocked integration for tests."""
+
+    config_entry = MockConfigEntry(domain="test")
+    config_entry.add_to_hass(hass)
+
+    async def help_async_setup_entry_init(
+        hass: HomeAssistant, config_entry: ConfigEntry
+    ) -> bool:
+        """Set up test config entry."""
+        await hass.config_entries.async_forward_entry_setups(
+            config_entry, [HUMIDIFIER_DOMAIN]
+        )
+        return True
+
+    async def help_async_unload_entry(
+        hass: HomeAssistant, config_entry: ConfigEntry
+    ) -> bool:
+        """Unload test config emntry."""
+        return await hass.config_entries.async_unload_platforms(
+            config_entry, [Platform.HUMIDIFIER]
+        )
+
+    mock_integration(
+        hass,
+        MockModule(
+            "test",
+            async_setup_entry=help_async_setup_entry_init,
+            async_unload_entry=help_async_unload_entry,
+        ),
+    )
+
+    return config_entry

--- a/tests/components/humidifier/test_init.py
+++ b/tests/components/humidifier/test_init.py
@@ -8,16 +8,28 @@ import pytest
 
 from homeassistant.components import humidifier
 from homeassistant.components.humidifier import (
+    ATTR_HUMIDITY,
     ATTR_MODE,
+    DOMAIN as HUMIDIFIER_DOMAIN,
+    MODE_ECO,
+    MODE_NORMAL,
+    SERVICE_SET_HUMIDITY,
     HumidifierEntity,
     HumidifierEntityFeature,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 
-from tests.common import help_test_all, import_and_test_deprecated_constant_enum
+from tests.common import (
+    MockConfigEntry,
+    MockEntity,
+    help_test_all,
+    import_and_test_deprecated_constant_enum,
+    setup_test_component_platform,
+)
 
 
-class MockHumidifierEntity(HumidifierEntity):
+class MockHumidifierEntity(MockEntity, HumidifierEntity):
     """Mock Humidifier device to use in tests."""
 
     @property
@@ -101,3 +113,70 @@ def test_deprecated_supported_features_ints(caplog: pytest.LogCaptureFixture) ->
     assert "is using deprecated supported features values" not in caplog.text
 
     assert entity.state_attributes[ATTR_MODE] == "mode1"
+
+
+async def test_humidity_validation(
+    hass: HomeAssistant,
+    register_test_integration: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test validation for humidity."""
+
+    class MockHumidifierEntityHumidity(MockEntity, HumidifierEntity):
+        """Mock climate class with mocked aux heater."""
+
+        _attr_supported_features = HumidifierEntityFeature.MODES
+        _attr_available_modes = [MODE_NORMAL, MODE_ECO]
+        _attr_mode = MODE_NORMAL
+        _attr_target_humidity = 50
+        _attr_min_humidity = 50
+        _attr_max_humidity = 60
+
+        def set_humidity(self, humidity: int) -> None:
+            """Set new target humidity."""
+            self._attr_target_humidity = humidity
+
+    test_humidifier = MockHumidifierEntityHumidity(
+        name="Test",
+        unique_id="unique_humidifier_test",
+    )
+
+    setup_test_component_platform(
+        hass, HUMIDIFIER_DOMAIN, entities=[test_humidifier], from_config_entry=True
+    )
+    await hass.config_entries.async_setup(register_test_integration.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("humidifier.test")
+    assert state.attributes.get(ATTR_HUMIDITY) == 50
+
+    with pytest.raises(
+        ServiceValidationError,
+        match="Provided humidity 1 is not valid. Accepted range is 50 to 60",
+    ) as exc:
+        await hass.services.async_call(
+            HUMIDIFIER_DOMAIN,
+            SERVICE_SET_HUMIDITY,
+            {
+                "entity_id": "humidifier.test",
+                ATTR_HUMIDITY: "1",
+            },
+            blocking=True,
+        )
+
+    assert exc.value.translation_key == "humidity_out_of_range"
+    assert "Check valid humidity 1 in range 50 - 60" in caplog.text
+
+    with pytest.raises(
+        ServiceValidationError,
+        match="Provided humidity 70 is not valid. Accepted range is 50 to 60",
+    ) as exc:
+        await hass.services.async_call(
+            HUMIDIFIER_DOMAIN,
+            SERVICE_SET_HUMIDITY,
+            {
+                "entity_id": "humidifier.test",
+                ATTR_HUMIDITY: "70",
+            },
+            blocking=True,
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Validation is now done for the `humidifier.set_humidity` action which enforces that the target humidity is within the min and max humidity levels of the targeted entity. Users may need to adjust automations and scripts to use valid values in the set humidity action.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Implements validation for the `set_humidity` method in `HumidifierEntity`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 