### PR TITLE
Addition of Flipr hub with switch platform

### DIFF
--- a/homeassistant/components/flipr/__init__.py
+++ b/homeassistant/components/flipr/__init__.py
@@ -13,9 +13,9 @@ from homeassistant.exceptions import ConfigEntryError
 from homeassistant.helpers import issue_registry as ir
 
 from .const import DOMAIN
-from .coordinator import FliprDataUpdateCoordinator
+from .coordinator import FliprDataUpdateCoordinator, HubDataUpdateCoordinator
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.SWITCH]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,6 +25,7 @@ class FliprData:
     """The Flipr data class."""
 
     flipr_coordinators: list[FliprDataUpdateCoordinator]
+    hub_coordinators: list[HubDataUpdateCoordinator]
 
 
 type FliprConfigEntry = ConfigEntry[FliprData]
@@ -53,7 +54,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: FliprConfigEntry) -> boo
         await flipr_coordinator.async_config_entry_first_refresh()
         flipr_coordinators.append(flipr_coordinator)
 
-    entry.runtime_data = FliprData(flipr_coordinators)
+    hub_coordinators = []
+    for hub_id in ids["hub"]:
+        hub_coordinator = HubDataUpdateCoordinator(hass, client, hub_id)
+        await hub_coordinator.async_config_entry_first_refresh()
+        hub_coordinators.append(hub_coordinator)
+
+    entry.runtime_data = FliprData(flipr_coordinators, hub_coordinators)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/flipr/__init__.py
+++ b/homeassistant/components/flipr/__init__.py
@@ -13,7 +13,7 @@ from homeassistant.exceptions import ConfigEntryError
 from homeassistant.helpers import issue_registry as ir
 
 from .const import DOMAIN
-from .coordinator import FliprDataUpdateCoordinator, HubDataUpdateCoordinator
+from .coordinator import FliprDataUpdateCoordinator, FliprHubDataUpdateCoordinator
 
 PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.SWITCH]
 
@@ -25,7 +25,7 @@ class FliprData:
     """The Flipr data class."""
 
     flipr_coordinators: list[FliprDataUpdateCoordinator]
-    hub_coordinators: list[HubDataUpdateCoordinator]
+    hub_coordinators: list[FliprHubDataUpdateCoordinator]
 
 
 type FliprConfigEntry = ConfigEntry[FliprData]
@@ -56,7 +56,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: FliprConfigEntry) -> boo
 
     hub_coordinators = []
     for hub_id in ids["hub"]:
-        hub_coordinator = HubDataUpdateCoordinator(hass, client, hub_id)
+        hub_coordinator = FliprHubDataUpdateCoordinator(hass, client, hub_id)
         await hub_coordinator.async_config_entry_first_refresh()
         hub_coordinators.append(hub_coordinator)
 

--- a/homeassistant/components/flipr/const.py
+++ b/homeassistant/components/flipr/const.py
@@ -6,5 +6,3 @@ ATTRIBUTION = "Flipr Data"
 
 MANUFACTURER = "CTAC-TECH"
 NAME = "Flipr"
-
-CONF_ENTRY_FLIPR_COORDINATORS = "flipr_coordinators"

--- a/homeassistant/components/flipr/coordinator.py
+++ b/homeassistant/components/flipr/coordinator.py
@@ -13,8 +13,8 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 _LOGGER = logging.getLogger(__name__)
 
 
-class FliprDataUpdateCoordinator(DataUpdateCoordinator):
-    """Class to hold Flipr data retrieval."""
+class BaseDataUpdateCoordinator(DataUpdateCoordinator):
+    """Parent class to hold Flipr and Hub data retrieval."""
 
     config_entry: ConfigEntry
 
@@ -32,11 +32,30 @@ class FliprDataUpdateCoordinator(DataUpdateCoordinator):
             update_interval=timedelta(minutes=15),
         )
 
+
+class FliprDataUpdateCoordinator(BaseDataUpdateCoordinator):
+    """Class to hold Flipr data retrieval."""
+
     async def _async_update_data(self):
         """Fetch data from API endpoint."""
         try:
             data = await self.hass.async_add_executor_job(
                 self.client.get_pool_measure_latest, self.device_id
+            )
+        except FliprError as error:
+            raise UpdateFailed(error) from error
+
+        return data
+
+
+class HubDataUpdateCoordinator(BaseDataUpdateCoordinator):
+    """Class to hold Flipr hub data retrieval."""
+
+    async def _async_update_data(self):
+        """Fetch data from API endpoint."""
+        try:
+            data = await self.hass.async_add_executor_job(
+                self.client.get_hub_state, self.device_id
             )
         except FliprError as error:
             raise UpdateFailed(error) from error

--- a/homeassistant/components/flipr/coordinator.py
+++ b/homeassistant/components/flipr/coordinator.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import Any
 
 from flipr_api import FliprAPIRestClient
 from flipr_api.exceptions import FliprError
@@ -13,7 +14,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 _LOGGER = logging.getLogger(__name__)
 
 
-class BaseDataUpdateCoordinator(DataUpdateCoordinator):
+class BaseDataUpdateCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
     """Parent class to hold Flipr and Hub data retrieval."""
 
     config_entry: ConfigEntry
@@ -33,10 +34,10 @@ class BaseDataUpdateCoordinator(DataUpdateCoordinator):
         )
 
 
-class FliprDataUpdateCoordinator(BaseDataUpdateCoordinator):
+class FliprDataUpdateCoordinator(BaseDataUpdateCoordinator[dict[str, Any]]):
     """Class to hold Flipr data retrieval."""
 
-    async def _async_update_data(self):
+    async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from API endpoint."""
         try:
             data = await self.hass.async_add_executor_job(
@@ -48,10 +49,10 @@ class FliprDataUpdateCoordinator(BaseDataUpdateCoordinator):
         return data
 
 
-class HubDataUpdateCoordinator(BaseDataUpdateCoordinator):
+class FliprHubDataUpdateCoordinator(BaseDataUpdateCoordinator[dict[str, Any]]):
     """Class to hold Flipr hub data retrieval."""
 
-    async def _async_update_data(self):
+    async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from API endpoint."""
         try:
             data = await self.hass.async_add_executor_job(

--- a/homeassistant/components/flipr/entity.py
+++ b/homeassistant/components/flipr/entity.py
@@ -26,6 +26,10 @@ class FliprEntity(CoordinatorEntity[BaseDataUpdateCoordinator]):
         self.entity_description = description
         self._attr_unique_id = f"{self.device_id}-{description.key}"
 
+        # Flipr hub entity is the default feature of the hub so there is no need to name it.
+        if is_flipr_hub:
+            self._attr_name = None
+
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self.device_id)},
             manufacturer=MANUFACTURER,

--- a/homeassistant/components/flipr/entity.py
+++ b/homeassistant/components/flipr/entity.py
@@ -5,7 +5,7 @@ from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import ATTRIBUTION, DOMAIN, MANUFACTURER
-from .coordinator import FliprDataUpdateCoordinator
+from .coordinator import BaseDataUpdateCoordinator
 
 
 class FliprEntity(CoordinatorEntity):
@@ -16,7 +16,7 @@ class FliprEntity(CoordinatorEntity):
 
     def __init__(
         self,
-        coordinator: FliprDataUpdateCoordinator,
+        coordinator: BaseDataUpdateCoordinator,
         description: EntityDescription,
         is_flipr_hub: bool = False,
     ) -> None:

--- a/homeassistant/components/flipr/entity.py
+++ b/homeassistant/components/flipr/entity.py
@@ -8,7 +8,7 @@ from .const import ATTRIBUTION, DOMAIN, MANUFACTURER
 from .coordinator import BaseDataUpdateCoordinator
 
 
-class FliprEntity(CoordinatorEntity):
+class FliprEntity(CoordinatorEntity[BaseDataUpdateCoordinator]):
     """Implements a common class elements representing the Flipr component."""
 
     _attr_attribution = ATTRIBUTION

--- a/homeassistant/components/flipr/entity.py
+++ b/homeassistant/components/flipr/entity.py
@@ -26,10 +26,6 @@ class FliprEntity(CoordinatorEntity[BaseDataUpdateCoordinator]):
         self.entity_description = description
         self._attr_unique_id = f"{self.device_id}-{description.key}"
 
-        # Flipr hub entity is the default feature of the hub so there is no need to name it.
-        if is_flipr_hub:
-            self._attr_name = None
-
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self.device_id)},
             manufacturer=MANUFACTURER,

--- a/homeassistant/components/flipr/strings.json
+++ b/homeassistant/components/flipr/strings.json
@@ -39,6 +39,11 @@
       "red_ox": {
         "name": "Red OX"
       }
+    },
+    "switch": {
+      "hub_state": {
+        "name": "state"
+      }
     }
   },
   "issues": {

--- a/homeassistant/components/flipr/strings.json
+++ b/homeassistant/components/flipr/strings.json
@@ -39,11 +39,6 @@
       "red_ox": {
         "name": "Red OX"
       }
-    },
-    "switch": {
-      "hub_state": {
-        "name": "state"
-      }
     }
   },
   "issues": {

--- a/homeassistant/components/flipr/switch.py
+++ b/homeassistant/components/flipr/switch.py
@@ -29,13 +29,13 @@ async def async_setup_entry(
     coordinators = config_entry.runtime_data.hub_coordinators
 
     async_add_entities(
-        HubSwitch(coordinator, description, True)
+        FliprHubSwitch(coordinator, description, True)
         for description in SWITCH_TYPES
         for coordinator in coordinators
     )
 
 
-class HubSwitch(FliprEntity, SwitchEntity):
+class FliprHubSwitch(FliprEntity, SwitchEntity):
     """Switch representing Hub state."""
 
     @property
@@ -48,7 +48,7 @@ class HubSwitch(FliprEntity, SwitchEntity):
         """Turn off the switch."""
         _LOGGER.debug("Switching off %s", self.device_id)
         data = await self.hass.async_add_executor_job(
-            self.coordinator.client.set_hub_state,  # type: ignore[attr-defined]
+            self.coordinator.client.set_hub_state,
             self.device_id,
             False,
         )
@@ -59,7 +59,7 @@ class HubSwitch(FliprEntity, SwitchEntity):
         """Turn on the switch."""
         _LOGGER.debug("Switching on %s", self.device_id)
         data = await self.hass.async_add_executor_job(
-            self.coordinator.client.set_hub_state,  # type: ignore[attr-defined]
+            self.coordinator.client.set_hub_state,
             self.device_id,
             True,
         )

--- a/homeassistant/components/flipr/switch.py
+++ b/homeassistant/components/flipr/switch.py
@@ -15,6 +15,7 @@ _LOGGER = logging.getLogger(__name__)
 SWITCH_TYPES: tuple[SwitchEntityDescription, ...] = (
     SwitchEntityDescription(
         key="hubState",
+        name=None,
     ),
 )
 

--- a/homeassistant/components/flipr/switch.py
+++ b/homeassistant/components/flipr/switch.py
@@ -15,7 +15,6 @@ _LOGGER = logging.getLogger(__name__)
 SWITCH_TYPES: tuple[SwitchEntityDescription, ...] = (
     SwitchEntityDescription(
         key="hubState",
-        translation_key="hub_state",
     ),
 )
 

--- a/homeassistant/components/flipr/switch.py
+++ b/homeassistant/components/flipr/switch.py
@@ -1,0 +1,67 @@
+"""Switch platform for the Flipr's Hub."""
+
+import logging
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import FliprConfigEntry
+from .entity import FliprEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+SWITCH_TYPES: tuple[SwitchEntityDescription, ...] = (
+    SwitchEntityDescription(
+        key="hubState",
+        translation_key="hub_state",
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: FliprConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up switch for Flipr hub."""
+    coordinators = config_entry.runtime_data.hub_coordinators
+
+    async_add_entities(
+        HubSwitch(coordinator, description, True)
+        for description in SWITCH_TYPES
+        for coordinator in coordinators
+    )
+
+
+class HubSwitch(FliprEntity, SwitchEntity):
+    """Switch representing Hub state."""
+
+    @property
+    def is_on(self) -> bool:
+        """Return state of the switch."""
+        _LOGGER.debug("coordinator data = %s", self.coordinator.data)
+        return self.coordinator.data["state"]
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the switch."""
+        _LOGGER.debug("Switching off %s", self.device_id)
+        data = await self.hass.async_add_executor_job(
+            self.coordinator.client.set_hub_state,  # type: ignore[attr-defined]
+            self.device_id,
+            False,
+        )
+        _LOGGER.debug("New hub infos are %s", data)
+        self.coordinator.async_set_updated_data(data)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the switch."""
+        _LOGGER.debug("Switching on %s", self.device_id)
+        data = await self.hass.async_add_executor_job(
+            self.coordinator.client.set_hub_state,  # type: ignore[attr-defined]
+            self.device_id,
+            True,
+        )
+        _LOGGER.debug("New hub infos are %s", data)
+        self.coordinator.async_set_updated_data(data)

--- a/tests/components/flipr/test_switch.py
+++ b/tests/components/flipr/test_switch.py
@@ -1,0 +1,115 @@
+"""Test the Flipr switch for Hub."""
+
+import logging
+from unittest.mock import AsyncMock
+
+from flipr_api.exceptions import FliprError
+
+from homeassistant.components.switch import (
+    DOMAIN as SWITCH_DOMAIN,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
+from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+from .conftest import MOCK_HUB_STATE_OFF
+
+from tests.common import MockConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+SWITCH_ENTITY_ID = "switch.flipr_hub_myhubid_state"
+
+
+async def test_entities(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    mock_flipr_client: AsyncMock,
+) -> None:
+    """Test the creation and values of the Flipr switch."""
+
+    mock_flipr_client.search_all_ids.return_value = {"flipr": [], "hub": ["myhubid"]}
+
+    await setup_integration(hass, mock_config_entry)
+
+    # Check entity unique_id value that is generated in FliprEntity base class.
+    entity = entity_registry.async_get(SWITCH_ENTITY_ID)
+    _LOGGER.debug("Found entity = %s", entity)
+    assert entity.unique_id == "myhubid-hubState"
+
+    state = hass.states.get(SWITCH_ENTITY_ID)
+    _LOGGER.debug("Found state = %s", state)
+    assert state
+    assert state.state == STATE_ON
+
+
+async def test_switch_actions(
+    hass: HomeAssistant,
+    mock_flipr_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the actions on the Flipr Hub switch."""
+
+    mock_flipr_client.search_all_ids.return_value = {"flipr": [], "hub": ["myhubid"]}
+
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: SWITCH_ENTITY_ID},
+        blocking=True,
+    )
+    state = hass.states.get(SWITCH_ENTITY_ID)
+    assert state.state == STATE_ON
+
+    mock_flipr_client.set_hub_state.return_value = MOCK_HUB_STATE_OFF
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: SWITCH_ENTITY_ID},
+        blocking=True,
+    )
+    state = hass.states.get(SWITCH_ENTITY_ID)
+    assert state.state == STATE_OFF
+
+
+async def test_no_switch_found(
+    hass: HomeAssistant,
+    mock_flipr_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the switch absence."""
+
+    mock_flipr_client.search_all_ids.return_value = {"flipr": [], "hub": []}
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert not hass.states.async_entity_ids(SWITCH_DOMAIN)
+
+
+async def test_error_flipr_api(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    mock_flipr_client: AsyncMock,
+) -> None:
+    """Test the Flipr sensors error."""
+
+    mock_flipr_client.search_all_ids.return_value = {"flipr": [], "hub": ["myhubid"]}
+
+    mock_flipr_client.get_hub_state.side_effect = FliprError(
+        "Error during flipr data retrieval..."
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    # Check entity is not generated because of the FliprError raised.
+    entity = entity_registry.async_get(SWITCH_ENTITY_ID)
+    assert entity is None

--- a/tests/components/flipr/test_switch.py
+++ b/tests/components/flipr/test_switch.py
@@ -18,7 +18,7 @@ from .conftest import MOCK_HUB_STATE_OFF
 
 from tests.common import MockConfigEntry
 
-SWITCH_ENTITY_ID = "switch.flipr_hub_myhubid_state"
+SWITCH_ENTITY_ID = "switch.flipr_hub_myhubid"
 
 
 async def test_entities(

--- a/tests/components/flipr/test_switch.py
+++ b/tests/components/flipr/test_switch.py
@@ -1,6 +1,5 @@
 """Test the Flipr switch for Hub."""
 
-import logging
 from unittest.mock import AsyncMock
 
 from flipr_api.exceptions import FliprError
@@ -19,8 +18,6 @@ from .conftest import MOCK_HUB_STATE_OFF
 
 from tests.common import MockConfigEntry
 
-_LOGGER = logging.getLogger(__name__)
-
 SWITCH_ENTITY_ID = "switch.flipr_hub_myhubid_state"
 
 
@@ -38,11 +35,9 @@ async def test_entities(
 
     # Check entity unique_id value that is generated in FliprEntity base class.
     entity = entity_registry.async_get(SWITCH_ENTITY_ID)
-    _LOGGER.debug("Found entity = %s", entity)
     assert entity.unique_id == "myhubid-hubState"
 
     state = hass.states.get(SWITCH_ENTITY_ID)
-    _LOGGER.debug("Found state = %s", state)
     assert state
     assert state.state == STATE_ON
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Addition of flipr hub devices (boxes that act like a relay to start/stop pool pump or lights) with its first platform which is a switch for the state (on, off).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/34586

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
