### PR TITLE
Make combined rmvtransport filters work

### DIFF
--- a/homeassistant/components/rmvtransport/sensor.py
+++ b/homeassistant/components/rmvtransport/sensor.py
@@ -271,7 +271,7 @@ class RMVDepartureData:
                 if not dest_found:
                     continue
 
-            elif (
+            if (
                 self._lines
                 and journey["number"] not in self._lines
                 or journey["minutes"] < self._time_offset

--- a/tests/components/rmvtransport/test_sensor.py
+++ b/tests/components/rmvtransport/test_sensor.py
@@ -41,6 +41,23 @@ VALID_CONFIG_DEST = {
                     "Frankfurt (Main) Flughafen Regionalbahnhof",
                     "Frankfurt (Main) Stadion",
                 ],
+                "lines": [12, "S8"],
+                "time_offset": 15,
+            }
+        ],
+    }
+}
+
+VALID_CONFIG_DEST_ONLY = {
+    "sensor": {
+        "platform": "rmvtransport",
+        "next_departure": [
+            {
+                "station": "3000010",
+                "destinations": [
+                    "Frankfurt (Main) Flughafen Regionalbahnhof",
+                    "Frankfurt (Main) Stadion",
+                ],
             }
         ],
     }
@@ -144,6 +161,19 @@ def get_departures_mock():
                 "info_long": None,
                 "icon": "https://products/32_pic.png",
             },
+            {
+                "product": "Bus",
+                "number": 12,
+                "trainId": "1234568",
+                "direction": "Frankfurt (Main) Hugo-Junkers-Straße/Schleife",
+                "departure_time": datetime.datetime(2018, 8, 6, 14, 30),
+                "minutes": 16,
+                "delay": 0,
+                "stops": ["Frankfurt (Main) Stadion"],
+                "info": None,
+                "info_long": None,
+                "icon": "https://products/32_pic.png",
+            },
         ],
     }
 
@@ -213,6 +243,26 @@ async def test_rmvtransport_dest_config(hass: HomeAssistant) -> None:
         return_value=get_departures_mock(),
     ):
         assert await async_setup_component(hass, "sensor", VALID_CONFIG_DEST)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.frankfurt_main_hauptbahnhof")
+    assert state is not None
+    assert state.state == "16"
+    assert (
+        state.attributes["direction"] == "Frankfurt (Main) Hugo-Junkers-Straße/Schleife"
+    )
+    assert state.attributes["line"] == 12
+    assert state.attributes["minutes"] == 16
+    assert state.attributes["departure_time"] == datetime.datetime(2018, 8, 6, 14, 30)
+
+
+async def test_rmvtransport_dest_only_config(hass: HomeAssistant) -> None:
+    """Test destination configuration."""
+    with patch(
+        "RMVtransport.RMVtransport.get_departures",
+        return_value=get_departures_mock(),
+    ):
+        assert await async_setup_component(hass, "sensor", VALID_CONFIG_DEST_ONLY)
         await hass.async_block_till_done()
 
     state = hass.states.get("sensor.frankfurt_main_hauptbahnhof")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

In the `rmvtransport` integration, the three config attributes `destination`, `lines`, and `time_offset` all act as filters. The expectation is that if multiple filters are given, all of them take effect.

However, as a consequence of using `elif` in the loop body, if a `destination` filter has been configured, then both the `lines` and the `time_offset` filters are ignored and have no effect.

This PR replaces the `elif` with an `if` clause to allow all filter settings to work as intended.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

I’ve looked at the open issues on the `rmvtransport` integration and found that none of them seem to be related to the PR at hand.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository] **← Not applicable**

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly. **← Not applicable**  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`. **← Not applicable**  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description. **← Not applicable**

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.
    - PR #125338
    - PR #125988

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
