### PR TITLE
Update repairs for Smlight integration to allow firmware updates where possible

### DIFF
--- a/homeassistant/components/smlight/coordinator.py
+++ b/homeassistant/components/smlight/coordinator.py
@@ -80,9 +80,8 @@ class SmBaseDataUpdateCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
 
         info = await self.client.get_info()
         self.unique_id = format_mac(info.MAC)
-
-        if info.legacy_api:
-            self.legacy_api = info.legacy_api
+        self.legacy_api = info.legacy_api
+        if info.legacy_api == 2:
             ir.async_create_issue(
                 self.hass,
                 DOMAIN,

--- a/homeassistant/components/smlight/update.py
+++ b/homeassistant/components/smlight/update.py
@@ -128,6 +128,12 @@ class SmUpdateEntity(SmEntity, UpdateEntity):
                 SmEvents.FW_UPD_done, self._update_finished
             )
         )
+        if self.coordinator.legacy_api == 1:
+            self._unload.append(
+                self.coordinator.client.sse.register_callback(
+                    SmEvents.ESP_UPD_done, self._update_finished
+                )
+            )
         self._unload.append(
             self.coordinator.client.sse.register_callback(
                 SmEvents.ZB_FW_err, self._update_failed

--- a/homeassistant/components/smlight/update.py
+++ b/homeassistant/components/smlight/update.py
@@ -102,6 +102,8 @@ class SmUpdateEntity(SmEntity, UpdateEntity):
     def latest_version(self) -> str | None:
         """Latest version available for install."""
         data = self.coordinator.data
+        if self.coordinator.legacy_api == 2:
+            return None
 
         fw = self.entity_description.fw_list(data)
 

--- a/tests/components/smlight/test_init.py
+++ b/tests/components/smlight/test_init.py
@@ -122,10 +122,10 @@ async def test_device_legacy_firmware(
     issue_registry: IssueRegistry,
 ) -> None:
     """Test device setup for old firmware version that dont support required API."""
-    LEGACY_VERSION = "v2.3.1"
+    LEGACY_VERSION = "v0.9.9"
     mock_smlight_client.get_sensors.side_effect = SmlightError
     mock_smlight_client.get_info.return_value = Info(
-        legacy_api=1, sw_version=LEGACY_VERSION, MAC="AA:BB:CC:DD:EE:FF"
+        legacy_api=2, sw_version=LEGACY_VERSION, MAC="AA:BB:CC:DD:EE:FF"
     )
     entry = await setup_integration(hass, mock_config_entry)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Now that we have the update platform in the SMLIGHT integration, we can improve handling of outdated firmware repairs.
There are two types of legacy firmwares that users could be running:
* legacy_api = 2, for users of v0.9.9. We can't upgrade these devices and the user must visit the link in the repair to flash new firmware. (we also make sure not to offer firmware updates in this case)
* legacy_api =1, users on old v2 firmware  will now be offered a firmware update within HA and thus have made it so the user wont get a repair notification


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/34787

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X]  Local tests pass. **Your PR cannot be merged unless tests pass**
- [X]  There is no commented out code in this PR.
- [X]  I have followed the [development checklist][dev-checklist]
- [X]  I have followed the [perfect PR recommendations][perfect-pr]
- [X]  The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X]  Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
