### PR TITLE
Fix Matter climate platform attributes when dedicated OnOff attribute is off

### DIFF
--- a/homeassistant/components/matter/climate.py
+++ b/homeassistant/components/matter/climate.py
@@ -190,48 +190,56 @@ class MatterClimate(MatterEntity, ClimateEntity):
             # if the mains power is off - treat it as if the HVAC mode is off
             self._attr_hvac_mode = HVACMode.OFF
             self._attr_hvac_action = None
-            return
-
-        # update hvac_mode from SystemMode
-        system_mode_value = int(
-            self.get_matter_attribute_value(clusters.Thermostat.Attributes.SystemMode)
-        )
-        match system_mode_value:
-            case SystemModeEnum.kAuto:
-                self._attr_hvac_mode = HVACMode.HEAT_COOL
-            case SystemModeEnum.kDry:
-                self._attr_hvac_mode = HVACMode.DRY
-            case SystemModeEnum.kFanOnly:
-                self._attr_hvac_mode = HVACMode.FAN_ONLY
-            case SystemModeEnum.kCool | SystemModeEnum.kPrecooling:
-                self._attr_hvac_mode = HVACMode.COOL
-            case SystemModeEnum.kHeat | SystemModeEnum.kEmergencyHeat:
-                self._attr_hvac_mode = HVACMode.HEAT
-            case SystemModeEnum.kFanOnly:
-                self._attr_hvac_mode = HVACMode.FAN_ONLY
-            case SystemModeEnum.kDry:
-                self._attr_hvac_mode = HVACMode.DRY
-            case _:
-                self._attr_hvac_mode = HVACMode.OFF
-        # running state is an optional attribute
-        # which we map to hvac_action if it exists (its value is not None)
-        self._attr_hvac_action = None
-        if running_state_value := self.get_matter_attribute_value(
-            clusters.Thermostat.Attributes.ThermostatRunningState
-        ):
-            match running_state_value:
-                case ThermostatRunningState.Heat | ThermostatRunningState.HeatStage2:
-                    self._attr_hvac_action = HVACAction.HEATING
-                case ThermostatRunningState.Cool | ThermostatRunningState.CoolStage2:
-                    self._attr_hvac_action = HVACAction.COOLING
-                case (
-                    ThermostatRunningState.Fan
-                    | ThermostatRunningState.FanStage2
-                    | ThermostatRunningState.FanStage3
-                ):
-                    self._attr_hvac_action = HVACAction.FAN
+        else:
+            # update hvac_mode from SystemMode
+            system_mode_value = int(
+                self.get_matter_attribute_value(
+                    clusters.Thermostat.Attributes.SystemMode
+                )
+            )
+            match system_mode_value:
+                case SystemModeEnum.kAuto:
+                    self._attr_hvac_mode = HVACMode.HEAT_COOL
+                case SystemModeEnum.kDry:
+                    self._attr_hvac_mode = HVACMode.DRY
+                case SystemModeEnum.kFanOnly:
+                    self._attr_hvac_mode = HVACMode.FAN_ONLY
+                case SystemModeEnum.kCool | SystemModeEnum.kPrecooling:
+                    self._attr_hvac_mode = HVACMode.COOL
+                case SystemModeEnum.kHeat | SystemModeEnum.kEmergencyHeat:
+                    self._attr_hvac_mode = HVACMode.HEAT
+                case SystemModeEnum.kFanOnly:
+                    self._attr_hvac_mode = HVACMode.FAN_ONLY
+                case SystemModeEnum.kDry:
+                    self._attr_hvac_mode = HVACMode.DRY
                 case _:
-                    self._attr_hvac_action = HVACAction.OFF
+                    self._attr_hvac_mode = HVACMode.OFF
+            # running state is an optional attribute
+            # which we map to hvac_action if it exists (its value is not None)
+            self._attr_hvac_action = None
+            if running_state_value := self.get_matter_attribute_value(
+                clusters.Thermostat.Attributes.ThermostatRunningState
+            ):
+                match running_state_value:
+                    case (
+                        ThermostatRunningState.Heat
+                        | ThermostatRunningState.HeatStage2
+                    ):
+                        self._attr_hvac_action = HVACAction.HEATING
+                    case (
+                        ThermostatRunningState.Cool
+                        | ThermostatRunningState.CoolStage2
+                    ):
+                        self._attr_hvac_action = HVACAction.COOLING
+                    case (
+                        ThermostatRunningState.Fan
+                        | ThermostatRunningState.FanStage2
+                        | ThermostatRunningState.FanStage3
+                    ):
+                        self._attr_hvac_action = HVACAction.FAN
+                    case _:
+                        self._attr_hvac_action = HVACAction.OFF
+
         # update target temperature high/low
         supports_range = (
             self._attr_supported_features


### PR DESCRIPTION
## Proposed change
Fix a small oversight/edgecase in the Matter climate platform code that parses the state attribute from the the node state.
When a climate device has a dedicated Power switch and that turned off at startup, none of the mandatory attributes are parsed. This PR fixes it and will only override the hvac_mode and hvac_action if that is the case but still parse the temperature attributes

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #126073 fixes #124932
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
