### PR TITLE
Use BSH keys as unique ID's suffix at Home Connect

### DIFF
--- a/homeassistant/components/home_connect/__init__.py
+++ b/homeassistant/components/home_connect/__init__.py
@@ -4,18 +4,20 @@ from __future__ import annotations
 
 from datetime import timedelta
 import logging
+from typing import Any
 
 from requests import HTTPError
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_DEVICE_ID, CONF_DEVICE, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import (
     config_entry_oauth2_flow,
     config_validation as cv,
     device_registry as dr,
 )
+from homeassistant.helpers.entity_registry import RegistryEntry, async_migrate_entries
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import Throttle
 
@@ -28,6 +30,7 @@ from .const import (
     BSH_PAUSE,
     BSH_RESUME,
     DOMAIN,
+    OLD_NEW_UNIQUE_ID_SUFFIX_MAP,
     SERVICE_OPTION_ACTIVE,
     SERVICE_OPTION_SELECTED,
     SERVICE_PAUSE_PROGRAM,
@@ -268,3 +271,31 @@ async def update_all_devices(hass: HomeAssistant, entry: ConfigEntry) -> None:
             await hass.async_add_executor_job(device.initialize)
     except HTTPError as err:
         _LOGGER.warning("Cannot update devices: %s", err.response.status_code)
+
+
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Migrate old entry."""
+    _LOGGER.debug("Migrating from version %s", config_entry.version)
+
+    if config_entry.version == 1 and config_entry.minor_version == 1:
+
+        @callback
+        def update_unique_id(
+            entity_entry: RegistryEntry,
+        ) -> dict[str, Any] | None:
+            """Update unique ID of entity entry."""
+            for old_id_suffix, new_id_suffix in OLD_NEW_UNIQUE_ID_SUFFIX_MAP.items():
+                if entity_entry.unique_id.endswith(f"-{old_id_suffix}"):
+                    return {
+                        "new_unique_id": entity_entry.unique_id.replace(
+                            old_id_suffix, new_id_suffix
+                        )
+                    }
+            return None
+
+        await async_migrate_entries(hass, config_entry.entry_id, update_unique_id)
+
+        hass.config_entries.async_update_entry(config_entry, minor_version=2)
+
+    _LOGGER.debug("Migration to version %s successful", config_entry.version)
+    return True

--- a/homeassistant/components/home_connect/api.py
+++ b/homeassistant/components/home_connect/api.py
@@ -24,6 +24,7 @@ from homeassistant.helpers.dispatcher import dispatcher_send
 
 from .const import (
     ATTR_AMBIENT,
+    ATTR_BSH_KEY,
     ATTR_DESC,
     ATTR_DEVICE,
     ATTR_KEY,
@@ -32,9 +33,16 @@ from .const import (
     ATTR_UNIT,
     ATTR_VALUE,
     BSH_ACTIVE_PROGRAM,
+    BSH_AMBIENT_LIGHT_ENABLED,
+    BSH_COMMON_OPTION_DURATION,
+    BSH_COMMON_OPTION_PROGRAM_PROGRESS,
     BSH_OPERATION_STATE,
     BSH_POWER_OFF,
     BSH_POWER_STANDBY,
+    BSH_REMAINING_PROGRAM_TIME,
+    BSH_REMOTE_CONTROL_ACTIVATION_STATE,
+    BSH_REMOTE_START_ALLOWANCE_STATE,
+    COOKING_LIGHTING,
     SIGNAL_UPDATE_ENTITIES,
 )
 
@@ -181,21 +189,39 @@ class DeviceWithPrograms(HomeConnectDevice):
         device.
         """
         sensors = {
-            "Remaining Program Time": (None, None, SensorDeviceClass.TIMESTAMP, 1),
-            "Duration": (UnitOfTime.SECONDS, "mdi:update", None, 1),
-            "Program Progress": (PERCENTAGE, "mdi:progress-clock", None, 1),
+            BSH_REMAINING_PROGRAM_TIME: (
+                "Remaining Program Time",
+                None,
+                None,
+                SensorDeviceClass.TIMESTAMP,
+                1,
+            ),
+            BSH_COMMON_OPTION_DURATION: (
+                "Duration",
+                UnitOfTime.SECONDS,
+                "mdi:update",
+                None,
+                1,
+            ),
+            BSH_COMMON_OPTION_PROGRAM_PROGRESS: (
+                "Program Progress",
+                PERCENTAGE,
+                "mdi:progress-clock",
+                None,
+                1,
+            ),
         }
         return [
             {
                 ATTR_DEVICE: self,
-                ATTR_DESC: k,
+                ATTR_BSH_KEY: k,
+                ATTR_DESC: desc,
                 ATTR_UNIT: unit,
-                ATTR_KEY: f"BSH.Common.Option.{k.replace(' ', '')}",
                 ATTR_ICON: icon,
                 ATTR_DEVICE_CLASS: device_class,
                 ATTR_SIGN: sign,
             }
-            for k, (unit, icon, device_class, sign) in sensors.items()
+            for k, (desc, unit, icon, device_class, sign) in sensors.items()
         ]
 
 
@@ -208,9 +234,9 @@ class DeviceWithOpState(HomeConnectDevice):
         return [
             {
                 ATTR_DEVICE: self,
+                ATTR_BSH_KEY: BSH_OPERATION_STATE,
                 ATTR_DESC: "Operation State",
                 ATTR_UNIT: None,
-                ATTR_KEY: BSH_OPERATION_STATE,
                 ATTR_ICON: "mdi:state-machine",
                 ATTR_DEVICE_CLASS: None,
                 ATTR_SIGN: 1,
@@ -225,6 +251,7 @@ class DeviceWithDoor(HomeConnectDevice):
         """Get a dictionary with info about the door binary sensor."""
         return {
             ATTR_DEVICE: self,
+            ATTR_BSH_KEY: "Door",
             ATTR_DESC: "Door",
             ATTR_SENSOR_TYPE: "door",
             ATTR_DEVICE_CLASS: "door",
@@ -236,7 +263,12 @@ class DeviceWithLight(HomeConnectDevice):
 
     def get_light_entity(self) -> dict[str, Any]:
         """Get a dictionary with info about the lighting."""
-        return {ATTR_DEVICE: self, ATTR_DESC: "Light", ATTR_AMBIENT: None}
+        return {
+            ATTR_DEVICE: self,
+            ATTR_BSH_KEY: COOKING_LIGHTING,
+            ATTR_DESC: "Light",
+            ATTR_AMBIENT: None,
+        }
 
 
 class DeviceWithAmbientLight(HomeConnectDevice):
@@ -244,7 +276,12 @@ class DeviceWithAmbientLight(HomeConnectDevice):
 
     def get_ambientlight_entity(self) -> dict[str, Any]:
         """Get a dictionary with info about the ambient lighting."""
-        return {ATTR_DEVICE: self, ATTR_DESC: "AmbientLight", ATTR_AMBIENT: True}
+        return {
+            ATTR_DEVICE: self,
+            ATTR_BSH_KEY: BSH_AMBIENT_LIGHT_ENABLED,
+            ATTR_DESC: "AmbientLight",
+            ATTR_AMBIENT: True,
+        }
 
 
 class DeviceWithRemoteControl(HomeConnectDevice):
@@ -254,6 +291,7 @@ class DeviceWithRemoteControl(HomeConnectDevice):
         """Get a dictionary with info about the remote control sensor."""
         return {
             ATTR_DEVICE: self,
+            ATTR_BSH_KEY: BSH_REMOTE_CONTROL_ACTIVATION_STATE,
             ATTR_DESC: "Remote Control",
             ATTR_SENSOR_TYPE: "remote_control",
         }
@@ -266,6 +304,7 @@ class DeviceWithRemoteStart(HomeConnectDevice):
         """Get a dictionary with info about the remote start sensor."""
         return {
             ATTR_DEVICE: self,
+            ATTR_BSH_KEY: BSH_REMOTE_START_ALLOWANCE_STATE,
             ATTR_DESC: "Remote Start",
             ATTR_SENSOR_TYPE: "remote_start",
         }

--- a/homeassistant/components/home_connect/config_flow.py
+++ b/homeassistant/components/home_connect/config_flow.py
@@ -14,6 +14,8 @@ class OAuth2FlowHandler(
 
     DOMAIN = DOMAIN
 
+    MINOR_VERSION = 2
+
     @property
     def logger(self) -> logging.Logger:
         """Return logger."""

--- a/homeassistant/components/home_connect/const.py
+++ b/homeassistant/components/home_connect/const.py
@@ -14,6 +14,10 @@ BSH_REMOTE_CONTROL_ACTIVATION_STATE = "BSH.Common.Status.RemoteControlActive"
 BSH_REMOTE_START_ALLOWANCE_STATE = "BSH.Common.Status.RemoteControlStartAllowed"
 BSH_CHILD_LOCK_STATE = "BSH.Common.Setting.ChildLock"
 
+BSH_REMAINING_PROGRAM_TIME = "BSH.Common.Option.RemainingProgramTime"
+BSH_COMMON_OPTION_DURATION = "BSH.Common.Option.Duration"
+BSH_COMMON_OPTION_PROGRAM_PROGRESS = "BSH.Common.Option.ProgramProgress"
+
 BSH_EVENT_PRESENT_STATE_PRESENT = "BSH.Common.EnumType.EventPresentState.Present"
 BSH_EVENT_PRESENT_STATE_CONFIRMED = "BSH.Common.EnumType.EventPresentState.Confirmed"
 BSH_EVENT_PRESENT_STATE_OFF = "BSH.Common.EnumType.EventPresentState.Off"
@@ -92,6 +96,7 @@ SERVICE_SETTING = "change_setting"
 SERVICE_START_PROGRAM = "start_program"
 
 ATTR_AMBIENT = "ambient"
+ATTR_BSH_KEY = "bsh_key"
 ATTR_DESC = "desc"
 ATTR_DEVICE = "device"
 ATTR_KEY = "key"
@@ -100,3 +105,30 @@ ATTR_SENSOR_TYPE = "sensor_type"
 ATTR_SIGN = "sign"
 ATTR_UNIT = "unit"
 ATTR_VALUE = "value"
+
+OLD_NEW_UNIQUE_ID_SUFFIX_MAP = {
+    "ChildLock": BSH_CHILD_LOCK_STATE,
+    "Operation State": BSH_OPERATION_STATE,
+    "Light": COOKING_LIGHTING,
+    "AmbientLight": BSH_AMBIENT_LIGHT_ENABLED,
+    "Power": BSH_POWER_STATE,
+    "Remaining Program Time": BSH_REMAINING_PROGRAM_TIME,
+    "Duration": BSH_COMMON_OPTION_DURATION,
+    "Program Progress": BSH_COMMON_OPTION_PROGRAM_PROGRESS,
+    "Remote Control": BSH_REMOTE_CONTROL_ACTIVATION_STATE,
+    "Remote Start": BSH_REMOTE_START_ALLOWANCE_STATE,
+    "Supermode Freezer": REFRIGERATION_SUPERMODEFREEZER,
+    "Supermode Refrigerator": REFRIGERATION_SUPERMODEREFRIGERATOR,
+    "Dispenser Enabled": REFRIGERATION_DISPENSER,
+    "Internal Light": REFRIGERATION_INTERNAL_LIGHT_POWER,
+    "External Light": REFRIGERATION_EXTERNAL_LIGHT_POWER,
+    "Chiller Door": REFRIGERATION_STATUS_DOOR_CHILLER,
+    "Freezer Door": REFRIGERATION_STATUS_DOOR_FREEZER,
+    "Refrigerator Door": REFRIGERATION_STATUS_DOOR_REFRIGERATOR,
+    "Door Alarm Freezer": REFRIGERATION_EVENT_DOOR_ALARM_FREEZER,
+    "Door Alarm Refrigerator": REFRIGERATION_EVENT_DOOR_ALARM_REFRIGERATOR,
+    "Temperature Alarm Freezer": REFRIGERATION_EVENT_TEMP_ALARM_FREEZER,
+    "Bean Container Empty": COFFEE_EVENT_BEAN_CONTAINER_EMPTY,
+    "Water Tank Empty": COFFEE_EVENT_WATER_TANK_EMPTY,
+    "Drip Tray Full": COFFEE_EVENT_DRIP_TRAY_FULL,
+}

--- a/homeassistant/components/home_connect/entity.py
+++ b/homeassistant/components/home_connect/entity.py
@@ -18,11 +18,12 @@ class HomeConnectEntity(Entity):
 
     _attr_should_poll = False
 
-    def __init__(self, device: HomeConnectDevice, desc: str) -> None:
+    def __init__(self, device: HomeConnectDevice, bsh_key: str, desc: str) -> None:
         """Initialize the entity."""
         self.device = device
+        self.bsh_key = bsh_key
         self._attr_name = f"{device.appliance.name} {desc}"
-        self._attr_unique_id = f"{device.appliance.haId}-{desc}"
+        self._attr_unique_id = f"{device.appliance.haId}-{bsh_key}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, device.appliance.haId)},
             manufacturer=device.appliance.brand,

--- a/tests/components/home_connect/conftest.py
+++ b/tests/components/home_connect/conftest.py
@@ -67,6 +67,20 @@ def mock_config_entry(token_entry: dict[str, Any]) -> MockConfigEntry:
             "auth_implementation": FAKE_AUTH_IMPL,
             "token": token_entry,
         },
+        minor_version=2,
+    )
+
+
+@pytest.fixture(name="config_entry_v1_1")
+def mock_config_entry_v1_1(token_entry: dict[str, Any]) -> MockConfigEntry:
+    """Fixture for a config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "auth_implementation": FAKE_AUTH_IMPL,
+            "token": token_entry,
+        },
+        minor_version=1,
     )
 
 

--- a/tests/components/home_connect/test_init.py
+++ b/tests/components/home_connect/test_init.py
@@ -371,3 +371,4 @@ async def test_entity_migration(
         assert entity_registry.async_get_entity_id(
             domain, DOMAIN, f"{appliance.haId}-{expected_unique_id_suffix}"
         )
+    assert config_entry_v1_1.minor_version == 2

--- a/tests/components/home_connect/test_init.py
+++ b/tests/components/home_connect/test_init.py
@@ -2,18 +2,31 @@
 
 from collections.abc import Awaitable, Callable
 from typing import Any
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from requests import HTTPError
 import requests_mock
 
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.home_connect import SCAN_INTERVAL
-from homeassistant.components.home_connect.const import DOMAIN, OAUTH2_TOKEN
+from homeassistant.components.home_connect.const import (
+    BSH_CHILD_LOCK_STATE,
+    BSH_OPERATION_STATE,
+    BSH_POWER_STATE,
+    BSH_REMOTE_START_ALLOWANCE_STATE,
+    COOKING_LIGHTING,
+    DOMAIN,
+    OAUTH2_TOKEN,
+)
+from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .conftest import (
     CLIENT_ID,
@@ -294,3 +307,67 @@ async def test_services_exception(
 
     with pytest.raises(ValueError):
         await hass.services.async_call(**service_call)
+
+
+async def test_entity_migration(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    config_entry_v1_1: MockConfigEntry,
+    appliance: Mock,
+    platforms: list[Platform],
+) -> None:
+    """Test entity migration."""
+
+    config_entry_v1_1.add_to_hass(hass)
+
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry_v1_1.entry_id,
+        identifiers={(DOMAIN, appliance.haId)},
+    )
+
+    test_entities = [
+        (
+            SENSOR_DOMAIN,
+            "Operation State",
+            BSH_OPERATION_STATE,
+        ),
+        (
+            SWITCH_DOMAIN,
+            "ChildLock",
+            BSH_CHILD_LOCK_STATE,
+        ),
+        (
+            SWITCH_DOMAIN,
+            "Power",
+            BSH_POWER_STATE,
+        ),
+        (
+            BINARY_SENSOR_DOMAIN,
+            "Remote Start",
+            BSH_REMOTE_START_ALLOWANCE_STATE,
+        ),
+        (
+            LIGHT_DOMAIN,
+            "Light",
+            COOKING_LIGHTING,
+        ),
+    ]
+
+    for domain, old_unique_id_suffix, _ in test_entities:
+        entity_registry.async_get_or_create(
+            domain,
+            DOMAIN,
+            f"{appliance.haId}-{old_unique_id_suffix}",
+            device_id=device_entry.id,
+            config_entry=config_entry_v1_1,
+        )
+
+    with patch("homeassistant.components.home_connect.PLATFORMS", platforms):
+        await hass.config_entries.async_setup(config_entry_v1_1.entry_id)
+        await hass.async_block_till_done()
+
+    for domain, _, expected_unique_id_suffix in test_entities:
+        assert entity_registry.async_get_entity_id(
+            domain, DOMAIN, f"{appliance.haId}-{expected_unique_id_suffix}"
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The breaking change is the change at the unique IDs, although migration has been done, I prefer to mark it as breaking change just in case

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In this change, BSH keys are used as unique ID's suffix instead of using a simple description.
This keys are used additionally to provide the translation key (which is transformed to snake case and dots are replaced by "-")
Entities will be migrated from the old unique id to the new ones, except for the ones that are becoming deprecated (see #126157 & #126158) and the ones that haven't been released yet.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
