### PR TITLE
Add event platform to Smlight integration

### DIFF
--- a/homeassistant/components/smlight/__init__.py
+++ b/homeassistant/components/smlight/__init__.py
@@ -16,6 +16,7 @@ from .coordinator import SmDataUpdateCoordinator, SmFirmwareUpdateCoordinator
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
+    Platform.EVENT,
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.UPDATE,

--- a/homeassistant/components/smlight/event.py
+++ b/homeassistant/components/smlight/event.py
@@ -1,0 +1,60 @@
+"""Support for SLZB-06 events."""
+
+from __future__ import annotations
+
+import json
+
+from pysmlight.const import Events as SmEvents, RebootReasons
+from pysmlight.sse import MessageEvent
+
+from homeassistant.components.event import EventEntity
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import SmConfigEntry
+from .coordinator import SmDataUpdateCoordinator
+from .entity import SmEntity
+
+EVENT_TYPE_CORE_REBOOT = "core-reboot"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: SmConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the slzb event platform."""
+    coordinator = entry.runtime_data.data
+    async_add_entities([SmEvent(coordinator)])
+
+
+class SmEvent(SmEntity, EventEntity):
+    """Representation of a slzb event entity."""
+
+    _attr_event_types = [EVENT_TYPE_CORE_REBOOT]
+
+    _attr_should_poll = False
+    _attr_translation_key = "event"
+
+    def __init__(self, coordinator: SmDataUpdateCoordinator) -> None:
+        """Initialize the slzb event entity."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.unique_id}_{self._attr_translation_key}"
+
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self.coordinator.client.sse.register_callback(
+                SmEvents.REBOOT, self._async_handle_event
+            )
+        )
+
+    @callback
+    def _async_handle_event(self, event: MessageEvent) -> None:
+        """Handle the reboot event."""
+        data = json.loads(event.data)
+        data["reason"] = RebootReasons(data["reason"]).name
+
+        self._trigger_event(EVENT_TYPE_CORE_REBOOT, data)
+        self.async_write_ha_state()

--- a/homeassistant/components/smlight/strings.json
+++ b/homeassistant/components/smlight/strings.json
@@ -56,6 +56,18 @@
         "name": "Wi-Fi"
       }
     },
+    "event": {
+      "event": {
+        "name": "Event",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "core": "Core reboot"
+            }
+          }
+        }
+      }
+    },
     "sensor": {
       "zigbee_temperature": {
         "name": "Zigbee chip temp"

--- a/tests/components/smlight/test_event.py
+++ b/tests/components/smlight/test_event.py
@@ -1,0 +1,58 @@
+"""Tests for the SMLIGHT event platform."""
+
+from unittest.mock import MagicMock
+
+from pysmlight.const import Events as SmEvents
+from pysmlight.sse import MessageEvent
+import pytest
+
+from homeassistant.const import STATE_UNKNOWN, Platform
+from homeassistant.core import HomeAssistant
+
+from . import get_mock_event_function
+from .conftest import setup_integration
+
+from tests.common import MockConfigEntry
+
+MOCK_REBOOT_EVENT = MessageEvent(
+    type="reboot",
+    message="reboot",
+    data='{"reason": 3, "epoch": 1634020800}',
+    origin="http://slzb-06.local",
+    last_event_id="",
+)
+
+
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Platforms, which should be loaded during the test."""
+    return [Platform.EVENT]
+
+
+@pytest.mark.freeze_time("2024-09-01 00:00:00+00:00")
+async def test_reboot_event(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_smlight_client: MagicMock,
+) -> None:
+    """Test event entity."""
+
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("event.mock_title_event")
+    assert state.state == STATE_UNKNOWN
+
+    event_function = get_mock_event_function(mock_smlight_client, SmEvents.REBOOT)
+    assert event_function is not None
+
+    event_function(MOCK_REBOOT_EVENT)
+
+    state = hass.states.get("event.mock_title_event")
+    assert state.state == "2024-09-01T00:00:00.000+00:00"
+    assert state.attributes == {
+        "event_types": ["core-reboot"],
+        "event_type": "core-reboot",
+        "reason": "ESP_RST_SW",
+        "epoch": 1634020800,
+        "friendly_name": "Mock Title Event",
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add event platform for Smlight integration. The event entity will detect core (ESP32) reboots. Additional events will likely be added in the future such zigbee reboot etc..

This requires core firmware update `v2.5.4.dev` which will be released as stable `v2.5.4` prior to HA beta

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/34842

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
