### PR TITLE
Bump aiostreammagic to 2.3.0

### DIFF
--- a/homeassistant/components/cambridge_audio/entity.py
+++ b/homeassistant/components/cambridge_audio/entity.py
@@ -5,6 +5,7 @@ from functools import wraps
 from typing import Any, Concatenate
 
 from aiostreammagic import StreamMagicClient
+from aiostreammagic.models import CallbackType
 
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
@@ -51,7 +52,9 @@ class CambridgeAudioEntity(Entity):
         )
 
     @callback
-    async def _state_update_callback(self, _client: StreamMagicClient) -> None:
+    async def _state_update_callback(
+        self, _client: StreamMagicClient, _callback_type: CallbackType
+    ) -> None:
         """Call when the device is notified of changes."""
         self._attr_available = _client.is_connected()
         self.async_write_ha_state()

--- a/homeassistant/components/cambridge_audio/manifest.json
+++ b/homeassistant/components/cambridge_audio/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "loggers": ["aiostreammagic"],
-  "requirements": ["aiostreammagic==2.2.5"],
+  "requirements": ["aiostreammagic==2.3.0"],
   "zeroconf": ["_stream-magic._tcp.local.", "_smoip._tcp.local."]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -377,7 +377,7 @@ aiosolaredge==0.2.0
 aiosteamist==1.0.0
 
 # homeassistant.components.cambridge_audio
-aiostreammagic==2.2.5
+aiostreammagic==2.3.0
 
 # homeassistant.components.switcher_kis
 aioswitcher==4.0.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -359,7 +359,7 @@ aiosolaredge==0.2.0
 aiosteamist==1.0.0
 
 # homeassistant.components.cambridge_audio
-aiostreammagic==2.2.5
+aiostreammagic==2.3.0
 
 # homeassistant.components.switcher_kis
 aioswitcher==4.0.3

--- a/tests/components/cambridge_audio/test_media_player.py
+++ b/tests/components/cambridge_audio/test_media_player.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock
 
 from aiostreammagic import TransportControl
+from aiostreammagic.models import CallbackType
 import pytest
 
 from homeassistant.components.media_player import (
@@ -33,7 +34,9 @@ from tests.common import MockConfigEntry
 
 async def mock_state_update(client: AsyncMock) -> None:
     """Trigger a callback in the media player."""
-    await client.register_state_update_callbacks.call_args[0][0](client)
+    await client.register_state_update_callbacks.call_args[0][0](
+        client, CallbackType.STATE
+    )
 
 
 async def test_entity_supported_features(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Includes necessary changes to support updated callback API.
Changelog: https://github.com/noahhusby/aiostreammagic/compare/2.2.5...2.3.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
