### PR TITLE
Add VPN sensor and switch for Smlight integration

### DIFF
--- a/homeassistant/components/smlight/binary_sensor.py
+++ b/homeassistant/components/smlight/binary_sensor.py
@@ -40,6 +40,12 @@ SENSORS = [
         value_fn=lambda x: x.ethernet,
     ),
     SmBinarySensorEntityDescription(
+        key="vpn",
+        translation_key="vpn",
+        entity_registry_enabled_default=False,
+        value_fn=lambda x: x.vpn_status,
+    ),
+    SmBinarySensorEntityDescription(
         key="wifi",
         translation_key="wifi",
         entity_registry_enabled_default=False,

--- a/homeassistant/components/smlight/strings.json
+++ b/homeassistant/components/smlight/strings.json
@@ -49,6 +49,9 @@
       "internet": {
         "name": "Internet"
       },
+      "vpn": {
+        "name": "VPN"
+      },
       "wifi": {
         "name": "Wi-Fi"
       }

--- a/homeassistant/components/smlight/strings.json
+++ b/homeassistant/components/smlight/strings.json
@@ -119,6 +119,9 @@
       },
       "night_mode": {
         "name": "LED night mode"
+      },
+      "vpn_enabled": {
+        "name": "VPN enabled"
       }
     },
     "update": {

--- a/homeassistant/components/smlight/switch.py
+++ b/homeassistant/components/smlight/switch.py
@@ -54,6 +54,13 @@ SWITCHES: list[SmSwitchEntityDescription] = [
         setting=Settings.ZB_AUTOUPDATE,
         state_fn=lambda x: x.auto_zigbee,
     ),
+    SmSwitchEntityDescription(
+        key="vpn_enabled",
+        translation_key="vpn_enabled",
+        setting=Settings.ENABLE_VPN,
+        entity_registry_enabled_default=False,
+        state_fn=lambda x: x.vpn_enabled,
+    ),
 ]
 
 

--- a/tests/components/smlight/fixtures/info.json
+++ b/tests/components/smlight/fixtures/info.json
@@ -11,6 +11,7 @@
   "sw_version": "v2.3.6",
   "wifi_mode": 0,
   "zb_flash_size": 704,
+  "zb_channel": 0,
   "zb_hw": "CC2652P7",
   "zb_ram_size": 152,
   "zb_version": "20240314",

--- a/tests/components/smlight/fixtures/sensors.json
+++ b/tests/components/smlight/fixtures/sensors.json
@@ -10,5 +10,7 @@
   "wifi_status": 255,
   "disable_leds": false,
   "night_mode": true,
-  "auto_zigbee": false
+  "auto_zigbee": false,
+  "vpn_enabled": false,
+  "vpn_status": true
 }

--- a/tests/components/smlight/snapshots/test_binary_sensor.ambr
+++ b/tests/components/smlight/snapshots/test_binary_sensor.ambr
@@ -93,6 +93,53 @@
     'state': 'unknown',
   })
 # ---
+# name: test_all_binary_sensors[binary_sensor.mock_title_vpn-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.mock_title_vpn',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': 'VPN',
+    'platform': 'smlight',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'vpn',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_vpn',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.mock_title_vpn-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'connectivity',
+      'friendly_name': 'Mock Title VPN',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.mock_title_vpn',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_all_binary_sensors[binary_sensor.mock_title_wi_fi-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/smlight/snapshots/test_switch.ambr
+++ b/tests/components/smlight/snapshots/test_switch.ambr
@@ -140,3 +140,50 @@
     'state': 'on',
   })
 # ---
+# name: test_switch_setup[switch.mock_title_vpn_enabled-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.mock_title_vpn_enabled',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SwitchDeviceClass.SWITCH: 'switch'>,
+    'original_icon': None,
+    'original_name': 'VPN enabled',
+    'platform': 'smlight',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'vpn_enabled',
+    'unique_id': 'aa:bb:cc:dd:ee:ff-vpn_enabled',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_setup[switch.mock_title_vpn_enabled-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'switch',
+      'friendly_name': 'Mock Title VPN enabled',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.mock_title_vpn_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/smlight/test_binary_sensor.py
+++ b/tests/components/smlight/test_binary_sensor.py
@@ -62,11 +62,14 @@ async def test_disabled_by_default_sensors(
     """Test wifi sensor is disabled by default ."""
     await setup_integration(hass, mock_config_entry)
 
-    assert not hass.states.get("binary_sensor.mock_title_wi_fi")
+    for sensor in ("wi_fi", "vpn"):
+        assert not hass.states.get(f"binary_sensor.mock_title_{sensor}")
 
-    assert (entry := entity_registry.async_get("binary_sensor.mock_title_wi_fi"))
-    assert entry.disabled
-    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+        assert (
+            entry := entity_registry.async_get(f"binary_sensor.mock_title_{sensor}")
+        )
+        assert entry.disabled
+        assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
 
 async def test_internet_sensor_event(

--- a/tests/components/smlight/test_switch.py
+++ b/tests/components/smlight/test_switch.py
@@ -34,6 +34,7 @@ def platforms() -> list[Platform]:
     return [Platform.SWITCH]
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_switch_setup(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
@@ -46,12 +47,29 @@ async def test_switch_setup(
     await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
 
 
+async def test_disabled_by_default_switch(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test vpn enabled switch is disabled by default ."""
+    await setup_integration(hass, mock_config_entry)
+
+    assert not hass.states.get("switch.mock_title_vpn_enabled")
+
+    assert (entry := entity_registry.async_get("switch.mock_title_vpn_enabled"))
+    assert entry.disabled
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 @pytest.mark.parametrize(
     ("entity", "setting"),
     [
         ("disable_leds", Settings.DISABLE_LEDS),
         ("led_night_mode", Settings.NIGHT_MODE),
         ("auto_zigbee_update", Settings.ZB_AUTOUPDATE),
+        ("vpn_enabled", Settings.ENABLE_VPN),
     ],
 )
 async def test_switches(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SLZB-06 firmware has an integrated Wireguard VPN client, add a connectivity sensor that displays vpn status and a switch to enable/disable VPN. Disabled by default since users can enable if they have vpn configured.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/34808

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
