### PR TITLE
Fix Auto mode for TCC devices like the Lyric Round

### DIFF
--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -210,9 +210,7 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
 
         # TCC devices like the Lyric round do not have the Auto
         # option in allowed_modes, but still support Auto mode
-        if LYRIC_HVAC_MODE_HEAT_COOL in device.allowed_modes:
-            self._attr_hvac_modes.append(HVACMode.HEAT_COOL)
-        elif (
+        if LYRIC_HVAC_MODE_HEAT_COOL in device.allowed_modes or (
             self._attr_thermostat_type is LyricThermostatType.TCC
             and LYRIC_HVAC_MODE_HEAT in device.allowed_modes
             and LYRIC_HVAC_MODE_COOL in device.allowed_modes

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -219,7 +219,7 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
             and LYRIC_HVAC_MODE_COOL in device.allowedModes
         ):
             self._attr_hvac_modes.append(HVACMode.HEAT_COOL)
-        
+
         # Setup supported features
         if self._attr_thermostat_type is LyricThermostatType.LCC:
             self._attr_supported_features = SUPPORT_FLAGS_LCC

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -215,8 +215,8 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
         # option in allowed_modes, but still support Auto mode
         if (
             self._attr_thermostat_type is LyricThermostatType.TCC
-            and LYRIC_HVAC_MODE_HEAT in device.allowedModes
-            and LYRIC_HVAC_MODE_COOL in device.allowedModes
+            and LYRIC_HVAC_MODE_HEAT in device.allowed_modes
+            and LYRIC_HVAC_MODE_COOL in device.allowed_modes
         ):
             self._attr_hvac_modes.append(HVACMode.HEAT_COOL)
 

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -211,6 +211,15 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
         if LYRIC_HVAC_MODE_HEAT_COOL in device.allowed_modes:
             self._attr_hvac_modes.append(HVACMode.HEAT_COOL)
 
+        # TCC devices like the Lyric round do not have the Auto
+        # option in allowed_modes, but still support Auto mode
+        if (
+            self._attr_thermostat_type is LyricThermostatType.TCC
+            and LYRIC_HVAC_MODE_HEAT in device.allowedModes
+            and LYRIC_HVAC_MODE_COOL in device.allowedModes
+        ):
+            self._attr_hvac_modes.append(HVACMode.HEAT_COOL)
+        
         # Setup supported features
         if self._attr_thermostat_type is LyricThermostatType.LCC:
             self._attr_supported_features = SUPPORT_FLAGS_LCC

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -208,12 +208,11 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
         if LYRIC_HVAC_MODE_COOL in device.allowed_modes:
             self._attr_hvac_modes.append(HVACMode.COOL)
 
-        if LYRIC_HVAC_MODE_HEAT_COOL in device.allowed_modes:
-            self._attr_hvac_modes.append(HVACMode.HEAT_COOL)
-
         # TCC devices like the Lyric round do not have the Auto
         # option in allowed_modes, but still support Auto mode
-        if (
+        if LYRIC_HVAC_MODE_HEAT_COOL in device.allowed_modes:
+            self._attr_hvac_modes.append(HVACMode.HEAT_COOL)
+        elif (
             self._attr_thermostat_type is LyricThermostatType.TCC
             and LYRIC_HVAC_MODE_HEAT in device.allowed_modes
             and LYRIC_HVAC_MODE_COOL in device.allowed_modes


### PR DESCRIPTION
## Proposed change
PR #123490 by @kristof-mattei introduced a change in the way the Auto mode is detected that does not work for TCC devices like the Lyric Round. I own both the Lyric Round (TCC device) and the T5 (LCC device), so I'm able to test code for both types of devices. I went into detail on the difference between the way Auto mode is implemented by TCC and LCC devices in PR #106853 and #106925, but I'll copy it here for ease of reference. 

"The source of the problem is the way the two types of devices use the autoChangeoverActive variable, as well as how they display the mode within changeableValues, and which modes they allow you to pass.

For LCC devices, auto mode is enabled in two steps. First, you have to allow it by setting autoChangeoverActive to true. Then, you can set the changeableValues.mode to "Auto" when you'd like to use it. LCC devices allow modes "Off", "Heat", "Cool", and "Auto". Of note, while working on this PR I realized if the user sets autoChangeoverActive to false in the physical device itself, and later tries to pass mode "Auto", it will not work, so I added code to the async_set_hvac_mode_lcc function to take care of this.

For TCC devices, auto mode is enabled directly by setting autoChangeoverActive to true or false. When you do this, changeableValues.mode will indeed display "Auto" (see image below). Nevertheless, TCC devices only allow you to set changeableModes.mode to "Off", "Heat", or "Cool", hence you can't actually pass mode="Auto" at any point or you get the the following error Mode 7 is not allowed. Allowed modes are Cool, Heat, Off. This is confusing, and poor form in the way they implemented the api for TCC devices. I have no idea why they didn't just design both devices to do things the same way."

This has unfortunately happened before, where an LCC device owner submits a PR that breaks something for those of us TCC owners. I wonder if the integration should be split up for the two types of devices, but that's a broader question for the integration owner.


## Type of change
- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

See PR #106853.

## Checklist
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
