### PR TITLE
Add Airzone Cloud switch entities to zones

### DIFF
--- a/homeassistant/components/airzone_cloud/__init__.py
+++ b/homeassistant/components/airzone_cloud/__init__.py
@@ -17,6 +17,7 @@ PLATFORMS: list[Platform] = [
     Platform.CLIMATE,
     Platform.SELECT,
     Platform.SENSOR,
+    Platform.SWITCH,
     Platform.WATER_HEATER,
 ]
 

--- a/homeassistant/components/airzone_cloud/switch.py
+++ b/homeassistant/components/airzone_cloud/switch.py
@@ -1,0 +1,113 @@
+"""Support for the Airzone Cloud switch."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Final
+
+from aioairzone_cloud.const import API_POWER, API_VALUE, AZD_POWER, AZD_ZONES
+
+from homeassistant.components.switch import (
+    SwitchDeviceClass,
+    SwitchEntity,
+    SwitchEntityDescription,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import AirzoneCloudConfigEntry
+from .coordinator import AirzoneUpdateCoordinator
+from .entity import AirzoneEntity, AirzoneZoneEntity
+
+
+@dataclass(frozen=True, kw_only=True)
+class AirzoneSwitchDescription(SwitchEntityDescription):
+    """Class to describe an Airzone switch entity."""
+
+    api_param: str
+
+
+ZONE_SWITCH_TYPES: Final[tuple[AirzoneSwitchDescription, ...]] = (
+    AirzoneSwitchDescription(
+        api_param=API_POWER,
+        device_class=SwitchDeviceClass.SWITCH,
+        key=AZD_POWER,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: AirzoneCloudConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Add Airzone Cloud switch from a config_entry."""
+    coordinator = entry.runtime_data
+
+    # Zones
+    async_add_entities(
+        AirzoneZoneSwitch(
+            coordinator,
+            description,
+            zone_id,
+            zone_data,
+        )
+        for description in ZONE_SWITCH_TYPES
+        for zone_id, zone_data in coordinator.data.get(AZD_ZONES, {}).items()
+        if description.key in zone_data
+    )
+
+
+class AirzoneBaseSwitch(AirzoneEntity, SwitchEntity):
+    """Define an Airzone Cloud switch."""
+
+    entity_description: AirzoneSwitchDescription
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Update attributes when the coordinator updates."""
+        self._async_update_attrs()
+        super()._handle_coordinator_update()
+
+    @callback
+    def _async_update_attrs(self) -> None:
+        """Update switch attributes."""
+        self._attr_is_on = self.get_airzone_value(self.entity_description.key)
+
+
+class AirzoneZoneSwitch(AirzoneZoneEntity, AirzoneBaseSwitch):
+    """Define an Airzone Cloud Zone switch."""
+
+    def __init__(
+        self,
+        coordinator: AirzoneUpdateCoordinator,
+        description: AirzoneSwitchDescription,
+        zone_id: str,
+        zone_data: dict[str, Any],
+    ) -> None:
+        """Initialize."""
+        super().__init__(coordinator, zone_id, zone_data)
+
+        self._attr_name = None
+        self._attr_unique_id = f"{zone_id}_{description.key}"
+        self.entity_description = description
+
+        self._async_update_attrs()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the entity on."""
+        param = self.entity_description.api_param
+        params: dict[str, Any] = {}
+        params[param] = {
+            API_VALUE: True,
+        }
+        await self._async_update_params(params)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the entity off."""
+        param = self.entity_description.api_param
+        params: dict[str, Any] = {}
+        params[param] = {
+            API_VALUE: False,
+        }
+        await self._async_update_params(params)

--- a/homeassistant/components/airzone_cloud/switch.py
+++ b/homeassistant/components/airzone_cloud/switch.py
@@ -97,17 +97,19 @@ class AirzoneZoneSwitch(AirzoneZoneEntity, AirzoneBaseSwitch):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         param = self.entity_description.api_param
-        params: dict[str, Any] = {}
-        params[param] = {
-            API_VALUE: True,
+        params: dict[str, Any] = {
+            param: {
+                API_VALUE: True,
+            }
         }
         await self._async_update_params(params)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         param = self.entity_description.api_param
-        params: dict[str, Any] = {}
-        params[param] = {
-            API_VALUE: False,
+        params: dict[str, Any] = {
+            param: {
+                API_VALUE: False,
+            }
         }
         await self._async_update_params(params)

--- a/tests/components/airzone_cloud/test_switch.py
+++ b/tests/components/airzone_cloud/test_switch.py
@@ -1,0 +1,71 @@
+"""The switch tests for the Airzone Cloud platform."""
+
+from unittest.mock import patch
+
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+)
+from homeassistant.core import HomeAssistant
+
+from .util import async_init_integration
+
+
+async def test_airzone_create_switches(hass: HomeAssistant) -> None:
+    """Test creation of switches."""
+
+    await async_init_integration(hass)
+
+    state = hass.states.get("switch.dormitorio")
+    assert state.state == STATE_OFF
+
+    state = hass.states.get("switch.salon")
+    assert state.state == STATE_ON
+
+
+async def test_airzone_switch_off(hass: HomeAssistant) -> None:
+    """Test switch off."""
+
+    await async_init_integration(hass)
+
+    with patch(
+        "homeassistant.components.airzone_cloud.AirzoneCloudApi.api_patch_device",
+        return_value=None,
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {
+                ATTR_ENTITY_ID: "switch.salon",
+            },
+            blocking=True,
+        )
+
+    state = hass.states.get("switch.salon")
+    assert state.state == STATE_OFF
+
+
+async def test_airzone_switch_on(hass: HomeAssistant) -> None:
+    """Test switch on."""
+
+    await async_init_integration(hass)
+
+    with patch(
+        "homeassistant.components.airzone_cloud.AirzoneCloudApi.api_patch_device",
+        return_value=None,
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {
+                ATTR_ENTITY_ID: "switch.dormitorio",
+            },
+            blocking=True,
+        )
+
+    state = hass.states.get("switch.dormitorio")
+    assert state.state == STATE_ON


### PR DESCRIPTION
## Proposed change
Add Airzone Cloud switch entities to zones.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/34722

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
