### PR TITLE
Use debug/warning instead of info log level in components [v]

### DIFF
--- a/homeassistant/components/verisure/__init__.py
+++ b/homeassistant/components/verisure/__init__.py
@@ -108,6 +108,6 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         hass.config_entries.async_update_entry(entry, version=2)
 
-    LOGGER.info("Migration to version %s successful", entry.version)
+    LOGGER.debug("Migration to version %s successful", entry.version)
 
     return True

--- a/homeassistant/components/versasense/__init__.py
+++ b/homeassistant/components/versasense/__init__.py
@@ -55,7 +55,7 @@ async def _configure_entities(hass, config, consumer):
     switch_info = {}
 
     for mac, device in devices.items():
-        _LOGGER.info("Device connected: %s %s", device.name, mac)
+        _LOGGER.debug("Device connected: %s %s", device.name, mac)
         hass.data[DOMAIN][mac] = {}
 
         for peripheral_id, peripheral in device.peripherals.items():

--- a/homeassistant/components/vesync/common.py
+++ b/homeassistant/components/vesync/common.py
@@ -21,17 +21,17 @@ async def async_process_devices(hass, manager):
         devices[VS_FANS].extend(manager.fans)
         # Expose fan sensors separately
         devices[VS_SENSORS].extend(manager.fans)
-        _LOGGER.info("%d VeSync fans found", len(manager.fans))
+        _LOGGER.debug("%d VeSync fans found", len(manager.fans))
 
     if manager.bulbs:
         devices[VS_LIGHTS].extend(manager.bulbs)
-        _LOGGER.info("%d VeSync lights found", len(manager.bulbs))
+        _LOGGER.debug("%d VeSync lights found", len(manager.bulbs))
 
     if manager.outlets:
         devices[VS_SWITCHES].extend(manager.outlets)
         # Expose outlets' voltage, power & energy usage as separate sensors
         devices[VS_SENSORS].extend(manager.outlets)
-        _LOGGER.info("%d VeSync outlets found", len(manager.outlets))
+        _LOGGER.debug("%d VeSync outlets found", len(manager.outlets))
 
     if manager.switches:
         for switch in manager.switches:
@@ -39,6 +39,6 @@ async def async_process_devices(hass, manager):
                 devices[VS_SWITCHES].append(switch)
             else:
                 devices[VS_LIGHTS].append(switch)
-        _LOGGER.info("%d VeSync switches found", len(manager.switches))
+        _LOGGER.debug("%d VeSync switches found", len(manager.switches))
 
     return devices

--- a/homeassistant/components/vilfo/__init__.py
+++ b/homeassistant/components/vilfo/__init__.py
@@ -105,5 +105,5 @@ class VilfoRouterData:
             return
 
         if self.available and self._unavailable_logged:
-            _LOGGER.info("Vilfo Router %s is available again", self.host)
+            _LOGGER.warning("Vilfo Router %s is available again", self.host)
             self._unavailable_logged = False

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -200,7 +200,7 @@ class VizioDevice(MediaPlayerEntity):
             return
 
         if not self._attr_available:
-            _LOGGER.info(
+            _LOGGER.warning(
                 "Restored connection to %s", self._config_entry.data[CONF_HOST]
             )
             self._attr_available = True

--- a/homeassistant/components/vlc_telnet/media_player.py
+++ b/homeassistant/components/vlc_telnet/media_player.py
@@ -131,7 +131,7 @@ class VlcDevice(MediaPlayerEntity):
 
             self._attr_state = MediaPlayerState.IDLE
             self._attr_available = True
-            LOGGER.info("Connected to vlc host: %s", self._vlc.host)
+            LOGGER.debug("Connected to vlc host: %s", self._vlc.host)
 
         status = await self._vlc.status()
         LOGGER.debug("Status: %s", status)

--- a/homeassistant/components/vulcan/calendar.py
+++ b/homeassistant/components/vulcan/calendar.py
@@ -133,7 +133,7 @@ class VulcanCalendarEntity(CalendarEntity):
             events = await get_lessons(self.client)
 
             if not self.available:
-                _LOGGER.info("Restored connection with API")
+                _LOGGER.warning("Restored connection with API")
                 self._attr_available = True
 
             if events == []:


### PR DESCRIPTION
## Proposed change
SSIA

Noticed in https://github.com/home-assistant/core/pull/125939

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
