### PR TITLE
Move raincloud shared constants to separate module

### DIFF
--- a/homeassistant/components/raincloud/__init__.py
+++ b/homeassistant/components/raincloud/__init__.py
@@ -8,13 +8,7 @@ from requests.exceptions import ConnectTimeout, HTTPError
 import voluptuous as vol
 
 from homeassistant.components import persistent_notification
-from homeassistant.const import (
-    CONF_PASSWORD,
-    CONF_SCAN_INTERVAL,
-    CONF_USERNAME,
-    PERCENTAGE,
-    UnitOfTime,
-)
+from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect, dispatcher_send
@@ -22,18 +16,14 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import track_time_interval
 from homeassistant.helpers.typing import ConfigType
 
+from .const import DATA_RAINCLOUD, SIGNAL_UPDATE_RAINCLOUD
+
 _LOGGER = logging.getLogger(__name__)
-
-ALLOWED_WATERING_TIME = [5, 10, 15, 30, 45, 60]
-
-CONF_WATERING_TIME = "watering_minutes"
 
 NOTIFICATION_ID = "raincloud_notification"
 NOTIFICATION_TITLE = "Rain Cloud Setup"
 
-DATA_RAINCLOUD = "raincloud"
 DOMAIN = "raincloud"
-DEFAULT_WATERING_TIME = 15
 
 KEY_MAP = {
     "auto_watering": "Automatic Watering",
@@ -57,26 +47,8 @@ ICON_MAP = {
     "watering_time": "mdi:water-pump",
 }
 
-UNIT_OF_MEASUREMENT_MAP = {
-    "auto_watering": "",
-    "battery": PERCENTAGE,
-    "is_watering": "",
-    "manual_watering": "",
-    "next_cycle": "",
-    "rain_delay": UnitOfTime.DAYS,
-    "status": "",
-    "watering_time": UnitOfTime.MINUTES,
-}
-
-BINARY_SENSORS = ["is_watering", "status"]
-
-SENSORS = ["battery", "next_cycle", "rain_delay", "watering_time"]
-
-SWITCHES = ["auto_watering", "manual_watering"]
 
 SCAN_INTERVAL = timedelta(seconds=20)
-
-SIGNAL_UPDATE_RAINCLOUD = "raincloud_update"
 
 CONFIG_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/raincloud/binary_sensor.py
+++ b/homeassistant/components/raincloud/binary_sensor.py
@@ -16,9 +16,12 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import BINARY_SENSORS, DATA_RAINCLOUD, ICON_MAP, RainCloudEntity
+from . import RainCloudEntity
+from .const import DATA_RAINCLOUD, ICON_MAP
 
 _LOGGER = logging.getLogger(__name__)
+
+BINARY_SENSORS = ["is_watering", "status"]
 
 PLATFORM_SCHEMA = BINARY_SENSOR_PLATFORM_SCHEMA.extend(
     {

--- a/homeassistant/components/raincloud/const.py
+++ b/homeassistant/components/raincloud/const.py
@@ -1,0 +1,17 @@
+"""Support for Melnor RainCloud sprinkler water timer."""
+
+DATA_RAINCLOUD = "raincloud"
+
+ICON_MAP = {
+    "auto_watering": "mdi:autorenew",
+    "battery": "",
+    "is_watering": "",
+    "manual_watering": "mdi:water-pump",
+    "next_cycle": "mdi:calendar-clock",
+    "rain_delay": "mdi:weather-rainy",
+    "status": "",
+    "watering_time": "mdi:water-pump",
+}
+
+
+SIGNAL_UPDATE_RAINCLOUD = "raincloud_update"

--- a/homeassistant/components/raincloud/sensor.py
+++ b/homeassistant/components/raincloud/sensor.py
@@ -10,22 +10,19 @@ from homeassistant.components.sensor import (
     PLATFORM_SCHEMA as SENSOR_PLATFORM_SCHEMA,
     SensorEntity,
 )
-from homeassistant.const import CONF_MONITORED_CONDITIONS
+from homeassistant.const import CONF_MONITORED_CONDITIONS, PERCENTAGE, UnitOfTime
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.icon import icon_for_battery_level
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import (
-    DATA_RAINCLOUD,
-    ICON_MAP,
-    SENSORS,
-    UNIT_OF_MEASUREMENT_MAP,
-    RainCloudEntity,
-)
+from . import RainCloudEntity
+from .const import DATA_RAINCLOUD, ICON_MAP
 
 _LOGGER = logging.getLogger(__name__)
+
+SENSORS = ["battery", "next_cycle", "rain_delay", "watering_time"]
 
 PLATFORM_SCHEMA = SENSOR_PLATFORM_SCHEMA.extend(
     {
@@ -34,6 +31,17 @@ PLATFORM_SCHEMA = SENSOR_PLATFORM_SCHEMA.extend(
         )
     }
 )
+
+UNIT_OF_MEASUREMENT_MAP = {
+    "auto_watering": "",
+    "battery": PERCENTAGE,
+    "is_watering": "",
+    "manual_watering": "",
+    "next_cycle": "",
+    "rain_delay": UnitOfTime.DAYS,
+    "status": "",
+    "watering_time": UnitOfTime.MINUTES,
+}
 
 
 def setup_platform(

--- a/homeassistant/components/raincloud/switch.py
+++ b/homeassistant/components/raincloud/switch.py
@@ -17,16 +17,16 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import (
-    ALLOWED_WATERING_TIME,
-    CONF_WATERING_TIME,
-    DATA_RAINCLOUD,
-    DEFAULT_WATERING_TIME,
-    SWITCHES,
-    RainCloudEntity,
-)
+from . import RainCloudEntity
+from .const import DATA_RAINCLOUD
 
 _LOGGER = logging.getLogger(__name__)
+
+ALLOWED_WATERING_TIME = [5, 10, 15, 30, 45, 60]
+CONF_WATERING_TIME = "watering_minutes"
+DEFAULT_WATERING_TIME = 15
+
+SWITCHES = ["auto_watering", "manual_watering"]
 
 PLATFORM_SCHEMA = SWITCH_PLATFORM_SCHEMA.extend(
     {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, preliminary step before moving the base entity

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
