### PR TITLE
Move wirelesstag shared constants to separate module

### DIFF
--- a/homeassistant/components/wirelesstag/binary_sensor.py
+++ b/homeassistant/components/wirelesstag/binary_sensor.py
@@ -15,12 +15,9 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import (
-    DOMAIN as WIRELESSTAG_DOMAIN,
-    SIGNAL_BINARY_EVENT_UPDATE,
-    WirelessTagBaseSensor,
-    async_migrate_unique_id,
-)
+from . import WirelessTagBaseSensor
+from .const import DOMAIN, SIGNAL_BINARY_EVENT_UPDATE
+from .util import async_migrate_unique_id
 
 # On means in range, Off means out of range
 SENSOR_PRESENCE = "presence"
@@ -84,7 +81,7 @@ async def async_setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the platform for a WirelessTags."""
-    platform = hass.data[WIRELESSTAG_DOMAIN]
+    platform = hass.data[DOMAIN]
 
     sensors = []
     tags = platform.tags

--- a/homeassistant/components/wirelesstag/const.py
+++ b/homeassistant/components/wirelesstag/const.py
@@ -1,0 +1,11 @@
+"""Support for Wireless Sensor Tags."""
+
+DOMAIN = "wirelesstag"
+
+# Template for signal - first parameter is tag_id,
+# second, tag manager mac address
+SIGNAL_TAG_UPDATE = "wirelesstag.tag_info_updated_{}_{}"
+
+# Template for signal - tag_id, sensor type and
+# tag manager mac address
+SIGNAL_BINARY_EVENT_UPDATE = "wirelesstag.binary_event_updated_{}_{}_{}"

--- a/homeassistant/components/wirelesstag/sensor.py
+++ b/homeassistant/components/wirelesstag/sensor.py
@@ -20,12 +20,9 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import (
-    DOMAIN as WIRELESSTAG_DOMAIN,
-    SIGNAL_TAG_UPDATE,
-    WirelessTagBaseSensor,
-    async_migrate_unique_id,
-)
+from . import WirelessTagBaseSensor
+from .const import DOMAIN, SIGNAL_TAG_UPDATE
+from .util import async_migrate_unique_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -81,7 +78,7 @@ async def async_setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the sensor platform."""
-    platform = hass.data[WIRELESSTAG_DOMAIN]
+    platform = hass.data[DOMAIN]
     sensors = []
     tags = platform.tags
     for tag in tags.values():
@@ -113,9 +110,7 @@ class WirelessTagSensor(WirelessTagBaseSensor, SensorEntity):
         # sensor.wirelesstag_bedroom_temperature
         # and not as sensor.bedroom for temperature and
         # sensor.bedroom_2 for humidity
-        self.entity_id = (
-            f"sensor.{WIRELESSTAG_DOMAIN}_{self.underscored_name}_{self._sensor_type}"
-        )
+        self.entity_id = f"sensor.{DOMAIN}_{self.underscored_name}_{self._sensor_type}"
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""

--- a/homeassistant/components/wirelesstag/switch.py
+++ b/homeassistant/components/wirelesstag/switch.py
@@ -17,11 +17,9 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import (
-    DOMAIN as WIRELESSTAG_DOMAIN,
-    WirelessTagBaseSensor,
-    async_migrate_unique_id,
-)
+from . import WirelessTagBaseSensor
+from .const import DOMAIN
+from .util import async_migrate_unique_id
 
 SWITCH_TYPES: tuple[SwitchEntityDescription, ...] = (
     SwitchEntityDescription(
@@ -64,7 +62,7 @@ async def async_setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up switches for a Wireless Sensor Tags."""
-    platform = hass.data[WIRELESSTAG_DOMAIN]
+    platform = hass.data[DOMAIN]
 
     tags = platform.load_tags()
     monitored_conditions = config[CONF_MONITORED_CONDITIONS]

--- a/homeassistant/components/wirelesstag/util.py
+++ b/homeassistant/components/wirelesstag/util.py
@@ -1,0 +1,28 @@
+"""Support for Wireless Sensor Tags."""
+
+import logging
+
+from wirelesstagpy.sensortag import SensorTag
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def async_migrate_unique_id(
+    hass: HomeAssistant, tag: SensorTag, domain: str, key: str
+) -> None:
+    """Migrate old unique id to new one with use of tag's uuid."""
+    registry = er.async_get(hass)
+    new_unique_id = f"{tag.uuid}_{key}"
+
+    if registry.async_get_entity_id(domain, DOMAIN, new_unique_id):
+        return
+
+    old_unique_id = f"{tag.tag_id}_{key}"
+    if entity_id := registry.async_get_entity_id(domain, DOMAIN, old_unique_id):
+        _LOGGER.debug("Updating unique id for %s %s", key, entity_id)
+        registry.async_update_entity(entity_id, new_unique_id=new_unique_id)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, preliminary step before moving the base entity

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
