### PR TITLE
Add internet binary sensor to Smlight integration

### DIFF
--- a/homeassistant/components/smlight/binary_sensor.py
+++ b/homeassistant/components/smlight/binary_sensor.py
@@ -6,6 +6,8 @@ from _collections_abc import Callable
 from dataclasses import dataclass
 
 from pysmlight import Sensors
+from pysmlight.const import Events as SmEvents
+from pysmlight.sse import MessageEvent
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -14,11 +16,14 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .const import SCAN_INTERNET_INTERVAL
 from .coordinator import SmDataUpdateCoordinator
 from .entity import SmEntity
+
+SCAN_INTERVAL = SCAN_INTERNET_INTERVAL
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -52,7 +57,13 @@ async def async_setup_entry(
     coordinator = entry.runtime_data
 
     async_add_entities(
-        SmBinarySensorEntity(coordinator, description) for description in SENSORS
+        [
+            *(
+                SmBinarySensorEntity(coordinator, description)
+                for description in SENSORS
+            ),
+            SmInternetSensorEntity(coordinator),
+        ]
     )
 
 
@@ -78,3 +89,47 @@ class SmBinarySensorEntity(SmEntity, BinarySensorEntity):
     def is_on(self) -> bool:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.coordinator.data.sensors)
+
+
+class SmInternetSensorEntity(SmEntity, BinarySensorEntity):
+    """Representation of the SLZB internet sensor."""
+
+    def __init__(
+        self,
+        coordinator: SmDataUpdateCoordinator,
+    ) -> None:
+        """Initialize slzb binary sensor."""
+        super().__init__(coordinator)
+        self._attr_name = "Internet"
+        self._attr_translation_key = "internet"
+        self._attr_unique_id = f"{coordinator.unique_id}_{self._attr_name}"
+        self._attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self.coordinator.client.sse.register_callback(
+                SmEvents.EVENT_INET_STATE, self.internet_callback
+            )
+        )
+        await self.async_update()
+
+    @callback
+    def internet_callback(self, event: MessageEvent) -> None:
+        """Update internet state from event."""
+        self._attr_is_on = event.data == "ok"
+        self.async_write_ha_state()
+
+    @property
+    def should_poll(self) -> bool:
+        """Poll entity for internet connected updates."""
+        return True
+
+    async def async_update(self) -> None:
+        """Update the sensor.
+
+        This is an async api, device will respond with EVENT_INET_STATE event.
+        """
+        await self.coordinator.client.get_param("inetState")

--- a/homeassistant/components/smlight/binary_sensor.py
+++ b/homeassistant/components/smlight/binary_sensor.py
@@ -94,17 +94,17 @@ class SmBinarySensorEntity(SmEntity, BinarySensorEntity):
 class SmInternetSensorEntity(SmEntity, BinarySensorEntity):
     """Representation of the SLZB internet sensor."""
 
+    _attr_translation_key = "internet"
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
     def __init__(
         self,
         coordinator: SmDataUpdateCoordinator,
     ) -> None:
         """Initialize slzb binary sensor."""
         super().__init__(coordinator)
-        self._attr_name = "Internet"
-        self._attr_translation_key = "internet"
-        self._attr_unique_id = f"{coordinator.unique_id}_{self._attr_name}"
-        self._attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
-        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self._attr_unique_id = f"{coordinator.unique_id}_{self._attr_translation_key}"
 
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""

--- a/homeassistant/components/smlight/const.py
+++ b/homeassistant/components/smlight/const.py
@@ -9,4 +9,5 @@ ATTR_MANUFACTURER = "SMLIGHT"
 
 LOGGER = logging.getLogger(__package__)
 SCAN_INTERVAL = timedelta(seconds=300)
+SCAN_INTERNET_INTERVAL = timedelta(minutes=15)
 UPTIME_DEVIATION = timedelta(seconds=5)

--- a/homeassistant/components/smlight/strings.json
+++ b/homeassistant/components/smlight/strings.json
@@ -46,6 +46,9 @@
       "ethernet": {
         "name": "Ethernet"
       },
+      "internet": {
+        "name": "Internet"
+      },
       "wifi": {
         "name": "Wi-Fi"
       }

--- a/tests/components/smlight/snapshots/test_binary_sensor.ambr
+++ b/tests/components/smlight/snapshots/test_binary_sensor.ambr
@@ -46,6 +46,53 @@
     'state': 'on',
   })
 # ---
+# name: test_all_binary_sensors[binary_sensor.mock_title_internet-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.mock_title_internet',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': 'Internet',
+    'platform': 'smlight',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'internet',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_Internet',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.mock_title_internet-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'connectivity',
+      'friendly_name': 'Mock Title Internet',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.mock_title_internet',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_all_binary_sensors[binary_sensor.mock_title_wi_fi-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/smlight/snapshots/test_binary_sensor.ambr
+++ b/tests/components/smlight/snapshots/test_binary_sensor.ambr
@@ -75,7 +75,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'internet',
-    'unique_id': 'aa:bb:cc:dd:ee:ff_Internet',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_internet',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/smlight/test_binary_sensor.py
+++ b/tests/components/smlight/test_binary_sensor.py
@@ -1,21 +1,36 @@
 """Tests for the SMLIGHT binary sensor platform."""
 
+from collections.abc import Callable
+from unittest.mock import MagicMock
+
+from freezegun.api import FrozenDateTimeFactory
+from pysmlight.const import Events
+from pysmlight.sse import MessageEvent
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.const import Platform
+from homeassistant.components.smlight.const import SCAN_INTERNET_INTERVAL
+from homeassistant.const import STATE_ON, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .conftest import setup_integration
 
-from tests.common import MockConfigEntry, snapshot_platform
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
 pytestmark = [
     pytest.mark.usefixtures(
         "mock_smlight_client",
     )
 ]
+
+MOCK_INET_STATE = MessageEvent(
+    type="EVENT_INET_STATE",
+    message="EVENT_INET_STATE",
+    data="ok",
+    origin="http://slzb-06.local",
+    last_event_id="",
+)
 
 
 @pytest.fixture
@@ -36,6 +51,8 @@ async def test_all_binary_sensors(
 
     await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
 
+    await hass.config_entries.async_unload(entry.entry_id)
+
 
 async def test_disabled_by_default_sensors(
     hass: HomeAssistant,
@@ -50,3 +67,43 @@ async def test_disabled_by_default_sensors(
     assert (entry := entity_registry.async_get("binary_sensor.mock_title_wi_fi"))
     assert entry.disabled
     assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+
+
+async def test_internet_sensor_event(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+    mock_smlight_client: MagicMock,
+) -> None:
+    """Test internet sensor event."""
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("binary_sensor.mock_title_internet")
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+    assert len(mock_smlight_client.get_param.mock_calls) == 1
+    mock_smlight_client.get_param.assert_called_with("inetState")
+
+    freezer.tick(SCAN_INTERNET_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert len(mock_smlight_client.get_param.mock_calls) == 2
+    mock_smlight_client.get_param.assert_called_with("inetState")
+
+    event_function: Callable[[MessageEvent], None] = next(
+        (
+            call_args[0][1]
+            for call_args in mock_smlight_client.sse.register_callback.call_args_list
+            if call_args[0][0] == Events.EVENT_INET_STATE
+        ),
+        None,
+    )
+
+    event_function(MOCK_INET_STATE)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.mock_title_internet")
+    assert state is not None
+    assert state.state == STATE_ON


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add internet sensor for SMLIGHT integration, this will display if the SLZB-06x device has internet connection.

Unlike other sensors this is an async api, and the state is returned via SSE event. It is set with slower update interval than the base data coordinator.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/34740

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X]  The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
