### PR TITLE
Add button platform to Tesla Fleet

### DIFF
--- a/homeassistant/components/tesla_fleet/__init__.py
+++ b/homeassistant/components/tesla_fleet/__init__.py
@@ -41,6 +41,7 @@ from .oauth import TeslaSystemImplementation
 
 PLATFORMS: Final = [
     Platform.BINARY_SENSOR,
+    Platform.BUTTON,
     Platform.CLIMATE,
     Platform.COVER,
     Platform.DEVICE_TRACKER,

--- a/homeassistant/components/tesla_fleet/button.py
+++ b/homeassistant/components/tesla_fleet/button.py
@@ -1,0 +1,90 @@
+"""Button platform for Tesla Fleet integration."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from tesla_fleet_api.const import Scope
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import TeslaFleetConfigEntry
+from .entity import TeslaFleetVehicleEntity
+from .helpers import handle_vehicle_command
+from .models import TeslaFleetVehicleData
+
+PARALLEL_UPDATES = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class TeslaFleetButtonEntityDescription(ButtonEntityDescription):
+    """Describes a TeslaFleet Button entity."""
+
+    func: Callable[[TeslaFleetButtonEntity], Awaitable[Any]] | None = None
+
+
+DESCRIPTIONS: tuple[TeslaFleetButtonEntityDescription, ...] = (
+    TeslaFleetButtonEntityDescription(key="wake"),  # Every button runs wakeup
+    TeslaFleetButtonEntityDescription(
+        key="flash_lights", func=lambda self: self.api.flash_lights()
+    ),
+    TeslaFleetButtonEntityDescription(
+        key="honk", func=lambda self: self.api.honk_horn()
+    ),
+    TeslaFleetButtonEntityDescription(
+        key="enable_keyless_driving", func=lambda self: self.api.remote_start_drive()
+    ),
+    TeslaFleetButtonEntityDescription(
+        key="boombox", func=lambda self: self.api.remote_boombox(0)
+    ),
+    TeslaFleetButtonEntityDescription(
+        key="homelink",
+        func=lambda self: self.api.trigger_homelink(
+            lat=self.coordinator.data["drive_state_latitude"],
+            lon=self.coordinator.data["drive_state_longitude"],
+        ),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: TeslaFleetConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the TeslaFleet Button platform from a config entry."""
+
+    async_add_entities(
+        TeslaFleetButtonEntity(vehicle, description)
+        for vehicle in entry.runtime_data.vehicles
+        for description in DESCRIPTIONS
+        if Scope.VEHICLE_CMDS in entry.runtime_data.scopes
+    )
+
+
+class TeslaFleetButtonEntity(TeslaFleetVehicleEntity, ButtonEntity):
+    """Base class for TeslaFleet buttons."""
+
+    entity_description: TeslaFleetButtonEntityDescription
+
+    def __init__(
+        self,
+        data: TeslaFleetVehicleData,
+        description: TeslaFleetButtonEntityDescription,
+    ) -> None:
+        """Initialize the button."""
+        self.entity_description = description
+        super().__init__(data, description.key)
+
+    def _async_update_attrs(self) -> None:
+        """Update the attributes of the entity."""
+
+    async def async_press(self) -> None:
+        """Press the button."""
+        await self.wake_up_if_asleep()
+        if self.entity_description.func:
+            await handle_vehicle_command(self.entity_description.func(self))

--- a/homeassistant/components/tesla_fleet/button.py
+++ b/homeassistant/components/tesla_fleet/button.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from asyncio import sleep
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
@@ -21,6 +20,10 @@ from .models import TeslaFleetVehicleData
 PARALLEL_UPDATES = 0
 
 
+async def do_nothing() -> None:
+    """Do nothing."""
+
+
 @dataclass(frozen=True, kw_only=True)
 class TeslaFleetButtonEntityDescription(ButtonEntityDescription):
     """Describes a TeslaFleet Button entity."""
@@ -30,7 +33,7 @@ class TeslaFleetButtonEntityDescription(ButtonEntityDescription):
 
 DESCRIPTIONS: tuple[TeslaFleetButtonEntityDescription, ...] = (
     TeslaFleetButtonEntityDescription(
-        key="wake", func=lambda self: sleep(0)
+        key="wake", func=lambda self: do_nothing()
     ),  # Every button runs wakeup, so func does nothing
     TeslaFleetButtonEntityDescription(
         key="flash_lights", func=lambda self: self.api.flash_lights()

--- a/homeassistant/components/tesla_fleet/button.py
+++ b/homeassistant/components/tesla_fleet/button.py
@@ -62,7 +62,7 @@ async def async_setup_entry(
         TeslaFleetButtonEntity(vehicle, description)
         for vehicle in entry.runtime_data.vehicles
         for description in DESCRIPTIONS
-        if Scope.VEHICLE_CMDS in entry.runtime_data.scopes
+        if Scope.VEHICLE_CMDS in entry.runtime_data.scopes and not vehicle.signing
     )
 
 

--- a/homeassistant/components/tesla_fleet/icons.json
+++ b/homeassistant/components/tesla_fleet/icons.json
@@ -38,6 +38,26 @@
         }
       }
     },
+    "button": {
+      "boombox": {
+        "default": "mdi:volume-high"
+      },
+      "enable_keyless_driving": {
+        "default": "mdi:car-key"
+      },
+      "flash_lights": {
+        "default": "mdi:flashlight"
+      },
+      "homelink": {
+        "default": "mdi:garage"
+      },
+      "honk": {
+        "default": "mdi:bullhorn"
+      },
+      "wake": {
+        "default": "mdi:sleep-off"
+      }
+    },
     "climate": {
       "driver_temp": {
         "state_attributes": {

--- a/homeassistant/components/tesla_fleet/strings.json
+++ b/homeassistant/components/tesla_fleet/strings.json
@@ -107,6 +107,26 @@
         "name": "Tire pressure warning rear right"
       }
     },
+    "button": {
+      "boombox": {
+        "name": "Play fart"
+      },
+      "enable_keyless_driving": {
+        "name": "Keyless driving"
+      },
+      "flash_lights": {
+        "name": "Flash lights"
+      },
+      "homelink": {
+        "name": "Homelink"
+      },
+      "honk": {
+        "name": "Honk horn"
+      },
+      "wake": {
+        "name": "Wake"
+      }
+    },
     "climate": {
       "climate_state_cabin_overheat_protection": {
         "name": "Cabin overheat protection"

--- a/tests/components/tesla_fleet/snapshots/test_button.ambr
+++ b/tests/components/tesla_fleet/snapshots/test_button.ambr
@@ -1,0 +1,277 @@
+# serializer version: 1
+# name: test_button[button.test_flash_lights-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.test_flash_lights',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Flash lights',
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'flash_lights',
+    'unique_id': 'LRWXF7EK4KC700000-flash_lights',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button[button.test_flash_lights-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Test Flash lights',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.test_flash_lights',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button[button.test_homelink-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.test_homelink',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Homelink',
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'homelink',
+    'unique_id': 'LRWXF7EK4KC700000-homelink',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button[button.test_homelink-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Test Homelink',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.test_homelink',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button[button.test_honk_horn-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.test_honk_horn',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Honk horn',
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'honk',
+    'unique_id': 'LRWXF7EK4KC700000-honk',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button[button.test_honk_horn-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Test Honk horn',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.test_honk_horn',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button[button.test_keyless_driving-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.test_keyless_driving',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Keyless driving',
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'enable_keyless_driving',
+    'unique_id': 'LRWXF7EK4KC700000-enable_keyless_driving',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button[button.test_keyless_driving-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Test Keyless driving',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.test_keyless_driving',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button[button.test_play_fart-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.test_play_fart',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Play fart',
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'boombox',
+    'unique_id': 'LRWXF7EK4KC700000-boombox',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button[button.test_play_fart-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Test Play fart',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.test_play_fart',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button[button.test_wake-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.test_wake',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Wake',
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'wake',
+    'unique_id': 'LRWXF7EK4KC700000-wake',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button[button.test_wake-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Test Wake',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.test_wake',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/tesla_fleet/test_button.py
+++ b/tests/components/tesla_fleet/test_button.py
@@ -46,7 +46,7 @@ async def test_press(
     await setup_platform(hass, normal_config_entry, [Platform.BUTTON])
 
     with patch(
-        f"homeassistant.components.TeslaFleet.VehicleSpecific.{func}",
+        f"homeassistant.components.tesla_fleet.VehicleSpecific.{func}",
         return_value=COMMAND_OK,
     ) as command:
         await hass.services.async_call(

--- a/tests/components/tesla_fleet/test_button.py
+++ b/tests/components/tesla_fleet/test_button.py
@@ -1,0 +1,58 @@
+"""Test the Tesla Fleet button platform."""
+
+from unittest.mock import patch
+
+import pytest
+from syrupy import SnapshotAssertion
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import assert_entities, setup_platform
+from .const import COMMAND_OK
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_button(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    normal_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Tests that the button entities are correct."""
+
+    await setup_platform(hass, normal_config_entry, [Platform.BUTTON])
+    assert_entities(hass, normal_config_entry.entry_id, entity_registry, snapshot)
+
+
+@pytest.mark.parametrize(
+    ("name", "func"),
+    [
+        ("flash_lights", "flash_lights"),
+        ("honk_horn", "honk_horn"),
+        ("keyless_driving", "remote_start_drive"),
+        ("play_fart", "remote_boombox"),
+        ("homelink", "trigger_homelink"),
+    ],
+)
+async def test_press(
+    hass: HomeAssistant, normal_config_entry: MockConfigEntry, name: str, func: str
+) -> None:
+    """Test pressing the API buttons."""
+    await setup_platform(hass, normal_config_entry, [Platform.BUTTON])
+
+    with patch(
+        f"homeassistant.components.TeslaFleet.VehicleSpecific.{func}",
+        return_value=COMMAND_OK,
+    ) as command:
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: [f"button.test_{name}"]},
+            blocking=True,
+        )
+        command.assert_called_once()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add button platform to Tesla Fleet

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/34857

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
