### PR TITLE
Use debug/warning instead of info log level in components [p]

### DIFF
--- a/homeassistant/components/pandora/media_player.py
+++ b/homeassistant/components/pandora/media_player.py
@@ -98,7 +98,7 @@ class PandoraMediaPlayer(MediaPlayerEntity):
         if self.state != MediaPlayerState.OFF:
             return
         self._pianobar = pexpect.spawn("pianobar")
-        _LOGGER.info("Started pianobar subprocess")
+        _LOGGER.debug("Started pianobar subprocess")
         mode = self._pianobar.expect(
             ["Receiving new playlist", "Select station:", "Email:"]
         )
@@ -126,7 +126,7 @@ class PandoraMediaPlayer(MediaPlayerEntity):
     def turn_off(self) -> None:
         """Turn the media player off."""
         if self._pianobar is None:
-            _LOGGER.info("Pianobar subprocess already stopped")
+            _LOGGER.warning("Pianobar subprocess already stopped")
             return
         self._pianobar.send("q")
         try:
@@ -212,7 +212,7 @@ class PandoraMediaPlayer(MediaPlayerEntity):
                 ]
             )
         except pexpect.exceptions.EOF:
-            _LOGGER.info("Pianobar process already exited")
+            _LOGGER.warning("Pianobar process already exited")
             return None
 
         self._log_match()
@@ -289,7 +289,7 @@ class PandoraMediaPlayer(MediaPlayerEntity):
         command = CMD_MAP.get(service_cmd)
         _LOGGER.debug("Sending pinaobar command %s for %s", command, service_cmd)
         if command is None:
-            _LOGGER.info("Command %s not supported yet", service_cmd)
+            _LOGGER.warning("Command %s not supported yet", service_cmd)
         self._clear_buffer()
         self._pianobar.sendline(command)
 

--- a/homeassistant/components/point/__init__.py
+++ b/homeassistant/components/point/__init__.py
@@ -125,7 +125,7 @@ async def async_setup_webhook(hass: HomeAssistant, entry: ConfigEntry, session):
     if CONF_WEBHOOK_ID not in entry.data:
         webhook_id = webhook.async_generate_id()
         webhook_url = webhook.async_generate_url(hass, webhook_id)
-        _LOGGER.info("Registering new webhook at: %s", webhook_url)
+        _LOGGER.debug("Registering new webhook at: %s", webhook_url)
 
         hass.config_entries.async_update_entry(
             entry,

--- a/homeassistant/components/point/config_flow.py
+++ b/homeassistant/components/point/config_flow.py
@@ -162,7 +162,7 @@ class PointFlowHandler(ConfigFlow, domain=DOMAIN):
             _LOGGER.error("Authentication Error")
             return self.async_abort(reason="auth_error")
 
-        _LOGGER.info("Successfully authenticated Point")
+        _LOGGER.debug("Successfully authenticated Point")
         user_email = (await point_session.user()).get("email") or ""
 
         return self.async_create_entry(

--- a/homeassistant/components/ps4/__init__.py
+++ b/homeassistant/components/ps4/__init__.py
@@ -111,7 +111,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     device[CONF_REGION] = country
                 version = 2
                 config_entries.async_update_entry(entry, data=data, version=2)
-                _LOGGER.info(
+                _LOGGER.debug(
                     "PlayStation 4 Config Updated: Region changed to: %s",
                     country,
                 )
@@ -143,7 +143,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 config_entry=entry,
                 device_id=e_entry.device_id,
             )
-            _LOGGER.info(
+            _LOGGER.debug(
                 "PlayStation 4 identifier for entity: %s has changed",
                 entity_id,
             )

--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -118,7 +118,7 @@ class PS4Device(MediaPlayerEntity):
         """Display logger msg if region is deprecated."""
         # Non-Breaking although data returned may be inaccurate.
         if self._region in deprecated_regions:
-            _LOGGER.info(
+            _LOGGER.warning(
                 """Region: %s has been deprecated.
                             Please remove PS4 integration
                             and Re-configure again to utilize
@@ -340,7 +340,7 @@ class PS4Device(MediaPlayerEntity):
         """Set device info for registry."""
         # If cannot get status on startup, assume info from registry.
         if status is None:
-            _LOGGER.info("Assuming status from registry")
+            _LOGGER.debug("Assuming status from registry")
             e_registry = er.async_get(self.hass)
             d_registry = dr.async_get(self.hass)
 

--- a/homeassistant/components/pushbullet/notify.py
+++ b/homeassistant/components/pushbullet/notify.py
@@ -92,7 +92,7 @@ class PushBulletNotificationService(BaseNotificationService):
             # This also seems to work to send to all devices in own account.
             if ttype == "email":
                 self._push_data(message, title, data, self.pushbullet, email=tname)
-                _LOGGER.info("Sent notification to email %s", tname)
+                _LOGGER.debug("Sent notification to email %s", tname)
                 continue
 
             # Target is sms, send directly, don't use a target object.
@@ -100,7 +100,7 @@ class PushBulletNotificationService(BaseNotificationService):
                 self._push_data(
                     message, title, data, self.pushbullet, phonenumber=tname
                 )
-                _LOGGER.info("Sent sms notification to %s", tname)
+                _LOGGER.debug("Sent sms notification to %s", tname)
                 continue
 
             if ttype not in self.pbtargets:


### PR DESCRIPTION
## Proposed change
SSIA

Noticed in https://github.com/home-assistant/core/pull/125939

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
