### PR TITLE
Use debug/warning instead of info log level in components [k]

### DIFF
--- a/homeassistant/components/kankun/switch.py
+++ b/homeassistant/components/kankun/switch.py
@@ -89,7 +89,7 @@ class KankunSwitch(SwitchEntity):
 
     def _switch(self, newstate):
         """Switch on or off."""
-        _LOGGER.info("Switching to state: %s", newstate)
+        _LOGGER.debug("Switching to state: %s", newstate)
 
         try:
             req = requests.get(
@@ -101,7 +101,7 @@ class KankunSwitch(SwitchEntity):
 
     def _query_state(self):
         """Query switch state."""
-        _LOGGER.info("Querying state from: %s", self._url)
+        _LOGGER.debug("Querying state from: %s", self._url)
 
         try:
             req = requests.get(f"{self._url}?get=state", auth=self._auth, timeout=5)

--- a/homeassistant/components/kira/__init__.py
+++ b/homeassistant/components/kira/__init__.py
@@ -141,7 +141,7 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
         """Stop the KIRA receiver."""
         for receiver in hass.data[DOMAIN][CONF_SENSOR].values():
             receiver.stop()
-        _LOGGER.info("Terminated receivers")
+        _LOGGER.debug("Terminated receivers")
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, _stop_kira)
 

--- a/homeassistant/components/kira/remote.py
+++ b/homeassistant/components/kira/remote.py
@@ -45,5 +45,5 @@ class KiraRemote(remote.RemoteEntity):
         """Send a command to one device."""
         for single_command in command:
             code_tuple = (single_command, kwargs.get(remote.ATTR_DEVICE))
-            _LOGGER.info("Sending Command: %s to %s", *code_tuple)
+            _LOGGER.debug("Sending Command: %s to %s", *code_tuple)
             self._kira.sendCode(code_tuple)

--- a/homeassistant/components/kiwi/lock.py
+++ b/homeassistant/components/kiwi/lock.py
@@ -55,7 +55,7 @@ def setup_platform(
         return
     if not (available_locks := kiwi.get_locks()):
         # No locks found; abort setup routine.
-        _LOGGER.info("No KIWI locks found in your account")
+        _LOGGER.debug("No KIWI locks found in your account")
         return
     add_entities([KiwiLock(lock, kiwi) for lock in available_locks], True)
 

--- a/homeassistant/components/konnected/panel.py
+++ b/homeassistant/components/konnected/panel.py
@@ -123,7 +123,7 @@ class AlarmPanel:
             self.api_version = KONN_API_VERSIONS.get(
                 self.status.get("model", KONN_MODEL), KONN_API_VERSIONS[KONN_MODEL]
             )
-            _LOGGER.info(
+            _LOGGER.debug(
                 "Connected to new %s device", self.status.get("model", "Konnected")
             )
             _LOGGER.debug(self.status)
@@ -145,7 +145,7 @@ class AlarmPanel:
 
         self.connect_attempts = 0
         self.connected = True
-        _LOGGER.info(
+        _LOGGER.debug(
             (
                 "Set up Konnected device %s. Open http://%s:%s in a "
                 "web browser to view device status"
@@ -380,7 +380,7 @@ class AlarmPanel:
             self.async_desired_settings_payload()
             != self.async_current_settings_payload()
         ):
-            _LOGGER.info("Pushing settings to device %s", self.device_id)
+            _LOGGER.debug("Pushing settings to device %s", self.device_id)
             await self.client.put_settings(**self.async_desired_settings_payload())
 
 

--- a/homeassistant/components/kraken/__init__.py
+++ b/homeassistant/components/kraken/__init__.py
@@ -77,7 +77,7 @@ class KrakenData:
                 return await self._hass.async_add_executor_job(self._get_kraken_data)
         except pykrakenapi.pykrakenapi.KrakenAPIError as error:
             if "Unknown asset pair" in str(error):
-                _LOGGER.info(
+                _LOGGER.warning(
                     "Kraken.com reported an unknown asset pair. Refreshing list of"
                     " tradable asset pairs"
                 )

--- a/homeassistant/components/kulersky/light.py
+++ b/homeassistant/components/kulersky/light.py
@@ -137,7 +137,7 @@ class KulerskyLight(LightEntity):
             self._attr_available = False
             return
         if self._attr_available is False:
-            _LOGGER.info("Reconnected to %s", self._light.address)
+            _LOGGER.warning("Reconnected to %s", self._light.address)
 
         self._attr_available = True
         brightness = max(rgbw)


### PR DESCRIPTION
## Proposed change
SSIA

Noticed in https://github.com/home-assistant/core/pull/125939

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
