### PR TITLE
Generic ZHA Zeroconf discovery

### DIFF
--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -72,7 +72,7 @@ REPAIR_MY_URL = "https://my.home-assistant.io/redirect/repairs/"
 LEGACY_ZEROCONF_PORT = 6638
 LEGACY_ZEROCONF_ESPHOME_API_PORT = 6053
 
-ZEROCONF_SERVICE_TYPE = "_zigbee-gateway._tcp.local."
+ZEROCONF_SERVICE_TYPE = "_zigbee-coordinator._tcp.local."
 ZEROCONF_PROPERTIES_SCHEMA = vol.Schema(
     {
         vol.Required("radio_type"): vol.All(str, vol.In([t.name for t in RadioType])),

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -635,15 +635,13 @@ class ZhaConfigFlowHandler(BaseZhaFlow, ConfigFlow, domain=DOMAIN):
 
             # Determine the radio type
             if "radio_type" in discovery_info.properties:
-                radio_type = self._radio_mgr.parse_radio_type(
-                    discovery_info.properties["radio_type"]
-                )
+                radio_type = discovery_info.properties["radio_type"]
             elif "efr32" in name:
-                radio_type = RadioType.ezsp
+                radio_type = RadioType.ezsp.name
             elif "zigate" in name:
-                radio_type = RadioType.zigate
+                radio_type = RadioType.zigate.name
             else:
-                radio_type = RadioType.znp
+                radio_type = RadioType.znp.name
 
             fallback_title = name.split("._", 1)[0]
             title = discovery_info.properties.get("name", fallback_title)
@@ -656,7 +654,7 @@ class ZhaConfigFlowHandler(BaseZhaFlow, ConfigFlow, domain=DOMAIN):
                 type=ZEROCONF_SERVICE_TYPE,
                 name=f"{title}.{ZEROCONF_SERVICE_TYPE}",
                 properties={
-                    "radio_type": radio_type.name,
+                    "radio_type": radio_type,
                     # To maintain backwards compatibility
                     "serial_number": discovery_info.hostname.removesuffix(".local."),
                 },

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -650,10 +650,10 @@ class ZhaConfigFlowHandler(BaseZhaFlow, ConfigFlow, domain=DOMAIN):
                 port=port,
                 hostname=discovery_info.hostname,
                 type="_zigbee-gateway._tcp.local.",
-                name=local_name,
+                name=discovery_info.properties.get("name", local_name),
                 properties={
                     "radio_type": radio_type.name,
-                    "serial_number": f"{radio_type}_{local_name}_{port}",
+                    "serial_number": local_name,  # To maintain backwards compatibility
                 },
             )
 

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -658,17 +658,15 @@ class ZhaConfigFlowHandler(BaseZhaFlow, ConfigFlow, domain=DOMAIN):
             )
 
         try:
-            ZEROCONF_PROPERTIES_SCHEMA(discovery_info.properties)
+            discovery_props = ZEROCONF_PROPERTIES_SCHEMA(discovery_info.properties)
         except vol.Invalid:
             return self.async_abort(reason="invalid_zeroconf_data")
 
-        radio_type = self._radio_mgr.parse_radio_type(
-            discovery_info.properties["radio_type"]
-        )
+        radio_type = self._radio_mgr.parse_radio_type(discovery_props["radio_type"])
         device_path = f"socket://{discovery_info.host}:{port}"
 
         await self._set_unique_id_and_update_ignored_flow(
-            unique_id=discovery_info.properties["serial_number"],
+            unique_id=discovery_props["serial_number"],
             device_path=device_path,
         )
 

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -663,7 +663,7 @@ class ZhaConfigFlowHandler(BaseZhaFlow, ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="invalid_zeroconf_data")
 
         radio_type = self._radio_mgr.parse_radio_type(discovery_props["radio_type"])
-        device_path = f"socket://{discovery_info.host}:{port}"
+        device_path = f"socket://{discovery_info.host}:{discovery_info.port}"
 
         await self._set_unique_id_and_update_ignored_flow(
             unique_id=discovery_props["serial_number"],

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -69,8 +69,16 @@ UPLOADED_BACKUP_FILE = "uploaded_backup_file"
 
 REPAIR_MY_URL = "https://my.home-assistant.io/redirect/repairs/"
 
-DEFAULT_ZHA_ZEROCONF_PORT = 6638
-ESPHOME_API_PORT = 6053
+LEGACY_ZEROCONF_PORT = 6638
+LEGACY_ZEROCONF_ESPHOME_API_PORT = 6053
+
+ZEROCONF_PROPERTIES_SCHEMA = vol.Schema(
+    {
+        vol.Required("radio_type"): vol.All(str, vol.In([t.name for t in RadioType])),
+        vol.Required("serial_number"): str,
+    },
+    extra=vol.ALLOW_EXTRA,
+)
 
 
 def _format_backup_choice(
@@ -615,32 +623,56 @@ class ZhaConfigFlowHandler(BaseZhaFlow, ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle zeroconf discovery."""
 
-        # Hostname is format: livingroom.local.
-        local_name = discovery_info.hostname[:-1]
-        port = discovery_info.port or DEFAULT_ZHA_ZEROCONF_PORT
+        # Transform legacy zeroconf discovery into the new format
+        if discovery_info.type != "_zigbee-gateway._tcp.local.":
+            local_name = discovery_info.hostname.removesuffix(".local.")
+            port = discovery_info.port or LEGACY_ZEROCONF_PORT
 
-        # Fix incorrect port for older TubesZB devices
-        if "tube" in local_name and port == ESPHOME_API_PORT:
-            port = DEFAULT_ZHA_ZEROCONF_PORT
+            # Fix incorrect port for older TubesZB devices
+            if "tube" in local_name and port == LEGACY_ZEROCONF_ESPHOME_API_PORT:
+                port = LEGACY_ZEROCONF_PORT
 
-        if "radio_type" in discovery_info.properties:
-            self._radio_mgr.radio_type = self._radio_mgr.parse_radio_type(
-                discovery_info.properties["radio_type"]
+            # Determine the radio type
+            if "radio_type" in discovery_info.properties:
+                radio_type = self._radio_mgr.parse_radio_type(
+                    discovery_info.properties["radio_type"]
+                )
+            elif "efr32" in local_name:
+                radio_type = RadioType.ezsp
+            elif "zigate" in local_name:
+                radio_type = RadioType.zigate
+            else:
+                radio_type = RadioType.znp
+
+            discovery_info = zeroconf.ZeroconfServiceInfo(
+                ip_address=discovery_info.ip_address,
+                ip_addresses=discovery_info.ip_addresses,
+                port=port,
+                hostname=discovery_info.hostname,
+                type="_zigbee-gateway._tcp.local.",
+                name=local_name,
+                properties={
+                    "radio_type": radio_type.name,
+                    "serial_number": f"{radio_type}_{local_name}_{port}",
+                },
             )
-        elif "efr32" in local_name:
-            self._radio_mgr.radio_type = RadioType.ezsp
-        else:
-            self._radio_mgr.radio_type = RadioType.znp
 
-        node_name = local_name.removesuffix(".local")
+        try:
+            ZEROCONF_PROPERTIES_SCHEMA(discovery_info.properties)
+        except vol.Invalid:
+            return self.async_abort(reason="invalid_zeroconf_data")
+
+        radio_type = self._radio_mgr.parse_radio_type(
+            discovery_info.properties["radio_type"]
+        )
         device_path = f"socket://{discovery_info.host}:{port}"
 
         await self._set_unique_id_and_update_ignored_flow(
-            unique_id=node_name,
+            unique_id=discovery_info.properties["serial_number"],
             device_path=device_path,
         )
 
-        self.context["title_placeholders"] = {CONF_NAME: node_name}
+        self.context["title_placeholders"] = {CONF_NAME: discovery_info.name}
         self._title = device_path
         self._radio_mgr.device_path = device_path
 

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -130,6 +130,10 @@
     {
       "type": "_czc._tcp.local.",
       "name": "czc*"
+    },
+    {
+      "type": "_zigbee-gateway._tcp.local.",
+      "name": "*"
     }
   ]
 }

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -132,7 +132,7 @@
       "name": "czc*"
     },
     {
-      "type": "_zigbee-gateway._tcp.local.",
+      "type": "_zigbee-coordinator._tcp.local.",
       "name": "*"
     }
   ]

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -76,7 +76,8 @@
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "not_zha_device": "This device is not a zha device",
       "usb_probe_failed": "Failed to probe the usb device",
-      "wrong_firmware_installed": "Your device is running the wrong firmware and cannot be used with ZHA until the correct firmware is installed. [A repair has been created]({repair_url}) with more information and instructions for how to fix this."
+      "wrong_firmware_installed": "Your device is running the wrong firmware and cannot be used with ZHA until the correct firmware is installed. [A repair has been created]({repair_url}) with more information and instructions for how to fix this.",
+      "invalid_zeroconf_data": "The coordinator has invalid zeroconf service info and cannot be identified by ZHA"
     }
   },
   "options": {

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -872,6 +872,12 @@ ZEROCONF = {
             "name": "*zigate*",
         },
     ],
+    "_zigbee-gateway._tcp.local.": [
+        {
+            "domain": "zha",
+            "name": "*",
+        },
+    ],
     "_zigstar_gw._tcp.local.": [
         {
             "domain": "zha",

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -872,7 +872,7 @@ ZEROCONF = {
             "name": "*zigate*",
         },
     ],
-    "_zigbee-gateway._tcp.local.": [
+    "_zigbee-coordinator._tcp.local.": [
         {
             "domain": "zha",
             "name": "*",

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -872,7 +872,7 @@ ZEROCONF = {
             "name": "*zigate*",
         },
     ],
-    "_zigbee-coordinator._tcp.local.": [
+    "_zigbee-gateway._tcp.local.": [
         {
             "domain": "zha",
             "name": "*",

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -210,7 +210,7 @@ async def test_legacy_zeroconf_discovery_zigate(
         hostname="_zigate-zigbee-gateway._tcp.local.",
         name="any",
         port=1234,
-        properties={"radio_type": "zigate"},
+        properties={},
         type="mock_type",
     )
     result = await hass.config_entries.flow.async_init(
@@ -249,6 +249,24 @@ async def test_legacy_zeroconf_discovery_zigate(
         },
         CONF_RADIO_TYPE: "zigate",
     }
+
+
+async def test_zeroconf_discovery_bad_payload(hass: HomeAssistant) -> None:
+    """Test zeroconf flow with a bad payload."""
+    service_info = zeroconf.ZeroconfServiceInfo(
+        ip_address=ip_address("192.168.1.200"),
+        ip_addresses=[ip_address("192.168.1.200")],
+        hostname="some.hostname",
+        name="any",
+        port=1234,
+        properties={"radio_type": "some bogus radio"},
+        type="_zigbee-gateway._tcp.local.",
+    )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_ZEROCONF}, data=service_info
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "invalid_zeroconf_data"
 
 
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -233,10 +233,10 @@ def com_port(device="/dev/ttyUSB1234") -> ListPortInfo:
                 ip_address=ip_address("192.168.1.200"),
                 ip_addresses=[ip_address("192.168.1.200")],
                 hostname="some-zigbee-gateway-12345.local.",
-                name="Some Zigbee Gateway (12345)._zigbee-gateway._tcp.local.",
+                name="Some Zigbee Gateway (12345)._zigbee-coordinator._tcp.local.",
                 port=6638,
                 properties={"radio_type": "znp", "serial_number": "aabbccddeeff"},
-                type="_zigbee-gateway._tcp.local.",
+                type="_zigbee-coordinator._tcp.local.",
             ),
         ),
     ],
@@ -346,7 +346,7 @@ async def test_zeroconf_discovery_bad_payload(hass: HomeAssistant) -> None:
         name="any",
         port=1234,
         properties={"radio_type": "some bogus radio"},
-        type="_zigbee-gateway._tcp.local.",
+        type="_zigbee-coordinator._tcp.local.",
     )
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=service_info

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -156,7 +156,7 @@ def com_port(device="/dev/ttyUSB1234") -> ListPortInfo:
 
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
 @patch(f"zigpy_znp.{PROBE_FUNCTION_PATH}", AsyncMock(return_value=True))
-async def test_zeroconf_discovery_znp(hass: HomeAssistant) -> None:
+async def test_legacy_zeroconf_discovery_znp(hass: HomeAssistant) -> None:
     """Test zeroconf flow -- radio detected."""
     service_info = zeroconf.ZeroconfServiceInfo(
         ip_address=ip_address("192.168.1.200"),
@@ -167,34 +167,28 @@ async def test_zeroconf_discovery_znp(hass: HomeAssistant) -> None:
         properties={"name": "tube_123456"},
         type="mock_type",
     )
-    flow = await hass.config_entries.flow.async_init(
+    result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=service_info
     )
-    assert flow["step_id"] == "confirm"
-
-    # Confirm discovery
-    result1 = await hass.config_entries.flow.async_configure(
-        flow["flow_id"], user_input={}
-    )
-    assert result1["step_id"] == "manual_port_config"
+    assert result["step_id"] == "confirm"
 
     # Confirm port settings
-    result2 = await hass.config_entries.flow.async_configure(
-        result1["flow_id"], user_input={}
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
     )
 
-    assert result2["type"] is FlowResultType.MENU
-    assert result2["step_id"] == "choose_formation_strategy"
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "choose_formation_strategy"
 
-    result3 = await hass.config_entries.flow.async_configure(
-        result2["flow_id"],
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
         user_input={"next_step_id": config_flow.FORMATION_REUSE_SETTINGS},
     )
     await hass.async_block_till_done()
 
-    assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert result3["title"] == "socket://192.168.1.200:6638"
-    assert result3["data"] == {
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "socket://192.168.1.200:6638"
+    assert result["data"] == {
         CONF_DEVICE: {
             CONF_BAUDRATE: 115200,
             CONF_FLOW_CONTROL: None,
@@ -206,7 +200,9 @@ async def test_zeroconf_discovery_znp(hass: HomeAssistant) -> None:
 
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
 @patch(f"zigpy_zigate.{PROBE_FUNCTION_PATH}")
-async def test_zigate_via_zeroconf(setup_entry_mock, hass: HomeAssistant) -> None:
+async def test_legacy_zeroconf_discovery_zigate(
+    setup_entry_mock, hass: HomeAssistant
+) -> None:
     """Test zeroconf flow -- zigate radio detected."""
     service_info = zeroconf.ZeroconfServiceInfo(
         ip_address=ip_address("192.168.1.200"),
@@ -217,41 +213,35 @@ async def test_zigate_via_zeroconf(setup_entry_mock, hass: HomeAssistant) -> Non
         properties={"radio_type": "zigate"},
         type="mock_type",
     )
-    flow = await hass.config_entries.flow.async_init(
+    result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=service_info
     )
-    assert flow["step_id"] == "confirm"
-
-    # Confirm discovery
-    result1 = await hass.config_entries.flow.async_configure(
-        flow["flow_id"], user_input={}
-    )
-    assert result1["step_id"] == "manual_port_config"
+    assert result["step_id"] == "confirm"
 
     # Confirm the radio is deprecated
-    result2 = await hass.config_entries.flow.async_configure(
-        flow["flow_id"], user_input={}
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
     )
-    assert result2["step_id"] == "verify_radio"
-    assert "ZiGate" in result2["description_placeholders"]["name"]
+    assert result["step_id"] == "verify_radio"
+    assert "ZiGate" in result["description_placeholders"]["name"]
 
     # Confirm port settings
-    result3 = await hass.config_entries.flow.async_configure(
-        result1["flow_id"], user_input={}
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
     )
 
-    assert result3["type"] is FlowResultType.MENU
-    assert result3["step_id"] == "choose_formation_strategy"
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "choose_formation_strategy"
 
-    result4 = await hass.config_entries.flow.async_configure(
-        result3["flow_id"],
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
         user_input={"next_step_id": config_flow.FORMATION_REUSE_SETTINGS},
     )
     await hass.async_block_till_done()
 
-    assert result4["type"] is FlowResultType.CREATE_ENTRY
-    assert result4["title"] == "socket://192.168.1.200:1234"
-    assert result4["data"] == {
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "socket://192.168.1.200:1234"
+    assert result["data"] == {
         CONF_DEVICE: {
             CONF_DEVICE_PATH: "socket://192.168.1.200:1234",
             CONF_BAUDRATE: 115200,
@@ -263,7 +253,7 @@ async def test_zigate_via_zeroconf(setup_entry_mock, hass: HomeAssistant) -> Non
 
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
 @patch(f"bellows.{PROBE_FUNCTION_PATH}", AsyncMock(return_value=True))
-async def test_efr32_via_zeroconf(hass: HomeAssistant) -> None:
+async def test_legacy_zeroconf_discovery_efr32(hass: HomeAssistant) -> None:
     """Test zeroconf flow -- efr32 radio detected."""
     service_info = zeroconf.ZeroconfServiceInfo(
         ip_address=ip_address("192.168.1.200"),
@@ -274,34 +264,28 @@ async def test_efr32_via_zeroconf(hass: HomeAssistant) -> None:
         properties={},
         type="mock_type",
     )
-    flow = await hass.config_entries.flow.async_init(
+    result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=service_info
     )
-    assert flow["step_id"] == "confirm"
-
-    # Confirm discovery
-    result1 = await hass.config_entries.flow.async_configure(
-        flow["flow_id"], user_input={}
-    )
-    assert result1["step_id"] == "manual_port_config"
+    assert result["step_id"] == "confirm"
 
     # Confirm port settings
-    result2 = await hass.config_entries.flow.async_configure(
-        result1["flow_id"], user_input={}
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
     )
 
-    assert result2["type"] is FlowResultType.MENU
-    assert result2["step_id"] == "choose_formation_strategy"
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "choose_formation_strategy"
 
-    result3 = await hass.config_entries.flow.async_configure(
-        result2["flow_id"],
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
         user_input={"next_step_id": config_flow.FORMATION_REUSE_SETTINGS},
     )
     await hass.async_block_till_done()
 
-    assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert result3["title"] == "socket://192.168.1.200:1234"
-    assert result3["data"] == {
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "socket://192.168.1.200:1234"
+    assert result["data"] == {
         CONF_DEVICE: {
             CONF_DEVICE_PATH: "socket://192.168.1.200:1234",
             CONF_BAUDRATE: 115200,
@@ -313,7 +297,7 @@ async def test_efr32_via_zeroconf(hass: HomeAssistant) -> None:
 
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
 @patch(f"zigpy_znp.{PROBE_FUNCTION_PATH}", AsyncMock(return_value=True))
-async def test_discovery_via_zeroconf_ip_change_ignored(hass: HomeAssistant) -> None:
+async def test_legacy_zeroconf_discovery_ip_change_ignored(hass: HomeAssistant) -> None:
     """Test zeroconf flow that was ignored gets updated."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -342,7 +326,9 @@ async def test_discovery_via_zeroconf_ip_change_ignored(hass: HomeAssistant) -> 
     }
 
 
-async def test_discovery_confirm_final_abort_if_entries(hass: HomeAssistant) -> None:
+async def test_legacy_zeroconf_discovery_confirm_final_abort_if_entries(
+    hass: HomeAssistant,
+) -> None:
     """Test discovery aborts if ZHA was set up after the confirmation dialog is shown."""
     service_info = zeroconf.ZeroconfServiceInfo(
         ip_address=ip_address("192.168.1.200"),
@@ -677,7 +663,7 @@ async def test_discovery_via_usb_zha_ignored_updates(hass: HomeAssistant) -> Non
 
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
 @patch(f"zigpy_znp.{PROBE_FUNCTION_PATH}", AsyncMock(return_value=True))
-async def test_discovery_already_setup(hass: HomeAssistant) -> None:
+async def test_legacy_zeroconf_discovery_already_setup(hass: HomeAssistant) -> None:
     """Test zeroconf flow -- radio detected."""
     service_info = zeroconf.ZeroconfServiceInfo(
         ip_address=ip_address("192.168.1.200"),

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -252,29 +252,29 @@ async def test_zeroconf_discovery(
     hass: HomeAssistant,
 ) -> None:
     """Test zeroconf flow -- radio detected."""
-    result = await hass.config_entries.flow.async_init(
+    result_init = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=service_info
     )
-    assert result["step_id"] == "confirm"
+    assert result_init["step_id"] == "confirm"
 
     # Confirm port settings
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={}
+    result_confirm = await hass.config_entries.flow.async_configure(
+        result_init["flow_id"], user_input={}
     )
 
-    assert result["type"] is FlowResultType.MENU
-    assert result["step_id"] == "choose_formation_strategy"
+    assert result_confirm["type"] is FlowResultType.MENU
+    assert result_confirm["step_id"] == "choose_formation_strategy"
 
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
+    result_form = await hass.config_entries.flow.async_configure(
+        result_confirm["flow_id"],
         user_input={"next_step_id": config_flow.FORMATION_REUSE_SETTINGS},
     )
     await hass.async_block_till_done()
 
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == entry_name
-    assert result["context"]["unique_id"] == unique_id
-    assert result["data"] == {
+    assert result_form["type"] is FlowResultType.CREATE_ENTRY
+    assert result_form["title"] == entry_name
+    assert result_form["context"]["unique_id"] == unique_id
+    assert result_form["data"] == {
         CONF_DEVICE: {
             CONF_BAUDRATE: 115200,
             CONF_FLOW_CONTROL: None,
@@ -299,35 +299,35 @@ async def test_legacy_zeroconf_discovery_zigate(
         properties={},
         type="mock_type",
     )
-    result = await hass.config_entries.flow.async_init(
+    result_init = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=service_info
     )
-    assert result["step_id"] == "confirm"
+    assert result_init["step_id"] == "confirm"
 
     # Confirm the radio is deprecated
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={}
+    result_confirm_deprecated = await hass.config_entries.flow.async_configure(
+        result_init["flow_id"], user_input={}
     )
-    assert result["step_id"] == "verify_radio"
-    assert "ZiGate" in result["description_placeholders"]["name"]
+    assert result_confirm_deprecated["step_id"] == "verify_radio"
+    assert "ZiGate" in result_confirm_deprecated["description_placeholders"]["name"]
 
     # Confirm port settings
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={}
+    result_confirm = await hass.config_entries.flow.async_configure(
+        result_confirm_deprecated["flow_id"], user_input={}
     )
 
-    assert result["type"] is FlowResultType.MENU
-    assert result["step_id"] == "choose_formation_strategy"
+    assert result_confirm["type"] is FlowResultType.MENU
+    assert result_confirm["step_id"] == "choose_formation_strategy"
 
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
+    result_form = await hass.config_entries.flow.async_configure(
+        result_confirm["flow_id"],
         user_input={"next_step_id": config_flow.FORMATION_REUSE_SETTINGS},
     )
     await hass.async_block_till_done()
 
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "some name"
-    assert result["data"] == {
+    assert result_form["type"] is FlowResultType.CREATE_ENTRY
+    assert result_form["title"] == "some name"
+    assert result_form["data"] == {
         CONF_DEVICE: {
             CONF_DEVICE_PATH: "socket://192.168.1.200:1234",
             CONF_BAUDRATE: 115200,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I'm introducing a new service type: `_zigbee-coordinator._tcp.local.`. This will allow all future TCP coordinators to be supported without an explicit PR to ZHA. The only expected properties are `radio_type` (one of `ezsp`, `znp`, etc.) and `serial_number` (must be unique per device and not derived from any Zigbee information, like the Ethernet MAC address). The service name will be shown as-is.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
