### PR TITLE
Fix ColorMode.WHITE support in Tuya

### DIFF
--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -766,9 +766,9 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
             # The light supports only a single color mode, return it
             return self._fixed_color_mode
 
-        # The light supports both color temperature and HS, determine which mode the
-        # light is in. We consider it to be in HS color mode, when work mode is anything
-        # else than "white".
+        # The light supports both white (with or without adjustable color temperature)
+        # and HS, determine which mode the light is in. We consider it to be in HS color
+        # mode, when work mode is anything else than "white".
         if (
             self._color_mode_dpcode
             and self.device.status.get(self._color_mode_dpcode) != WorkMode.WHITE

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -12,6 +12,7 @@ from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_TEMP_KELVIN,
     ATTR_HS_COLOR,
+    ATTR_WHITE,
     ColorMode,
     LightEntity,
     LightEntityDescription,
@@ -488,6 +489,7 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
     _color_data_type: ColorTypeData | None = None
     _color_mode: DPCode | None = None
     _color_temp: IntegerTypeData | None = None
+    _white_color_mode: ColorMode | None = None
     _fixed_color_mode: ColorMode | None = None
     _attr_min_color_temp_kelvin = 2000  # 500 Mireds
     _attr_max_color_temp_kelvin = 6500  # 153 Mireds
@@ -526,6 +528,19 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
         ):
             self._color_temp = int_type
             color_modes.add(ColorMode.COLOR_TEMP)
+            self._white_color_mode = ColorMode.COLOR_TEMP
+        elif (
+            workmode_type
+            := self.find_dpcode(  # If entity does not have color_temp, check if it has work_mode "white"
+                description.color_mode, dptype=DPType.ENUM, prefer_function=True
+            )
+        ):
+            if WorkMode.WHITE.value in workmode_type.range:
+                color_modes.add(ColorMode.WHITE)
+                self._white_color_mode = ColorMode.WHITE
+
+        if not self._white_color_mode:
+            self._white_color_mode = ColorMode.COLOR_TEMP  # default to COLOR_TEMP
 
         if (
             dpcode := self.find_dpcode(description.color_data, prefer_function=True)
@@ -566,7 +581,7 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
         """Turn on or control the light."""
         commands = [{"code": self.entity_description.key, "value": True}]
 
-        if self._color_temp and ATTR_COLOR_TEMP_KELVIN in kwargs:
+        if ATTR_WHITE in kwargs or ATTR_COLOR_TEMP_KELVIN in kwargs:
             if self._color_mode_dpcode:
                 commands += [
                     {
@@ -575,27 +590,27 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
                     },
                 ]
 
-            commands += [
-                {
-                    "code": self._color_temp.dpcode,
-                    "value": round(
-                        self._color_temp.remap_value_from(
-                            color_util.color_temperature_kelvin_to_mired(
-                                kwargs[ATTR_COLOR_TEMP_KELVIN]
-                            ),
-                            MIN_MIREDS,
-                            MAX_MIREDS,
-                            reverse=True,
-                        )
-                    ),
-                },
-            ]
+            if ATTR_COLOR_TEMP_KELVIN in kwargs and self._color_temp:
+                commands += [
+                    {
+                        "code": self._color_temp.dpcode,
+                        "value": round(
+                            self._color_temp.remap_value_from(
+                                kwargs[ATTR_COLOR_TEMP_KELVIN],
+                                self.min_mireds,
+                                self.max_mireds,
+                                reverse=True,
+                            )
+                        ),
+                    },
+                ]
 
         if self._color_data_type and (
             ATTR_HS_COLOR in kwargs
             or (
                 ATTR_BRIGHTNESS in kwargs
                 and self.color_mode == ColorMode.HS
+                and ATTR_WHITE not in kwargs
                 and ATTR_COLOR_TEMP_KELVIN not in kwargs
             )
         ):
@@ -763,7 +778,9 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
             and self.device.status.get(self._color_mode_dpcode) != WorkMode.WHITE
         ):
             return ColorMode.HS
-        return ColorMode.COLOR_TEMP
+        return (
+            self._white_color_mode if self._white_color_mode else ColorMode.COLOR_TEMP
+        )  # default to COLOR_TEMP
 
     def _get_color_data(self) -> ColorData | None:
         """Get current color data from device."""

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -596,9 +596,11 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
                         "code": self._color_temp.dpcode,
                         "value": round(
                             self._color_temp.remap_value_from(
-                                kwargs[ATTR_COLOR_TEMP_KELVIN],
-                                self.min_mireds,
-                                self.max_mireds,
+                                color_util.color_temperature_kelvin_to_mired(
+                                    kwargs[ATTR_COLOR_TEMP_KELVIN]
+                                ),
+                                MIN_MIREDS,
+                                MAX_MIREDS,
                                 reverse=True,
                             )
                         ),

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -575,31 +575,32 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
         """Turn on or control the light."""
         commands = [{"code": self.entity_description.key, "value": True}]
 
-        if ATTR_WHITE in kwargs or ATTR_COLOR_TEMP_KELVIN in kwargs:
-            if self._color_mode_dpcode:
-                commands += [
-                    {
-                        "code": self._color_mode_dpcode,
-                        "value": WorkMode.WHITE,
-                    },
-                ]
+        if self._color_mode_dpcode and (
+            ATTR_WHITE in kwargs or ATTR_COLOR_TEMP_KELVIN in kwargs
+        ):
+            commands += [
+                {
+                    "code": self._color_mode_dpcode,
+                    "value": WorkMode.WHITE,
+                },
+            ]
 
-            if ATTR_COLOR_TEMP_KELVIN in kwargs and self._color_temp:
-                commands += [
-                    {
-                        "code": self._color_temp.dpcode,
-                        "value": round(
-                            self._color_temp.remap_value_from(
-                                color_util.color_temperature_kelvin_to_mired(
-                                    kwargs[ATTR_COLOR_TEMP_KELVIN]
-                                ),
-                                MIN_MIREDS,
-                                MAX_MIREDS,
-                                reverse=True,
-                            )
-                        ),
-                    },
-                ]
+        if self._color_temp and ATTR_COLOR_TEMP_KELVIN in kwargs:
+            commands += [
+                {
+                    "code": self._color_temp.dpcode,
+                    "value": round(
+                        self._color_temp.remap_value_from(
+                            color_util.color_temperature_kelvin_to_mired(
+                                kwargs[ATTR_COLOR_TEMP_KELVIN]
+                            ),
+                            MIN_MIREDS,
+                            MAX_MIREDS,
+                            reverse=True,
+                        )
+                    ),
+                },
+            ]
 
         if self._color_data_type and (
             ATTR_HS_COLOR in kwargs

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -529,10 +529,10 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
             self._color_temp = int_type
             color_modes.add(ColorMode.COLOR_TEMP)
         # If entity does not have color_temp, check if it has work_mode "white"
-        elif workmode_type := self.find_dpcode(
+        elif color_mode_enum := self.find_dpcode(
             description.color_mode, dptype=DPType.ENUM, prefer_function=True
         ):
-            if WorkMode.WHITE.value in workmode_type.range:
+            if WorkMode.WHITE.value in color_mode_enum.range:
                 color_modes.add(ColorMode.WHITE)
                 self._white_color_mode = ColorMode.WHITE
 

--- a/tests/components/tuya/snapshots/test_light.ambr
+++ b/tests/components/tuya/snapshots/test_light.ambr
@@ -64,6 +64,7 @@
     'capabilities': dict({
       'supported_color_modes': list([
         <ColorMode.HS: 'hs'>,
+        <ColorMode.WHITE: 'white'>,
       ]),
     }),
     'config_entry_id': <ANY>,

--- a/tests/components/tuya/snapshots/test_light.ambr
+++ b/tests/components/tuya/snapshots/test_light.ambr
@@ -100,25 +100,16 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'brightness': 138,
-      'color_mode': <ColorMode.HS: 'hs'>,
+      'color_mode': <ColorMode.WHITE: 'white'>,
       'friendly_name': 'Garage light',
-      'hs_color': tuple(
-        243.0,
-        86.0,
-      ),
-      'rgb_color': tuple(
-        47,
-        36,
-        255,
-      ),
+      'hs_color': None,
+      'rgb_color': None,
       'supported_color_modes': list([
         <ColorMode.HS: 'hs'>,
+        <ColorMode.WHITE: 'white'>,
       ]),
       'supported_features': <LightEntityFeature: 0>,
-      'xy_color': tuple(
-        0.148,
-        0.055,
-      ),
+      'xy_color': None,
     }),
     'context': <ANY>,
     'entity_id': 'light.garage_light',

--- a/tests/components/tuya/test_light.py
+++ b/tests/components/tuya/test_light.py
@@ -8,6 +8,11 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 from tuya_sharing import CustomerDevice
 
+from homeassistant.components.light import (
+    DOMAIN as LIGHT_DOMAIN,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
 from homeassistant.components.tuya import ManagerCompat
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -54,4 +59,67 @@ async def test_platform_setup_no_discovery(
 
     assert not er.async_entries_for_config_entry(
         entity_registry, mock_config_entry.entry_id
+    )
+
+
+@pytest.mark.parametrize(
+    "mock_device_code",
+    ["dj_smart_light_bulb"],
+)
+async def test_turn_on_white(
+    hass: HomeAssistant,
+    mock_manager: ManagerCompat,
+    mock_config_entry: MockConfigEntry,
+    mock_device: CustomerDevice,
+) -> None:
+    """Test turn_on service."""
+    entity_id = "light.garage_light"
+    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
+
+    state = hass.states.get(entity_id)
+    assert state is not None, f"{entity_id} does not exist"
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {
+            "entity_id": entity_id,
+            "white": 150,
+        },
+    )
+    await hass.async_block_till_done()
+    mock_manager.send_commands.assert_called_once_with(
+        mock_device.id,
+        [
+            {"code": "switch_led", "value": True},
+            {"code": "work_mode", "value": "white"},
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    "mock_device_code",
+    ["dj_smart_light_bulb"],
+)
+async def test_turn_off(
+    hass: HomeAssistant,
+    mock_manager: ManagerCompat,
+    mock_config_entry: MockConfigEntry,
+    mock_device: CustomerDevice,
+) -> None:
+    """Test turn_off service."""
+    entity_id = "light.garage_light"
+    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
+
+    state = hass.states.get(entity_id)
+    assert state is not None, f"{entity_id} does not exist"
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_OFF,
+        {
+            "entity_id": entity_id,
+        },
+    )
+    await hass.async_block_till_done()
+    mock_manager.send_commands.assert_called_once_with(
+        mock_device.id, [{"code": "switch_led", "value": False}]
     )


### PR DESCRIPTION
Tuya: Add ColorMode.WHITE when bulb supports white but doesn't have temp_value

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
N/A

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Tuya bulbs that support a white color mode but don't have adjustable white color temp were broken several versions of HA ago. [See this large thread.](https://github.com/home-assistant/core/issues/115056) 

I added a check after the check for color temp to check if the bulb supports work_mode white. If the bulb does not support color_temp, but it still supports white work_mode, I will add ColorMode.WHITE to the list of supported color_modes. I also added a new entity value _white_color_mode which will hold the color mode corresponding to how the bulb supports white. It will either be WHITE or COLOR_TEMP. 

Modified the turn_on function to check for ATTR_WHITE as well as ATTR_COLOR_TEMP in determining if the command should include setting the work_mode to WHITE. If the _white_color_mode is COLOR_TEMP, it will also set the color temp in the commands.

Modified the color_mode function to return the _white_color_mode when the work_mode is white. Again, this can be either WHITE or COLOR_TEMP.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #115056
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
