### PR TITLE
Fix set temperature action in AVM FRITZ!SmartHome

### DIFF
--- a/homeassistant/components/fritzbox/climate.py
+++ b/homeassistant/components/fritzbox/climate.py
@@ -137,17 +137,14 @@ class FritzboxThermostat(FritzBoxDeviceEntity, ClimateEntity):
         """Set new target temperature."""
         target_temp = kwargs.get(ATTR_TEMPERATURE)
         hvac_mode = kwargs.get(ATTR_HVAC_MODE)
-        if target_temp is None and hvac_mode is None:
-            return
-
         if hvac_mode == HVACMode.OFF:
             await self.async_set_hvac_mode(hvac_mode)
         elif target_temp is not None:
             await self.hass.async_add_executor_job(
                 self.data.set_target_temperature, target_temp
             )
-        elif hvac_mode is not None:
-            await self.async_set_hvac_mode(hvac_mode)
+        else:
+            return
         await self.coordinator.async_refresh()
 
     @property

--- a/homeassistant/components/fritzbox/climate.py
+++ b/homeassistant/components/fritzbox/climate.py
@@ -135,14 +135,19 @@ class FritzboxThermostat(FritzBoxDeviceEntity, ClimateEntity):
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
-        if kwargs.get(ATTR_HVAC_MODE) is not None:
-            hvac_mode = kwargs[ATTR_HVAC_MODE]
+        target_temp = kwargs.get(ATTR_TEMPERATURE)
+        hvac_mode = kwargs.get(ATTR_HVAC_MODE)
+        if target_temp is None and hvac_mode is None:
+            return
+
+        if hvac_mode == HVACMode.OFF:
             await self.async_set_hvac_mode(hvac_mode)
-        elif kwargs.get(ATTR_TEMPERATURE) is not None:
-            temperature = kwargs[ATTR_TEMPERATURE]
+        elif target_temp is not None:
             await self.hass.async_add_executor_job(
-                self.data.set_target_temperature, temperature
+                self.data.set_target_temperature, target_temp
             )
+        elif hvac_mode is not None:
+            await self.async_set_hvac_mode(hvac_mode)
         await self.coordinator.async_refresh()
 
     @property

--- a/tests/components/fritzbox/test_climate.py
+++ b/tests/components/fritzbox/test_climate.py
@@ -1,7 +1,7 @@
 """Tests for AVM Fritz!Box climate component."""
 
 from datetime import timedelta
-from unittest.mock import Mock, call
+from unittest.mock import Mock, _Call, call
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
@@ -270,8 +270,33 @@ async def test_update_error(hass: HomeAssistant, fritz: Mock) -> None:
     assert fritz().login.call_count == 4
 
 
-async def test_set_temperature_temperature(hass: HomeAssistant, fritz: Mock) -> None:
-    """Test setting temperature by temperature."""
+@pytest.mark.parametrize(
+    ("service_data", "expected_call_args"),
+    [
+        ({ATTR_TEMPERATURE: 23}, [call(23)]),
+        (
+            {
+                ATTR_HVAC_MODE: HVACMode.OFF,
+                ATTR_TEMPERATURE: 23,
+            },
+            [call(0)],
+        ),
+        (
+            {
+                ATTR_HVAC_MODE: HVACMode.HEAT,
+                ATTR_TEMPERATURE: 23,
+            },
+            [call(23)],
+        ),
+    ],
+)
+async def test_set_temperature(
+    hass: HomeAssistant,
+    fritz: Mock,
+    service_data: dict,
+    expected_call_args: list[_Call],
+) -> None:
+    """Test setting temperature."""
     device = FritzDeviceClimateMock()
     assert await setup_config_entry(
         hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
@@ -280,56 +305,31 @@ async def test_set_temperature_temperature(hass: HomeAssistant, fritz: Mock) -> 
     await hass.services.async_call(
         CLIMATE_DOMAIN,
         SERVICE_SET_TEMPERATURE,
-        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_TEMPERATURE: 23},
+        {ATTR_ENTITY_ID: ENTITY_ID, **service_data},
         True,
     )
-    assert device.set_target_temperature.call_args_list == [call(23)]
+    assert device.set_target_temperature.call_args_list == expected_call_args
 
 
-async def test_set_temperature_mode_off(hass: HomeAssistant, fritz: Mock) -> None:
-    """Test setting temperature by mode."""
-    device = FritzDeviceClimateMock()
-    assert await setup_config_entry(
-        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
-    )
-
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_SET_TEMPERATURE,
-        {
-            ATTR_ENTITY_ID: ENTITY_ID,
-            ATTR_HVAC_MODE: HVACMode.OFF,
-            ATTR_TEMPERATURE: 23,
-        },
-        True,
-    )
-    assert device.set_target_temperature.call_args_list == [call(0)]
-
-
-async def test_set_temperature_mode_heat(hass: HomeAssistant, fritz: Mock) -> None:
-    """Test setting temperature by mode."""
-    device = FritzDeviceClimateMock()
-    device.target_temperature = 0.0
-    assert await setup_config_entry(
-        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
-    )
-
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_SET_TEMPERATURE,
-        {
-            ATTR_ENTITY_ID: ENTITY_ID,
-            ATTR_HVAC_MODE: HVACMode.HEAT,
-            ATTR_TEMPERATURE: 23,
-        },
-        True,
-    )
-    assert device.set_target_temperature.call_args_list == [call(22)]
-
-
-async def test_set_hvac_mode_off(hass: HomeAssistant, fritz: Mock) -> None:
+@pytest.mark.parametrize(
+    ("service_data", "target_temperature", "expected_call_args"),
+    [
+        ({ATTR_HVAC_MODE: HVACMode.OFF}, 22, [call(0)]),
+        ({ATTR_HVAC_MODE: HVACMode.HEAT}, 0.0, [call(22)]),
+        ({ATTR_HVAC_MODE: HVACMode.HEAT}, 18, []),
+        ({ATTR_HVAC_MODE: HVACMode.HEAT}, 22, []),
+    ],
+)
+async def test_set_hvac_mode(
+    hass: HomeAssistant,
+    fritz: Mock,
+    service_data: dict,
+    target_temperature: float,
+    expected_call_args: list[_Call],
+) -> None:
     """Test setting hvac mode."""
     device = FritzDeviceClimateMock()
+    device.target_temperature = target_temperature
     assert await setup_config_entry(
         hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
     )
@@ -337,43 +337,12 @@ async def test_set_hvac_mode_off(hass: HomeAssistant, fritz: Mock) -> None:
     await hass.services.async_call(
         CLIMATE_DOMAIN,
         SERVICE_SET_HVAC_MODE,
-        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_HVAC_MODE: HVACMode.OFF},
+        {ATTR_ENTITY_ID: ENTITY_ID, **service_data},
         True,
     )
-    assert device.set_target_temperature.call_args_list == [call(0)]
 
-
-async def test_no_reset_hvac_mode_heat(hass: HomeAssistant, fritz: Mock) -> None:
-    """Test setting hvac mode."""
-    device = FritzDeviceClimateMock()
-    assert await setup_config_entry(
-        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
-    )
-
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_SET_HVAC_MODE,
-        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_HVAC_MODE: HVACMode.HEAT},
-        True,
-    )
-    assert device.set_target_temperature.call_count == 0
-
-
-async def test_set_hvac_mode_heat(hass: HomeAssistant, fritz: Mock) -> None:
-    """Test setting hvac mode."""
-    device = FritzDeviceClimateMock()
-    device.target_temperature = 0.0
-    assert await setup_config_entry(
-        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
-    )
-
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_SET_HVAC_MODE,
-        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_HVAC_MODE: HVACMode.HEAT},
-        True,
-    )
-    assert device.set_target_temperature.call_args_list == [call(22)]
+    assert device.set_target_temperature.call_count == len(expected_call_args)
+    assert device.set_target_temperature.call_args_list == expected_call_args
 
 
 async def test_set_preset_mode_comfort(hass: HomeAssistant, fritz: Mock) -> None:

--- a/tests/components/fritzbox/test_climate.py
+++ b/tests/components/fritzbox/test_climate.py
@@ -15,6 +15,8 @@ from homeassistant.components.climate import (
     ATTR_MIN_TEMP,
     ATTR_PRESET_MODE,
     ATTR_PRESET_MODES,
+    ATTR_TARGET_TEMP_HIGH,
+    ATTR_TARGET_TEMP_LOW,
     DOMAIN as CLIMATE_DOMAIN,
     PRESET_COMFORT,
     PRESET_ECO,
@@ -288,6 +290,13 @@ async def test_update_error(hass: HomeAssistant, fritz: Mock) -> None:
             },
             [call(23)],
         ),
+        (
+            {
+                ATTR_TARGET_TEMP_HIGH: 16,
+                ATTR_TARGET_TEMP_LOW: 10,
+            },
+            [],
+        ),
     ],
 )
 async def test_set_temperature(
@@ -308,6 +317,7 @@ async def test_set_temperature(
         {ATTR_ENTITY_ID: ENTITY_ID, **service_data},
         True,
     )
+    assert device.set_target_temperature.call_count == len(expected_call_args)
     assert device.set_target_temperature.call_args_list == expected_call_args
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The current logic ignores given `temperature` attribute in `set_temperature` as long as a `hvac_mode` is specified, which leads to the following decisions:
- when `temperature=n` and `hvac_mode=off` is given, than hvac mode is set to `off`
- when `temperature=n` and `hvac_mode=heat` is given, than hvac mode is set to `heat` (_without respecting the temperature_)
- when `temperature=n` and no `hvac_mode` is given, than target temperature is set to `n` 

The fixed logic is as follows:
- when `temperature=n` and `hvac_mode=off` is given, than hvac mode is set to `off`
- when `temperature=n` and `hvac_mode=heat` is given, than target temperature is set to `n` 
- when `temperature=n` and no `hvac_mode` is given, than target temperature is set to `n` 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #126044
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
