### PR TITLE
Add router reconnect button for Smlight integration

### DIFF
--- a/homeassistant/components/smlight/button.py
+++ b/homeassistant/components/smlight/button.py
@@ -56,8 +56,8 @@ BUTTONS: list[SmButtonDescription] = [
 ]
 
 ROUTER = SmButtonDescription(
-    key="zigbee_router_reconnect",
-    translation_key="zigbee_router_reconnect",
+    key="reconnect_zigbee_router",
+    translation_key="reconnect_zigbee_router",
     entity_registry_enabled_default=False,
     press_fn=lambda cmd: cmd.zb_router(),
 )

--- a/homeassistant/components/smlight/button.py
+++ b/homeassistant/components/smlight/button.py
@@ -9,6 +9,7 @@ import logging
 from pysmlight.web import CmdWrapper
 
 from homeassistant.components.button import (
+    DOMAIN as BUTTON_DOMAIN,
     ButtonDeviceClass,
     ButtonEntity,
     ButtonEntityDescription,
@@ -16,8 +17,10 @@ from homeassistant.components.button import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .const import DOMAIN
 from .coordinator import SmDataUpdateCoordinator
 from .entity import SmEntity
 
@@ -69,8 +72,15 @@ async def async_setup_entry(
     coordinator = entry.runtime_data.data
 
     entities = [SmButton(coordinator, button) for button in BUTTONS]
+
     if coordinator.data.info.zb_type == 1:
         entities.append(SmButton(coordinator, ROUTER))
+    else:
+        entity_registry = er.async_get(hass)
+        if entity_id := entity_registry.async_get_entity_id(
+            BUTTON_DOMAIN, DOMAIN, f"{coordinator.unique_id}-{ROUTER.key}"
+        ):
+            entity_registry.async_remove(entity_id)
 
     async_add_entities(entities)
 

--- a/homeassistant/components/smlight/strings.json
+++ b/homeassistant/components/smlight/strings.json
@@ -109,8 +109,8 @@
       "zigbee_flash_mode": {
         "name": "Zigbee flash mode"
       },
-      "zigbee_router_reconnect": {
-        "name": "Zigbee router reconnect"
+      "reconnect_zigbee_router": {
+        "name": "Reconnect zigbee router"
       }
     },
     "switch": {

--- a/homeassistant/components/smlight/strings.json
+++ b/homeassistant/components/smlight/strings.json
@@ -108,6 +108,9 @@
       },
       "zigbee_flash_mode": {
         "name": "Zigbee flash mode"
+      },
+      "zigbee_router_reconnect": {
+        "name": "Zigbee router reconnect"
       }
     },
     "switch": {

--- a/tests/components/smlight/test_button.py
+++ b/tests/components/smlight/test_button.py
@@ -45,11 +45,7 @@ async def test_buttons(
     mock_smlight_client: MagicMock,
 ) -> None:
     """Test creation of button entities."""
-    translation_key = entity_id
-    if entity_id == "reconnect_zigbee_router":
-        translation_key = "zigbee_router_reconnect"
-        mock_smlight_client.get_info.return_value = MOCK_ROUTER
-
+    mock_smlight_client.get_info.return_value = MOCK_ROUTER
     await setup_integration(hass, mock_config_entry)
 
     state = hass.states.get(f"button.mock_title_{entity_id}")
@@ -58,7 +54,7 @@ async def test_buttons(
 
     entry = entity_registry.async_get(f"button.mock_title_{entity_id}")
     assert entry is not None
-    assert entry.unique_id == f"aa:bb:cc:dd:ee:ff-{translation_key}"
+    assert entry.unique_id == f"aa:bb:cc:dd:ee:ff-{entity_id}"
 
     mock_method = getattr(mock_smlight_client.cmds, method)
 
@@ -82,8 +78,7 @@ async def test_disabled_by_default_buttons(
     mock_smlight_client: MagicMock,
 ) -> None:
     """Test the disabled by default buttons."""
-    if entity_id == "reconnect_zigbee_router":
-        mock_smlight_client.get_info.return_value = MOCK_ROUTER
+    mock_smlight_client.get_info.return_value = MOCK_ROUTER
     await setup_integration(hass, mock_config_entry)
 
     assert not hass.states.get(f"button.mock_{entity_id}")
@@ -109,7 +104,7 @@ async def test_remove_router_reconnect(
         entity_registry, mock_config_entry.entry_id
     )
     assert len(entities) == 4
-    assert entities[3].unique_id == "aa:bb:cc:dd:ee:ff-zigbee_router_reconnect"
+    assert entities[3].unique_id == "aa:bb:cc:dd:ee:ff-reconnect_zigbee_router"
 
     mock_smlight_client.get_info.return_value = save_mock
 

--- a/tests/components/smlight/test_button.py
+++ b/tests/components/smlight/test_button.py
@@ -28,7 +28,7 @@ def platforms() -> Platform | list[Platform]:
         ("core_restart", "reboot"),
         ("zigbee_flash_mode", "zb_bootloader"),
         ("zigbee_restart", "zb_restart"),
-        ("zigbee_router_reconnect", "zb_router"),
+        ("reconnect_zigbee_router", "zb_router"),
     ],
 )
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -41,7 +41,9 @@ async def test_buttons(
     mock_smlight_client: MagicMock,
 ) -> None:
     """Test creation of button entities."""
-    if entity_id == "zigbee_router_reconnect":
+    translation_key = entity_id
+    if entity_id == "reconnect_zigbee_router":
+        translation_key = "zigbee_router_reconnect"
         mock_smlight_client.get_info.return_value = Info(
             MAC="AA:BB:CC:DD:EE:FF", zb_type=1
         )
@@ -54,7 +56,7 @@ async def test_buttons(
 
     entry = entity_registry.async_get(f"button.mock_title_{entity_id}")
     assert entry is not None
-    assert entry.unique_id == f"aa:bb:cc:dd:ee:ff-{entity_id}"
+    assert entry.unique_id == f"aa:bb:cc:dd:ee:ff-{translation_key}"
 
     mock_method = getattr(mock_smlight_client.cmds, method)
 
@@ -69,7 +71,7 @@ async def test_buttons(
     mock_method.assert_called_with()
 
 
-@pytest.mark.parametrize("entity_id", ["zigbee_flash_mode", "zigbee_router_reconnect"])
+@pytest.mark.parametrize("entity_id", ["zigbee_flash_mode", "reconnect_zigbee_router"])
 async def test_disabled_by_default_buttons(
     hass: HomeAssistant,
     entity_id: str,
@@ -78,7 +80,7 @@ async def test_disabled_by_default_buttons(
     mock_smlight_client: MagicMock,
 ) -> None:
     """Test the disabled by default buttons."""
-    if entity_id == "zigbee_router_reconnect":
+    if entity_id == "reconnect_zigbee_router":
         mock_smlight_client.get_info.return_value = Info(
             MAC="AA:BB:CC:DD:EE:FF", zb_type=1
         )
@@ -118,5 +120,5 @@ async def test_remove_router_reconnect(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    entity = entity_registry.async_get("button.mock_title_zigbee_router_reconnect")
+    entity = entity_registry.async_get("button.mock_title_reconnect_zigbee_router")
     assert entity is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a router reconnect button that is added only if SLZB-06 device is in Zigbee router mode. This allows the user to re-pair the router with a new network.
We also remove the orphaned entity if the user switches SLZB-06 back to coordinator mode.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/34856

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
