### PR TITLE
Use debug/warning/error instead of info log level in components [n]

### DIFF
--- a/homeassistant/components/nanoleaf/config_flow.py
+++ b/homeassistant/components/nanoleaf/config_flow.py
@@ -215,7 +215,7 @@ class NanoleafConfigFlow(ConfigFlow, domain=DOMAIN):
                 self.discovery_conf.pop(self.nanoleaf.host)
             if self.device_id in self.discovery_conf:
                 self.discovery_conf.pop(self.device_id)
-            _LOGGER.info(
+            _LOGGER.debug(
                 "Successfully imported Nanoleaf %s from the discovery integration",
                 name,
             )

--- a/homeassistant/components/neato/vacuum.py
+++ b/homeassistant/components/neato/vacuum.py
@@ -376,7 +376,9 @@ class NeatoConnectedVacuum(NeatoEntity, StateVacuumEntity):
                     "Zone '%s' was not found for the robot '%s'", zone, self.entity_id
                 )
                 return
-            _LOGGER.info("Start cleaning zone '%s' with robot %s", zone, self.entity_id)
+            _LOGGER.debug(
+                "Start cleaning zone '%s' with robot %s", zone, self.entity_id
+            )
 
         self._attr_state = STATE_CLEANING
         try:

--- a/homeassistant/components/netatmo/__init__.py
+++ b/homeassistant/components/netatmo/__init__.py
@@ -164,7 +164,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         try:
             await hass.data[DOMAIN][entry.entry_id][AUTH].async_addwebhook(webhook_url)
-            _LOGGER.info("Register Netatmo webhook: %s", webhook_url)
+            _LOGGER.debug("Register Netatmo webhook: %s", webhook_url)
         except pyatmo.ApiError as err:
             _LOGGER.error("Error during webhook registration - %s", err)
         else:
@@ -224,7 +224,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             await data[entry.entry_id][AUTH].async_dropwebhook()
         except pyatmo.ApiError:
             _LOGGER.debug("No webhook to be dropped")
-        _LOGGER.info("Unregister Netatmo webhook")
+        _LOGGER.debug("Unregister Netatmo webhook")
 
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 

--- a/homeassistant/components/netatmo/data_handler.py
+++ b/homeassistant/components/netatmo/data_handler.py
@@ -215,11 +215,11 @@ class NetatmoDataHandler:
     async def handle_event(self, event: dict) -> None:
         """Handle webhook events."""
         if event["data"][WEBHOOK_PUSH_TYPE] == WEBHOOK_ACTIVATION:
-            _LOGGER.info("%s webhook successfully registered", MANUFACTURER)
+            _LOGGER.debug("%s webhook successfully registered", MANUFACTURER)
             self._webhook = True
 
         elif event["data"][WEBHOOK_PUSH_TYPE] == WEBHOOK_DEACTIVATION:
-            _LOGGER.info("%s webhook unregistered", MANUFACTURER)
+            _LOGGER.debug("%s webhook unregistered", MANUFACTURER)
             self._webhook = False
 
         elif event["data"][WEBHOOK_PUSH_TYPE] == WEBHOOK_NACAMERA_CONNECTION:

--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -48,7 +48,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if port != router.port or ssl != router.ssl:
         data = {**entry.data, CONF_PORT: router.port, CONF_SSL: router.ssl}
         hass.config_entries.async_update_entry(entry, data=data)
-        _LOGGER.info(
+        _LOGGER.warning(
             (
                 "Netgear port-SSL combination updated from (%i, %r) to (%i, %r), "
                 "this should only occur after a firmware update"

--- a/homeassistant/components/nmap_tracker/__init__.py
+++ b/homeassistant/components/nmap_tracker/__init__.py
@@ -380,7 +380,7 @@ class NmapDeviceScanner:
             )
             if mac is None:
                 self._async_device_offline(ipv4, "No MAC address found", now)
-                _LOGGER.info("No MAC address found for %s", ipv4)
+                _LOGGER.warning("No MAC address found for %s", ipv4)
                 continue
 
             formatted_mac = format_mac(mac)

--- a/homeassistant/components/numato/__init__.py
+++ b/homeassistant/components/numato/__init__.py
@@ -139,11 +139,11 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
     try:
         gpio.discover(config[DOMAIN][CONF_DISCOVER])
     except gpio.NumatoGpioError as err:
-        _LOGGER.info("Error discovering Numato devices: %s", err)
+        _LOGGER.error("Error discovering Numato devices: %s", err)
         gpio.cleanup()
         return False
 
-    _LOGGER.info(
+    _LOGGER.debug(
         "Initializing Numato 32 port USB GPIO expanders with IDs: %s",
         ", ".join(str(d) for d in gpio.devices),
     )

--- a/homeassistant/components/numato/binary_sensor.py
+++ b/homeassistant/components/numato/binary_sensor.py
@@ -71,7 +71,7 @@ def setup_platform(
                 api.edge_detect(device_id, port, partial(read_gpio, device_id))
 
             except NumatoGpioError as err:
-                _LOGGER.info(
+                _LOGGER.error(
                     "Notification setup failed on device %s, "
                     "updates on binary sensor %s only in polling mode: %s",
                     device_id,


### PR DESCRIPTION
## Proposed change
SSIA

Noticed in https://github.com/home-assistant/core/pull/125939

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
