### PR TITLE
Bump plugwise to v1.4.0

### DIFF
--- a/homeassistant/components/plugwise/manifest.json
+++ b/homeassistant/components/plugwise/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["plugwise"],
-  "requirements": ["plugwise==1.0.0"],
+  "requirements": ["plugwise==1.4.0"],
   "zeroconf": ["_plugwise._tcp.local."]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1603,7 +1603,7 @@ plexauth==0.0.6
 plexwebsocket==0.0.14
 
 # homeassistant.components.plugwise
-plugwise==1.0.0
+plugwise==1.4.0
 
 # homeassistant.components.plum_lightpad
 plumlightpad==0.0.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1310,7 +1310,7 @@ plexauth==0.0.6
 plexwebsocket==0.0.14
 
 # homeassistant.components.plugwise
-plugwise==1.0.0
+plugwise==1.4.0
 
 # homeassistant.components.plum_lightpad
 plumlightpad==0.0.11

--- a/tests/components/plugwise/fixtures/adam_multiple_devices_per_zone/all_data.json
+++ b/tests/components/plugwise/fixtures/adam_multiple_devices_per_zone/all_data.json
@@ -6,6 +6,7 @@
       "firmware": "2019-06-21T02:00:00+02:00",
       "location": "cd143c07248f491493cea0533bc3d669",
       "model": "Plug",
+      "model_id": "160-01",
       "name": "NVR",
       "sensors": {
         "electricity_consumed": 34.0,
@@ -26,6 +27,7 @@
       "firmware": "2019-06-21T02:00:00+02:00",
       "location": "cd143c07248f491493cea0533bc3d669",
       "model": "Plug",
+      "model_id": "160-01",
       "name": "Playstation Smart Plug",
       "sensors": {
         "electricity_consumed": 84.1,
@@ -46,6 +48,7 @@
       "firmware": "2019-06-21T02:00:00+02:00",
       "location": "cd143c07248f491493cea0533bc3d669",
       "model": "Plug",
+      "model_id": "160-01",
       "name": "USG Smart Plug",
       "sensors": {
         "electricity_consumed": 8.5,
@@ -66,6 +69,7 @@
       "firmware": "2019-06-21T02:00:00+02:00",
       "location": "cd143c07248f491493cea0533bc3d669",
       "model": "Plug",
+      "model_id": "160-01",
       "name": "Ziggo Modem",
       "sensors": {
         "electricity_consumed": 12.2,
@@ -82,11 +86,15 @@
     },
     "680423ff840043738f42cc7f1ff97a36": {
       "available": true,
+      "binary_sensors": {
+        "low_battery": false
+      },
       "dev_class": "thermo_sensor",
       "firmware": "2019-03-27T01:00:00+01:00",
       "hardware": "1",
       "location": "08963fec7c53423ca5680aa4cb502c63",
       "model": "Tom/Floor",
+      "model_id": "106-03",
       "name": "Thermostatic Radiator Badkamer",
       "sensors": {
         "battery": 51,
@@ -115,12 +123,16 @@
         "CV Jessie",
         "off"
       ],
+      "binary_sensors": {
+        "low_battery": false
+      },
       "dev_class": "zone_thermostat",
       "firmware": "2016-10-27T02:00:00+02:00",
       "hardware": "255",
       "location": "82fa13f017d240daa0d0ea1775420f24",
       "mode": "auto",
       "model": "Lisa",
+      "model_id": "158-01",
       "name": "Zone Thermostat Jessie",
       "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
       "select_schedule": "CV Jessie",
@@ -150,6 +162,7 @@
       "firmware": "2019-06-21T02:00:00+02:00",
       "location": "c50f167537524366a5af7aa3942feb1e",
       "model": "Plug",
+      "model_id": "160-01",
       "name": "CV Pomp",
       "sensors": {
         "electricity_consumed": 35.6,
@@ -183,6 +196,7 @@
       "firmware": "2019-06-21T02:00:00+02:00",
       "location": "cd143c07248f491493cea0533bc3d669",
       "model": "Plug",
+      "model_id": "160-01",
       "name": "Fibaro HC2",
       "sensors": {
         "electricity_consumed": 12.5,
@@ -199,11 +213,15 @@
     },
     "a2c3583e0a6349358998b760cea82d2a": {
       "available": true,
+      "binary_sensors": {
+        "low_battery": false
+      },
       "dev_class": "thermo_sensor",
       "firmware": "2019-03-27T01:00:00+01:00",
       "hardware": "1",
       "location": "12493538af164a409c6a1c79e38afe1c",
       "model": "Tom/Floor",
+      "model_id": "106-03",
       "name": "Bios Cv Thermostatic Radiator ",
       "sensors": {
         "battery": 62,
@@ -228,6 +246,7 @@
       "hardware": "1",
       "location": "c50f167537524366a5af7aa3942feb1e",
       "model": "Tom/Floor",
+      "model_id": "106-03",
       "name": "Floor kraan",
       "sensors": {
         "setpoint": 21.5,
@@ -255,12 +274,16 @@
         "CV Jessie",
         "off"
       ],
+      "binary_sensors": {
+        "low_battery": false
+      },
       "dev_class": "zone_thermostat",
       "firmware": "2016-08-02T02:00:00+02:00",
       "hardware": "255",
       "location": "c50f167537524366a5af7aa3942feb1e",
       "mode": "auto",
       "model": "Lisa",
+      "model_id": "158-01",
       "name": "Zone Lisa WK",
       "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
       "select_schedule": "GF7  Woonkamer",
@@ -290,6 +313,7 @@
       "firmware": "2019-06-21T02:00:00+02:00",
       "location": "cd143c07248f491493cea0533bc3d669",
       "model": "Plug",
+      "model_id": "160-01",
       "name": "NAS",
       "sensors": {
         "electricity_consumed": 16.5,
@@ -306,11 +330,15 @@
     },
     "d3da73bde12a47d5a6b8f9dad971f2ec": {
       "available": true,
+      "binary_sensors": {
+        "low_battery": false
+      },
       "dev_class": "thermo_sensor",
       "firmware": "2019-03-27T01:00:00+01:00",
       "hardware": "1",
       "location": "82fa13f017d240daa0d0ea1775420f24",
       "model": "Tom/Floor",
+      "model_id": "106-03",
       "name": "Thermostatic Radiator Jessie",
       "sensors": {
         "battery": 62,
@@ -339,12 +367,16 @@
         "CV Jessie",
         "off"
       ],
+      "binary_sensors": {
+        "low_battery": false
+      },
       "dev_class": "zone_thermostat",
       "firmware": "2016-10-27T02:00:00+02:00",
       "hardware": "255",
       "location": "12493538af164a409c6a1c79e38afe1c",
       "mode": "heat",
       "model": "Lisa",
+      "model_id": "158-01",
       "name": "Zone Lisa Bios",
       "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
       "select_schedule": "off",
@@ -379,12 +411,16 @@
         "CV Jessie",
         "off"
       ],
+      "binary_sensors": {
+        "low_battery": false
+      },
       "dev_class": "thermostatic_radiator_valve",
       "firmware": "2019-03-27T01:00:00+01:00",
       "hardware": "1",
       "location": "446ac08dd04d4eff8ac57489757b7314",
       "mode": "heat",
       "model": "Tom/Floor",
+      "model_id": "106-03",
       "name": "CV Kraan Garage",
       "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
       "select_schedule": "off",
@@ -421,12 +457,16 @@
         "CV Jessie",
         "off"
       ],
+      "binary_sensors": {
+        "low_battery": false
+      },
       "dev_class": "zone_thermostat",
       "firmware": "2016-10-27T02:00:00+02:00",
       "hardware": "255",
       "location": "08963fec7c53423ca5680aa4cb502c63",
       "mode": "auto",
       "model": "Lisa",
+      "model_id": "158-01",
       "name": "Zone Thermostat Badkamer",
       "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
       "select_schedule": "Badkamer Schema",
@@ -460,6 +500,7 @@
       "location": "1f9dcf83fd4e4b66b72ff787957bfe5d",
       "mac_address": "012345670001",
       "model": "Gateway",
+      "model_id": "smile_open_therm",
       "name": "Adam",
       "select_regulation_mode": "heating",
       "sensors": {
@@ -473,7 +514,7 @@
     "cooling_present": false,
     "gateway_id": "fe799307f1624099878210aa0b9f1475",
     "heater_id": "90986d591dcd426cae3ec3e8111ff730",
-    "item_count": 315,
+    "item_count": 340,
     "notifications": {
       "af82e4ccf9c548528166d38e560662a4": {
         "warning": "Node Plug (with MAC address 000D6F000D13CB01, in room 'n.a.') has been unreachable since 23:03 2020-01-18. Please check the connection and restart the device."

--- a/tests/components/plugwise/fixtures/anna_heatpump_heating/all_data.json
+++ b/tests/components/plugwise/fixtures/anna_heatpump_heating/all_data.json
@@ -10,6 +10,7 @@
       "location": "a57efe5f145f498c9be62a9b63626fbf",
       "mac_address": "012345670001",
       "model": "Gateway",
+      "model_id": "smile_thermo",
       "name": "Smile Anna",
       "sensors": {
         "outdoor_temperature": 20.2
@@ -97,7 +98,7 @@
     "cooling_present": true,
     "gateway_id": "015ae9ea3f964e668e490fa39da3870b",
     "heater_id": "1cbf783bb11e4a7c8a6843dee3a86927",
-    "item_count": 66,
+    "item_count": 67,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/tests/components/plugwise/fixtures/m_adam_cooling/all_data.json
+++ b/tests/components/plugwise/fixtures/m_adam_cooling/all_data.json
@@ -28,11 +28,15 @@
     },
     "1772a4ea304041adb83f357b751341ff": {
       "available": true,
+      "binary_sensors": {
+        "low_battery": false
+      },
       "dev_class": "thermo_sensor",
       "firmware": "2020-11-04T01:00:00+01:00",
       "hardware": "1",
       "location": "f871b8c4d63549319221e294e4f88074",
       "model": "Tom/Floor",
+      "model_id": "106-03",
       "name": "Tom Badkamer",
       "sensors": {
         "battery": 99,
@@ -64,6 +68,7 @@
       "location": "f2bf9048bef64cc5b6d5110154e33c81",
       "mode": "cool",
       "model": "ThermoTouch",
+      "model_id": "143.1",
       "name": "Anna",
       "preset_modes": ["no_frost", "asleep", "vacation", "home", "away"],
       "select_schedule": "off",
@@ -90,6 +95,7 @@
       "location": "bc93488efab249e5bc54fd7e175a6f91",
       "mac_address": "012345679891",
       "model": "Gateway",
+      "model_id": "smile_open_therm",
       "name": "Adam",
       "regulation_modes": [
         "bleeding_hot",
@@ -116,6 +122,9 @@
         "Weekschema",
         "off"
       ],
+      "binary_sensors": {
+        "low_battery": true
+      },
       "control_state": "preheating",
       "dev_class": "zone_thermostat",
       "firmware": "2016-10-10T02:00:00+02:00",
@@ -123,11 +132,12 @@
       "location": "f871b8c4d63549319221e294e4f88074",
       "mode": "auto",
       "model": "Lisa",
+      "model_id": "158-01",
       "name": "Lisa Badkamer",
       "preset_modes": ["no_frost", "asleep", "vacation", "home", "away"],
       "select_schedule": "Badkamer",
       "sensors": {
-        "battery": 38,
+        "battery": 14,
         "setpoint": 23.5,
         "temperature": 23.9
       },
@@ -163,7 +173,7 @@
     "cooling_present": true,
     "gateway_id": "da224107914542988a88561b4452b0f6",
     "heater_id": "056ee145a816487eaa69243c3280f8bf",
-    "item_count": 147,
+    "item_count": 157,
     "notifications": {},
     "reboot": true,
     "smile_name": "Adam"

--- a/tests/components/plugwise/fixtures/m_adam_heating/all_data.json
+++ b/tests/components/plugwise/fixtures/m_adam_heating/all_data.json
@@ -33,11 +33,15 @@
     },
     "1772a4ea304041adb83f357b751341ff": {
       "available": true,
+      "binary_sensors": {
+        "low_battery": false
+      },
       "dev_class": "thermo_sensor",
       "firmware": "2020-11-04T01:00:00+01:00",
       "hardware": "1",
       "location": "f871b8c4d63549319221e294e4f88074",
       "model": "Tom/Floor",
+      "model_id": "106-03",
       "name": "Tom Badkamer",
       "sensors": {
         "battery": 99,
@@ -69,6 +73,7 @@
       "location": "f2bf9048bef64cc5b6d5110154e33c81",
       "mode": "heat",
       "model": "ThermoTouch",
+      "model_id": "143.1",
       "name": "Anna",
       "preset_modes": ["no_frost", "asleep", "vacation", "home", "away"],
       "select_schedule": "off",
@@ -95,6 +100,7 @@
       "location": "bc93488efab249e5bc54fd7e175a6f91",
       "mac_address": "012345679891",
       "model": "Gateway",
+      "model_id": "smile_open_therm",
       "name": "Adam",
       "regulation_modes": ["bleeding_hot", "bleeding_cold", "off", "heating"],
       "select_gateway_mode": "full",
@@ -115,6 +121,9 @@
         "Weekschema",
         "off"
       ],
+      "binary_sensors": {
+        "low_battery": true
+      },
       "control_state": "off",
       "dev_class": "zone_thermostat",
       "firmware": "2016-10-10T02:00:00+02:00",
@@ -122,11 +131,12 @@
       "location": "f871b8c4d63549319221e294e4f88074",
       "mode": "auto",
       "model": "Lisa",
+      "model_id": "158-01",
       "name": "Lisa Badkamer",
       "preset_modes": ["no_frost", "asleep", "vacation", "home", "away"],
       "select_schedule": "Badkamer",
       "sensors": {
-        "battery": 38,
+        "battery": 14,
         "setpoint": 15.0,
         "temperature": 17.9
       },
@@ -162,7 +172,7 @@
     "cooling_present": false,
     "gateway_id": "da224107914542988a88561b4452b0f6",
     "heater_id": "056ee145a816487eaa69243c3280f8bf",
-    "item_count": 147,
+    "item_count": 157,
     "notifications": {},
     "reboot": true,
     "smile_name": "Adam"

--- a/tests/components/plugwise/fixtures/m_adam_jip/all_data.json
+++ b/tests/components/plugwise/fixtures/m_adam_jip/all_data.json
@@ -3,6 +3,9 @@
     "1346fbd8498d4dbcab7e18d51b771f3d": {
       "active_preset": "no_frost",
       "available": true,
+      "binary_sensors": {
+        "low_battery": false
+      },
       "control_state": "off",
       "dev_class": "zone_thermostat",
       "firmware": "2016-10-27T02:00:00+02:00",
@@ -10,6 +13,7 @@
       "location": "06aecb3d00354375924f50c47af36bd2",
       "mode": "off",
       "model": "Lisa",
+      "model_id": "158-01",
       "name": "Slaapkamer",
       "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
       "sensors": {
@@ -39,6 +43,7 @@
       "hardware": "1",
       "location": "d58fec52899f4f1c92e4f8fad6d8c48c",
       "model": "Tom/Floor",
+      "model_id": "106-03",
       "name": "Tom Logeerkamer",
       "sensors": {
         "setpoint": 13.0,
@@ -62,6 +67,7 @@
       "hardware": "1",
       "location": "06aecb3d00354375924f50c47af36bd2",
       "model": "Tom/Floor",
+      "model_id": "106-03",
       "name": "Tom Slaapkamer",
       "sensors": {
         "setpoint": 13.0,
@@ -82,7 +88,8 @@
       "available": true,
       "dev_class": "zz_misc",
       "location": "9e4433a9d69f40b3aefd15e74395eaec",
-      "model": "lumi.plug.maeu01",
+      "model": "Aqara Smart Plug",
+      "model_id": "lumi.plug.maeu01",
       "name": "Plug",
       "sensors": {
         "electricity_consumed_interval": 0.0
@@ -97,6 +104,9 @@
     "6f3e9d7084214c21b9dfa46f6eeb8700": {
       "active_preset": "home",
       "available": true,
+      "binary_sensors": {
+        "low_battery": false
+      },
       "control_state": "off",
       "dev_class": "zone_thermostat",
       "firmware": "2016-10-27T02:00:00+02:00",
@@ -104,6 +114,7 @@
       "location": "d27aede973b54be484f6842d1b2802ad",
       "mode": "heat",
       "model": "Lisa",
+      "model_id": "158-01",
       "name": "Kinderkamer",
       "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
       "sensors": {
@@ -133,6 +144,7 @@
       "hardware": "1",
       "location": "13228dab8ce04617af318a2888b3c548",
       "model": "Tom/Floor",
+      "model_id": "106-03",
       "name": "Tom Woonkamer",
       "sensors": {
         "setpoint": 9.0,
@@ -152,6 +164,9 @@
     "a6abc6a129ee499c88a4d420cc413b47": {
       "active_preset": "home",
       "available": true,
+      "binary_sensors": {
+        "low_battery": false
+      },
       "control_state": "off",
       "dev_class": "zone_thermostat",
       "firmware": "2016-10-27T02:00:00+02:00",
@@ -159,6 +174,7 @@
       "location": "d58fec52899f4f1c92e4f8fad6d8c48c",
       "mode": "heat",
       "model": "Lisa",
+      "model_id": "158-01",
       "name": "Logeerkamer",
       "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
       "sensors": {
@@ -192,6 +208,7 @@
       "location": "9e4433a9d69f40b3aefd15e74395eaec",
       "mac_address": "012345670001",
       "model": "Gateway",
+      "model_id": "smile_open_therm",
       "name": "Adam",
       "regulation_modes": ["heating", "off", "bleeding_cold", "bleeding_hot"],
       "select_gateway_mode": "full",
@@ -209,6 +226,7 @@
       "hardware": "1",
       "location": "d27aede973b54be484f6842d1b2802ad",
       "model": "Tom/Floor",
+      "model_id": "106-03",
       "name": "Tom Kinderkamer",
       "sensors": {
         "setpoint": 13.0,
@@ -246,7 +264,8 @@
         "setpoint": 90.0,
         "upper_bound": 90.0
       },
-      "model": "10.20",
+      "model": "Generic heater",
+      "model_id": "10.20",
       "name": "OpenTherm",
       "sensors": {
         "intended_boiler_temperature": 0.0,
@@ -263,6 +282,9 @@
     "f61f1a2535f54f52ad006a3d18e459ca": {
       "active_preset": "home",
       "available": true,
+      "binary_sensors": {
+        "low_battery": false
+      },
       "control_state": "off",
       "dev_class": "zone_thermometer",
       "firmware": "2020-09-01T02:00:00+02:00",
@@ -270,6 +292,7 @@
       "location": "13228dab8ce04617af318a2888b3c548",
       "mode": "heat",
       "model": "Jip",
+      "model_id": "168-01",
       "name": "Woonkamer",
       "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
       "sensors": {
@@ -298,7 +321,7 @@
     "cooling_present": false,
     "gateway_id": "b5c2386c6f6342669e50fe49dd05b188",
     "heater_id": "e4684553153b44afbef2200885f379dc",
-    "item_count": 213,
+    "item_count": 228,
     "notifications": {},
     "reboot": true,
     "smile_name": "Adam"

--- a/tests/components/plugwise/fixtures/m_anna_heatpump_cooling/all_data.json
+++ b/tests/components/plugwise/fixtures/m_anna_heatpump_cooling/all_data.json
@@ -10,6 +10,7 @@
       "location": "a57efe5f145f498c9be62a9b63626fbf",
       "mac_address": "012345670001",
       "model": "Gateway",
+      "model_id": "smile_thermo",
       "name": "Smile Anna",
       "sensors": {
         "outdoor_temperature": 28.2
@@ -97,7 +98,7 @@
     "cooling_present": true,
     "gateway_id": "015ae9ea3f964e668e490fa39da3870b",
     "heater_id": "1cbf783bb11e4a7c8a6843dee3a86927",
-    "item_count": 66,
+    "item_count": 67,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/tests/components/plugwise/fixtures/m_anna_heatpump_idle/all_data.json
+++ b/tests/components/plugwise/fixtures/m_anna_heatpump_idle/all_data.json
@@ -10,6 +10,7 @@
       "location": "a57efe5f145f498c9be62a9b63626fbf",
       "mac_address": "012345670001",
       "model": "Gateway",
+      "model_id": "smile_thermo",
       "name": "Smile Anna",
       "sensors": {
         "outdoor_temperature": 28.2
@@ -97,7 +98,7 @@
     "cooling_present": true,
     "gateway_id": "015ae9ea3f964e668e490fa39da3870b",
     "heater_id": "1cbf783bb11e4a7c8a6843dee3a86927",
-    "item_count": 66,
+    "item_count": 67,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/tests/components/plugwise/fixtures/p1v4_442_single/all_data.json
+++ b/tests/components/plugwise/fixtures/p1v4_442_single/all_data.json
@@ -10,6 +10,7 @@
       "location": "a455b61e52394b2db5081ce025a430f3",
       "mac_address": "012345670001",
       "model": "Gateway",
+      "model_id": "smile",
       "name": "Smile P1",
       "vendor": "Plugwise"
     },
@@ -42,7 +43,7 @@
   },
   "gateway": {
     "gateway_id": "a455b61e52394b2db5081ce025a430f3",
-    "item_count": 31,
+    "item_count": 32,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile P1"

--- a/tests/components/plugwise/fixtures/p1v4_442_triple/all_data.json
+++ b/tests/components/plugwise/fixtures/p1v4_442_triple/all_data.json
@@ -10,6 +10,7 @@
       "location": "03e65b16e4b247a29ae0d75a78cb492e",
       "mac_address": "012345670001",
       "model": "Gateway",
+      "model_id": "smile",
       "name": "Smile P1",
       "vendor": "Plugwise"
     },
@@ -51,7 +52,7 @@
   },
   "gateway": {
     "gateway_id": "03e65b16e4b247a29ae0d75a78cb492e",
-    "item_count": 40,
+    "item_count": 41,
     "notifications": {
       "97a04c0c263049b29350a660b4cdd01e": {
         "warning": "The Smile P1 is not connected to a smart meter."

--- a/tests/components/plugwise/fixtures/stretch_v23/all_data.json
+++ b/tests/components/plugwise/fixtures/stretch_v23/all_data.json
@@ -1,0 +1,340 @@
+{
+  "devices": {
+    "0000aaaa0000aaaa0000aaaa0000aa00": {
+      "dev_class": "gateway",
+      "firmware": "2.3.12",
+      "location": "0000aaaa0000aaaa0000aaaa0000aa00",
+      "mac_address": "01:23:45:67:89:AB",
+      "model": "Gateway",
+      "name": "Stretch",
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670101"
+    },
+    "09c8ce93d7064fa6a233c0e4c2449bfe": {
+      "dev_class": "lamp",
+      "firmware": "2011-06-27T10:52:18+02:00",
+      "hardware": "0000-0440-0107",
+      "location": "0000aaaa0000aaaa0000aaaa0000aa00",
+      "model": "Circle type F",
+      "name": "kerstboom buiten 043B016",
+      "sensors": {
+        "electricity_consumed": 0.0,
+        "electricity_consumed_interval": 0.0,
+        "electricity_produced": 0.0
+      },
+      "switches": {
+        "lock": false,
+        "relay": false
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A01"
+    },
+    "199fd4b2caa44197aaf5b3128f6464ed": {
+      "dev_class": "airconditioner",
+      "firmware": "2011-06-27T10:52:18+02:00",
+      "hardware": "6539-0701-4026",
+      "location": "0000aaaa0000aaaa0000aaaa0000aa00",
+      "model": "Circle type F",
+      "name": "Airco 25F69E3",
+      "sensors": {
+        "electricity_consumed": 2.06,
+        "electricity_consumed_interval": 1.62,
+        "electricity_produced": 0.0,
+        "electricity_produced_interval": 0.0
+      },
+      "switches": {
+        "lock": false,
+        "relay": true
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A10"
+    },
+    "24b2ed37c8964c73897db6340a39c129": {
+      "dev_class": "router",
+      "firmware": "2011-06-27T10:47:37+02:00",
+      "hardware": "6539-0700-7325",
+      "location": "0000aaaa0000aaaa0000aaaa0000aa00",
+      "model": "Circle+ type F",
+      "name": "MK Netwerk 1A4455E",
+      "sensors": {
+        "electricity_consumed": 4.63,
+        "electricity_consumed_interval": 0.65,
+        "electricity_produced": 0.0,
+        "electricity_produced_interval": 0.0
+      },
+      "switches": {
+        "lock": true,
+        "relay": true
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "0123456789AB"
+    },
+    "2587a7fcdd7e482dab03fda256076b4b": {
+      "dev_class": "zz_misc",
+      "firmware": "2011-06-27T10:52:18+02:00",
+      "hardware": "0000-0440-0107",
+      "location": "0000aaaa0000aaaa0000aaaa0000aa00",
+      "model": "Circle type F",
+      "name": "00469CA1",
+      "sensors": {
+        "electricity_consumed": 0.0,
+        "electricity_consumed_interval": 0.0,
+        "electricity_produced": 0.0
+      },
+      "switches": {
+        "lock": false,
+        "relay": true
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A16"
+    },
+    "2cc9a0fe70ef4441a9e4f55dfd64b776": {
+      "dev_class": "lamp",
+      "firmware": "2011-06-27T10:52:18+02:00",
+      "hardware": "6539-0701-4026",
+      "location": "0000aaaa0000aaaa0000aaaa0000aa00",
+      "model": "Circle type F",
+      "name": "Lamp TV 025F698F",
+      "sensors": {
+        "electricity_consumed": 4.0,
+        "electricity_consumed_interval": 0.58,
+        "electricity_produced": 0.0,
+        "electricity_produced_interval": 0.0
+      },
+      "switches": {
+        "lock": false,
+        "relay": true
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A15"
+    },
+    "305452ce97c243c0a7b4ab2a4ebfe6e3": {
+      "dev_class": "lamp",
+      "firmware": "2011-06-27T10:52:18+02:00",
+      "hardware": "6539-0701-4026",
+      "location": "0000aaaa0000aaaa0000aaaa0000aa00",
+      "model": "Circle type F",
+      "name": "Lamp piano 025F6819",
+      "sensors": {
+        "electricity_consumed": 0.0,
+        "electricity_consumed_interval": 0.0,
+        "electricity_produced": 0.0,
+        "electricity_produced_interval": 0.0
+      },
+      "switches": {
+        "lock": false,
+        "relay": false
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A05"
+    },
+    "33a1c784a9ff4c2d8766a0212714be09": {
+      "dev_class": "lighting",
+      "firmware": "2011-06-27T10:52:18+02:00",
+      "hardware": "6539-0701-4026",
+      "location": "0000aaaa0000aaaa0000aaaa0000aa00",
+      "model": "Circle type F",
+      "name": "Barverlichting",
+      "sensors": {
+        "electricity_consumed": 0.0,
+        "electricity_consumed_interval": 0.0,
+        "electricity_produced": 0.0,
+        "electricity_produced_interval": 0.0
+      },
+      "switches": {
+        "lock": false,
+        "relay": false
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A13"
+    },
+    "407aa1c1099d463c9137a3a9eda787fd": {
+      "dev_class": "zz_misc",
+      "firmware": "2011-06-27T10:52:18+02:00",
+      "hardware": "0000-0440-0107",
+      "location": "0000aaaa0000aaaa0000aaaa0000aa00",
+      "model": "Circle type F",
+      "name": "0043B013",
+      "sensors": {
+        "electricity_consumed": 0.0,
+        "electricity_consumed_interval": 0.0,
+        "electricity_produced": 0.0
+      },
+      "switches": {
+        "lock": false,
+        "relay": false
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A09"
+    },
+    "6518f3f72a82486c97b91e26f2e9bd1d": {
+      "dev_class": "charger",
+      "firmware": "2011-06-27T10:52:18+02:00",
+      "hardware": "6539-0701-4026",
+      "location": "0000aaaa0000aaaa0000aaaa0000aa00",
+      "model": "Circle type F",
+      "name": "Bed 025F6768",
+      "sensors": {
+        "electricity_consumed": 0.0,
+        "electricity_consumed_interval": 0.0,
+        "electricity_produced": 0.0,
+        "electricity_produced_interval": 0.0
+      },
+      "switches": {
+        "lock": false,
+        "relay": true
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A14"
+    },
+    "713427748874454ca1eb4488d7919cf2": {
+      "dev_class": "freezer",
+      "firmware": "2011-06-27T10:52:18+02:00",
+      "hardware": "0000-0440-0107",
+      "location": "0000aaaa0000aaaa0000aaaa0000aa00",
+      "model": "Circle type F",
+      "name": "Leeg 043220D",
+      "sensors": {
+        "electricity_consumed": 0.0,
+        "electricity_consumed_interval": 0.0,
+        "electricity_produced": 0.0
+      },
+      "switches": {
+        "lock": false,
+        "relay": false
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A12"
+    },
+    "71e3e65ffc5a41518b19460c6e8ee34f": {
+      "dev_class": "tv",
+      "firmware": "2011-06-27T10:52:18+02:00",
+      "hardware": "0000-0440-0107",
+      "location": "0000aaaa0000aaaa0000aaaa0000aa00",
+      "model": "Circle type F",
+      "name": "Leeg 043AEC6",
+      "sensors": {
+        "electricity_consumed": 0.0,
+        "electricity_consumed_interval": 0.0,
+        "electricity_produced": 0.0
+      },
+      "switches": {
+        "lock": false,
+        "relay": false
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A08"
+    },
+    "828f6ce1e36744689baacdd6ddb1d12c": {
+      "dev_class": "washingmachine",
+      "firmware": "2011-06-27T10:52:18+02:00",
+      "hardware": "0000-0440-0107",
+      "location": "0000aaaa0000aaaa0000aaaa0000aa00",
+      "model": "Circle type F",
+      "name": "Wasmachine 043AEC7",
+      "sensors": {
+        "electricity_consumed": 3.5,
+        "electricity_consumed_interval": 0.5,
+        "electricity_produced": 0.0
+      },
+      "switches": {
+        "lock": true,
+        "relay": true
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A02"
+    },
+    "a28e6f5afc0e4fc68498c1f03e82a052": {
+      "dev_class": "lamp",
+      "firmware": "2011-06-27T10:52:18+02:00",
+      "hardware": "6539-0701-4026",
+      "location": "0000aaaa0000aaaa0000aaaa0000aa00",
+      "model": "Circle type F",
+      "name": "Lamp bank 25F67F8",
+      "sensors": {
+        "electricity_consumed": 4.19,
+        "electricity_consumed_interval": 0.62,
+        "electricity_produced": 0.0,
+        "electricity_produced_interval": 0.0
+      },
+      "switches": {
+        "lock": false,
+        "relay": true
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A03"
+    },
+    "bc0adbebc50d428d9444a5d805c89da9": {
+      "dev_class": "watercooker",
+      "firmware": "2011-06-27T10:52:18+02:00",
+      "hardware": "0000-0440-0107",
+      "location": "0000aaaa0000aaaa0000aaaa0000aa00",
+      "model": "Circle type F",
+      "name": "Waterkoker 043AF7F",
+      "sensors": {
+        "electricity_consumed": 0.0,
+        "electricity_consumed_interval": 0.0,
+        "electricity_produced": 0.0
+      },
+      "switches": {
+        "lock": false,
+        "relay": true
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A07"
+    },
+    "c71f1cb2100b42ca942f056dcb7eb01f": {
+      "dev_class": "tv",
+      "firmware": "2011-06-27T10:52:18+02:00",
+      "hardware": "6539-0701-4026",
+      "location": "0000aaaa0000aaaa0000aaaa0000aa00",
+      "model": "Circle type F",
+      "name": "Tv hoek 25F6790",
+      "sensors": {
+        "electricity_consumed": 33.3,
+        "electricity_consumed_interval": 4.93,
+        "electricity_produced": 0.0,
+        "electricity_produced_interval": 0.0
+      },
+      "switches": {
+        "lock": false,
+        "relay": true
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A11"
+    },
+    "f7b145c8492f4dd7a4de760456fdef3e": {
+      "dev_class": "switching",
+      "members": ["407aa1c1099d463c9137a3a9eda787fd"],
+      "model": "Switchgroup",
+      "name": "Test",
+      "switches": {
+        "relay": false
+      }
+    },
+    "fd1b74f59e234a9dae4e23b2b5cf07ed": {
+      "dev_class": "dryer",
+      "firmware": "2011-06-27T10:52:18+02:00",
+      "hardware": "0000-0440-0107",
+      "location": "0000aaaa0000aaaa0000aaaa0000aa00",
+      "model": "Circle type F",
+      "name": "Wasdroger 043AECA",
+      "sensors": {
+        "electricity_consumed": 1.31,
+        "electricity_consumed_interval": 0.21,
+        "electricity_produced": 0.0
+      },
+      "switches": {
+        "lock": true,
+        "relay": true
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A04"
+    }
+  },
+  "gateway": {
+    "gateway_id": "0000aaaa0000aaaa0000aaaa0000aa00",
+    "item_count": 229,
+    "smile_name": "Stretch"
+  }
+}

--- a/tests/components/plugwise/snapshots/test_diagnostics.ambr
+++ b/tests/components/plugwise/snapshots/test_diagnostics.ambr
@@ -8,6 +8,7 @@
         'firmware': '2019-06-21T02:00:00+02:00',
         'location': 'cd143c07248f491493cea0533bc3d669',
         'model': 'Plug',
+        'model_id': '160-01',
         'name': 'NVR',
         'sensors': dict({
           'electricity_consumed': 34.0,
@@ -28,6 +29,7 @@
         'firmware': '2019-06-21T02:00:00+02:00',
         'location': 'cd143c07248f491493cea0533bc3d669',
         'model': 'Plug',
+        'model_id': '160-01',
         'name': 'Playstation Smart Plug',
         'sensors': dict({
           'electricity_consumed': 84.1,
@@ -48,6 +50,7 @@
         'firmware': '2019-06-21T02:00:00+02:00',
         'location': 'cd143c07248f491493cea0533bc3d669',
         'model': 'Plug',
+        'model_id': '160-01',
         'name': 'USG Smart Plug',
         'sensors': dict({
           'electricity_consumed': 8.5,
@@ -68,6 +71,7 @@
         'firmware': '2019-06-21T02:00:00+02:00',
         'location': 'cd143c07248f491493cea0533bc3d669',
         'model': 'Plug',
+        'model_id': '160-01',
         'name': 'Ziggo Modem',
         'sensors': dict({
           'electricity_consumed': 12.2,
@@ -84,11 +88,15 @@
       }),
       '680423ff840043738f42cc7f1ff97a36': dict({
         'available': True,
+        'binary_sensors': dict({
+          'low_battery': False,
+        }),
         'dev_class': 'thermo_sensor',
         'firmware': '2019-03-27T01:00:00+01:00',
         'hardware': '1',
         'location': '08963fec7c53423ca5680aa4cb502c63',
         'model': 'Tom/Floor',
+        'model_id': '106-03',
         'name': 'Thermostatic Radiator Badkamer',
         'sensors': dict({
           'battery': 51,
@@ -117,12 +125,16 @@
           'CV Jessie',
           'off',
         ]),
+        'binary_sensors': dict({
+          'low_battery': False,
+        }),
         'dev_class': 'zone_thermostat',
         'firmware': '2016-10-27T02:00:00+02:00',
         'hardware': '255',
         'location': '82fa13f017d240daa0d0ea1775420f24',
         'mode': 'auto',
         'model': 'Lisa',
+        'model_id': '158-01',
         'name': 'Zone Thermostat Jessie',
         'preset_modes': list([
           'home',
@@ -158,6 +170,7 @@
         'firmware': '2019-06-21T02:00:00+02:00',
         'location': 'c50f167537524366a5af7aa3942feb1e',
         'model': 'Plug',
+        'model_id': '160-01',
         'name': 'CV Pomp',
         'sensors': dict({
           'electricity_consumed': 35.6,
@@ -191,6 +204,7 @@
         'firmware': '2019-06-21T02:00:00+02:00',
         'location': 'cd143c07248f491493cea0533bc3d669',
         'model': 'Plug',
+        'model_id': '160-01',
         'name': 'Fibaro HC2',
         'sensors': dict({
           'electricity_consumed': 12.5,
@@ -207,11 +221,15 @@
       }),
       'a2c3583e0a6349358998b760cea82d2a': dict({
         'available': True,
+        'binary_sensors': dict({
+          'low_battery': False,
+        }),
         'dev_class': 'thermo_sensor',
         'firmware': '2019-03-27T01:00:00+01:00',
         'hardware': '1',
         'location': '12493538af164a409c6a1c79e38afe1c',
         'model': 'Tom/Floor',
+        'model_id': '106-03',
         'name': 'Bios Cv Thermostatic Radiator ',
         'sensors': dict({
           'battery': 62,
@@ -236,6 +254,7 @@
         'hardware': '1',
         'location': 'c50f167537524366a5af7aa3942feb1e',
         'model': 'Tom/Floor',
+        'model_id': '106-03',
         'name': 'Floor kraan',
         'sensors': dict({
           'setpoint': 21.5,
@@ -263,12 +282,16 @@
           'CV Jessie',
           'off',
         ]),
+        'binary_sensors': dict({
+          'low_battery': False,
+        }),
         'dev_class': 'zone_thermostat',
         'firmware': '2016-08-02T02:00:00+02:00',
         'hardware': '255',
         'location': 'c50f167537524366a5af7aa3942feb1e',
         'mode': 'auto',
         'model': 'Lisa',
+        'model_id': '158-01',
         'name': 'Zone Lisa WK',
         'preset_modes': list([
           'home',
@@ -304,6 +327,7 @@
         'firmware': '2019-06-21T02:00:00+02:00',
         'location': 'cd143c07248f491493cea0533bc3d669',
         'model': 'Plug',
+        'model_id': '160-01',
         'name': 'NAS',
         'sensors': dict({
           'electricity_consumed': 16.5,
@@ -320,11 +344,15 @@
       }),
       'd3da73bde12a47d5a6b8f9dad971f2ec': dict({
         'available': True,
+        'binary_sensors': dict({
+          'low_battery': False,
+        }),
         'dev_class': 'thermo_sensor',
         'firmware': '2019-03-27T01:00:00+01:00',
         'hardware': '1',
         'location': '82fa13f017d240daa0d0ea1775420f24',
         'model': 'Tom/Floor',
+        'model_id': '106-03',
         'name': 'Thermostatic Radiator Jessie',
         'sensors': dict({
           'battery': 62,
@@ -353,12 +381,16 @@
           'CV Jessie',
           'off',
         ]),
+        'binary_sensors': dict({
+          'low_battery': False,
+        }),
         'dev_class': 'zone_thermostat',
         'firmware': '2016-10-27T02:00:00+02:00',
         'hardware': '255',
         'location': '12493538af164a409c6a1c79e38afe1c',
         'mode': 'heat',
         'model': 'Lisa',
+        'model_id': '158-01',
         'name': 'Zone Lisa Bios',
         'preset_modes': list([
           'home',
@@ -399,12 +431,16 @@
           'CV Jessie',
           'off',
         ]),
+        'binary_sensors': dict({
+          'low_battery': False,
+        }),
         'dev_class': 'thermostatic_radiator_valve',
         'firmware': '2019-03-27T01:00:00+01:00',
         'hardware': '1',
         'location': '446ac08dd04d4eff8ac57489757b7314',
         'mode': 'heat',
         'model': 'Tom/Floor',
+        'model_id': '106-03',
         'name': 'CV Kraan Garage',
         'preset_modes': list([
           'home',
@@ -447,12 +483,16 @@
           'CV Jessie',
           'off',
         ]),
+        'binary_sensors': dict({
+          'low_battery': False,
+        }),
         'dev_class': 'zone_thermostat',
         'firmware': '2016-10-27T02:00:00+02:00',
         'hardware': '255',
         'location': '08963fec7c53423ca5680aa4cb502c63',
         'mode': 'auto',
         'model': 'Lisa',
+        'model_id': '158-01',
         'name': 'Zone Thermostat Badkamer',
         'preset_modes': list([
           'home',
@@ -492,6 +532,7 @@
         'location': '1f9dcf83fd4e4b66b72ff787957bfe5d',
         'mac_address': '012345670001',
         'model': 'Gateway',
+        'model_id': 'smile_open_therm',
         'name': 'Adam',
         'select_regulation_mode': 'heating',
         'sensors': dict({
@@ -505,7 +546,7 @@
       'cooling_present': False,
       'gateway_id': 'fe799307f1624099878210aa0b9f1475',
       'heater_id': '90986d591dcd426cae3ec3e8111ff730',
-      'item_count': 315,
+      'item_count': 340,
       'notifications': dict({
         'af82e4ccf9c548528166d38e560662a4': dict({
           'warning': "Node Plug (with MAC address 000D6F000D13CB01, in room 'n.a.') has been unreachable since 23:03 2020-01-18. Please check the connection and restart the device.",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump the plugwise-backend to the latest version.

https://github.com/plugwise/python-plugwise/releases/tag/v1.1.0
https://github.com/plugwise/python-plugwise/releases/tag/v1.2.0
https://github.com/plugwise/python-plugwise/releases/tag/v1.3.0
https://github.com/plugwise/python-plugwise/releases/tag/v1.3.1
https://github.com/plugwise/python-plugwise/releases/tag/v1.4.0

https://github.com/plugwise/python-plugwise/compare/v1.0.0...v1.1.0
https://github.com/plugwise/python-plugwise/compare/v1.1.0...v1.2.0
https://github.com/plugwise/python-plugwise/compare/v1.2.0...v1.3.0
https://github.com/plugwise/python-plugwise/compare/v1.3.0...v1.3.1
https://github.com/plugwise/python-plugwise/compare/v1.3.1...v1.4.0

In summary, these updates prepare for :
- the implementation of battery `binary_sensors` for battery-powered devices connected to the Adam,
- the implementation of `model_id`'s for non-legacy devices.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
