### PR TITLE
Dont count unrecorded time for history_stats

### DIFF
--- a/homeassistant/components/history_stats/data.py
+++ b/homeassistant/components/history_stats/data.py
@@ -176,18 +176,19 @@ class HistoryStats:
         # state_changes_during_period is called with include_start_time_state=True
         # which is the default and always provides the state at the start
         # of the period
-        previous_state_matches = (
-            self._history_current_period
-            and self._history_current_period[0].state in self._entity_states
-        )
-        last_state_change_timestamp = start_timestamp
+        previous_state_matches = False
+        last_state_change_timestamp = 0.0
         elapsed = 0.0
-        match_count = 1 if previous_state_matches else 0
+        match_count = 0
 
         # Make calculations
         for history_state in self._history_current_period:
             current_state_matches = history_state.state in self._entity_states
             state_change_timestamp = history_state.last_changed
+
+            if state_change_timestamp > now_timestamp:
+                # Shouldn't count states that are in the future
+                continue
 
             if previous_state_matches:
                 elapsed += state_change_timestamp - last_state_change_timestamp
@@ -195,7 +196,7 @@ class HistoryStats:
                 match_count += 1
 
             previous_state_matches = current_state_matches
-            last_state_change_timestamp = state_change_timestamp
+            last_state_change_timestamp = max(start_timestamp, state_change_timestamp)
 
         # Count time elapsed between last history state and end of measure
         if previous_state_matches:

--- a/tests/components/history_stats/test_sensor.py
+++ b/tests/components/history_stats/test_sensor.py
@@ -437,10 +437,10 @@ async def test_measure(recorder_mock: Recorder, hass: HomeAssistant) -> None:
             await async_update_entity(hass, f"sensor.sensor{i}")
         await hass.async_block_till_done()
 
-    assert hass.states.get("sensor.sensor1").state == "0.83"
-    assert hass.states.get("sensor.sensor2").state == "0.833333333333333"
+    assert hass.states.get("sensor.sensor1").state == "0.5"
+    assert 0.499 < float(hass.states.get("sensor.sensor2").state) < 0.501
     assert hass.states.get("sensor.sensor3").state == "2"
-    assert hass.states.get("sensor.sensor4").state == "83.3"
+    assert hass.states.get("sensor.sensor4").state == "50.0"
 
 
 async def test_async_on_entire_period(
@@ -1254,10 +1254,10 @@ async def test_measure_sliding_window(
             await async_update_entity(hass, f"sensor.sensor{i}")
         await hass.async_block_till_done()
 
-    assert hass.states.get("sensor.sensor1").state == "0.83"
-    assert hass.states.get("sensor.sensor2").state == "0.833333333333333"
-    assert hass.states.get("sensor.sensor3").state == "2"
-    assert hass.states.get("sensor.sensor4").state == "41.7"
+    assert hass.states.get("sensor.sensor1").state == "0.0"
+    assert float(hass.states.get("sensor.sensor2").state) == 0
+    assert hass.states.get("sensor.sensor3").state == "0"
+    assert hass.states.get("sensor.sensor4").state == "0.0"
 
     past_next_update = start_time + timedelta(minutes=30)
     with (
@@ -1268,12 +1268,12 @@ async def test_measure_sliding_window(
         freeze_time(past_next_update),
     ):
         async_fire_time_changed(hass, past_next_update)
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert hass.states.get("sensor.sensor1").state == "0.83"
-    assert hass.states.get("sensor.sensor2").state == "0.833333333333333"
-    assert hass.states.get("sensor.sensor3").state == "2"
-    assert hass.states.get("sensor.sensor4").state == "41.7"
+    assert hass.states.get("sensor.sensor1").state == "0.17"
+    assert 0.166 < float(hass.states.get("sensor.sensor2").state) < 0.167
+    assert hass.states.get("sensor.sensor3").state == "1"
+    assert hass.states.get("sensor.sensor4").state == "8.3"
 
 
 async def test_measure_from_end_going_backwards(
@@ -1355,10 +1355,10 @@ async def test_measure_from_end_going_backwards(
             await async_update_entity(hass, f"sensor.sensor{i}")
         await hass.async_block_till_done()
 
-    assert hass.states.get("sensor.sensor1").state == "0.83"
-    assert hass.states.get("sensor.sensor2").state == "0.833333333333333"
-    assert hass.states.get("sensor.sensor3").state == "2"
-    assert hass.states.get("sensor.sensor4").state == "83.3"
+    assert hass.states.get("sensor.sensor1").state == "0.0"
+    assert float(hass.states.get("sensor.sensor2").state) == 0
+    assert hass.states.get("sensor.sensor3").state == "0"
+    assert hass.states.get("sensor.sensor4").state == "0.0"
 
     past_next_update = start_time + timedelta(minutes=30)
     with (
@@ -1369,12 +1369,12 @@ async def test_measure_from_end_going_backwards(
         freeze_time(past_next_update),
     ):
         async_fire_time_changed(hass, past_next_update)
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert hass.states.get("sensor.sensor1").state == "0.83"
-    assert hass.states.get("sensor.sensor2").state == "0.833333333333333"
-    assert hass.states.get("sensor.sensor3").state == "2"
-    assert hass.states.get("sensor.sensor4").state == "83.3"
+    assert hass.states.get("sensor.sensor1").state == "0.17"
+    assert 0.166 < float(hass.states.get("sensor.sensor2").state) < 0.167
+    assert hass.states.get("sensor.sensor3").state == "1"
+    assert 16.6 <= float(hass.states.get("sensor.sensor4").state) <= 16.7
 
 
 async def test_measure_cet(recorder_mock: Recorder, hass: HomeAssistant) -> None:
@@ -1403,7 +1403,7 @@ async def test_measure_cet(recorder_mock: Recorder, hass: HomeAssistant) -> None
             "homeassistant.components.recorder.history.state_changes_during_period",
             _fake_states,
         ),
-        freeze_time(start_time),
+        freeze_time(start_time + timedelta(minutes=60)),
     ):
         await async_setup_component(
             hass,
@@ -1455,10 +1455,10 @@ async def test_measure_cet(recorder_mock: Recorder, hass: HomeAssistant) -> None
             await async_update_entity(hass, f"sensor.sensor{i}")
         await hass.async_block_till_done()
 
-    assert hass.states.get("sensor.sensor1").state == "0.83"
-    assert hass.states.get("sensor.sensor2").state == "0.833333333333333"
+    assert hass.states.get("sensor.sensor1").state == "0.5"
+    assert 0.499 < float(hass.states.get("sensor.sensor2").state) < 0.501
     assert hass.states.get("sensor.sensor3").state == "2"
-    assert hass.states.get("sensor.sensor4").state == "83.3"
+    assert hass.states.get("sensor.sensor4").state == "50.0"
 
 
 @pytest.mark.parametrize("time_zone", ["Europe/Berlin", "America/Chicago", "US/Hawaii"])
@@ -1537,18 +1537,19 @@ async def test_end_time_with_microseconds_zeroed(
         await hass.async_block_till_done()
         await async_update_entity(hass, "sensor.heatpump_compressor_today")
         await hass.async_block_till_done()
-        assert hass.states.get("sensor.heatpump_compressor_today").state == "1.83"
+        assert hass.states.get("sensor.heatpump_compressor_today").state == "0.5"
         assert (
-            hass.states.get("sensor.heatpump_compressor_today2").state
-            == "1.83333333333333"
+            0.499
+            < float(hass.states.get("sensor.heatpump_compressor_today2").state)
+            < 0.501
         )
 
         async_fire_time_changed(hass, time_200)
-        await hass.async_block_till_done(wait_background_tasks=True)
-        assert hass.states.get("sensor.heatpump_compressor_today").state == "1.83"
+        assert hass.states.get("sensor.heatpump_compressor_today").state == "0.5"
         assert (
-            hass.states.get("sensor.heatpump_compressor_today2").state
-            == "1.83333333333333"
+            0.499
+            < float(hass.states.get("sensor.heatpump_compressor_today2").state)
+            < 0.501
         )
         hass.states.async_set("binary_sensor.heatpump_compressor_state", "off")
         await hass.async_block_till_done()
@@ -1557,10 +1558,11 @@ async def test_end_time_with_microseconds_zeroed(
     with freeze_time(time_400):
         async_fire_time_changed(hass, time_400)
         await hass.async_block_till_done(wait_background_tasks=True)
-        assert hass.states.get("sensor.heatpump_compressor_today").state == "1.83"
+        assert hass.states.get("sensor.heatpump_compressor_today").state == "0.5"
         assert (
-            hass.states.get("sensor.heatpump_compressor_today2").state
-            == "1.83333333333333"
+            0.499
+            < float(hass.states.get("sensor.heatpump_compressor_today2").state)
+            < 0.501
         )
         hass.states.async_set("binary_sensor.heatpump_compressor_state", "on")
         await async_wait_recording_done(hass)
@@ -1568,10 +1570,11 @@ async def test_end_time_with_microseconds_zeroed(
     with freeze_time(time_600):
         async_fire_time_changed(hass, time_600)
         await hass.async_block_till_done(wait_background_tasks=True)
-        assert hass.states.get("sensor.heatpump_compressor_today").state == "3.83"
+        assert hass.states.get("sensor.heatpump_compressor_today").state == "2.5"
         assert (
-            hass.states.get("sensor.heatpump_compressor_today2").state
-            == "3.83333333333333"
+            2.499
+            < float(hass.states.get("sensor.heatpump_compressor_today2").state)
+            < 2.501
         )
 
     rolled_to_next_day = start_of_today + timedelta(days=1)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

After this change, `history_stats` in `time` or `ratio` mode will only count time that is definitively known based on recorder data. 

Prior to this change, if the start of the time window was earlier than the oldest datapoint in the recorder, `history_stats` would count time using the assumption that an entity was in the first state it found since the beginning of time. This could lead to wild overcalculations when a switch was turned on after a long period of inactivity, and `history_stats` would assume it has _always_ been on, and calculate a huge value based on that.


## Proposed change

History stats seems to have undesired behavior when the observed window starts earlier than what data is available in the recorder. Consider the following case:

- Your recorder is set for 10 days history
- You have a history stats to monitor "How long has the sprinkler been on in the last 7 days"
- You haven't used sprinklers in a long time and all previous states are purged from the recorder.
- You turn on the sprinklers for the first time.
- The history stats sensor immediately jumps to **168 hours** of on time, despite that it is actually only on for a few seconds. 

I see this kind of bug reported many times and it's always difficult to explain why this happens. The reason is because history_stats currently looks for the first datapoint that it can find in the recorder, and it backdates this to the start of the observation window. 

I would like to have a discussion if this is the correct behavior or not, since it seems pretty wrong to me.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #114762 fixes #125085
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
