### PR TITLE
Move and rename crownstone base entity to separate module

### DIFF
--- a/homeassistant/components/crownstone/entity.py
+++ b/homeassistant/components/crownstone/entity.py
@@ -10,7 +10,7 @@ from homeassistant.helpers.entity import Entity
 from .const import CROWNSTONE_INCLUDE_TYPES, DOMAIN
 
 
-class CrownstoneBaseEntity(Entity):
+class CrownstoneEntity(Entity):
     """Base entity class for Crownstone devices."""
 
     _attr_should_poll = False

--- a/homeassistant/components/crownstone/light.py
+++ b/homeassistant/components/crownstone/light.py
@@ -24,7 +24,7 @@ from .const import (
     SIG_CROWNSTONE_STATE_UPDATE,
     SIG_UART_STATE_CHANGE,
 )
-from .devices import CrownstoneBaseEntity
+from .entity import CrownstoneEntity
 from .helpers import map_from_to
 
 if TYPE_CHECKING:
@@ -39,7 +39,7 @@ async def async_setup_entry(
     """Set up crownstones from a config entry."""
     manager: CrownstoneEntryManager = hass.data[DOMAIN][config_entry.entry_id]
 
-    entities: list[CrownstoneEntity] = []
+    entities: list[CrownstoneLightEntity] = []
 
     # Add Crownstone entities that support switching/dimming
     for sphere in manager.cloud.cloud_data:
@@ -47,10 +47,10 @@ async def async_setup_entry(
             if crownstone.type in CROWNSTONE_INCLUDE_TYPES:
                 # Crownstone can communicate with Crownstone USB
                 if manager.uart and sphere.cloud_id == manager.usb_sphere_id:
-                    entities.append(CrownstoneEntity(crownstone, manager.uart))
+                    entities.append(CrownstoneLightEntity(crownstone, manager.uart))
                 # Crownstone can't communicate with Crownstone USB
                 else:
-                    entities.append(CrownstoneEntity(crownstone))
+                    entities.append(CrownstoneLightEntity(crownstone))
 
     async_add_entities(entities)
 
@@ -65,7 +65,7 @@ def hass_to_crownstone_state(value: int) -> int:
     return map_from_to(value, 0, 255, 0, 100)
 
 
-class CrownstoneEntity(CrownstoneBaseEntity, LightEntity):
+class CrownstoneLightEntity(CrownstoneEntity, LightEntity):
     """Representation of a crownstone.
 
     Light platform is used to support dimming.


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #126026

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
