### PR TITLE
Route non-TTS media through ESPHome ffmpeg proxy

### DIFF
--- a/homeassistant/components/esphome/assist_satellite.py
+++ b/homeassistant/components/esphome/assist_satellite.py
@@ -14,6 +14,7 @@ import wave
 
 from aioesphomeapi import (
     MediaPlayerFormatPurpose,
+    MediaPlayerSupportedFormat,
     VoiceAssistantAnnounceFinished,
     VoiceAssistantAudioSettings,
     VoiceAssistantCommandFlag,
@@ -44,6 +45,7 @@ from .const import DOMAIN
 from .entity import EsphomeAssistEntity
 from .entry_data import ESPHomeConfigEntry, RuntimeEntryData
 from .enum_mapper import EsphomeEnumMapper
+from .ffmpeg_proxy import async_create_proxy_url
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -325,6 +327,31 @@ class EsphomeAssistSatellite(
             announcement.message,
             announcement.media_id,
         )
+        if not message:
+            # Route non-TTS media through the proxy
+            format_to_use: MediaPlayerSupportedFormat | None = None
+            for supported_format in chain(
+                *self.entry_data.media_player_formats.values()
+            ):
+                if supported_format.purpose == MediaPlayerFormatPurpose.ANNOUNCEMENT:
+                    format_to_use = supported_format
+                    break
+
+            if format_to_use is not None:
+                assert (self.registry_entry is not None) and (
+                    self.registry_entry.device_id is not None
+                )
+                proxy_url = async_create_proxy_url(
+                    self.hass,
+                    self.registry_entry.device_id,
+                    media_id,
+                    media_format=format_to_use.format,
+                    rate=format_to_use.sample_rate or None,
+                    channels=format_to_use.num_channels or None,
+                    width=format_to_use.sample_bytes or None,
+                )
+                media_id = async_process_play_media_url(self.hass, proxy_url)
+
         await self.cli.send_voice_assistant_announcement_await_response(
             announcement.media_id, _ANNOUNCEMENT_TIMEOUT_SEC, announcement.message
         )

--- a/homeassistant/components/esphome/assist_satellite.py
+++ b/homeassistant/components/esphome/assist_satellite.py
@@ -327,7 +327,8 @@ class EsphomeAssistSatellite(
             announcement.message,
             announcement.media_id,
         )
-        if not message:
+        media_id = announcement.media_id
+        if announcement.media_id_source != "tts":
             # Route non-TTS media through the proxy
             format_to_use: MediaPlayerSupportedFormat | None = None
             for supported_format in chain(
@@ -353,7 +354,7 @@ class EsphomeAssistSatellite(
                 media_id = async_process_play_media_url(self.hass, proxy_url)
 
         await self.cli.send_voice_assistant_announcement_await_response(
-            announcement.media_id, _ANNOUNCEMENT_TIMEOUT_SEC, announcement.message
+            media_id, _ANNOUNCEMENT_TIMEOUT_SEC, announcement.message
         )
 
     async def handle_pipeline_start(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If a user `media_id` is provided to the ESPHome Assist satellite announce action, it was not running through the ffmpeg proxy to ensure it has the correct audio format.

This PR routes media ids that were not generated from text-to-speech through the proxy.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
