### PR TITLE
Use debug/warning instead of info log level in components [m]

### DIFF
--- a/homeassistant/components/mediaroom/media_player.py
+++ b/homeassistant/components/mediaroom/media_player.py
@@ -149,7 +149,7 @@ class MediaroomDevice(MediaPlayerEntity):
 
         self.host = host
         self.stb = Remote(host)
-        _LOGGER.info(
+        _LOGGER.debug(
             "Found STB at %s%s", host, " - I'm optimistic" if optimistic else ""
         )
         self._channel = None

--- a/homeassistant/components/minio/__init__.py
+++ b/homeassistant/components/minio/__init__.py
@@ -181,7 +181,7 @@ class QueueListener(threading.Thread):
 
     def run(self):
         """Listen to queue events, and forward them to Home Assistant event bus."""
-        _LOGGER.info("Running QueueListener")
+        _LOGGER.debug("Running QueueListener")
         while True:
             if (event := self._queue.get()) is None:
                 break
@@ -203,10 +203,10 @@ class QueueListener(threading.Thread):
 
     def stop(self):
         """Stop run by putting None into queue and join the thread."""
-        _LOGGER.info("Stopping QueueListener")
+        _LOGGER.debug("Stopping QueueListener")
         self._queue.put(None)
         self.join()
-        _LOGGER.info("Stopped QueueListener")
+        _LOGGER.debug("Stopped QueueListener")
 
     def start_handler(self, _):
         """Start handler helper method."""

--- a/homeassistant/components/minio/minio_helper.py
+++ b/homeassistant/components/minio/minio_helper.py
@@ -116,7 +116,7 @@ class MinioEventThread(threading.Thread):
 
     def run(self):
         """Create MinioClient and run the loop."""
-        _LOGGER.info("Running MinioEventThread")
+        _LOGGER.debug("Running MinioEventThread")
 
         self._should_stop = False
 
@@ -125,7 +125,7 @@ class MinioEventThread(threading.Thread):
         )
 
         while not self._should_stop:
-            _LOGGER.info("Connecting to minio event stream")
+            _LOGGER.debug("Connecting to minio event stream")
             response = None
             try:
                 response = get_minio_notification_response(

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -464,7 +464,7 @@ async def async_reset_platform(hass: HomeAssistant, integration_name: str) -> No
     if DOMAIN not in hass.data:
         _LOGGER.error("Modbus cannot reload, because it was never loaded")
         return
-    _LOGGER.info("Modbus reloading")
+    _LOGGER.debug("Modbus reloading")
     hubs = hass.data[DOMAIN]
     for name in hubs:
         await hubs[name].async_close()

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -341,7 +341,7 @@ class ModbusHub:
                 self._log_error(err, error_state=False)
                 return
             message = f"modbus {self.name} communication open"
-            _LOGGER.info(message)
+            _LOGGER.warning(message)
 
     async def async_setup(self) -> bool:
         """Set up pymodbus client."""

--- a/homeassistant/components/monoprice/media_player.py
+++ b/homeassistant/components/monoprice/media_player.py
@@ -71,7 +71,7 @@ async def async_setup_entry(
     for i in range(1, 4):
         for j in range(1, 7):
             zone_id = (i * 10) + j
-            _LOGGER.info("Adding zone %d for port %s", zone_id, port)
+            _LOGGER.debug("Adding zone %d for port %s", zone_id, port)
             entities.append(
                 MonopriceZone(monoprice, sources, config_entry.entry_id, zone_id)
             )

--- a/homeassistant/components/mysensors/__init__.py
+++ b/homeassistant/components/mysensors/__init__.py
@@ -148,7 +148,7 @@ def setup_mysensors_platform(
         devices[dev_id] = device_class_copy(*args_copy)
         new_devices.append(devices[dev_id])
     if new_devices:
-        _LOGGER.info("Adding new devices: %s", new_devices)
+        _LOGGER.debug("Adding new devices: %s", new_devices)
         if async_add_entities is not None:
             async_add_entities(new_devices)
     return new_devices

--- a/homeassistant/components/mysensors/gateway.py
+++ b/homeassistant/components/mysensors/gateway.py
@@ -114,14 +114,14 @@ async def try_connect(
                 await gateway_ready.wait()
                 return True
         except TimeoutError:
-            _LOGGER.info("Try gateway connect failed with timeout")
+            _LOGGER.warning("Try gateway connect failed with timeout")
             return False
         finally:
             if connect_task is not None and not connect_task.done():
                 connect_task.cancel()
             await gateway.stop()
     except OSError as err:
-        _LOGGER.info("Try gateway connect failed with exception", exc_info=err)
+        _LOGGER.warning("Try gateway connect failed with exception", exc_info=err)
         return False
 
 

--- a/homeassistant/components/mystrom/binary_sensor.py
+++ b/homeassistant/components/mystrom/binary_sensor.py
@@ -60,7 +60,7 @@ class MyStromView(HomeAssistantView):
         button_id = data[button_action]
         entity_id = f"{BINARY_SENSOR_DOMAIN}.{button_id}_{button_action}"
         if entity_id not in self.buttons:
-            _LOGGER.info(
+            _LOGGER.debug(
                 "New myStrom button/action detected: %s/%s", button_id, button_action
             )
             self.buttons[entity_id] = MyStromBinarySensor(

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -1168,7 +1168,7 @@ async def test_stop_restart(
 ) -> None:
     """Run test for service stop."""
 
-    caplog.set_level(logging.INFO)
+    caplog.set_level(logging.WARNING)
     entity_id = f"{SENSOR_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
     assert hass.states.get(entity_id).state in (STATE_UNKNOWN, STATE_UNAVAILABLE)
     hass.states.async_set(entity_id, 17)
@@ -1234,7 +1234,7 @@ async def test_integration_reload(
 ) -> None:
     """Run test for integration reload."""
 
-    caplog.set_level(logging.INFO)
+    caplog.set_level(logging.DEBUG)
     caplog.clear()
 
     yaml_path = get_fixture_path("configuration.yaml", "modbus")
@@ -1253,7 +1253,7 @@ async def test_integration_reload_failed(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture, mock_modbus
 ) -> None:
     """Run test for integration connect failure on reload."""
-    caplog.set_level(logging.INFO)
+    caplog.set_level(logging.DEBUG)
     caplog.clear()
 
     yaml_path = get_fixture_path("configuration.yaml", "modbus")


### PR DESCRIPTION
## Proposed change
SSIA

Noticed in https://github.com/home-assistant/core/pull/125939

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
