### PR TITLE
Move shared rflink constants to separate module

### DIFF
--- a/homeassistant/components/rflink/__init__.py
+++ b/homeassistant/components/rflink/__init__.py
@@ -32,38 +32,32 @@ from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType
 
-from .utils import brightness_to_rflink
+from .const import (
+    DATA_DEVICE_REGISTER,
+    DATA_ENTITY_LOOKUP,
+    DEFAULT_SIGNAL_REPETITIONS,
+    EVENT_KEY_COMMAND,
+    EVENT_KEY_ID,
+    EVENT_KEY_SENSOR,
+    SIGNAL_AVAILABILITY,
+    SIGNAL_HANDLE_EVENT,
+    TMP_ENTITY,
+)
+from .utils import brightness_to_rflink, identify_event_type
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_EVENT = "event"
-
-CONF_ALIASES = "aliases"
-CONF_GROUP_ALIASES = "group_aliases"
-CONF_GROUP = "group"
-CONF_NOGROUP_ALIASES = "nogroup_aliases"
-CONF_DEVICE_DEFAULTS = "device_defaults"
-CONF_AUTOMATIC_ADD = "automatic_add"
-CONF_FIRE_EVENT = "fire_event"
 CONF_IGNORE_DEVICES = "ignore_devices"
 CONF_RECONNECT_INTERVAL = "reconnect_interval"
-CONF_SIGNAL_REPETITIONS = "signal_repetitions"
 CONF_WAIT_FOR_ACK = "wait_for_ack"
 CONF_KEEPALIVE_IDLE = "tcp_keepalive_idle_timer"
 
-DATA_DEVICE_REGISTER = "rflink_device_register"
-DATA_ENTITY_LOOKUP = "rflink_entity_lookup"
 DATA_ENTITY_GROUP_LOOKUP = "rflink_entity_group_only_lookup"
 DEFAULT_RECONNECT_INTERVAL = 10
-DEFAULT_SIGNAL_REPETITIONS = 1
 DEFAULT_TCP_KEEPALIVE_IDLE_TIMER = 3600
 CONNECTION_TIMEOUT = 10
 
 EVENT_BUTTON_PRESSED = "button_pressed"
-EVENT_KEY_COMMAND = "command"
-EVENT_KEY_ID = "id"
-EVENT_KEY_SENSOR = "sensor"
-EVENT_KEY_UNIT = "unit"
 
 RFLINK_GROUP_COMMANDS = ["allon", "alloff"]
 
@@ -71,20 +65,8 @@ DOMAIN = "rflink"
 
 SERVICE_SEND_COMMAND = "send_command"
 
-SIGNAL_AVAILABILITY = "rflink_device_available"
-SIGNAL_HANDLE_EVENT = "rflink_handle_event_{}"
 SIGNAL_EVENT = "rflink_event"
 
-TMP_ENTITY = "tmp.{}"
-
-DEVICE_DEFAULTS_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean,
-        vol.Optional(
-            CONF_SIGNAL_REPETITIONS, default=DEFAULT_SIGNAL_REPETITIONS
-        ): vol.Coerce(int),
-    }
-)
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -111,18 +93,6 @@ CONFIG_SCHEMA = vol.Schema(
 SEND_COMMAND_SCHEMA = vol.Schema(
     {vol.Required(CONF_DEVICE_ID): cv.string, vol.Required(CONF_COMMAND): cv.string}
 )
-
-
-def identify_event_type(event):
-    """Look at event to determine type of device.
-
-    Async friendly.
-    """
-    if EVENT_KEY_COMMAND in event:
-        return EVENT_KEY_COMMAND
-    if EVENT_KEY_SENSOR in event:
-        return EVENT_KEY_SENSOR
-    return "unknown"
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/homeassistant/components/rflink/binary_sensor.py
+++ b/homeassistant/components/rflink/binary_sensor.py
@@ -26,7 +26,8 @@ import homeassistant.helpers.event as evt
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import CONF_ALIASES, RflinkDevice
+from . import RflinkDevice
+from .const import CONF_ALIASES
 
 CONF_OFF_DELAY = "off_delay"
 DEFAULT_FORCE_UPDATE = False

--- a/homeassistant/components/rflink/const.py
+++ b/homeassistant/components/rflink/const.py
@@ -1,0 +1,39 @@
+"""Support for Rflink devices."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+
+CONF_ALIASES = "aliases"
+CONF_GROUP_ALIASES = "group_aliases"
+CONF_GROUP = "group"
+CONF_NOGROUP_ALIASES = "nogroup_aliases"
+CONF_DEVICE_DEFAULTS = "device_defaults"
+CONF_AUTOMATIC_ADD = "automatic_add"
+CONF_FIRE_EVENT = "fire_event"
+CONF_SIGNAL_REPETITIONS = "signal_repetitions"
+
+DATA_DEVICE_REGISTER = "rflink_device_register"
+DATA_ENTITY_LOOKUP = "rflink_entity_lookup"
+DEFAULT_SIGNAL_REPETITIONS = 1
+
+EVENT_KEY_COMMAND = "command"
+EVENT_KEY_ID = "id"
+EVENT_KEY_SENSOR = "sensor"
+EVENT_KEY_UNIT = "unit"
+
+SIGNAL_AVAILABILITY = "rflink_device_available"
+SIGNAL_HANDLE_EVENT = "rflink_handle_event_{}"
+
+TMP_ENTITY = "tmp.{}"
+
+DEVICE_DEFAULTS_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean,
+        vol.Optional(
+            CONF_SIGNAL_REPETITIONS, default=DEFAULT_SIGNAL_REPETITIONS
+        ): vol.Coerce(int),
+    }
+)

--- a/homeassistant/components/rflink/cover.py
+++ b/homeassistant/components/rflink/cover.py
@@ -18,7 +18,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import (
+from . import RflinkCommand
+from .const import (
     CONF_ALIASES,
     CONF_DEVICE_DEFAULTS,
     CONF_FIRE_EVENT,
@@ -27,7 +28,6 @@ from . import (
     CONF_NOGROUP_ALIASES,
     CONF_SIGNAL_REPETITIONS,
     DEVICE_DEFAULTS_SCHEMA,
-    RflinkCommand,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/rflink/light.py
+++ b/homeassistant/components/rflink/light.py
@@ -20,7 +20,8 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import (
+from . import SwitchableRflinkDevice
+from .const import (
     CONF_ALIASES,
     CONF_AUTOMATIC_ADD,
     CONF_DEVICE_DEFAULTS,
@@ -33,7 +34,6 @@ from . import (
     DEVICE_DEFAULTS_SCHEMA,
     EVENT_KEY_COMMAND,
     EVENT_KEY_ID,
-    SwitchableRflinkDevice,
 )
 from .utils import brightness_to_rflink, rflink_to_brightness
 

--- a/homeassistant/components/rflink/sensor.py
+++ b/homeassistant/components/rflink/sensor.py
@@ -40,7 +40,8 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import (
+from . import RflinkDevice
+from .const import (
     CONF_ALIASES,
     CONF_AUTOMATIC_ADD,
     DATA_DEVICE_REGISTER,
@@ -51,7 +52,6 @@ from . import (
     SIGNAL_AVAILABILITY,
     SIGNAL_HANDLE_EVENT,
     TMP_ENTITY,
-    RflinkDevice,
 )
 
 SENSOR_TYPES = (

--- a/homeassistant/components/rflink/switch.py
+++ b/homeassistant/components/rflink/switch.py
@@ -14,7 +14,8 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import (
+from . import SwitchableRflinkDevice
+from .const import (
     CONF_ALIASES,
     CONF_DEVICE_DEFAULTS,
     CONF_FIRE_EVENT,
@@ -23,7 +24,6 @@ from . import (
     CONF_NOGROUP_ALIASES,
     CONF_SIGNAL_REPETITIONS,
     DEVICE_DEFAULTS_SCHEMA,
-    SwitchableRflinkDevice,
 )
 
 PARALLEL_UPDATES = 0

--- a/homeassistant/components/rflink/utils.py
+++ b/homeassistant/components/rflink/utils.py
@@ -1,5 +1,7 @@
 """RFLink integration utils."""
 
+from .const import EVENT_KEY_COMMAND, EVENT_KEY_SENSOR
+
 
 def brightness_to_rflink(brightness: int) -> int:
     """Convert 0-255 brightness to RFLink dim level (0-15)."""
@@ -9,3 +11,15 @@ def brightness_to_rflink(brightness: int) -> int:
 def rflink_to_brightness(dim_level: int) -> int:
     """Convert RFLink dim level (0-15) to 0-255 brightness."""
     return int(dim_level * 17)
+
+
+def identify_event_type(event):
+    """Look at event to determine type of device.
+
+    Async friendly.
+    """
+    if EVENT_KEY_COMMAND in event:
+        return EVENT_KEY_COMMAND
+    if EVENT_KEY_SENSOR in event:
+        return EVENT_KEY_SENSOR
+    return "unknown"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, preliminary step before moving the base entities to `entity.py`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
