### PR TITLE
Use sample bytes in ESPHome media format

### DIFF
--- a/homeassistant/components/esphome/assist_satellite.py
+++ b/homeassistant/components/esphome/assist_satellite.py
@@ -402,10 +402,23 @@ class EsphomeAssistSatellite(
             if supported_format.purpose == MediaPlayerFormatPurpose.ANNOUNCEMENT:
                 self._attr_tts_options = {
                     tts.ATTR_PREFERRED_FORMAT: supported_format.format,
-                    tts.ATTR_PREFERRED_SAMPLE_RATE: supported_format.sample_rate,
-                    tts.ATTR_PREFERRED_SAMPLE_CHANNELS: supported_format.num_channels,
-                    tts.ATTR_PREFERRED_SAMPLE_BYTES: supported_format.sample_bytes,
                 }
+
+                if supported_format.sample_rate > 0:
+                    self._attr_tts_options[tts.ATTR_PREFERRED_SAMPLE_RATE] = (
+                        supported_format.sample_rate
+                    )
+
+                if supported_format.sample_rate > 0:
+                    self._attr_tts_options[tts.ATTR_PREFERRED_SAMPLE_CHANNELS] = (
+                        supported_format.num_channels
+                    )
+
+                if supported_format.sample_rate > 0:
+                    self._attr_tts_options[tts.ATTR_PREFERRED_SAMPLE_BYTES] = (
+                        supported_format.sample_bytes
+                    )
+
                 break
 
     async def _stream_tts_audio(

--- a/homeassistant/components/esphome/assist_satellite.py
+++ b/homeassistant/components/esphome/assist_satellite.py
@@ -404,7 +404,7 @@ class EsphomeAssistSatellite(
                     tts.ATTR_PREFERRED_FORMAT: supported_format.format,
                     tts.ATTR_PREFERRED_SAMPLE_RATE: supported_format.sample_rate,
                     tts.ATTR_PREFERRED_SAMPLE_CHANNELS: supported_format.num_channels,
-                    tts.ATTR_PREFERRED_SAMPLE_BYTES: 2,
+                    tts.ATTR_PREFERRED_SAMPLE_BYTES: supported_format.sample_bytes,
                 }
                 break
 

--- a/homeassistant/components/esphome/media_player.py
+++ b/homeassistant/components/esphome/media_player.py
@@ -170,13 +170,28 @@ class EsphomeMediaPlayer(
         _LOGGER.debug("Proxying media url %s with format %s", url, format_to_use)
         device_id = self.device_entry.id
         media_format = format_to_use.format
+
+        # 0 = None
+        rate: int | None = None
+        channels: int | None = None
+        width: int | None = None
+        if format_to_use.sample_rate > 0:
+            rate = format_to_use.sample_rate
+
+        if format_to_use.num_channels > 0:
+            channels = format_to_use.num_channels
+
+        if format_to_use.sample_bytes > 0:
+            width = format_to_use.sample_bytes
+
         proxy_url = async_create_proxy_url(
             self.hass,
             device_id,
             url,
             media_format=media_format,
-            rate=format_to_use.sample_rate,
-            channels=format_to_use.num_channels,
+            rate=rate,
+            channels=channels,
+            width=width,
         )
 
         # Resolve URL

--- a/tests/components/esphome/test_assist_satellite.py
+++ b/tests/components/esphome/test_assist_satellite.py
@@ -1006,6 +1006,7 @@ async def test_tts_format_from_media_player(
                         sample_rate=48000,
                         num_channels=2,
                         purpose=MediaPlayerFormatPurpose.DEFAULT,
+                        sample_bytes=2,
                     ),
                     # This is the format that should be used for tts
                     MediaPlayerSupportedFormat(
@@ -1013,6 +1014,7 @@ async def test_tts_format_from_media_player(
                         sample_rate=22050,
                         num_channels=1,
                         purpose=MediaPlayerFormatPurpose.ANNOUNCEMENT,
+                        sample_bytes=2,
                     ),
                 ],
             )

--- a/tests/components/esphome/test_assist_satellite.py
+++ b/tests/components/esphome/test_assist_satellite.py
@@ -1052,6 +1052,73 @@ async def test_tts_format_from_media_player(
         }
 
 
+async def test_tts_minimal_format_from_media_player(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: Callable[
+        [APIClient, list[EntityInfo], list[UserService], list[EntityState]],
+        Awaitable[MockESPHomeDevice],
+    ],
+) -> None:
+    """Test text-to-speech format when media player only specifies the codec."""
+    mock_device: MockESPHomeDevice = await mock_esphome_device(
+        mock_client=mock_client,
+        entity_info=[
+            MediaPlayerInfo(
+                object_id="mymedia_player",
+                key=1,
+                name="my media_player",
+                unique_id="my_media_player",
+                supports_pause=True,
+                supported_formats=[
+                    MediaPlayerSupportedFormat(
+                        format="flac",
+                        sample_rate=48000,
+                        num_channels=2,
+                        purpose=MediaPlayerFormatPurpose.DEFAULT,
+                        sample_bytes=2,
+                    ),
+                    # This is the format that should be used for tts
+                    MediaPlayerSupportedFormat(
+                        format="mp3",
+                        sample_rate=0,  # source rate
+                        num_channels=0,  # source channels
+                        purpose=MediaPlayerFormatPurpose.ANNOUNCEMENT,
+                        sample_bytes=0,  # source width
+                    ),
+                ],
+            )
+        ],
+        user_service=[],
+        states=[],
+        device_info={
+            "voice_assistant_feature_flags": VoiceAssistantFeature.VOICE_ASSISTANT
+        },
+    )
+    await hass.async_block_till_done()
+
+    satellite = get_satellite_entity(hass, mock_device.device_info.mac_address)
+    assert satellite is not None
+
+    with patch(
+        "homeassistant.components.assist_satellite.entity.async_pipeline_from_audio_stream",
+    ) as mock_pipeline_from_audio_stream:
+        await satellite.handle_pipeline_start(
+            conversation_id="",
+            flags=0,
+            audio_settings=VoiceAssistantAudioSettings(),
+            wake_word_phrase=None,
+        )
+
+        mock_pipeline_from_audio_stream.assert_called_once()
+        kwargs = mock_pipeline_from_audio_stream.call_args_list[0].kwargs
+
+        # Should be ANNOUNCEMENT format from media player
+        assert kwargs.get("tts_audio_output") == {
+            tts.ATTR_PREFERRED_FORMAT: "mp3",
+        }
+
+
 async def test_announce_supported_features(
     hass: HomeAssistant,
     mock_client: APIClient,

--- a/tests/components/esphome/test_media_player.py
+++ b/tests/components/esphome/test_media_player.py
@@ -310,15 +310,17 @@ async def test_media_player_proxy(
                 supported_formats=[
                     MediaPlayerSupportedFormat(
                         format="flac",
-                        sample_rate=48000,
-                        num_channels=2,
+                        sample_rate=0,  # source rate
+                        num_channels=0,  # source channels
                         purpose=MediaPlayerFormatPurpose.DEFAULT,
+                        sample_bytes=0,  # source width
                     ),
                     MediaPlayerSupportedFormat(
                         format="wav",
                         sample_rate=16000,
                         num_channels=1,
                         purpose=MediaPlayerFormatPurpose.ANNOUNCEMENT,
+                        sample_bytes=2,
                     ),
                     MediaPlayerSupportedFormat(
                         format="mp3",
@@ -369,7 +371,13 @@ async def test_media_player_proxy(
         mock_async_create_proxy_url.assert_called_once()
         device_id = mock_async_create_proxy_url.call_args[0][1]
         mock_async_create_proxy_url.assert_called_once_with(
-            hass, device_id, media_url, media_format="flac", rate=48000, channels=2
+            hass,
+            device_id,
+            media_url,
+            media_format="flac",
+            rate=None,
+            channels=None,
+            width=None,
         )
 
         media_args = mock_client.media_player_command.call_args.kwargs
@@ -395,7 +403,13 @@ async def test_media_player_proxy(
         mock_async_create_proxy_url.assert_called_once()
         device_id = mock_async_create_proxy_url.call_args[0][1]
         mock_async_create_proxy_url.assert_called_once_with(
-            hass, device_id, media_url, media_format="wav", rate=16000, channels=1
+            hass,
+            device_id,
+            media_url,
+            media_format="wav",
+            rate=16000,
+            channels=1,
+            width=2,
         )
 
         media_args = mock_client.media_player_command.call_args.kwargs


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Uses the `sample_bytes` field in the media player supported format within the ESPHome media proxy to convert sample widths. Also passes this to the preferred TTS format.

Requires:
* https://github.com/esphome/esphome/pull/7451
* https://github.com/esphome/voice-kit/pull/110

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
