### PR TITLE
Improve readability in hass_imports pylint plugin

### DIFF
--- a/pylint/plugins/hass_imports.py
+++ b/pylint/plugins/hass_imports.py
@@ -601,7 +601,7 @@ class HassImportsFormatChecker(BaseChecker):
 
         return True
 
-    def _check_for_component_relative_import(
+    def _check_for_relative_import(
         self,
         current_package: str,
         node: nodes.ImportFrom,
@@ -642,7 +642,7 @@ class HassImportsFormatChecker(BaseChecker):
                 current_component = self.current_package.split(".")[2]
 
         # Checks for hass-relative-import
-        if not self._check_for_component_relative_import(
+        if not self._check_for_relative_import(
             self.current_package, node, current_component
         ):
             return

--- a/pylint/plugins/hass_imports.py
+++ b/pylint/plugins/hass_imports.py
@@ -548,13 +548,13 @@ class HassImportsFormatChecker(BaseChecker):
         if len(split_package) < node.level + 2:
             self.add_message("hass-absolute-import", node=node)
 
-    def _check_constant_alias(
+    def _check_for_constant_alias(
         self,
         node: nodes.ImportFrom,
         current_component: str | None,
         imported_component: str,
     ) -> bool:
-        """Check for improper alias `from homeassistant.components.component import CONSTANT` invocations."""
+        """Check for hass-import-constant-alias."""
         if current_component == imported_component:
             return True
 
@@ -574,14 +574,14 @@ class HassImportsFormatChecker(BaseChecker):
 
         return True
 
-    def _check_component_root_import(
+    def _check_for_component_root_import(
         self,
         node: nodes.ImportFrom,
         current_component: str | None,
         imported_parts: list[str],
         imported_component: str,
     ) -> bool:
-        """Check for improper root imports."""
+        """Check for hass-component-root-import."""
         if (
             current_component == imported_component
             or imported_component in _IGNORE_ROOT_IMPORT
@@ -601,13 +601,13 @@ class HassImportsFormatChecker(BaseChecker):
 
         return True
 
-    def _check_for_relative_import(
+    def _check_for_component_relative_import(
         self,
         current_package: str,
         node: nodes.ImportFrom,
         current_component: str | None,
     ) -> bool:
-        """Check for improper relative imports."""
+        """Check for hass-relative-import."""
         if node.modname == current_package or node.modname.startswith(
             f"{current_package}."
         ):
@@ -642,7 +642,7 @@ class HassImportsFormatChecker(BaseChecker):
                 current_component = self.current_package.split(".")[2]
 
         # Checks for hass-relative-import
-        if not self._check_for_relative_import(
+        if not self._check_for_component_relative_import(
             self.current_package, node, current_component
         ):
             return
@@ -652,13 +652,13 @@ class HassImportsFormatChecker(BaseChecker):
             imported_component = imported_parts[2]
 
             # Checks for hass-component-root-import
-            if not self._check_component_root_import(
+            if not self._check_for_component_root_import(
                 node, current_component, imported_parts, imported_component
             ):
                 return
 
             # Checks for hass-import-constant-alias
-            if not self._check_constant_alias(
+            if not self._check_for_constant_alias(
                 node, current_component, imported_component
             ):
                 return


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`visit_importfrom` has 5 different checks - and it is becoming quite difficult to follow what it is doing.

With no change in functionnality, this moves 3 of those checks to separate methods:
- one for `hass-relative-import`
- one for `hass-component-root-import`
- one for `hass-import-constant-alias`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
