### PR TITLE
Add Home Connect light entity for cooling appliances

### DIFF
--- a/homeassistant/components/home_connect/const.py
+++ b/homeassistant/components/home_connect/const.py
@@ -32,6 +32,15 @@ COFFEE_EVENT_BEAN_CONTAINER_EMPTY = (
 COFFEE_EVENT_WATER_TANK_EMPTY = "ConsumerProducts.CoffeeMaker.Event.WaterTankEmpty"
 COFFEE_EVENT_DRIP_TRAY_FULL = "ConsumerProducts.CoffeeMaker.Event.DripTrayFull"
 
+REFRIGERATION_INTERNAL_LIGHT_POWER = "Refrigeration.Common.Setting.Light.Internal.Power"
+REFRIGERATION_INTERNAL_LIGHT_BRIGHTNESS = (
+    "Refrigeration.Common.Setting.Light.Internal.Brightness"
+)
+REFRIGERATION_EXTERNAL_LIGHT_POWER = "Refrigeration.Common.Setting.Light.External.Power"
+REFRIGERATION_EXTERNAL_LIGHT_BRIGHTNESS = (
+    "Refrigeration.Common.Setting.Light.External.Brightness"
+)
+
 REFRIGERATION_SUPERMODEFREEZER = "Refrigeration.FridgeFreezer.Setting.SuperModeFreezer"
 REFRIGERATION_SUPERMODEREFRIGERATOR = (
     "Refrigeration.FridgeFreezer.Setting.SuperModeRefrigerator"

--- a/homeassistant/components/home_connect/light.py
+++ b/homeassistant/components/home_connect/light.py
@@ -257,6 +257,6 @@ class HomeConnectCoolingLight(HomeConnectLight):
         """Initialize Cooling Light Entity."""
         super().__init__(device, entity_description.key, ambient)
         self.entity_description = entity_description
-        self._key = self.entity_description.on_key
-        self._brightness_key = self.entity_description.brightness_key
+        self._key = entity_description.on_key
+        self._brightness_key = entity_description.brightness_key
         self._percentage_scale = (1, 100)

--- a/homeassistant/components/home_connect/light.py
+++ b/homeassistant/components/home_connect/light.py
@@ -1,5 +1,6 @@
 """Provides a light for Home Connect."""
 
+from dataclasses import dataclass
 import logging
 from math import ceil
 from typing import Any
@@ -11,13 +12,15 @@ from homeassistant.components.light import (
     ATTR_HS_COLOR,
     ColorMode,
     LightEntity,
+    LightEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ENTITIES
+from homeassistant.const import CONF_DEVICE, CONF_ENTITIES
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.color as color_util
 
+from .api import HomeConnectDevice
 from .const import (
     ATTR_VALUE,
     BSH_AMBIENT_LIGHT_BRIGHTNESS,
@@ -28,10 +31,36 @@ from .const import (
     COOKING_LIGHTING,
     COOKING_LIGHTING_BRIGHTNESS,
     DOMAIN,
+    REFRIGERATION_EXTERNAL_LIGHT_BRIGHTNESS,
+    REFRIGERATION_EXTERNAL_LIGHT_POWER,
+    REFRIGERATION_INTERNAL_LIGHT_BRIGHTNESS,
+    REFRIGERATION_INTERNAL_LIGHT_POWER,
 )
 from .entity import HomeConnectEntity
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True)
+class HomeConnectLightEntityDescription(LightEntityDescription):
+    """Light entity description."""
+
+    on_key: str
+    brightness_key: str | None
+
+
+LIGHTS: tuple[HomeConnectLightEntityDescription, ...] = (
+    HomeConnectLightEntityDescription(
+        key="Internal Light",
+        on_key=REFRIGERATION_INTERNAL_LIGHT_POWER,
+        brightness_key=REFRIGERATION_INTERNAL_LIGHT_BRIGHTNESS,
+    ),
+    HomeConnectLightEntityDescription(
+        key="External Light",
+        on_key=REFRIGERATION_EXTERNAL_LIGHT_POWER,
+        brightness_key=REFRIGERATION_EXTERNAL_LIGHT_BRIGHTNESS,
+    ),
+)
 
 
 async def async_setup_entry(
@@ -48,7 +77,18 @@ async def async_setup_entry(
         for device_dict in hc_api.devices:
             entity_dicts = device_dict.get(CONF_ENTITIES, {}).get("light", [])
             entity_list = [HomeConnectLight(**d) for d in entity_dicts]
-            entities += entity_list
+            device: HomeConnectDevice = device_dict[CONF_DEVICE]
+            # Auto-discover entities
+            entities.extend(
+                HomeConnectCoolingLight(
+                    device=device,
+                    ambient=False,
+                    entity_description=description,
+                )
+                for description in LIGHTS
+                if description.on_key in device.appliance.status
+            )
+            entities.extend(entity_list)
         return entities
 
     async_add_entities(await hass.async_add_executor_job(get_entities), True)
@@ -57,10 +97,14 @@ async def async_setup_entry(
 class HomeConnectLight(HomeConnectEntity, LightEntity):
     """Light for Home Connect."""
 
-    def __init__(self, device, desc, ambient):
+    def __init__(self, device, desc, ambient) -> None:
         """Initialize the entity."""
         super().__init__(device, desc)
         self._ambient = ambient
+        self._percentage_scale = (10, 100)
+        self._brightness_key: str | None
+        self._custom_color_key: str | None
+        self._color_key: str | None
         if ambient:
             self._brightness_key = BSH_AMBIENT_LIGHT_BRIGHTNESS
             self._key = BSH_AMBIENT_LIGHT_ENABLED
@@ -97,10 +141,15 @@ class HomeConnectLight(HomeConnectEntity, LightEntity):
                 except HomeConnectError as err:
                     _LOGGER.error("Error while trying selecting customcolor: %s", err)
                 if self._attr_brightness is not None:
-                    brightness = 10 + ceil(self._attr_brightness / 255 * 90)
+                    brightness_arg = self._attr_brightness
                     if ATTR_BRIGHTNESS in kwargs:
-                        brightness = 10 + ceil(kwargs[ATTR_BRIGHTNESS] / 255 * 90)
+                        brightness_arg = kwargs[ATTR_BRIGHTNESS]
 
+                    brightness = ceil(
+                        color_util.brightness_to_value(
+                            self._percentage_scale, brightness_arg
+                        )
+                    )
                     hs_color = kwargs.get(ATTR_HS_COLOR, self._attr_hs_color)
 
                     if hs_color is not None:
@@ -120,8 +169,16 @@ class HomeConnectLight(HomeConnectEntity, LightEntity):
                             )
 
         elif ATTR_BRIGHTNESS in kwargs:
-            _LOGGER.debug("Changing brightness for: %s", self.name)
-            brightness = 10 + ceil(kwargs[ATTR_BRIGHTNESS] / 255 * 90)
+            _LOGGER.debug(
+                "Changing brightness for: %s, to: %s",
+                self.name,
+                kwargs[ATTR_BRIGHTNESS],
+            )
+            brightness = ceil(
+                color_util.brightness_to_value(
+                    self._percentage_scale, kwargs[ATTR_BRIGHTNESS]
+                )
+            )
             try:
                 await self.hass.async_add_executor_job(
                     self.device.appliance.set_setting, self._brightness_key, brightness
@@ -172,7 +229,9 @@ class HomeConnectLight(HomeConnectEntity, LightEntity):
                 rgb = color_util.rgb_hex_to_rgb_list(colorvalue)
                 hsv = color_util.color_RGB_to_hsv(rgb[0], rgb[1], rgb[2])
                 self._attr_hs_color = (hsv[0], hsv[1])
-                self._attr_brightness = ceil((hsv[2] - 10) * 255 / 90)
+                self._attr_brightness = color_util.value_to_brightness(
+                    self._percentage_scale, hsv[2]
+                )
                 _LOGGER.debug("Updated, new brightness: %s", self._attr_brightness)
 
         else:
@@ -180,7 +239,24 @@ class HomeConnectLight(HomeConnectEntity, LightEntity):
             if brightness is None:
                 self._attr_brightness = None
             else:
-                self._attr_brightness = ceil(
-                    (brightness.get(ATTR_VALUE) - 10) * 255 / 90
+                self._attr_brightness = color_util.value_to_brightness(
+                    self._percentage_scale, brightness[ATTR_VALUE]
                 )
             _LOGGER.debug("Updated, new brightness: %s", self._attr_brightness)
+
+
+class HomeConnectCoolingLight(HomeConnectLight):
+    """Light entity for Cooling Appliances."""
+
+    def __init__(
+        self,
+        device: HomeConnectDevice,
+        ambient: bool,
+        entity_description: HomeConnectLightEntityDescription,
+    ) -> None:
+        """Initialize Cooling Light Entity."""
+        super().__init__(device, entity_description.key, ambient)
+        self.entity_description = entity_description
+        self._key = self.entity_description.on_key
+        self._brightness_key = self.entity_description.brightness_key
+        self._percentage_scale = (1, 100)

--- a/tests/components/home_connect/fixtures/settings.json
+++ b/tests/components/home_connect/fixtures/settings.json
@@ -138,6 +138,22 @@
           "constraints": {
             "access": "readWrite"
           }
+        },
+        {
+          "key": "Refrigeration.Common.Setting.Light.External.Power",
+          "value": true,
+          "type": "Boolean"
+        },
+        {
+          "key": "Refrigeration.Common.Setting.Light.External.Brightness",
+          "value": 70,
+          "unit": "%",
+          "type": "Double",
+          "constraints": {
+            "min": 0,
+            "max": 100,
+            "access": "readWrite"
+          }
         }
       ]
     }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add light entities for different cooling appliances and also refactor the `HomeConnectLightEntity` code to use a percent range for `color_util` methods.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: #91216 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
