### PR TITLE
Add buttons to cast skills in Habitica integration

### DIFF
--- a/homeassistant/components/habitica/button.py
+++ b/homeassistant/components/habitica/button.py
@@ -210,22 +210,26 @@ async def async_setup_entry(
     async_add_entities(
         HabiticaButton(coordinator, description) for description in BUTTON_DESCRIPTIONS
     )
-    if coordinator.data.user["stats"]["class"] == "wizard":
-        async_add_entities(
-            HabiticaButton(coordinator, description) for description in WIZARD_SKILLS
-        )
-    if coordinator.data.user["stats"]["class"] == "warrior":
-        async_add_entities(
-            HabiticaButton(coordinator, description) for description in WARRIOR_SKILLS
-        )
-    if coordinator.data.user["stats"]["class"] == "rogue":
-        async_add_entities(
-            HabiticaButton(coordinator, description) for description in ROGUE_SKILLS
-        )
-    if coordinator.data.user["stats"]["class"] == "healer":
-        async_add_entities(
-            HabiticaButton(coordinator, description) for description in HEALER_SKILLS
-        )
+    if coordinator.data.user["stats"]["lvl"] > 10:
+        if coordinator.data.user["stats"]["class"] == "wizard":
+            async_add_entities(
+                HabiticaButton(coordinator, description)
+                for description in WIZARD_SKILLS
+            )
+        if coordinator.data.user["stats"]["class"] == "warrior":
+            async_add_entities(
+                HabiticaButton(coordinator, description)
+                for description in WARRIOR_SKILLS
+            )
+        if coordinator.data.user["stats"]["class"] == "rogue":
+            async_add_entities(
+                HabiticaButton(coordinator, description) for description in ROGUE_SKILLS
+            )
+        if coordinator.data.user["stats"]["class"] == "healer":
+            async_add_entities(
+                HabiticaButton(coordinator, description)
+                for description in HEALER_SKILLS
+            )
 
 
 class HabiticaButton(HabiticaBase, ButtonEntity):

--- a/homeassistant/components/habitica/button.py
+++ b/homeassistant/components/habitica/button.py
@@ -91,17 +91,21 @@ MAGE_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
         key=HabitipyButtonEntity.MPHEAL,
         translation_key=HabitipyButtonEntity.MPHEAL,
         press_fn=lambda coordinator: coordinator.api.user.class_.cast["mpheal"].post(),
-        available_fn=lambda data: data.user["stats"]["lvl"] >= 12
-        and data.user["stats"]["mp"] >= 30
-        and data.user["stats"]["class"] == MAGE,
+        available_fn=(
+            lambda data: data.user["stats"]["lvl"] >= 12
+            and data.user["stats"]["mp"] >= 30
+            and data.user["stats"]["class"] == MAGE
+        ),
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.EARTH,
         translation_key=HabitipyButtonEntity.EARTH,
         press_fn=lambda coordinator: coordinator.api.user.class_.cast["earth"].post(),
-        available_fn=lambda data: data.user["stats"]["lvl"] >= 13
-        and data.user["stats"]["mp"] >= 35
-        and data.user["stats"]["class"] == MAGE,
+        available_fn=(
+            lambda data: data.user["stats"]["lvl"] >= 13
+            and data.user["stats"]["mp"] >= 35
+            and data.user["stats"]["class"] == MAGE
+        ),
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.FROST,
@@ -109,9 +113,11 @@ MAGE_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
         press_fn=lambda coordinator: coordinator.api.user.class_.cast["frost"].post(
             targetId=coordinator.config_entry.unique_id
         ),
-        available_fn=lambda data: data.user["stats"]["lvl"] >= 14
-        and data.user["stats"]["mp"] >= 40
-        and data.user["stats"]["class"] == MAGE,
+        available_fn=(
+            lambda data: data.user["stats"]["lvl"] >= 14
+            and data.user["stats"]["mp"] >= 40
+            and data.user["stats"]["class"] == MAGE
+        ),
     ),
 )
 
@@ -122,9 +128,11 @@ WARRIOR_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
         press_fn=lambda coordinator: coordinator.api.user.class_.cast[
             "defensiveStance"
         ].post(targetId=coordinator.config_entry.unique_id),
-        available_fn=lambda data: data.user["stats"]["lvl"] >= 12
-        and data.user["stats"]["mp"] >= 25
-        and data.user["stats"]["class"] == WARRIOR,
+        available_fn=(
+            lambda data: data.user["stats"]["lvl"] >= 12
+            and data.user["stats"]["mp"] >= 25
+            and data.user["stats"]["class"] == WARRIOR
+        ),
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.VALOROUS_PRESENCE,
@@ -132,9 +140,11 @@ WARRIOR_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
         press_fn=lambda coordinator: coordinator.api.user.class_.cast[
             "valorousPresence"
         ].post(targetId=coordinator.config_entry.unique_id),
-        available_fn=lambda data: data.user["stats"]["lvl"] >= 13
-        and data.user["stats"]["mp"] >= 20
-        and data.user["stats"]["class"] == WARRIOR,
+        available_fn=(
+            lambda data: data.user["stats"]["lvl"] >= 13
+            and data.user["stats"]["mp"] >= 20
+            and data.user["stats"]["class"] == WARRIOR
+        ),
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.INTIMIDATE,
@@ -142,9 +152,11 @@ WARRIOR_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
         press_fn=lambda coordinator: coordinator.api.user.class_.cast[
             "intimidate"
         ].post(targetId=coordinator.config_entry.unique_id),
-        available_fn=lambda data: data.user["stats"]["lvl"] >= 14
-        and data.user["stats"]["mp"] >= 15
-        and data.user["stats"]["class"] == WARRIOR,
+        available_fn=(
+            lambda data: data.user["stats"]["lvl"] >= 14
+            and data.user["stats"]["mp"] >= 15
+            and data.user["stats"]["class"] == WARRIOR
+        ),
     ),
 )
 
@@ -155,9 +167,11 @@ ROGUE_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
         press_fn=lambda coordinator: coordinator.api.user.class_.cast[
             "toolsOfTrade"
         ].post(),
-        available_fn=lambda data: data.user["stats"]["lvl"] >= 13
-        and data.user["stats"]["mp"] >= 25
-        and data.user["stats"]["class"] == ROGUE,
+        available_fn=(
+            lambda data: data.user["stats"]["lvl"] >= 13
+            and data.user["stats"]["mp"] >= 25
+            and data.user["stats"]["class"] == ROGUE
+        ),
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.STEALTH,
@@ -165,9 +179,11 @@ ROGUE_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
         press_fn=lambda coordinator: coordinator.api.user.class_.cast["stealth"].post(
             targetId=coordinator.config_entry.unique_id
         ),
-        available_fn=lambda data: data.user["stats"]["lvl"] >= 14
-        and data.user["stats"]["mp"] >= 45
-        and data.user["stats"]["class"] == ROGUE,
+        available_fn=(
+            lambda data: data.user["stats"]["lvl"] >= 14
+            and data.user["stats"]["mp"] >= 45
+            and data.user["stats"]["class"] == ROGUE
+        ),
     ),
 )
 
@@ -178,9 +194,11 @@ HEALER_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
         press_fn=lambda coordinator: coordinator.api.user.class_.cast["heal"].post(
             targetId=coordinator.config_entry.unique_id
         ),
-        available_fn=lambda data: data.user["stats"]["lvl"] >= 11
-        and data.user["stats"]["mp"] >= 15
-        and data.user["stats"]["class"] == HEALER,
+        available_fn=(
+            lambda data: data.user["stats"]["lvl"] >= 11
+            and data.user["stats"]["mp"] >= 15
+            and data.user["stats"]["class"] == HEALER
+        ),
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.BRIGHTNESS,
@@ -188,9 +206,11 @@ HEALER_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
         press_fn=lambda coordinator: coordinator.api.user.class_.cast[
             "brightness"
         ].post(targetId=coordinator.config_entry.unique_id),
-        available_fn=lambda data: data.user["stats"]["lvl"] >= 12
-        and data.user["stats"]["mp"] >= 15
-        and data.user["stats"]["class"] == HEALER,
+        available_fn=(
+            lambda data: data.user["stats"]["lvl"] >= 12
+            and data.user["stats"]["mp"] >= 15
+            and data.user["stats"]["class"] == HEALER
+        ),
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.PROTECT_AURA,
@@ -198,17 +218,21 @@ HEALER_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
         press_fn=lambda coordinator: coordinator.api.user.class_.cast[
             "protectAura"
         ].post(),
-        available_fn=lambda data: data.user["stats"]["lvl"] >= 13
-        and data.user["stats"]["mp"] >= 30
-        and data.user["stats"]["class"] == HEALER,
+        available_fn=(
+            lambda data: data.user["stats"]["lvl"] >= 13
+            and data.user["stats"]["mp"] >= 30
+            and data.user["stats"]["class"] == HEALER
+        ),
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.HEAL_ALL,
         translation_key=HabitipyButtonEntity.HEAL_ALL,
         press_fn=lambda coordinator: coordinator.api.user.class_.cast["healAll"].post(),
-        available_fn=lambda data: data.user["stats"]["lvl"] >= 14
-        and data.user["stats"]["mp"] >= 25
-        and data.user["stats"]["class"] == HEALER,
+        available_fn=(
+            lambda data: data.user["stats"]["lvl"] >= 14
+            and data.user["stats"]["mp"] >= 25
+            and data.user["stats"]["class"] == HEALER
+        ),
     ),
 )
 

--- a/homeassistant/components/habitica/button.py
+++ b/homeassistant/components/habitica/button.py
@@ -103,7 +103,7 @@ CLASS_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             and data.user["stats"]["mp"] >= 30
         ),
         class_needed=MAGE,
-        entity_picture=f"{ASSETS_URL}shop_mpheal.png",
+        entity_picture="shop_mpheal.png",
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.EARTH,
@@ -114,7 +114,7 @@ CLASS_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             and data.user["stats"]["mp"] >= 35
         ),
         class_needed=MAGE,
-        entity_picture=f"{ASSETS_URL}shop_earth.png",
+        entity_picture="shop_earth.png",
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.FROST,
@@ -129,7 +129,7 @@ CLASS_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             and data.user["stats"]["mp"] >= 40
         ),
         class_needed=MAGE,
-        entity_picture=f"{ASSETS_URL}shop_frost.png",
+        entity_picture="shop_frost.png",
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.DEFENSIVE_STANCE,
@@ -144,7 +144,7 @@ CLASS_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             and data.user["stats"]["mp"] >= 25
         ),
         class_needed=WARRIOR,
-        entity_picture=f"{ASSETS_URL}shop_defensiveStance.png",
+        entity_picture="shop_defensiveStance.png",
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.VALOROUS_PRESENCE,
@@ -159,7 +159,7 @@ CLASS_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             and data.user["stats"]["mp"] >= 20
         ),
         class_needed=WARRIOR,
-        entity_picture=f"{ASSETS_URL}shop_valorousPresence.png",
+        entity_picture="shop_valorousPresence.png",
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.INTIMIDATE,
@@ -174,7 +174,7 @@ CLASS_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             and data.user["stats"]["mp"] >= 15
         ),
         class_needed=WARRIOR,
-        entity_picture=f"{ASSETS_URL}shop_intimidate.png",
+        entity_picture="shop_intimidate.png",
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.TOOLS_OF_TRADE,
@@ -187,7 +187,7 @@ CLASS_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             and data.user["stats"]["mp"] >= 25
         ),
         class_needed=ROGUE,
-        entity_picture=f"{ASSETS_URL}shop_toolsOfTrade.png",
+        entity_picture="shop_toolsOfTrade.png",
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.STEALTH,
@@ -202,7 +202,7 @@ CLASS_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             and data.user["stats"]["mp"] >= 45
         ),
         class_needed=ROGUE,
-        entity_picture=f"{ASSETS_URL}shop_stealth.png",
+        entity_picture="shop_stealth.png",
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.HEAL,
@@ -231,7 +231,7 @@ CLASS_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             and data.user["stats"]["mp"] >= 15
         ),
         class_needed=HEALER,
-        entity_picture=f"{ASSETS_URL}shop_brightness.png",
+        entity_picture="shop_brightness.png",
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.PROTECT_AURA,
@@ -244,7 +244,7 @@ CLASS_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             and data.user["stats"]["mp"] >= 30
         ),
         class_needed=HEALER,
-        entity_picture=f"{ASSETS_URL}shop_protectAura.png",
+        entity_picture="shop_protectAura.png",
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.HEAL_ALL,
@@ -255,7 +255,7 @@ CLASS_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             and data.user["stats"]["mp"] >= 25
         ),
         class_needed=HEALER,
-        entity_picture=f"{ASSETS_URL}shop_healAll.png",
+        entity_picture="shop_healAll.png",
     ),
 )
 
@@ -347,4 +347,6 @@ class HabiticaButton(HabiticaBase, ButtonEntity):
     @property
     def entity_picture(self) -> str | None:
         """Return the entity picture to use in the frontend, if any."""
-        return self.entity_description.entity_picture
+        if entity_picture := self.entity_description.entity_picture:
+            return f"{ASSETS_URL}{entity_picture}"
+        return None

--- a/homeassistant/components/habitica/button.py
+++ b/homeassistant/components/habitica/button.py
@@ -21,7 +21,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import HabiticaConfigEntry
-from .const import DOMAIN, HEALER, MAGE, ROGUE, WARRIOR
+from .const import ASSETS_URL, DOMAIN, HEALER, MAGE, ROGUE, WARRIOR
 from .coordinator import HabiticaData, HabiticaDataUpdateCoordinator
 from .entity import HabiticaBase
 
@@ -33,6 +33,7 @@ class HabiticaButtonEntityDescription(ButtonEntityDescription):
     press_fn: Callable[[HabiticaDataUpdateCoordinator], Any]
     available_fn: Callable[[HabiticaData], bool] | None = None
     class_needed: str | None = None
+    entity_picture: str | None = None
 
 
 class HabitipyButtonEntity(StrEnum):
@@ -102,6 +103,7 @@ CLASS_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             and data.user["stats"]["mp"] >= 30
         ),
         class_needed=MAGE,
+        entity_picture=f"{ASSETS_URL}shop_mpheal.png",
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.EARTH,
@@ -112,6 +114,7 @@ CLASS_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             and data.user["stats"]["mp"] >= 35
         ),
         class_needed=MAGE,
+        entity_picture=f"{ASSETS_URL}shop_earth.png",
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.FROST,
@@ -126,6 +129,7 @@ CLASS_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             and data.user["stats"]["mp"] >= 40
         ),
         class_needed=MAGE,
+        entity_picture=f"{ASSETS_URL}shop_frost.png",
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.DEFENSIVE_STANCE,
@@ -140,6 +144,7 @@ CLASS_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             and data.user["stats"]["mp"] >= 25
         ),
         class_needed=WARRIOR,
+        entity_picture=f"{ASSETS_URL}shop_defensiveStance.png",
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.VALOROUS_PRESENCE,
@@ -154,6 +159,7 @@ CLASS_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             and data.user["stats"]["mp"] >= 20
         ),
         class_needed=WARRIOR,
+        entity_picture=f"{ASSETS_URL}shop_valorousPresence.png",
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.INTIMIDATE,
@@ -168,6 +174,7 @@ CLASS_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             and data.user["stats"]["mp"] >= 15
         ),
         class_needed=WARRIOR,
+        entity_picture=f"{ASSETS_URL}shop_intimidate.png",
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.TOOLS_OF_TRADE,
@@ -180,6 +187,7 @@ CLASS_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             and data.user["stats"]["mp"] >= 25
         ),
         class_needed=ROGUE,
+        entity_picture=f"{ASSETS_URL}shop_toolsOfTrade.png",
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.STEALTH,
@@ -194,6 +202,7 @@ CLASS_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             and data.user["stats"]["mp"] >= 45
         ),
         class_needed=ROGUE,
+        entity_picture=f"{ASSETS_URL}shop_stealth.png",
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.HEAL,
@@ -222,6 +231,7 @@ CLASS_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             and data.user["stats"]["mp"] >= 15
         ),
         class_needed=HEALER,
+        entity_picture=f"{ASSETS_URL}shop_brightness.png",
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.PROTECT_AURA,
@@ -234,6 +244,7 @@ CLASS_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             and data.user["stats"]["mp"] >= 30
         ),
         class_needed=HEALER,
+        entity_picture=f"{ASSETS_URL}shop_protectAura.png",
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.HEAL_ALL,
@@ -244,6 +255,7 @@ CLASS_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             and data.user["stats"]["mp"] >= 25
         ),
         class_needed=HEALER,
+        entity_picture=f"{ASSETS_URL}shop_healAll.png",
     ),
 )
 
@@ -331,3 +343,8 @@ class HabiticaButton(HabiticaBase, ButtonEntity):
         if self.entity_description.available_fn:
             return self.entity_description.available_fn(self.coordinator.data)
         return True
+
+    @property
+    def entity_picture(self) -> str | None:
+        """Return the entity picture to use in the frontend, if any."""
+        return self.entity_description.entity_picture

--- a/homeassistant/components/habitica/button.py
+++ b/homeassistant/components/habitica/button.py
@@ -36,6 +36,19 @@ class HabitipyButtonEntity(StrEnum):
     BUY_HEALTH_POTION = "buy_health_potion"
     ALLOCATE_ALL_STAT_POINTS = "allocate_all_stat_points"
     REVIVE = "revive"
+    FIREBALL = "fireball"
+    MPHEAL = "mpheal"
+    EARTH = "earth"
+    FROST = "frost"
+    DEFENSIVE_STANCE = "defensive_stance"
+    VALOROUS_PRESENCE = "valorous_presence"
+    INTIMIDATE = "intimidate"
+    TOOLS_OF_TRADE = "tools_of_trade"
+    STEALTH = "stealth"
+    HEAL = "heal"
+    PROTECT_AURA = "protect_aura"
+    BRIGHTNESS = "brightness"
+    HEAL_ALL = "heal_all"
 
 
 BUTTON_DESCRIPTIONS: tuple[HabiticaButtonEntityDescription, ...] = (
@@ -74,6 +87,117 @@ BUTTON_DESCRIPTIONS: tuple[HabiticaButtonEntityDescription, ...] = (
 )
 
 
+WIZARD_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
+    HabiticaButtonEntityDescription(
+        key=HabitipyButtonEntity.FIREBALL,
+        translation_key=HabitipyButtonEntity.FIREBALL,
+        press_fn=lambda coordinator: coordinator.api.user.class_.cast[
+            "fireball"
+        ].post(),
+        available_fn=lambda data: data.user["stats"]["lvl"] >= 11,
+    ),
+    HabiticaButtonEntityDescription(
+        key=HabitipyButtonEntity.MPHEAL,
+        translation_key=HabitipyButtonEntity.MPHEAL,
+        press_fn=lambda coordinator: coordinator.api.user.class_.cast["mpheal"].post(),
+        available_fn=lambda data: data.user["stats"]["lvl"] >= 12,
+    ),
+    HabiticaButtonEntityDescription(
+        key=HabitipyButtonEntity.EARTH,
+        translation_key=HabitipyButtonEntity.EARTH,
+        press_fn=lambda coordinator: coordinator.api.user.class_.cast["earth"].post(),
+        available_fn=lambda data: data.user["stats"]["lvl"] >= 13,
+    ),
+    HabiticaButtonEntityDescription(
+        key=HabitipyButtonEntity.FROST,
+        translation_key=HabitipyButtonEntity.FROST,
+        press_fn=lambda coordinator: coordinator.api.user.class_.cast["frost"].post(
+            targetId=coordinator.config_entry.unique_id
+        ),
+        available_fn=lambda data: data.user["stats"]["lvl"] >= 14,
+    ),
+)
+
+WARRIOR_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
+    HabiticaButtonEntityDescription(
+        key=HabitipyButtonEntity.DEFENSIVE_STANCE,
+        translation_key=HabitipyButtonEntity.DEFENSIVE_STANCE,
+        press_fn=lambda coordinator: coordinator.api.user.class_.cast[
+            "defensiveStance"
+        ].post(targetId=coordinator.config_entry.unique_id),
+        available_fn=lambda data: data.user["stats"]["lvl"] >= 12,
+    ),
+    HabiticaButtonEntityDescription(
+        key=HabitipyButtonEntity.VALOROUS_PRESENCE,
+        translation_key=HabitipyButtonEntity.VALOROUS_PRESENCE,
+        press_fn=lambda coordinator: coordinator.api.user.class_.cast[
+            "valorousPresence"
+        ].post(targetId=coordinator.config_entry.unique_id),
+        available_fn=lambda data: data.user["stats"]["lvl"] >= 13,
+    ),
+    HabiticaButtonEntityDescription(
+        key=HabitipyButtonEntity.INTIMIDATE,
+        translation_key=HabitipyButtonEntity.INTIMIDATE,
+        press_fn=lambda coordinator: coordinator.api.user.class_.cast[
+            "intimidate"
+        ].post(targetId=coordinator.config_entry.unique_id),
+        available_fn=lambda data: data.user["stats"]["lvl"] >= 14,
+    ),
+)
+
+ROGUE_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
+    HabiticaButtonEntityDescription(
+        key=HabitipyButtonEntity.TOOLS_OF_TRADE,
+        translation_key=HabitipyButtonEntity.TOOLS_OF_TRADE,
+        press_fn=lambda coordinator: coordinator.api.user.class_.cast[
+            "toolsOfTrade"
+        ].post(),
+        available_fn=lambda data: data.user["stats"]["lvl"] >= 13,
+    ),
+    HabiticaButtonEntityDescription(
+        key=HabitipyButtonEntity.STEALTH,
+        translation_key=HabitipyButtonEntity.STEALTH,
+        press_fn=lambda coordinator: coordinator.api.user.class_.cast["stealth"].post(
+            targetId=coordinator.config_entry.unique_id
+        ),
+        available_fn=lambda data: data.user["stats"]["lvl"] >= 14,
+    ),
+)
+
+HEALER_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
+    HabiticaButtonEntityDescription(
+        key=HabitipyButtonEntity.HEAL,
+        translation_key=HabitipyButtonEntity.HEAL,
+        press_fn=lambda coordinator: coordinator.api.user.class_.cast["heal"].post(
+            targetId=coordinator.config_entry.unique_id
+        ),
+        available_fn=lambda data: data.user["stats"]["lvl"] >= 11,
+    ),
+    HabiticaButtonEntityDescription(
+        key=HabitipyButtonEntity.BRIGHTNESS,
+        translation_key=HabitipyButtonEntity.BRIGHTNESS,
+        press_fn=lambda coordinator: coordinator.api.user.class_.cast[
+            "brightness"
+        ].post(targetId=coordinator.config_entry.unique_id),
+        available_fn=lambda data: data.user["stats"]["lvl"] >= 12,
+    ),
+    HabiticaButtonEntityDescription(
+        key=HabitipyButtonEntity.PROTECT_AURA,
+        translation_key=HabitipyButtonEntity.PROTECT_AURA,
+        press_fn=lambda coordinator: coordinator.api.user.class_.cast[
+            "protectAura"
+        ].post(),
+        available_fn=lambda data: data.user["stats"]["lvl"] >= 13,
+    ),
+    HabiticaButtonEntityDescription(
+        key=HabitipyButtonEntity.HEAL_ALL,
+        translation_key=HabitipyButtonEntity.HEAL_ALL,
+        press_fn=lambda coordinator: coordinator.api.user.class_.cast["healAll"].post(),
+        available_fn=lambda data: data.user["stats"]["lvl"] >= 14,
+    ),
+)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: HabiticaConfigEntry,
@@ -86,6 +210,22 @@ async def async_setup_entry(
     async_add_entities(
         HabiticaButton(coordinator, description) for description in BUTTON_DESCRIPTIONS
     )
+    if coordinator.data.user["stats"]["class"] == "wizard":
+        async_add_entities(
+            HabiticaButton(coordinator, description) for description in WIZARD_SKILLS
+        )
+    if coordinator.data.user["stats"]["class"] == "warrior":
+        async_add_entities(
+            HabiticaButton(coordinator, description) for description in WARRIOR_SKILLS
+        )
+    if coordinator.data.user["stats"]["class"] == "rogue":
+        async_add_entities(
+            HabiticaButton(coordinator, description) for description in ROGUE_SKILLS
+        )
+    if coordinator.data.user["stats"]["class"] == "healer":
+        async_add_entities(
+            HabiticaButton(coordinator, description) for description in HEALER_SKILLS
+        )
 
 
 class HabiticaButton(HabiticaBase, ButtonEntity):

--- a/homeassistant/components/habitica/button.py
+++ b/homeassistant/components/habitica/button.py
@@ -95,6 +95,7 @@ MAGE_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             "fireball"
         ].post(),
         available_fn=lambda data: data.user["stats"]["lvl"] >= 11
+        and data.user["stats"]["mp"] >= 10
         and data.user["stats"]["class"] == MAGE,
     ),
     HabiticaButtonEntityDescription(
@@ -102,6 +103,7 @@ MAGE_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
         translation_key=HabitipyButtonEntity.MPHEAL,
         press_fn=lambda coordinator: coordinator.api.user.class_.cast["mpheal"].post(),
         available_fn=lambda data: data.user["stats"]["lvl"] >= 12
+        and data.user["stats"]["mp"] >= 30
         and data.user["stats"]["class"] == MAGE,
     ),
     HabiticaButtonEntityDescription(
@@ -109,6 +111,7 @@ MAGE_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
         translation_key=HabitipyButtonEntity.EARTH,
         press_fn=lambda coordinator: coordinator.api.user.class_.cast["earth"].post(),
         available_fn=lambda data: data.user["stats"]["lvl"] >= 13
+        and data.user["stats"]["mp"] >= 35
         and data.user["stats"]["class"] == MAGE,
     ),
     HabiticaButtonEntityDescription(
@@ -118,6 +121,7 @@ MAGE_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             targetId=coordinator.config_entry.unique_id
         ),
         available_fn=lambda data: data.user["stats"]["lvl"] >= 14
+        and data.user["stats"]["mp"] >= 40
         and data.user["stats"]["class"] == MAGE,
     ),
 )
@@ -130,6 +134,7 @@ WARRIOR_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             "defensiveStance"
         ].post(targetId=coordinator.config_entry.unique_id),
         available_fn=lambda data: data.user["stats"]["lvl"] >= 12
+        and data.user["stats"]["mp"] >= 25
         and data.user["stats"]["class"] == WARRIOR,
     ),
     HabiticaButtonEntityDescription(
@@ -139,6 +144,7 @@ WARRIOR_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             "valorousPresence"
         ].post(targetId=coordinator.config_entry.unique_id),
         available_fn=lambda data: data.user["stats"]["lvl"] >= 13
+        and data.user["stats"]["mp"] >= 20
         and data.user["stats"]["class"] == WARRIOR,
     ),
     HabiticaButtonEntityDescription(
@@ -148,6 +154,7 @@ WARRIOR_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             "intimidate"
         ].post(targetId=coordinator.config_entry.unique_id),
         available_fn=lambda data: data.user["stats"]["lvl"] >= 14
+        and data.user["stats"]["mp"] >= 15
         and data.user["stats"]["class"] == WARRIOR,
     ),
 )
@@ -160,6 +167,7 @@ ROGUE_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             "toolsOfTrade"
         ].post(),
         available_fn=lambda data: data.user["stats"]["lvl"] >= 13
+        and data.user["stats"]["mp"] >= 25
         and data.user["stats"]["class"] == ROGUE,
     ),
     HabiticaButtonEntityDescription(
@@ -169,6 +177,7 @@ ROGUE_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             targetId=coordinator.config_entry.unique_id
         ),
         available_fn=lambda data: data.user["stats"]["lvl"] >= 14
+        and data.user["stats"]["mp"] >= 45
         and data.user["stats"]["class"] == ROGUE,
     ),
 )
@@ -181,6 +190,7 @@ HEALER_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             targetId=coordinator.config_entry.unique_id
         ),
         available_fn=lambda data: data.user["stats"]["lvl"] >= 11
+        and data.user["stats"]["mp"] >= 15
         and data.user["stats"]["class"] == HEALER,
     ),
     HabiticaButtonEntityDescription(
@@ -190,6 +200,7 @@ HEALER_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             "brightness"
         ].post(targetId=coordinator.config_entry.unique_id),
         available_fn=lambda data: data.user["stats"]["lvl"] >= 12
+        and data.user["stats"]["mp"] >= 15
         and data.user["stats"]["class"] == HEALER,
     ),
     HabiticaButtonEntityDescription(
@@ -199,6 +210,7 @@ HEALER_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
             "protectAura"
         ].post(),
         available_fn=lambda data: data.user["stats"]["lvl"] >= 13
+        and data.user["stats"]["mp"] >= 30
         and data.user["stats"]["class"] == HEALER,
     ),
     HabiticaButtonEntityDescription(
@@ -206,6 +218,7 @@ HEALER_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
         translation_key=HabitipyButtonEntity.HEAL_ALL,
         press_fn=lambda coordinator: coordinator.api.user.class_.cast["healAll"].post(),
         available_fn=lambda data: data.user["stats"]["lvl"] >= 14
+        and data.user["stats"]["mp"] >= 25
         and data.user["stats"]["class"] == HEALER,
     ),
 )

--- a/homeassistant/components/habitica/button.py
+++ b/homeassistant/components/habitica/button.py
@@ -110,8 +110,10 @@ MAGE_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.FROST,
         translation_key=HabitipyButtonEntity.FROST,
-        press_fn=lambda coordinator: coordinator.api.user.class_.cast["frost"].post(
-            targetId=coordinator.config_entry.unique_id
+        press_fn=(
+            lambda coordinator: coordinator.api.user.class_.cast["frost"].post(
+                targetId=coordinator.config_entry.unique_id
+            )
         ),
         available_fn=(
             lambda data: data.user["stats"]["lvl"] >= 14
@@ -125,9 +127,11 @@ WARRIOR_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.DEFENSIVE_STANCE,
         translation_key=HabitipyButtonEntity.DEFENSIVE_STANCE,
-        press_fn=lambda coordinator: coordinator.api.user.class_.cast[
-            "defensiveStance"
-        ].post(targetId=coordinator.config_entry.unique_id),
+        press_fn=(
+            lambda coordinator: coordinator.api.user.class_.cast[
+                "defensiveStance"
+            ].post(targetId=coordinator.config_entry.unique_id)
+        ),
         available_fn=(
             lambda data: data.user["stats"]["lvl"] >= 12
             and data.user["stats"]["mp"] >= 25
@@ -137,9 +141,11 @@ WARRIOR_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.VALOROUS_PRESENCE,
         translation_key=HabitipyButtonEntity.VALOROUS_PRESENCE,
-        press_fn=lambda coordinator: coordinator.api.user.class_.cast[
-            "valorousPresence"
-        ].post(targetId=coordinator.config_entry.unique_id),
+        press_fn=(
+            lambda coordinator: coordinator.api.user.class_.cast[
+                "valorousPresence"
+            ].post(targetId=coordinator.config_entry.unique_id)
+        ),
         available_fn=(
             lambda data: data.user["stats"]["lvl"] >= 13
             and data.user["stats"]["mp"] >= 20
@@ -149,9 +155,11 @@ WARRIOR_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.INTIMIDATE,
         translation_key=HabitipyButtonEntity.INTIMIDATE,
-        press_fn=lambda coordinator: coordinator.api.user.class_.cast[
-            "intimidate"
-        ].post(targetId=coordinator.config_entry.unique_id),
+        press_fn=(
+            lambda coordinator: coordinator.api.user.class_.cast["intimidate"].post(
+                targetId=coordinator.config_entry.unique_id
+            )
+        ),
         available_fn=(
             lambda data: data.user["stats"]["lvl"] >= 14
             and data.user["stats"]["mp"] >= 15
@@ -164,9 +172,9 @@ ROGUE_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.TOOLS_OF_TRADE,
         translation_key=HabitipyButtonEntity.TOOLS_OF_TRADE,
-        press_fn=lambda coordinator: coordinator.api.user.class_.cast[
-            "toolsOfTrade"
-        ].post(),
+        press_fn=(
+            lambda coordinator: coordinator.api.user.class_.cast["toolsOfTrade"].post()
+        ),
         available_fn=(
             lambda data: data.user["stats"]["lvl"] >= 13
             and data.user["stats"]["mp"] >= 25
@@ -176,8 +184,10 @@ ROGUE_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.STEALTH,
         translation_key=HabitipyButtonEntity.STEALTH,
-        press_fn=lambda coordinator: coordinator.api.user.class_.cast["stealth"].post(
-            targetId=coordinator.config_entry.unique_id
+        press_fn=(
+            lambda coordinator: coordinator.api.user.class_.cast["stealth"].post(
+                targetId=coordinator.config_entry.unique_id
+            )
         ),
         available_fn=(
             lambda data: data.user["stats"]["lvl"] >= 14
@@ -191,8 +201,10 @@ HEALER_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.HEAL,
         translation_key=HabitipyButtonEntity.HEAL,
-        press_fn=lambda coordinator: coordinator.api.user.class_.cast["heal"].post(
-            targetId=coordinator.config_entry.unique_id
+        press_fn=(
+            lambda coordinator: coordinator.api.user.class_.cast["heal"].post(
+                targetId=coordinator.config_entry.unique_id
+            )
         ),
         available_fn=(
             lambda data: data.user["stats"]["lvl"] >= 11
@@ -203,9 +215,11 @@ HEALER_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.BRIGHTNESS,
         translation_key=HabitipyButtonEntity.BRIGHTNESS,
-        press_fn=lambda coordinator: coordinator.api.user.class_.cast[
-            "brightness"
-        ].post(targetId=coordinator.config_entry.unique_id),
+        press_fn=(
+            lambda coordinator: coordinator.api.user.class_.cast["brightness"].post(
+                targetId=coordinator.config_entry.unique_id
+            )
+        ),
         available_fn=(
             lambda data: data.user["stats"]["lvl"] >= 12
             and data.user["stats"]["mp"] >= 15
@@ -215,9 +229,9 @@ HEALER_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.PROTECT_AURA,
         translation_key=HabitipyButtonEntity.PROTECT_AURA,
-        press_fn=lambda coordinator: coordinator.api.user.class_.cast[
-            "protectAura"
-        ].post(),
+        press_fn=(
+            lambda coordinator: coordinator.api.user.class_.cast["protectAura"].post()
+        ),
         available_fn=(
             lambda data: data.user["stats"]["lvl"] >= 13
             and data.user["stats"]["mp"] >= 30

--- a/homeassistant/components/habitica/button.py
+++ b/homeassistant/components/habitica/button.py
@@ -36,7 +36,6 @@ class HabitipyButtonEntity(StrEnum):
     BUY_HEALTH_POTION = "buy_health_potion"
     ALLOCATE_ALL_STAT_POINTS = "allocate_all_stat_points"
     REVIVE = "revive"
-    FIREBALL = "fireball"
     MPHEAL = "mpheal"
     EARTH = "earth"
     FROST = "frost"
@@ -88,16 +87,6 @@ BUTTON_DESCRIPTIONS: tuple[HabiticaButtonEntityDescription, ...] = (
 
 
 MAGE_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
-    HabiticaButtonEntityDescription(
-        key=HabitipyButtonEntity.FIREBALL,
-        translation_key=HabitipyButtonEntity.FIREBALL,
-        press_fn=lambda coordinator: coordinator.api.user.class_.cast[
-            "fireball"
-        ].post(),
-        available_fn=lambda data: data.user["stats"]["lvl"] >= 11
-        and data.user["stats"]["mp"] >= 10
-        and data.user["stats"]["class"] == MAGE,
-    ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.MPHEAL,
         translation_key=HabitipyButtonEntity.MPHEAL,

--- a/homeassistant/components/habitica/button.py
+++ b/homeassistant/components/habitica/button.py
@@ -87,7 +87,7 @@ BUTTON_DESCRIPTIONS: tuple[HabiticaButtonEntityDescription, ...] = (
 )
 
 
-MAGE_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
+CLASS_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.MPHEAL,
         translation_key=HabitipyButtonEntity.MPHEAL,
@@ -122,9 +122,6 @@ MAGE_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
         ),
         class_needed=MAGE,
     ),
-)
-
-WARRIOR_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.DEFENSIVE_STANCE,
         translation_key=HabitipyButtonEntity.DEFENSIVE_STANCE,
@@ -167,9 +164,6 @@ WARRIOR_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
         ),
         class_needed=WARRIOR,
     ),
-)
-
-ROGUE_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.TOOLS_OF_TRADE,
         translation_key=HabitipyButtonEntity.TOOLS_OF_TRADE,
@@ -198,9 +192,6 @@ ROGUE_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
         ),
         class_needed=ROGUE,
     ),
-)
-
-HEALER_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.HEAL,
         translation_key=HabitipyButtonEntity.HEAL,
@@ -263,9 +254,7 @@ async def async_setup_entry(
 
     coordinator = entry.runtime_data
     listener: Callable[[], None] | None = None
-    not_setup: set[HabiticaButtonEntityDescription] = set(
-        HEALER_SKILLS + MAGE_SKILLS + ROGUE_SKILLS + WARRIOR_SKILLS
-    )
+    not_setup: set[HabiticaButtonEntityDescription] = set(CLASS_SKILLS)
 
     @callback
     def add_entities() -> None:

--- a/homeassistant/components/habitica/button.py
+++ b/homeassistant/components/habitica/button.py
@@ -298,25 +298,6 @@ async def async_setup_entry(
     async_add_entities(
         HabiticaButton(coordinator, description) for description in BUTTON_DESCRIPTIONS
     )
-    if coordinator.data.user["stats"]["lvl"] >= 10:
-        if coordinator.data.user["stats"]["class"] == MAGE:
-            async_add_entities(
-                HabiticaButton(coordinator, description) for description in MAGE_SKILLS
-            )
-        if coordinator.data.user["stats"]["class"] == WARRIOR:
-            async_add_entities(
-                HabiticaButton(coordinator, description)
-                for description in WARRIOR_SKILLS
-            )
-        if coordinator.data.user["stats"]["class"] == ROGUE:
-            async_add_entities(
-                HabiticaButton(coordinator, description) for description in ROGUE_SKILLS
-            )
-        if coordinator.data.user["stats"]["class"] == HEALER:
-            async_add_entities(
-                HabiticaButton(coordinator, description)
-                for description in HEALER_SKILLS
-            )
 
 
 class HabiticaButton(HabiticaBase, ButtonEntity):

--- a/homeassistant/components/habitica/button.py
+++ b/homeassistant/components/habitica/button.py
@@ -16,7 +16,7 @@ from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import HabiticaConfigEntry
-from .const import DOMAIN
+from .const import DOMAIN, HEALER, MAGE, ROGUE, WARRIOR
 from .coordinator import HabiticaData, HabiticaDataUpdateCoordinator
 from .entity import HabiticaBase
 
@@ -87,26 +87,29 @@ BUTTON_DESCRIPTIONS: tuple[HabiticaButtonEntityDescription, ...] = (
 )
 
 
-WIZARD_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
+MAGE_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.FIREBALL,
         translation_key=HabitipyButtonEntity.FIREBALL,
         press_fn=lambda coordinator: coordinator.api.user.class_.cast[
             "fireball"
         ].post(),
-        available_fn=lambda data: data.user["stats"]["lvl"] >= 11,
+        available_fn=lambda data: data.user["stats"]["lvl"] >= 11
+        and data.user["stats"]["class"] == MAGE,
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.MPHEAL,
         translation_key=HabitipyButtonEntity.MPHEAL,
         press_fn=lambda coordinator: coordinator.api.user.class_.cast["mpheal"].post(),
-        available_fn=lambda data: data.user["stats"]["lvl"] >= 12,
+        available_fn=lambda data: data.user["stats"]["lvl"] >= 12
+        and data.user["stats"]["class"] == MAGE,
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.EARTH,
         translation_key=HabitipyButtonEntity.EARTH,
         press_fn=lambda coordinator: coordinator.api.user.class_.cast["earth"].post(),
-        available_fn=lambda data: data.user["stats"]["lvl"] >= 13,
+        available_fn=lambda data: data.user["stats"]["lvl"] >= 13
+        and data.user["stats"]["class"] == MAGE,
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.FROST,
@@ -114,7 +117,8 @@ WIZARD_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
         press_fn=lambda coordinator: coordinator.api.user.class_.cast["frost"].post(
             targetId=coordinator.config_entry.unique_id
         ),
-        available_fn=lambda data: data.user["stats"]["lvl"] >= 14,
+        available_fn=lambda data: data.user["stats"]["lvl"] >= 14
+        and data.user["stats"]["class"] == MAGE,
     ),
 )
 
@@ -125,7 +129,8 @@ WARRIOR_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
         press_fn=lambda coordinator: coordinator.api.user.class_.cast[
             "defensiveStance"
         ].post(targetId=coordinator.config_entry.unique_id),
-        available_fn=lambda data: data.user["stats"]["lvl"] >= 12,
+        available_fn=lambda data: data.user["stats"]["lvl"] >= 12
+        and data.user["stats"]["class"] == WARRIOR,
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.VALOROUS_PRESENCE,
@@ -133,7 +138,8 @@ WARRIOR_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
         press_fn=lambda coordinator: coordinator.api.user.class_.cast[
             "valorousPresence"
         ].post(targetId=coordinator.config_entry.unique_id),
-        available_fn=lambda data: data.user["stats"]["lvl"] >= 13,
+        available_fn=lambda data: data.user["stats"]["lvl"] >= 13
+        and data.user["stats"]["class"] == WARRIOR,
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.INTIMIDATE,
@@ -141,7 +147,8 @@ WARRIOR_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
         press_fn=lambda coordinator: coordinator.api.user.class_.cast[
             "intimidate"
         ].post(targetId=coordinator.config_entry.unique_id),
-        available_fn=lambda data: data.user["stats"]["lvl"] >= 14,
+        available_fn=lambda data: data.user["stats"]["lvl"] >= 14
+        and data.user["stats"]["class"] == WARRIOR,
     ),
 )
 
@@ -152,7 +159,8 @@ ROGUE_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
         press_fn=lambda coordinator: coordinator.api.user.class_.cast[
             "toolsOfTrade"
         ].post(),
-        available_fn=lambda data: data.user["stats"]["lvl"] >= 13,
+        available_fn=lambda data: data.user["stats"]["lvl"] >= 13
+        and data.user["stats"]["class"] == ROGUE,
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.STEALTH,
@@ -160,7 +168,8 @@ ROGUE_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
         press_fn=lambda coordinator: coordinator.api.user.class_.cast["stealth"].post(
             targetId=coordinator.config_entry.unique_id
         ),
-        available_fn=lambda data: data.user["stats"]["lvl"] >= 14,
+        available_fn=lambda data: data.user["stats"]["lvl"] >= 14
+        and data.user["stats"]["class"] == ROGUE,
     ),
 )
 
@@ -171,7 +180,8 @@ HEALER_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
         press_fn=lambda coordinator: coordinator.api.user.class_.cast["heal"].post(
             targetId=coordinator.config_entry.unique_id
         ),
-        available_fn=lambda data: data.user["stats"]["lvl"] >= 11,
+        available_fn=lambda data: data.user["stats"]["lvl"] >= 11
+        and data.user["stats"]["class"] == HEALER,
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.BRIGHTNESS,
@@ -179,7 +189,8 @@ HEALER_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
         press_fn=lambda coordinator: coordinator.api.user.class_.cast[
             "brightness"
         ].post(targetId=coordinator.config_entry.unique_id),
-        available_fn=lambda data: data.user["stats"]["lvl"] >= 12,
+        available_fn=lambda data: data.user["stats"]["lvl"] >= 12
+        and data.user["stats"]["class"] == HEALER,
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.PROTECT_AURA,
@@ -187,13 +198,15 @@ HEALER_SKILLS: tuple[HabiticaButtonEntityDescription, ...] = (
         press_fn=lambda coordinator: coordinator.api.user.class_.cast[
             "protectAura"
         ].post(),
-        available_fn=lambda data: data.user["stats"]["lvl"] >= 13,
+        available_fn=lambda data: data.user["stats"]["lvl"] >= 13
+        and data.user["stats"]["class"] == HEALER,
     ),
     HabiticaButtonEntityDescription(
         key=HabitipyButtonEntity.HEAL_ALL,
         translation_key=HabitipyButtonEntity.HEAL_ALL,
         press_fn=lambda coordinator: coordinator.api.user.class_.cast["healAll"].post(),
-        available_fn=lambda data: data.user["stats"]["lvl"] >= 14,
+        available_fn=lambda data: data.user["stats"]["lvl"] >= 14
+        and data.user["stats"]["class"] == HEALER,
     ),
 )
 
@@ -211,21 +224,20 @@ async def async_setup_entry(
         HabiticaButton(coordinator, description) for description in BUTTON_DESCRIPTIONS
     )
     if coordinator.data.user["stats"]["lvl"] > 10:
-        if coordinator.data.user["stats"]["class"] == "wizard":
+        if coordinator.data.user["stats"]["class"] == MAGE:
             async_add_entities(
-                HabiticaButton(coordinator, description)
-                for description in WIZARD_SKILLS
+                HabiticaButton(coordinator, description) for description in MAGE_SKILLS
             )
-        if coordinator.data.user["stats"]["class"] == "warrior":
+        if coordinator.data.user["stats"]["class"] == WARRIOR:
             async_add_entities(
                 HabiticaButton(coordinator, description)
                 for description in WARRIOR_SKILLS
             )
-        if coordinator.data.user["stats"]["class"] == "rogue":
+        if coordinator.data.user["stats"]["class"] == ROGUE:
             async_add_entities(
                 HabiticaButton(coordinator, description) for description in ROGUE_SKILLS
             )
-        if coordinator.data.user["stats"]["class"] == "healer":
+        if coordinator.data.user["stats"]["class"] == HEALER:
             async_add_entities(
                 HabiticaButton(coordinator, description)
                 for description in HEALER_SKILLS

--- a/homeassistant/components/habitica/button.py
+++ b/homeassistant/components/habitica/button.py
@@ -223,7 +223,7 @@ async def async_setup_entry(
     async_add_entities(
         HabiticaButton(coordinator, description) for description in BUTTON_DESCRIPTIONS
     )
-    if coordinator.data.user["stats"]["lvl"] > 10:
+    if coordinator.data.user["stats"]["lvl"] >= 10:
         if coordinator.data.user["stats"]["class"] == MAGE:
             async_add_entities(
                 HabiticaButton(coordinator, description) for description in MAGE_SKILLS

--- a/homeassistant/components/habitica/const.py
+++ b/homeassistant/components/habitica/const.py
@@ -27,4 +27,9 @@ ATTR_SKILL = "skill"
 ATTR_TASK = "task"
 SERVICE_CAST_SKILL = "cast_skill"
 
+WARRIOR = "warrior"
+ROGUE = "rogue"
+HEALER = "healer"
+MAGE = "wizard"
+
 DEVELOPER_ID = "4c4ca53f-c059-4ffa-966e-9d29dd405daf"

--- a/homeassistant/components/habitica/icons.json
+++ b/homeassistant/components/habitica/icons.json
@@ -20,6 +20,45 @@
       },
       "revive": {
         "default": "mdi:grave-stone"
+      },
+      "fireball": {
+        "default": "mdi:fire"
+      },
+      "mpheal": {
+        "default": "mdi:broadcast"
+      },
+      "earth": {
+        "default": "mdi:landslide"
+      },
+      "frost": {
+        "default": "mdi:snowflake"
+      },
+      "defensive_stance": {
+        "default": "mdi:sword-cross"
+      },
+      "valorous_presence": {
+        "default": "mdi:shield-sun"
+      },
+      "intimidate": {
+        "default": "mdi:emoticon-angry"
+      },
+      "tools_of_trade": {
+        "default": "mdi:atom-variant"
+      },
+      "stealth": {
+        "default": "mdi:ninja"
+      },
+      "heal": {
+        "default": "mdi:aurora"
+      },
+      "brightness": {
+        "default": "mdi:flare"
+      },
+      "protect_aura": {
+        "default": "mdi:shield-star-outline"
+      },
+      "heal_all": {
+        "default": "mdi:hand-heart-outline"
       }
     },
     "sensor": {

--- a/homeassistant/components/habitica/icons.json
+++ b/homeassistant/components/habitica/icons.json
@@ -34,7 +34,7 @@
         "default": "mdi:snowflake"
       },
       "defensive_stance": {
-        "default": "mdi:sword-cross"
+        "default": "mdi:shield-sword"
       },
       "valorous_presence": {
         "default": "mdi:shield-sun"

--- a/homeassistant/components/habitica/icons.json
+++ b/homeassistant/components/habitica/icons.json
@@ -55,7 +55,7 @@
         "default": "mdi:flare"
       },
       "protect_aura": {
-        "default": "mdi:shield-star-outline"
+        "default": "mdi:shimmer"
       },
       "heal_all": {
         "default": "mdi:hand-heart-outline"

--- a/homeassistant/components/habitica/icons.json
+++ b/homeassistant/components/habitica/icons.json
@@ -43,7 +43,7 @@
         "default": "mdi:emoticon-angry"
       },
       "tools_of_trade": {
-        "default": "mdi:atom-variant"
+        "default": "mdi:domino-mask"
       },
       "stealth": {
         "default": "mdi:ninja"

--- a/homeassistant/components/habitica/icons.json
+++ b/homeassistant/components/habitica/icons.json
@@ -21,9 +21,6 @@
       "revive": {
         "default": "mdi:grave-stone"
       },
-      "fireball": {
-        "default": "mdi:fire"
-      },
       "mpheal": {
         "default": "mdi:broadcast"
       },

--- a/homeassistant/components/habitica/strings.json
+++ b/homeassistant/components/habitica/strings.json
@@ -69,7 +69,7 @@
         "name": "Cast intimidating gaze"
       },
       "tools_of_trade": {
-        "name": "Cast tools of trade"
+        "name": "Cast tools of the trade"
       },
       "stealth": {
         "name": "Cast stealth"

--- a/homeassistant/components/habitica/strings.json
+++ b/homeassistant/components/habitica/strings.json
@@ -46,6 +46,45 @@
       },
       "revive": {
         "name": "Revive from death"
+      },
+      "fireball": {
+        "name": "Cast burst of flames"
+      },
+      "mpheal": {
+        "name": "Cast ethereal surge"
+      },
+      "earth": {
+        "name": "Cast earthquake"
+      },
+      "frost": {
+        "name": "Cast chilling frost"
+      },
+      "defensive_stance": {
+        "name": "Cast defensive stance"
+      },
+      "valorous_presence": {
+        "name": "Cast valorous presence"
+      },
+      "intimidate": {
+        "name": "Cast intimidating gaze"
+      },
+      "tools_of_trade": {
+        "name": "Cast tools of trade"
+      },
+      "stealth": {
+        "name": "Cast stealth"
+      },
+      "heal": {
+        "name": "Cast healing light"
+      },
+      "brightness": {
+        "name": "Cast searing brightness"
+      },
+      "protect_aura": {
+        "name": "Cast protective aura"
+      },
+      "heal_all": {
+        "name": "Cast blessing"
       }
     },
     "sensor": {

--- a/homeassistant/components/habitica/strings.json
+++ b/homeassistant/components/habitica/strings.json
@@ -48,40 +48,40 @@
         "name": "Revive from death"
       },
       "mpheal": {
-        "name": "Cast ethereal surge"
+        "name": "Ethereal surge"
       },
       "earth": {
-        "name": "Cast earthquake"
+        "name": "Earthquake"
       },
       "frost": {
-        "name": "Cast chilling frost"
+        "name": "Chilling frost"
       },
       "defensive_stance": {
-        "name": "Cast defensive stance"
+        "name": "Defensive stance"
       },
       "valorous_presence": {
-        "name": "Cast valorous presence"
+        "name": "Valorous presence"
       },
       "intimidate": {
-        "name": "Cast intimidating gaze"
+        "name": "Intimidating gaze"
       },
       "tools_of_trade": {
-        "name": "Cast tools of the trade"
+        "name": "Tools of the trade"
       },
       "stealth": {
-        "name": "Cast stealth"
+        "name": "Stealth"
       },
       "heal": {
-        "name": "Cast healing light"
+        "name": "Healing light"
       },
       "brightness": {
-        "name": "Cast searing brightness"
+        "name": "Searing brightness"
       },
       "protect_aura": {
-        "name": "Cast protective aura"
+        "name": "Protective aura"
       },
       "heal_all": {
-        "name": "Cast blessing"
+        "name": "Blessing"
       }
     },
     "sensor": {

--- a/homeassistant/components/habitica/strings.json
+++ b/homeassistant/components/habitica/strings.json
@@ -47,9 +47,6 @@
       "revive": {
         "name": "Revive from death"
       },
-      "fireball": {
-        "name": "Cast burst of flames"
-      },
       "mpheal": {
         "name": "Cast ethereal surge"
       },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Adds button entities for skills and spells that are cast on the player or the party.
Entities are created depending on the players class. The class system is unlocked at level 10, the first skill is unlocked after reaching level 11.




## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/34884

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
