### PR TITLE
Fix Matter Model ID for bridged devices

### DIFF
--- a/homeassistant/components/matter/adapter.py
+++ b/homeassistant/components/matter/adapter.py
@@ -210,8 +210,7 @@ class MatterAdapter:
         # we prefer the matter product ID so we can look it up in Matter DCL
         if isinstance(basic_info, clusters.BridgedDeviceBasicInformation):
             # On bridged devices, the productID is not available
-            # we use the product name as fallback model ID
-            model_id = get_clean_name(basic_info.productName)
+            model_id = None
         else:
             model_id = str(product_id) if (product_id := basic_info.productID) else None
 

--- a/homeassistant/components/matter/adapter.py
+++ b/homeassistant/components/matter/adapter.py
@@ -213,7 +213,7 @@ class MatterAdapter:
             # we use the product name as fallback model ID
             model_id = get_clean_name(basic_info.productName)
         else:
-            model_id = str(basic_info.productID) if basic_info.productID else None
+            model_id = str(product_id) if (product_id := basic_info.productID) else None
 
         dr.async_get(self.hass).async_get_or_create(
             name=name,

--- a/homeassistant/components/matter/adapter.py
+++ b/homeassistant/components/matter/adapter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
 
+from chip.clusters import Objects as clusters
 from matter_server.client.models.device_types import BridgedDevice
 from matter_server.common.models import EventType, ServerInfoMessage
 
@@ -194,11 +195,26 @@ class MatterAdapter:
             identifiers.add((DOMAIN, f"{ID_TYPE_SERIAL}_{basic_info_serial_number}"))
             serial_number = basic_info_serial_number
 
-        model = (
-            get_clean_name(basic_info.productName) or device_type.__name__
+        # Model name is the human readable name of the model/product name
+        model_name = (
+            # productLabel is optional but preferred (e.g. Hue Bloom)
+            get_clean_name(basic_info.productLabel)
+            # alternative is the productName (e.g. LCT001)
+            or get_clean_name(basic_info.productName)
+            # if no product name, use the device type name
+            or device_type.__name__
             if device_type
             else None
         )
+        # Model ID is the non-human readable product ID
+        # we prefer the matter product ID so we can look it up in Matter DCL
+        if isinstance(basic_info, clusters.BridgedDeviceBasicInformation):
+            # On bridged devices, the productID is not available
+            # we use the product name as fallback model ID
+            model_id = get_clean_name(basic_info.productName)
+        else:
+            model_id = str(basic_info.productID) if basic_info.productID else None
+
         dr.async_get(self.hass).async_get_or_create(
             name=name,
             config_entry_id=self.config_entry.entry_id,
@@ -206,8 +222,8 @@ class MatterAdapter:
             hw_version=basic_info.hardwareVersionString,
             sw_version=basic_info.softwareVersionString,
             manufacturer=basic_info.vendorName or endpoint.node.device_info.vendorName,
-            model=model,
-            model_id=str(basic_info.productID) if basic_info.productID else None,
+            model=model_name,
+            model_id=model_id,
             serial_number=serial_number,
             via_device=(DOMAIN, bridge_device_id) if bridge_device_id else None,
         )


### PR DESCRIPTION
## Proposed change

We've added the modelID to the HA device object but it turns out productID isn't used on Bridged devices.
Handle that and also add a bit more comments to the code what we use when/where/why.
Prefer productlabel if it exists on a device as it will contain a pretty name for the device if the manufacturer fills it.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #125620
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
