### PR TITLE
Use debug/warning instead of info log level in components [g]

### DIFF
--- a/homeassistant/components/generic_hygrostat/humidifier.py
+++ b/homeassistant/components/generic_hygrostat/humidifier.py
@@ -480,7 +480,7 @@ class GenericHygrostat(HumidifierEntity, RestoreEntity):
             ):
                 self._active = True
                 force = True
-                _LOGGER.info(
+                _LOGGER.debug(
                     (
                         "Obtained current and target humidity. "
                         "Generic hygrostat active. %s, %s"
@@ -530,7 +530,7 @@ class GenericHygrostat(HumidifierEntity, RestoreEntity):
                 ) or (
                     self._device_class == HumidifierDeviceClass.DEHUMIDIFIER and too_dry
                 ):
-                    _LOGGER.info("Turning off humidifier %s", self._switch_entity_id)
+                    _LOGGER.debug("Turning off humidifier %s", self._switch_entity_id)
                     await self._async_device_turn_off()
                 elif time is not None:
                     # The time argument is passed only in keep-alive case
@@ -538,7 +538,7 @@ class GenericHygrostat(HumidifierEntity, RestoreEntity):
             elif (
                 self._device_class == HumidifierDeviceClass.HUMIDIFIER and too_dry
             ) or (self._device_class == HumidifierDeviceClass.DEHUMIDIFIER and too_wet):
-                _LOGGER.info("Turning on humidifier %s", self._switch_entity_id)
+                _LOGGER.debug("Turning on humidifier %s", self._switch_entity_id)
                 await self._async_device_turn_on()
             elif time is not None:
                 # The time argument is passed only in keep-alive case

--- a/homeassistant/components/generic_thermostat/climate.py
+++ b/homeassistant/components/generic_thermostat/climate.py
@@ -500,7 +500,7 @@ class GenericThermostat(ClimateEntity, RestoreEntity):
                 self._target_temp,
             ):
                 self._active = True
-                _LOGGER.info(
+                _LOGGER.debug(
                     (
                         "Obtained current and target temperature. "
                         "Generic thermostat active. %s, %s"
@@ -539,21 +539,21 @@ class GenericThermostat(ClimateEntity, RestoreEntity):
             too_hot = self._cur_temp >= self._target_temp + self._hot_tolerance
             if self._is_device_active:
                 if (self.ac_mode and too_cold) or (not self.ac_mode and too_hot):
-                    _LOGGER.info("Turning off heater %s", self.heater_entity_id)
+                    _LOGGER.debug("Turning off heater %s", self.heater_entity_id)
                     await self._async_heater_turn_off()
                 elif time is not None:
                     # The time argument is passed only in keep-alive case
-                    _LOGGER.info(
+                    _LOGGER.debug(
                         "Keep-alive - Turning on heater heater %s",
                         self.heater_entity_id,
                     )
                     await self._async_heater_turn_on()
             elif (self.ac_mode and too_hot) or (not self.ac_mode and too_cold):
-                _LOGGER.info("Turning on heater %s", self.heater_entity_id)
+                _LOGGER.debug("Turning on heater %s", self.heater_entity_id)
                 await self._async_heater_turn_on()
             elif time is not None:
                 # The time argument is passed only in keep-alive case
-                _LOGGER.info(
+                _LOGGER.debug(
                     "Keep-alive - Turning off heater %s", self.heater_entity_id
                 )
                 await self._async_heater_turn_off()

--- a/homeassistant/components/geniushub/__init__.py
+++ b/homeassistant/components/geniushub/__init__.py
@@ -239,7 +239,7 @@ class GeniusBroker:
             await self.client.update()
             if self._connect_error:
                 self._connect_error = False
-                _LOGGER.info("Connection to geniushub re-established")
+                _LOGGER.warning("Connection to geniushub re-established")
         except (
             aiohttp.ClientResponseError,
             aiohttp.client_exceptions.ClientConnectorError,

--- a/homeassistant/components/gree/coordinator.py
+++ b/homeassistant/components/gree/coordinator.py
@@ -138,7 +138,7 @@ class DiscoveryService(Listener):
         except DeviceTimeoutError:
             _LOGGER.error("Timeout trying to bind to gree device: %s", device_info)
 
-        _LOGGER.info(
+        _LOGGER.debug(
             "Adding Gree device %s at %s:%i",
             device.device_info.name,
             device.device_info.ip,

--- a/homeassistant/components/growatt_server/sensor/__init__.py
+++ b/homeassistant/components/growatt_server/sensor/__init__.py
@@ -72,7 +72,7 @@ async def async_setup_entry(
 
     # If the URL has been deprecated then change to the default instead
     if url in DEPRECATED_URLS:
-        _LOGGER.info(
+        _LOGGER.warning(
             "URL: %s has been deprecated, migrating to the latest default: %s",
             url,
             DEFAULT_URL,

--- a/homeassistant/components/guardian/util.py
+++ b/homeassistant/components/guardian/util.py
@@ -55,7 +55,7 @@ def async_finish_entity_domain_replacements(
             continue
 
         old_entity_id = registry_entry.entity_id
-        LOGGER.info('Removing old entity: "%s"', old_entity_id)
+        LOGGER.debug('Removing old entity: "%s"', old_entity_id)
         ent_reg.async_remove(old_entity_id)
 
 


### PR DESCRIPTION
## Proposed change
SSIA

Noticed in https://github.com/home-assistant/core/pull/125939

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
