### PR TITLE
Move wirelesstag base entity to separate module

### DIFF
--- a/homeassistant/components/wirelesstag/__init__.py
+++ b/homeassistant/components/wirelesstag/__init__.py
@@ -8,33 +8,15 @@ from wirelesstagpy import WirelessTags
 from wirelesstagpy.exceptions import WirelessTagsException
 
 from homeassistant.components import persistent_notification
-from homeassistant.const import (
-    ATTR_BATTERY_LEVEL,
-    ATTR_VOLTAGE,
-    CONF_PASSWORD,
-    CONF_USERNAME,
-    PERCENTAGE,
-    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
-    UnitOfElectricPotential,
-)
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import dispatcher_send
-from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN, SIGNAL_BINARY_EVENT_UPDATE, SIGNAL_TAG_UPDATE
 
 _LOGGER = logging.getLogger(__name__)
-
-
-# Strength of signal in dBm
-ATTR_TAG_SIGNAL_STRENGTH = "signal_strength"
-# Indicates if tag is out of range or not
-ATTR_TAG_OUT_OF_RANGE = "out_of_range"
-# Number in percents from max power of tag receiver
-ATTR_TAG_POWER_CONSUMPTION = "power_consumption"
-
 
 NOTIFICATION_ID = "wirelesstag_notification"
 NOTIFICATION_TITLE = "Wireless Sensor Tag Setup"
@@ -144,76 +126,3 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
         return False
 
     return True
-
-
-class WirelessTagBaseSensor(Entity):
-    """Base class for HA implementation for Wireless Sensor Tag."""
-
-    def __init__(self, api, tag):
-        """Initialize a base sensor for Wireless Sensor Tag platform."""
-        self._api = api
-        self._tag = tag
-        self._uuid = self._tag.uuid
-        self.tag_id = self._tag.tag_id
-        self.tag_manager_mac = self._tag.tag_manager_mac
-        self._name = self._tag.name
-        self._state = None
-
-    @property
-    def name(self):
-        """Return the name of the sensor."""
-        return self._name
-
-    @property
-    def principal_value(self):
-        """Return base value.
-
-        Subclasses need override based on type of sensor.
-        """
-        return 0
-
-    def updated_state_value(self):
-        """Return formatted value.
-
-        The default implementation formats principal value.
-        """
-        return self.decorate_value(self.principal_value)
-
-    def decorate_value(self, value):
-        """Decorate input value to be well presented for end user."""
-        return f"{value:.1f}"
-
-    @property
-    def available(self):
-        """Return True if entity is available."""
-        return self._tag.is_alive
-
-    def update(self):
-        """Update state."""
-        if not self.should_poll:
-            return
-
-        updated_tags = self._api.load_tags()
-        if (updated_tag := updated_tags[self._uuid]) is None:
-            _LOGGER.error('Unable to update tag: "%s"', self.name)
-            return
-
-        self._tag = updated_tag
-        self._state = self.updated_state_value()
-
-    @property
-    def extra_state_attributes(self):
-        """Return the state attributes."""
-        return {
-            ATTR_BATTERY_LEVEL: int(self._tag.battery_remaining * 100),
-            ATTR_VOLTAGE: (
-                f"{self._tag.battery_volts:.2f}{UnitOfElectricPotential.VOLT}"
-            ),
-            ATTR_TAG_SIGNAL_STRENGTH: (
-                f"{self._tag.signal_strength}{SIGNAL_STRENGTH_DECIBELS_MILLIWATT}"
-            ),
-            ATTR_TAG_OUT_OF_RANGE: not self._tag.is_in_range,
-            ATTR_TAG_POWER_CONSUMPTION: (
-                f"{self._tag.power_consumption:.2f}{PERCENTAGE}"
-            ),
-        }

--- a/homeassistant/components/wirelesstag/binary_sensor.py
+++ b/homeassistant/components/wirelesstag/binary_sensor.py
@@ -15,8 +15,8 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import WirelessTagBaseSensor
 from .const import DOMAIN, SIGNAL_BINARY_EVENT_UPDATE
+from .entity import WirelessTagBaseSensor
 from .util import async_migrate_unique_id
 
 # On means in range, Off means out of range

--- a/homeassistant/components/wirelesstag/entity.py
+++ b/homeassistant/components/wirelesstag/entity.py
@@ -1,0 +1,95 @@
+"""Support for Wireless Sensor Tags."""
+
+import logging
+
+from homeassistant.const import (
+    ATTR_BATTERY_LEVEL,
+    ATTR_VOLTAGE,
+    PERCENTAGE,
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    UnitOfElectricPotential,
+)
+from homeassistant.helpers.entity import Entity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# Strength of signal in dBm
+ATTR_TAG_SIGNAL_STRENGTH = "signal_strength"
+# Indicates if tag is out of range or not
+ATTR_TAG_OUT_OF_RANGE = "out_of_range"
+# Number in percents from max power of tag receiver
+ATTR_TAG_POWER_CONSUMPTION = "power_consumption"
+
+
+class WirelessTagBaseSensor(Entity):
+    """Base class for HA implementation for Wireless Sensor Tag."""
+
+    def __init__(self, api, tag):
+        """Initialize a base sensor for Wireless Sensor Tag platform."""
+        self._api = api
+        self._tag = tag
+        self._uuid = self._tag.uuid
+        self.tag_id = self._tag.tag_id
+        self.tag_manager_mac = self._tag.tag_manager_mac
+        self._name = self._tag.name
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def principal_value(self):
+        """Return base value.
+
+        Subclasses need override based on type of sensor.
+        """
+        return 0
+
+    def updated_state_value(self):
+        """Return formatted value.
+
+        The default implementation formats principal value.
+        """
+        return self.decorate_value(self.principal_value)
+
+    def decorate_value(self, value):
+        """Decorate input value to be well presented for end user."""
+        return f"{value:.1f}"
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self._tag.is_alive
+
+    def update(self):
+        """Update state."""
+        if not self.should_poll:
+            return
+
+        updated_tags = self._api.load_tags()
+        if (updated_tag := updated_tags[self._uuid]) is None:
+            _LOGGER.error('Unable to update tag: "%s"', self.name)
+            return
+
+        self._tag = updated_tag
+        self._state = self.updated_state_value()
+
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            ATTR_BATTERY_LEVEL: int(self._tag.battery_remaining * 100),
+            ATTR_VOLTAGE: (
+                f"{self._tag.battery_volts:.2f}{UnitOfElectricPotential.VOLT}"
+            ),
+            ATTR_TAG_SIGNAL_STRENGTH: (
+                f"{self._tag.signal_strength}{SIGNAL_STRENGTH_DECIBELS_MILLIWATT}"
+            ),
+            ATTR_TAG_OUT_OF_RANGE: not self._tag.is_in_range,
+            ATTR_TAG_POWER_CONSUMPTION: (
+                f"{self._tag.power_consumption:.2f}{PERCENTAGE}"
+            ),
+        }

--- a/homeassistant/components/wirelesstag/sensor.py
+++ b/homeassistant/components/wirelesstag/sensor.py
@@ -20,8 +20,8 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import WirelessTagBaseSensor
 from .const import DOMAIN, SIGNAL_TAG_UPDATE
+from .entity import WirelessTagBaseSensor
 from .util import async_migrate_unique_id
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/wirelesstag/switch.py
+++ b/homeassistant/components/wirelesstag/switch.py
@@ -17,8 +17,8 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import WirelessTagBaseSensor
 from .const import DOMAIN
+from .entity import WirelessTagBaseSensor
 from .util import async_migrate_unique_id
 
 SWITCH_TYPES: tuple[SwitchEntityDescription, ...] = (


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #126026

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
