### PR TITLE
Move and rename envisalink base entity to separate module

### DIFF
--- a/homeassistant/components/envisalink/__init__.py
+++ b/homeassistant/components/envisalink/__init__.py
@@ -17,7 +17,6 @@ from homeassistant.core import HomeAssistant, ServiceCall, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import ConfigType
 
 _LOGGER = logging.getLogger(__name__)
@@ -244,20 +243,3 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     )
 
     return True
-
-
-class EnvisalinkDevice(Entity):
-    """Representation of an Envisalink device."""
-
-    _attr_should_poll = False
-
-    def __init__(self, name, info, controller):
-        """Initialize the device."""
-        self._controller = controller
-        self._info = info
-        self._name = name
-
-    @property
-    def name(self):
-        """Return the name of the device."""
-        return self._name

--- a/homeassistant/components/envisalink/alarm_control_panel.py
+++ b/homeassistant/components/envisalink/alarm_control_panel.py
@@ -37,8 +37,8 @@ from . import (
     PARTITION_SCHEMA,
     SIGNAL_KEYPAD_UPDATE,
     SIGNAL_PARTITION_UPDATE,
-    EnvisalinkDevice,
 )
+from .entity import EnvisalinkEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -102,7 +102,7 @@ async def async_setup_platform(
     )
 
 
-class EnvisalinkAlarm(EnvisalinkDevice, AlarmControlPanelEntity):
+class EnvisalinkAlarm(EnvisalinkEntity, AlarmControlPanelEntity):
     """Representation of an Envisalink-based alarm panel."""
 
     _attr_supported_features = (

--- a/homeassistant/components/envisalink/binary_sensor.py
+++ b/homeassistant/components/envisalink/binary_sensor.py
@@ -13,14 +13,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt as dt_util
 
-from . import (
-    CONF_ZONENAME,
-    CONF_ZONETYPE,
-    DATA_EVL,
-    SIGNAL_ZONE_UPDATE,
-    ZONE_SCHEMA,
-    EnvisalinkDevice,
-)
+from . import CONF_ZONENAME, CONF_ZONETYPE, DATA_EVL, SIGNAL_ZONE_UPDATE, ZONE_SCHEMA
+from .entity import EnvisalinkEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -52,7 +46,7 @@ async def async_setup_platform(
     async_add_entities(entities)
 
 
-class EnvisalinkBinarySensor(EnvisalinkDevice, BinarySensorEntity):
+class EnvisalinkBinarySensor(EnvisalinkEntity, BinarySensorEntity):
     """Representation of an Envisalink binary sensor."""
 
     def __init__(self, hass, zone_number, zone_name, zone_type, info, controller):

--- a/homeassistant/components/envisalink/entity.py
+++ b/homeassistant/components/envisalink/entity.py
@@ -1,0 +1,20 @@
+"""Support for Envisalink devices."""
+
+from homeassistant.helpers.entity import Entity
+
+
+class EnvisalinkEntity(Entity):
+    """Representation of an Envisalink device."""
+
+    _attr_should_poll = False
+
+    def __init__(self, name, info, controller):
+        """Initialize the device."""
+        self._controller = controller
+        self._info = info
+        self._name = name
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name

--- a/homeassistant/components/envisalink/sensor.py
+++ b/homeassistant/components/envisalink/sensor.py
@@ -16,8 +16,8 @@ from . import (
     PARTITION_SCHEMA,
     SIGNAL_KEYPAD_UPDATE,
     SIGNAL_PARTITION_UPDATE,
-    EnvisalinkDevice,
 )
+from .entity import EnvisalinkEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -49,7 +49,7 @@ async def async_setup_platform(
     async_add_entities(entities)
 
 
-class EnvisalinkSensor(EnvisalinkDevice, SensorEntity):
+class EnvisalinkSensor(EnvisalinkEntity, SensorEntity):
     """Representation of an Envisalink keypad."""
 
     def __init__(self, hass, partition_name, partition_number, info, controller):

--- a/homeassistant/components/envisalink/switch.py
+++ b/homeassistant/components/envisalink/switch.py
@@ -11,13 +11,8 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import (
-    CONF_ZONENAME,
-    DATA_EVL,
-    SIGNAL_ZONE_BYPASS_UPDATE,
-    ZONE_SCHEMA,
-    EnvisalinkDevice,
-)
+from . import CONF_ZONENAME, DATA_EVL, SIGNAL_ZONE_BYPASS_UPDATE, ZONE_SCHEMA
+from .entity import EnvisalinkEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -51,7 +46,7 @@ async def async_setup_platform(
     async_add_entities(entities)
 
 
-class EnvisalinkSwitch(EnvisalinkDevice, SwitchEntity):
+class EnvisalinkSwitch(EnvisalinkEntity, SwitchEntity):
     """Representation of an Envisalink switch."""
 
     def __init__(self, hass, zone_number, zone_name, info, controller):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #126026

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
