### PR TITLE
Fix next change (scheduler) sensors in AVM FRITZ!SmartHome

### DIFF
--- a/homeassistant/components/fritzbox/sensor.py
+++ b/homeassistant/components/fritzbox/sensor.py
@@ -83,18 +83,36 @@ def entity_category_temperature(device: FritzhomeDevice) -> EntityCategory | Non
     return None
 
 
-def value_nextchange_preset(device: FritzhomeDevice) -> str:
+def value_nextchange_preset(device: FritzhomeDevice) -> str | None:
     """Return native value for next scheduled preset sensor."""
+    if not device.nextchange_endperiod:
+        return None
     if device.nextchange_temperature == device.eco_temperature:
         return PRESET_ECO
     return PRESET_COMFORT
 
 
-def value_scheduled_preset(device: FritzhomeDevice) -> str:
+def value_scheduled_preset(device: FritzhomeDevice) -> str | None:
     """Return native value for current scheduled preset sensor."""
+    if not device.nextchange_endperiod:
+        return None
     if device.nextchange_temperature == device.eco_temperature:
         return PRESET_COMFORT
     return PRESET_ECO
+
+
+def value_nextchange_temperature(device: FritzhomeDevice) -> float | None:
+    """Return native value for next scheduled temperature time sensor."""
+    if device.nextchange_endperiod and isinstance(device.nextchange_temperature, float):
+        return device.nextchange_temperature
+    return None
+
+
+def value_nextchange_time(device: FritzhomeDevice) -> datetime | None:
+    """Return native value for next scheduled changed time sensor."""
+    if device.nextchange_endperiod:
+        return utc_from_timestamp(device.nextchange_endperiod)
+    return None
 
 
 SENSOR_TYPES: Final[tuple[FritzSensorEntityDescription, ...]] = (
@@ -181,7 +199,7 @@ SENSOR_TYPES: Final[tuple[FritzSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_category=EntityCategory.DIAGNOSTIC,
         suitable=suitable_nextchange_temperature,
-        native_value=lambda device: device.nextchange_temperature,
+        native_value=value_nextchange_temperature,
     ),
     FritzSensorEntityDescription(
         key="nextchange_time",
@@ -189,7 +207,7 @@ SENSOR_TYPES: Final[tuple[FritzSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.TIMESTAMP,
         entity_category=EntityCategory.DIAGNOSTIC,
         suitable=suitable_nextchange_time,
-        native_value=lambda device: utc_from_timestamp(device.nextchange_endperiod),
+        native_value=value_nextchange_time,
     ),
     FritzSensorEntityDescription(
         key="nextchange_preset",

--- a/tests/components/fritzbox/__init__.py
+++ b/tests/components/fritzbox/__init__.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import Mock
 
-from homeassistant.components.climate import PRESET_COMFORT, PRESET_ECO
 from homeassistant.components.fritzbox.const import DOMAIN
 from homeassistant.core import HomeAssistant
 
@@ -110,9 +109,7 @@ class FritzDeviceClimateMock(FritzEntityBaseMock):
     target_temperature = 19.5
     window_open = "fake_window"
     nextchange_temperature = 22.0
-    nextchange_endperiod = 0
-    nextchange_preset = PRESET_COMFORT
-    scheduled_preset = PRESET_ECO
+    nextchange_endperiod = 1726855200
 
 
 class FritzDeviceClimateWithoutTempSensorMock(FritzDeviceClimateMock):

--- a/tests/components/fritzbox/test_climate.py
+++ b/tests/components/fritzbox/test_climate.py
@@ -125,7 +125,7 @@ async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
         f"{SENSOR_DOMAIN}.{CONF_FAKE_NAME}_next_scheduled_change_time"
     )
     assert state
-    assert state.state == "1970-01-01T00:00:00+00:00"
+    assert state.state == "2024-09-20T18:00:00+00:00"
     assert (
         state.attributes[ATTR_FRIENDLY_NAME]
         == f"{CONF_FAKE_NAME} Next scheduled change time"

--- a/tests/components/fritzbox/test_sensor.py
+++ b/tests/components/fritzbox/test_sensor.py
@@ -3,8 +3,10 @@
 from datetime import timedelta
 from unittest.mock import Mock
 
+import pytest
 from requests.exceptions import HTTPError
 
+from homeassistant.components.climate import PRESET_COMFORT, PRESET_ECO
 from homeassistant.components.fritzbox.const import DOMAIN as FB_DOMAIN
 from homeassistant.components.sensor import (
     ATTR_STATE_CLASS,
@@ -16,6 +18,7 @@ from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     CONF_DEVICES,
     PERCENTAGE,
+    STATE_UNKNOWN,
     EntityCategory,
     UnitOfTemperature,
 )
@@ -23,7 +26,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 import homeassistant.util.dt as dt_util
 
-from . import FritzDeviceSensorMock, set_devices, setup_config_entry
+from . import (
+    FritzDeviceClimateMock,
+    FritzDeviceSensorMock,
+    set_devices,
+    setup_config_entry,
+)
 from .const import CONF_FAKE_NAME, MOCK_CONFIG
 
 from tests.common import async_fire_time_changed
@@ -136,3 +144,55 @@ async def test_discover_new_device(hass: HomeAssistant, fritz: Mock) -> None:
 
     state = hass.states.get(f"{SENSOR_DOMAIN}.new_device_temperature")
     assert state
+
+
+@pytest.mark.parametrize(
+    ("next_changes", "expected_states"),
+    [
+        (
+            [0, 16],
+            [STATE_UNKNOWN, STATE_UNKNOWN, STATE_UNKNOWN, STATE_UNKNOWN],
+        ),
+        (
+            [0, 22],
+            [STATE_UNKNOWN, STATE_UNKNOWN, STATE_UNKNOWN, STATE_UNKNOWN],
+        ),
+        (
+            [1726855200, 16.0],
+            ["2024-09-20T18:00:00+00:00", "16.0", PRESET_ECO, PRESET_COMFORT],
+        ),
+        (
+            [1726855200, 22.0],
+            ["2024-09-20T18:00:00+00:00", "22.0", PRESET_COMFORT, PRESET_ECO],
+        ),
+    ],
+)
+async def test_next_change_sensors(
+    hass: HomeAssistant, fritz: Mock, next_changes: list, expected_states: list
+) -> None:
+    """Test next change sensors."""
+    device = FritzDeviceClimateMock()
+    device.nextchange_endperiod = next_changes[0]
+    device.nextchange_temperature = next_changes[1]
+
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
+
+    base_name = f"{SENSOR_DOMAIN}.{CONF_FAKE_NAME}"
+
+    state = hass.states.get(f"{base_name}_next_scheduled_change_time")
+    assert state
+    assert state.state == expected_states[0]
+
+    state = hass.states.get(f"{base_name}_next_scheduled_temperature")
+    assert state
+    assert state.state == expected_states[1]
+
+    state = hass.states.get(f"{base_name}_next_scheduled_preset")
+    assert state
+    assert state.state == expected_states[2]
+
+    state = hass.states.get(f"{base_name}_current_scheduled_preset")
+    assert state
+    assert state.state == expected_states[3]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
You can set up a scheduler on the device, were you define, whether the eco or comfort temperature should be active or disable the scheduler at all. The api return the "nextchange" timestamp and temperature. When the scheduler is disabled, the nextchange timestamp will be 0, but the nextchange temperature is still set to the comfort temperature.

With this PR the nextchange timestamp is now used to consider the correct current and next preset sensors - these sensors will no be set to unknown (_`None`_) when the scheduler is disabled to reflect the real scheduler configuration.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #126044
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
