### PR TITLE
Use Home Assistant aiohttp session for Reolink

### DIFF
--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -25,11 +25,11 @@ from homeassistant.const import (
 )
 from homeassistant.core import CALLBACK_TYPE, HassJob, HomeAssistant, callback
 from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.network import NoURLAvailableError, get_url
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import CONF_USE_HTTPS, DOMAIN
 from .exceptions import (
@@ -79,7 +79,7 @@ class ReolinkHost:
             use_https=config.get(CONF_USE_HTTPS),
             protocol=options[CONF_PROTOCOL],
             timeout=DEFAULT_TIMEOUT,
-            aiohttp_get_session_callback = get_aiohttp_session,
+            aiohttp_get_session_callback=get_aiohttp_session,
         )
 
         self.last_wake: float = 0

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -67,7 +67,9 @@ class ReolinkHost:
         self._hass: HomeAssistant = hass
         self._unique_id: str = ""
 
-        get_aiohttp_session = lambda: async_get_clientsession(hass, verify_ssl=False) 
+        def get_aiohttp_session() -> aiohttp.ClientSession:
+            """Return the HA aiohttp session."""
+            return async_get_clientsession(hass, verify_ssl=False)
 
         self._api = Host(
             config[CONF_HOST],

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -29,6 +29,7 @@ from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.network import NoURLAvailableError, get_url
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import CONF_USE_HTTPS, DOMAIN
 from .exceptions import (
@@ -64,9 +65,9 @@ class ReolinkHost:
     ) -> None:
         """Initialize Reolink Host. Could be either NVR, or Camera."""
         self._hass: HomeAssistant = hass
-
-        self._clientsession: aiohttp.ClientSession | None = None
         self._unique_id: str = ""
+
+        get_aiohttp_session = lambda: async_get_clientsession(hass, verify_ssl=False) 
 
         self._api = Host(
             config[CONF_HOST],
@@ -76,6 +77,7 @@ class ReolinkHost:
             use_https=config.get(CONF_USE_HTTPS),
             protocol=options[CONF_PROTOCOL],
             timeout=DEFAULT_TIMEOUT,
+            aiohttp_get_session_callback = get_aiohttp_session,
         )
 
         self.last_wake: float = 0

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -2,8 +2,9 @@
 
 import json
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, call
+from unittest.mock import ANY, AsyncMock, MagicMock, call
 
+from aiohttp import ClientSession
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from reolink_aio.exceptions import ApiError, CredentialsInvalidError, ReolinkError
@@ -492,11 +493,14 @@ async def test_dhcp_ip_update(
             use_https=TEST_USE_HTTPS,
             protocol=DEFAULT_PROTOCOL,
             timeout=DEFAULT_TIMEOUT,
+            aiohttp_get_session_callback=ANY,
         )
         assert expected_call in reolink_connect_class.call_args_list
 
     for exc_call in reolink_connect_class.call_args_list:
         assert exc_call[0][0] in host_call_list
+        get_session = exc_call[1]["aiohttp_get_session_callback"]
+        assert isinstance(get_session(), ClientSession)
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use the Home Assistant aiohttp session for the Reolink integration.


In the past this would result in SSL errors since reolink does something weird with their SSL certificates, even if you specified `verify_ssl=false`.
In the past to get it to work I needed to pass in the following SSL_CONTEXT:
```
SSL_CONTEXT = ssl.create_default_context()
SSL_CONTEXT.set_ciphers("DEFAULT")
SSL_CONTEXT.check_hostname = False
SSL_CONTEXT.verify_mode = ssl.CERT_NONE

aiohttp.ClientSession(timeout=self._timeout, connector=aiohttp.TCPConnector(ssl=SSL_CONTEXT))
```

However, I have tested this again and now it does work when using `verify_ssl=false`.
I think aiohttp has gotten a update in the meantime that resolved the specific SSL error I was dealing with in the past.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
