### PR TITLE
Enable all TID ruff rules

### DIFF
--- a/homeassistant/components/trace/websocket_api.py
+++ b/homeassistant/components/trace/websocket_api.py
@@ -26,7 +26,7 @@ from homeassistant.helpers.script import (
     debug_stop,
 )
 
-from .. import trace
+from .. import trace  # noqa: TID252 (see PR 125822)
 
 TRACE_DOMAINS = ("automation", "script")
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1119,7 +1119,8 @@ def custom_serializer(schema: Any) -> Any:
 
 def _custom_serializer(schema: Any, *, allow_section: bool) -> Any:
     """Serialize additional types for voluptuous_serialize."""
-    from .. import data_entry_flow  # pylint: disable=import-outside-toplevel
+    from homeassistant import data_entry_flow  # pylint: disable=import-outside-toplevel
+
     from . import selector  # pylint: disable=import-outside-toplevel
 
     if schema is positive_time_period_dict:

--- a/homeassistant/helpers/discovery.py
+++ b/homeassistant/helpers/discovery.py
@@ -14,8 +14,8 @@ from typing import Any, TypedDict
 from homeassistant import core, setup
 from homeassistant.const import Platform
 from homeassistant.loader import bind_hass
+from homeassistant.util.signal_type import SignalTypeFormat
 
-from ..util.signal_type import SignalTypeFormat
 from .dispatcher import async_dispatcher_connect, async_dispatcher_send_internal
 from .typing import ConfigType, DiscoveryInfoType
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -773,7 +773,7 @@ select = [
     "T100", # Trace found: {name} used
     "T20", # flake8-print
     "TCH", # flake8-type-checking
-    "TID251", # Banned imports
+    "TID", # Tidy imports
     "TRY", # tryceratops
     "UP", # pyupgrade
     "UP031", # Use format specifiers instead of percent format
@@ -910,6 +910,11 @@ split-on-trailing-comma = false
 "homeassistant/__main__.py" = ["T201"]
 "homeassistant/scripts/*" = ["T201"]
 "script/*" = ["T20"]
+
+# Allow relative imports within components
+"homeassistant/auth/*/*" = ["TID252"]
+"homeassistant/components/*/*/*" = ["TID252"]
+"tests/components/*/*/*" = ["TID252"]
 
 # Temporary
 "homeassistant/**" = ["PTH"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -911,7 +911,7 @@ split-on-trailing-comma = false
 "homeassistant/scripts/*" = ["T201"]
 "script/*" = ["T20"]
 
-# Allow relative imports within components
+# Allow relative imports within auth and within components
 "homeassistant/auth/*/*" = ["TID252"]
 "homeassistant/components/*/*/*" = ["TID252"]
 "tests/components/*/*/*" = ["TID252"]

--- a/tests/helpers/test_debounce.py
+++ b/tests/helpers/test_debounce.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import debounce
 from homeassistant.util.dt import utcnow
 
-from ..common import async_fire_time_changed
+from tests.common import async_fire_time_changed
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://docs.astral.sh/ruff/rules/#flake8-tidy-imports-tid

In particular `TID252`: https://docs.astral.sh/ruff/rules/relative-imports/

Replaces #126246


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
