### PR TITLE
Bump ring-doorbell to 0.9.5

### DIFF
--- a/homeassistant/components/ring/manifest.json
+++ b/homeassistant/components/ring/manifest.json
@@ -14,5 +14,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["ring_doorbell"],
   "quality_scale": "silver",
-  "requirements": ["ring-doorbell[listen]==0.9.3"]
+  "requirements": ["ring-doorbell[listen]==0.9.5"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2540,7 +2540,7 @@ rfk101py==0.0.1
 rflink==0.0.66
 
 # homeassistant.components.ring
-ring-doorbell[listen]==0.9.3
+ring-doorbell[listen]==0.9.5
 
 # homeassistant.components.fleetgo
 ritassist==0.9.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2022,7 +2022,7 @@ reolink-aio==0.9.8
 rflink==0.0.66
 
 # homeassistant.components.ring
-ring-doorbell[listen]==0.9.3
+ring-doorbell[listen]==0.9.5
 
 # homeassistant.components.roku
 rokuecp==0.19.3

--- a/tests/components/ring/snapshots/test_number.ambr
+++ b/tests/components/ring/snapshots/test_number.ambr
@@ -397,7 +397,7 @@
     }),
     'area_id': None,
     'capabilities': dict({
-      'max': 10,
+      'max': 11,
       'min': 0,
       'mode': <NumberMode.SLIDER: 'slider'>,
       'step': 1,
@@ -434,7 +434,7 @@
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Ring.com',
       'friendly_name': 'Downstairs Volume',
-      'max': 10,
+      'max': 11,
       'min': 0,
       'mode': <NumberMode.SLIDER: 'slider'>,
       'step': 1,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bump ring-doorbell library to 0.9.5

Most library changes are either cli, housekeeping or do not impact any functionality currently active in HA. Other than:

- A change in `const.py` to correct the `DOORBELL_EXISTING_DURATION_MAX` which will allow setting this value in HA in a future PR
- Correct the `const.py` `CHIME_VOL_MAX` from 10 to 11 **requires minor test snapshot update**
- A new WebRTC session controller to be enabled in a future PR

Release notes - [python-ring-doorbell/python-ring-doorbell/releases](https://github.com/python-ring-doorbell/python-ring-doorbell/releases)

[Full Changelog between 0.9.3 and 0.9.5](https://github.com/python-ring-doorbell/python-ring-doorbell/compare/0.9.3...0.9.5)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
