### PR TITLE
Move tellstick shared constants to separate module

### DIFF
--- a/homeassistant/components/tellstick/__init__.py
+++ b/homeassistant/components/tellstick/__init__.py
@@ -25,16 +25,19 @@ from homeassistant.helpers.dispatcher import (
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import ConfigType
 
+from .const import (
+    ATTR_DISCOVER_CONFIG,
+    ATTR_DISCOVER_DEVICES,
+    DATA_TELLSTICK,
+    DEFAULT_SIGNAL_REPETITIONS,
+)
+
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_DISCOVER_CONFIG = "config"
-ATTR_DISCOVER_DEVICES = "devices"
 CONF_SIGNAL_REPETITIONS = "signal_repetitions"
 
-DEFAULT_SIGNAL_REPETITIONS = 1
 DOMAIN = "tellstick"
 
-DATA_TELLSTICK = "tellstick_device"
 SIGNAL_TELLCORE_CALLBACK = "tellstick_callback"
 
 # Use a global tellstick domain lock to avoid getting Tellcore errors when

--- a/homeassistant/components/tellstick/const.py
+++ b/homeassistant/components/tellstick/const.py
@@ -1,0 +1,8 @@
+"""Support for Tellstick."""
+
+ATTR_DISCOVER_CONFIG = "config"
+ATTR_DISCOVER_DEVICES = "devices"
+
+DATA_TELLSTICK = "tellstick_device"
+
+DEFAULT_SIGNAL_REPETITIONS = 1

--- a/homeassistant/components/tellstick/cover.py
+++ b/homeassistant/components/tellstick/cover.py
@@ -9,12 +9,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import (
+from . import TellstickDevice
+from .const import (
     ATTR_DISCOVER_CONFIG,
     ATTR_DISCOVER_DEVICES,
     DATA_TELLSTICK,
     DEFAULT_SIGNAL_REPETITIONS,
-    TellstickDevice,
 )
 
 

--- a/homeassistant/components/tellstick/light.py
+++ b/homeassistant/components/tellstick/light.py
@@ -7,12 +7,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import (
+from . import TellstickDevice
+from .const import (
     ATTR_DISCOVER_CONFIG,
     ATTR_DISCOVER_DEVICES,
     DATA_TELLSTICK,
     DEFAULT_SIGNAL_REPETITIONS,
-    TellstickDevice,
 )
 
 

--- a/homeassistant/components/tellstick/switch.py
+++ b/homeassistant/components/tellstick/switch.py
@@ -7,12 +7,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import (
+from . import TellstickDevice
+from .const import (
     ATTR_DISCOVER_CONFIG,
     ATTR_DISCOVER_DEVICES,
     DATA_TELLSTICK,
     DEFAULT_SIGNAL_REPETITIONS,
-    TellstickDevice,
 )
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, preliminary step before moving the base entity

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
