### PR TITLE
Update pylint to 3.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,7 @@ disable = [
     "too-many-locals",
     "too-many-public-methods",
     "too-many-boolean-expressions",
+    "too-many-positional-arguments",
     "wrong-import-order",
     "consider-using-namedtuple-or-dataclass",
     "consider-using-assignment-expr",

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,14 +7,14 @@
 
 -c homeassistant/package_constraints.txt
 -r requirements_test_pre_commit.txt
-astroid==3.2.4
+astroid==3.3.3
 coverage==7.6.0
 freezegun==1.5.1
 mock-open==1.4.0
 mypy-dev==1.12.0a3
 pre-commit==3.7.1
 pydantic==1.10.17
-pylint==3.2.6
+pylint==3.3.0
 pylint-per-file-ignores==1.3.2
 pipdeptree==2.23.1
 pip-licenses==4.5.1

--- a/tests/components/bsblan/conftest.py
+++ b/tests/components/bsblan/conftest.py
@@ -40,7 +40,7 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_bsblan() -> Generator[MagicMock, None, None]:
+def mock_bsblan() -> Generator[MagicMock]:
     """Return a mocked BSBLAN client."""
     with (
         patch("homeassistant.components.bsblan.BSBLAN", autospec=True) as bsblan_mock,

--- a/tests/components/ibeacon/test_device_tracker.py
+++ b/tests/components/ibeacon/test_device_tracker.py
@@ -11,9 +11,7 @@ from homeassistant.components.bluetooth import (
     async_ble_device_from_address,
     async_last_service_info,
 )
-from homeassistant.components.bluetooth.const import (  # pylint: disable=hass-component-root-import
-    UNAVAILABLE_TRACK_SECONDS,
-)
+from homeassistant.components.bluetooth.const import UNAVAILABLE_TRACK_SECONDS
 from homeassistant.components.ibeacon.const import (
     DOMAIN,
     UNAVAILABLE_TIMEOUT,

--- a/tests/components/ibeacon/test_sensor.py
+++ b/tests/components/ibeacon/test_sensor.py
@@ -4,9 +4,7 @@ from datetime import timedelta
 
 import pytest
 
-from homeassistant.components.bluetooth.const import (  # pylint: disable=hass-component-root-import
-    UNAVAILABLE_TRACK_SECONDS,
-)
+from homeassistant.components.bluetooth.const import UNAVAILABLE_TRACK_SECONDS
 from homeassistant.components.ibeacon.const import DOMAIN, UPDATE_INTERVAL
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.const import (

--- a/tests/components/sensoterra/conftest.py
+++ b/tests/components/sensoterra/conftest.py
@@ -9,7 +9,7 @@ from .const import API_TOKEN
 
 
 @pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with patch(
         "homeassistant.components.sensoterra.async_setup_entry",
@@ -19,7 +19,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def mock_customer_api_client() -> Generator[AsyncMock, None, None]:
+def mock_customer_api_client() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
     with (
         patch(


### PR DESCRIPTION
## Proposed change
Adds initial support for Python 3.13.

**New checks**
- `too-many-positional-arguments` this one is quite noisy and doesn't add much value for us. Disabled it along with the other `too-many-*` errors.
- `unnecessary-default-type-args` can detect the unnecessary type args for `Generator` and `AsyncGenerator` and suggests removing them. This will help so we don't have to do that manually anymore,
e.g. https://github.com/home-assistant/core/pull/125228

https://github.com/pylint-dev/pylint/releases/tag/v3.2.7
https://github.com/pylint-dev/pylint/releases/tag/v3.3.0
https://github.com/pylint-dev/pylint/compare/v3.2.6...v3.3.0

https://github.com/pylint-dev/astroid/releases/tag/v3.3.0
https://github.com/pylint-dev/astroid/releases/tag/v3.3.1
https://github.com/pylint-dev/astroid/releases/tag/v3.3.2
https://github.com/pylint-dev/astroid/releases/tag/v3.3.3
https://github.com/pylint-dev/astroid/compare/v3.2.4...v3.3.3


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
