### PR TITLE
Addition of select platform for flipr hub

### DIFF
--- a/homeassistant/components/flipr/__init__.py
+++ b/homeassistant/components/flipr/__init__.py
@@ -15,7 +15,7 @@ from homeassistant.helpers import issue_registry as ir
 from .const import DOMAIN
 from .coordinator import FliprDataUpdateCoordinator, FliprHubDataUpdateCoordinator
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.SELECT, Platform.SENSOR, Platform.SWITCH]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/flipr/select.py
+++ b/homeassistant/components/flipr/select.py
@@ -1,0 +1,56 @@
+"""Select platform for the Flipr's Hub."""
+
+import logging
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import FliprConfigEntry
+from .entity import FliprEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+SELECT_TYPES: tuple[SelectEntityDescription, ...] = (
+    SelectEntityDescription(
+        key="hubMode",
+        name=None,
+        options=["auto", "manual", "planning"],
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: FliprConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up select for Flipr hub mode."""
+    coordinators = config_entry.runtime_data.hub_coordinators
+
+    async_add_entities(
+        FliprHubSelect(coordinator, description, True)
+        for description in SELECT_TYPES
+        for coordinator in coordinators
+    )
+
+
+class FliprHubSelect(FliprEntity, SelectEntity):
+    """Select representing Hub mode."""
+
+    @property
+    def current_option(self) -> str | None:
+        """Return current select option."""
+        _LOGGER.debug("coordinator data = %s", self.coordinator.data)
+        return self.coordinator.data["mode"]
+
+    async def async_select_option(self, option: str) -> None:
+        """Select new mode for Hub."""
+        _LOGGER.debug("Changing mode of %s to %s", self.device_id, option)
+        data = await self.hass.async_add_executor_job(
+            self.coordinator.client.set_hub_mode,
+            self.device_id,
+            option,
+        )
+        _LOGGER.debug("New hub infos are %s", data)
+        self.coordinator.async_set_updated_data(data)

--- a/homeassistant/components/flipr/select.py
+++ b/homeassistant/components/flipr/select.py
@@ -14,7 +14,7 @@ _LOGGER = logging.getLogger(__name__)
 SELECT_TYPES: tuple[SelectEntityDescription, ...] = (
     SelectEntityDescription(
         key="hubMode",
-        name=None,
+        translation_key="hub_mode",
         options=["auto", "manual", "planning"],
     ),
 )

--- a/homeassistant/components/flipr/strings.json
+++ b/homeassistant/components/flipr/strings.json
@@ -42,6 +42,7 @@
     },
     "select": {
       "hub_mode": {
+        "name": "Mode",
         "state": {
           "auto": "Automatic",
           "manual": "Manual",

--- a/homeassistant/components/flipr/strings.json
+++ b/homeassistant/components/flipr/strings.json
@@ -39,6 +39,15 @@
       "red_ox": {
         "name": "Red OX"
       }
+    },
+    "select": {
+      "hub_mode": {
+        "state": {
+          "auto": "Automatic",
+          "manual": "Manual",
+          "planning": "Planning"
+        }
+      }
     }
   },
   "issues": {

--- a/tests/components/flipr/test_select.py
+++ b/tests/components/flipr/test_select.py
@@ -1,0 +1,106 @@
+"""Test the Flipr select for Hub."""
+
+import logging
+from unittest.mock import AsyncMock
+
+from flipr_api.exceptions import FliprError
+
+from homeassistant.components.select import (
+    DOMAIN as SELECT_DOMAIN,
+    SERVICE_SELECT_OPTION,
+)
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+SELECT_ENTITY_ID = "select.flipr_hub_myhubid"
+
+
+async def test_entities(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    mock_flipr_client: AsyncMock,
+) -> None:
+    """Test the creation and values of the Flipr select."""
+
+    mock_flipr_client.search_all_ids.return_value = {"flipr": [], "hub": ["myhubid"]}
+
+    await setup_integration(hass, mock_config_entry)
+
+    # Check entity unique_id value that is generated in FliprEntity base class.
+    entity = entity_registry.async_get(SELECT_ENTITY_ID)
+    _LOGGER.debug("Found entity = %s", entity)
+    assert entity.unique_id == "myhubid-hubMode"
+
+    state = hass.states.get(SELECT_ENTITY_ID)
+    _LOGGER.debug("Found state = %s", state)
+    assert state
+    assert state.state == "planning"
+
+
+async def test_select_actions(
+    hass: HomeAssistant,
+    mock_flipr_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the actions on the Flipr Hub select."""
+
+    mock_flipr_client.search_all_ids.return_value = {"flipr": [], "hub": ["myhubid"]}
+
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get(SELECT_ENTITY_ID)
+    assert state.state == "planning"
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: SELECT_ENTITY_ID, "option": "manual"},
+        blocking=True,
+    )
+    state = hass.states.get(SELECT_ENTITY_ID)
+    assert state.state == "manual"
+
+
+async def test_no_select_found(
+    hass: HomeAssistant,
+    mock_flipr_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the select absence."""
+
+    mock_flipr_client.search_all_ids.return_value = {"flipr": [], "hub": []}
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert not hass.states.async_entity_ids(SELECT_ENTITY_ID)
+
+
+async def test_error_flipr_api(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    mock_flipr_client: AsyncMock,
+) -> None:
+    """Test the Flipr sensors error."""
+
+    mock_flipr_client.search_all_ids.return_value = {"flipr": [], "hub": ["myhubid"]}
+
+    mock_flipr_client.get_hub_state.side_effect = FliprError(
+        "Error during flipr data retrieval..."
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    # Check entity is not generated because of the FliprError raised.
+    entity = entity_registry.async_get(SELECT_ENTITY_ID)
+    assert entity is None

--- a/tests/components/flipr/test_select.py
+++ b/tests/components/flipr/test_select.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock
 from flipr_api.exceptions import FliprError
 
 from homeassistant.components.select import (
+    ATTR_OPTION,
+    ATTR_OPTIONS,
     DOMAIN as SELECT_DOMAIN,
     SERVICE_SELECT_OPTION,
 )
@@ -19,7 +21,7 @@ from tests.common import MockConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
-SELECT_ENTITY_ID = "select.flipr_hub_myhubid"
+SELECT_ENTITY_ID = "select.flipr_hub_myhubid_mode"
 
 
 async def test_entities(
@@ -39,10 +41,11 @@ async def test_entities(
     _LOGGER.debug("Found entity = %s", entity)
     assert entity.unique_id == "myhubid-hubMode"
 
-    state = hass.states.get(SELECT_ENTITY_ID)
-    _LOGGER.debug("Found state = %s", state)
-    assert state
-    assert state.state == "planning"
+    mode = hass.states.get(SELECT_ENTITY_ID)
+    _LOGGER.debug("Found mode = %s", mode)
+    assert mode
+    assert mode.state == "planning"
+    assert mode.attributes.get(ATTR_OPTIONS) == ["auto", "manual", "planning"]
 
 
 async def test_select_actions(
@@ -63,7 +66,7 @@ async def test_select_actions(
     await hass.services.async_call(
         SELECT_DOMAIN,
         SERVICE_SELECT_OPTION,
-        {ATTR_ENTITY_ID: SELECT_ENTITY_ID, "option": "manual"},
+        {ATTR_ENTITY_ID: SELECT_ENTITY_ID, ATTR_OPTION: "manual"},
         blocking=True,
     )
     state = hass.states.get(SELECT_ENTITY_ID)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Addition of select platform to flipr hub. The select is for the mode of flipr hub device (auto, planning or manual).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/34586

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
