### PR TITLE
Add cover platform to Tesla Fleet

### DIFF
--- a/homeassistant/components/tesla_fleet/__init__.py
+++ b/homeassistant/components/tesla_fleet/__init__.py
@@ -42,6 +42,7 @@ from .oauth import TeslaSystemImplementation
 PLATFORMS: Final = [
     Platform.BINARY_SENSOR,
     Platform.CLIMATE,
+    Platform.COVER,
     Platform.DEVICE_TRACKER,
     Platform.SELECT,
     Platform.SENSOR,

--- a/homeassistant/components/tesla_fleet/cover.py
+++ b/homeassistant/components/tesla_fleet/cover.py
@@ -1,0 +1,253 @@
+"""Cover platform for Tesla Fleet integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tesla_fleet_api.const import Scope, SunRoofCommand, Trunk, WindowCommand
+
+from homeassistant.components.cover import (
+    CoverDeviceClass,
+    CoverEntity,
+    CoverEntityFeature,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import TeslaFleetConfigEntry
+from .entity import TeslaFleetVehicleEntity
+from .helpers import handle_vehicle_command
+from .models import TeslaFleetVehicleData
+
+OPEN = 1
+CLOSED = 0
+
+PARALLEL_UPDATES = 0
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: TeslaFleetConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the TeslaFleet cover platform from a config entry."""
+
+    async_add_entities(
+        klass(vehicle, entry.runtime_data.scopes)
+        for (klass) in (
+            TeslaFleetWindowEntity,
+            TeslaFleetChargePortEntity,
+            TeslaFleetFrontTrunkEntity,
+            TeslaFleetRearTrunkEntity,
+            TeslaFleetSunroofEntity,
+        )
+        for vehicle in entry.runtime_data.vehicles
+    )
+
+
+class TeslaFleetWindowEntity(TeslaFleetVehicleEntity, CoverEntity):
+    """Cover entity for the windows."""
+
+    _attr_device_class = CoverDeviceClass.WINDOW
+
+    def __init__(self, data: TeslaFleetVehicleData, scopes: list[Scope]) -> None:
+        """Initialize the cover."""
+        super().__init__(data, "windows")
+        self.scoped = Scope.VEHICLE_CMDS in scopes
+        self._attr_supported_features = (
+            CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
+        )
+        if not self.scoped or self.vehicle.signing:
+            self._attr_supported_features = CoverEntityFeature(0)
+
+    def _async_update_attrs(self) -> None:
+        """Update the entity attributes."""
+        fd = self.get("vehicle_state_fd_window")
+        fp = self.get("vehicle_state_fp_window")
+        rd = self.get("vehicle_state_rd_window")
+        rp = self.get("vehicle_state_rp_window")
+
+        # Any open set to open
+        if OPEN in (fd, fp, rd, rp):
+            self._attr_is_closed = False
+        # All closed set to closed
+        elif CLOSED == fd == fp == rd == rp:
+            self._attr_is_closed = True
+        # Otherwise, set to unknown
+        else:
+            self._attr_is_closed = None
+
+    async def async_open_cover(self, **kwargs: Any) -> None:
+        """Vent windows."""
+        await self.wake_up_if_asleep()
+        await handle_vehicle_command(
+            self.api.window_control(command=WindowCommand.VENT)
+        )
+        self._attr_is_closed = False
+        self.async_write_ha_state()
+
+    async def async_close_cover(self, **kwargs: Any) -> None:
+        """Close windows."""
+        await self.wake_up_if_asleep()
+        await handle_vehicle_command(
+            self.api.window_control(command=WindowCommand.CLOSE)
+        )
+        self._attr_is_closed = True
+        self.async_write_ha_state()
+
+
+class TeslaFleetChargePortEntity(TeslaFleetVehicleEntity, CoverEntity):
+    """Cover entity for the charge port."""
+
+    _attr_device_class = CoverDeviceClass.DOOR
+
+    def __init__(self, vehicle: TeslaFleetVehicleData, scopes: list[Scope]) -> None:
+        """Initialize the cover."""
+        super().__init__(vehicle, "charge_state_charge_port_door_open")
+        self.scoped = any(
+            scope in scopes
+            for scope in (Scope.VEHICLE_CMDS, Scope.VEHICLE_CHARGING_CMDS)
+        )
+        self._attr_supported_features = (
+            CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
+        )
+        if not self.scoped or self.vehicle.signing:
+            self._attr_supported_features = CoverEntityFeature(0)
+
+    def _async_update_attrs(self) -> None:
+        """Update the entity attributes."""
+        self._attr_is_closed = not self._value
+
+    async def async_open_cover(self, **kwargs: Any) -> None:
+        """Open charge port."""
+        await self.wake_up_if_asleep()
+        await handle_vehicle_command(self.api.charge_port_door_open())
+        self._attr_is_closed = False
+        self.async_write_ha_state()
+
+    async def async_close_cover(self, **kwargs: Any) -> None:
+        """Close charge port."""
+        await self.wake_up_if_asleep()
+        await handle_vehicle_command(self.api.charge_port_door_close())
+        self._attr_is_closed = True
+        self.async_write_ha_state()
+
+
+class TeslaFleetFrontTrunkEntity(TeslaFleetVehicleEntity, CoverEntity):
+    """Cover entity for the front trunk."""
+
+    _attr_device_class = CoverDeviceClass.DOOR
+
+    def __init__(self, vehicle: TeslaFleetVehicleData, scopes: list[Scope]) -> None:
+        """Initialize the cover."""
+        super().__init__(vehicle, "vehicle_state_ft")
+
+        self.scoped = Scope.VEHICLE_CMDS in scopes
+        self._attr_supported_features = CoverEntityFeature.OPEN
+        if not self.scoped or self.vehicle.signing:
+            self._attr_supported_features = CoverEntityFeature(0)
+
+    def _async_update_attrs(self) -> None:
+        """Update the entity attributes."""
+        self._attr_is_closed = self._value == CLOSED
+
+    async def async_open_cover(self, **kwargs: Any) -> None:
+        """Open front trunk."""
+        await self.wake_up_if_asleep()
+        await handle_vehicle_command(self.api.actuate_trunk(Trunk.FRONT))
+        self._attr_is_closed = False
+        self.async_write_ha_state()
+
+
+class TeslaFleetRearTrunkEntity(TeslaFleetVehicleEntity, CoverEntity):
+    """Cover entity for the rear trunk."""
+
+    _attr_device_class = CoverDeviceClass.DOOR
+
+    def __init__(self, vehicle: TeslaFleetVehicleData, scopes: list[Scope]) -> None:
+        """Initialize the cover."""
+        super().__init__(vehicle, "vehicle_state_rt")
+
+        self.scoped = Scope.VEHICLE_CMDS in scopes
+        self._attr_supported_features = (
+            CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
+        )
+        if not self.scoped or self.vehicle.signing:
+            self._attr_supported_features = CoverEntityFeature(0)
+
+    def _async_update_attrs(self) -> None:
+        """Update the entity attributes."""
+        value = self._value
+        if value == CLOSED:
+            self._attr_is_closed = True
+        elif value == OPEN:
+            self._attr_is_closed = False
+        else:
+            self._attr_is_closed = None
+
+    async def async_open_cover(self, **kwargs: Any) -> None:
+        """Open rear trunk."""
+        if self.is_closed is not False:
+            await self.wake_up_if_asleep()
+            await handle_vehicle_command(self.api.actuate_trunk(Trunk.REAR))
+            self._attr_is_closed = False
+            self.async_write_ha_state()
+
+    async def async_close_cover(self, **kwargs: Any) -> None:
+        """Close rear trunk."""
+        if self.is_closed is not True:
+            await self.wake_up_if_asleep()
+            await handle_vehicle_command(self.api.actuate_trunk(Trunk.REAR))
+            self._attr_is_closed = True
+            self.async_write_ha_state()
+
+
+class TeslaFleetSunroofEntity(TeslaFleetVehicleEntity, CoverEntity):
+    """Cover entity for the sunroof."""
+
+    _attr_device_class = CoverDeviceClass.WINDOW
+    _attr_supported_features = (
+        CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE | CoverEntityFeature.STOP
+    )
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, vehicle: TeslaFleetVehicleData, scopes: list[Scope]) -> None:
+        """Initialize the sensor."""
+        super().__init__(vehicle, "vehicle_state_sun_roof_state")
+
+        self.scoped = Scope.VEHICLE_CMDS in scopes
+        if not self.scoped or self.vehicle.signing:
+            self._attr_supported_features = CoverEntityFeature(0)
+
+    def _async_update_attrs(self) -> None:
+        """Update the entity attributes."""
+        value = self._value
+        if value in (None, "unknown"):
+            self._attr_is_closed = None
+        else:
+            self._attr_is_closed = value == "closed"
+
+        self._attr_current_cover_position = self.get(
+            "vehicle_state_sun_roof_percent_open"
+        )
+
+    async def async_open_cover(self, **kwargs: Any) -> None:
+        """Open sunroof."""
+        await self.wake_up_if_asleep()
+        await handle_vehicle_command(self.api.sun_roof_control(SunRoofCommand.VENT))
+        self._attr_is_closed = False
+        self.async_write_ha_state()
+
+    async def async_close_cover(self, **kwargs: Any) -> None:
+        """Close sunroof."""
+        await self.wake_up_if_asleep()
+        await handle_vehicle_command(self.api.sun_roof_control(SunRoofCommand.CLOSE))
+        self._attr_is_closed = True
+        self.async_write_ha_state()
+
+    async def async_stop_cover(self, **kwargs: Any) -> None:
+        """Close sunroof."""
+        await self.wake_up_if_asleep()
+        await handle_vehicle_command(self.api.sun_roof_control(SunRoofCommand.STOP))
+        self._attr_is_closed = False
+        self.async_write_ha_state()

--- a/homeassistant/components/tesla_fleet/icons.json
+++ b/homeassistant/components/tesla_fleet/icons.json
@@ -52,6 +52,11 @@
         }
       }
     },
+    "cover": {
+      "charge_state_charge_port_door_open": {
+        "default": "mdi:ev-plug-ccs2"
+      }
+    },
     "device_tracker": {
       "location": {
         "default": "mdi:map-marker"

--- a/homeassistant/components/tesla_fleet/strings.json
+++ b/homeassistant/components/tesla_fleet/strings.json
@@ -125,6 +125,23 @@
         }
       }
     },
+    "cover": {
+      "charge_state_charge_port_door_open": {
+        "name": "Charge port door"
+      },
+      "vehicle_state_ft": {
+        "name": "Frunk"
+      },
+      "vehicle_state_rt": {
+        "name": "Trunk"
+      },
+      "vehicle_state_sun_roof_state": {
+        "name": "Sunroof"
+      },
+      "windows": {
+        "name": "Windows"
+      }
+    },
     "device_tracker": {
       "location": {
         "name": "Location"

--- a/tests/components/tesla_fleet/snapshots/test_cover.ambr
+++ b/tests/components/tesla_fleet/snapshots/test_cover.ambr
@@ -1,0 +1,1201 @@
+# serializer version: 1
+# name: test_cover[cover.test_charge_port_door-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.test_charge_port_door',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.DOOR: 'door'>,
+    'original_icon': None,
+    'original_name': 'Charge port door',
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': <CoverEntityFeature: 3>,
+    'translation_key': 'charge_state_charge_port_door_open',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_charge_port_door_open',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover[cover.test_charge_port_door-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Test Charge port door',
+      'supported_features': <CoverEntityFeature: 3>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_charge_port_door',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'open',
+  })
+# ---
+# name: test_cover[cover.test_frunk-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.test_frunk',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.DOOR: 'door'>,
+    'original_icon': None,
+    'original_name': 'Frunk',
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': <CoverEntityFeature: 1>,
+    'translation_key': 'vehicle_state_ft',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_ft',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover[cover.test_frunk-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Test Frunk',
+      'supported_features': <CoverEntityFeature: 1>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_frunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'closed',
+  })
+# ---
+# name: test_cover[cover.test_none-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.test_none',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.WINDOW: 'window'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': <CoverEntityFeature: 3>,
+    'translation_key': 'windows',
+    'unique_id': 'LRWXF7EK4KC700000-windows',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover[cover.test_none-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Test None',
+      'supported_features': <CoverEntityFeature: 3>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_none',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'closed',
+  })
+# ---
+# name: test_cover[cover.test_none_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.test_none_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.DOOR: 'door'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': <CoverEntityFeature: 3>,
+    'translation_key': 'charge_state_charge_port_door_open',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_charge_port_door_open',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover[cover.test_none_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Test None',
+      'supported_features': <CoverEntityFeature: 3>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_none_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'open',
+  })
+# ---
+# name: test_cover[cover.test_none_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.test_none_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.DOOR: 'door'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': <CoverEntityFeature: 1>,
+    'translation_key': 'vehicle_state_ft',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_ft',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover[cover.test_none_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Test None',
+      'supported_features': <CoverEntityFeature: 1>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_none_3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'closed',
+  })
+# ---
+# name: test_cover[cover.test_none_4-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.test_none_4',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.DOOR: 'door'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': <CoverEntityFeature: 3>,
+    'translation_key': 'vehicle_state_rt',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_rt',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover[cover.test_none_4-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Test None',
+      'supported_features': <CoverEntityFeature: 3>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_none_4',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'closed',
+  })
+# ---
+# name: test_cover[cover.test_none_5-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.test_none_5',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.WINDOW: 'window'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': <CoverEntityFeature: 11>,
+    'translation_key': 'vehicle_state_sun_roof_state',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_sun_roof_state',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover[cover.test_none_5-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Test None',
+      'supported_features': <CoverEntityFeature: 11>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_none_5',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'open',
+  })
+# ---
+# name: test_cover[cover.test_sunroof-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.test_sunroof',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.WINDOW: 'window'>,
+    'original_icon': None,
+    'original_name': 'Sunroof',
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': <CoverEntityFeature: 11>,
+    'translation_key': 'vehicle_state_sun_roof_state',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_sun_roof_state',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover[cover.test_sunroof-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Test Sunroof',
+      'supported_features': <CoverEntityFeature: 11>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_sunroof',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'open',
+  })
+# ---
+# name: test_cover[cover.test_trunk-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.test_trunk',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.DOOR: 'door'>,
+    'original_icon': None,
+    'original_name': 'Trunk',
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': <CoverEntityFeature: 3>,
+    'translation_key': 'vehicle_state_rt',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_rt',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover[cover.test_trunk-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Test Trunk',
+      'supported_features': <CoverEntityFeature: 3>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'closed',
+  })
+# ---
+# name: test_cover[cover.test_windows-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.test_windows',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.WINDOW: 'window'>,
+    'original_icon': None,
+    'original_name': 'Windows',
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': <CoverEntityFeature: 3>,
+    'translation_key': 'windows',
+    'unique_id': 'LRWXF7EK4KC700000-windows',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover[cover.test_windows-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Test Windows',
+      'supported_features': <CoverEntityFeature: 3>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_windows',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'closed',
+  })
+# ---
+# name: test_cover_alt[cover.test_charge_port_door-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.test_charge_port_door',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.DOOR: 'door'>,
+    'original_icon': None,
+    'original_name': 'Charge port door',
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': <CoverEntityFeature: 3>,
+    'translation_key': 'charge_state_charge_port_door_open',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_charge_port_door_open',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover_alt[cover.test_charge_port_door-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Test Charge port door',
+      'supported_features': <CoverEntityFeature: 3>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_charge_port_door',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'open',
+  })
+# ---
+# name: test_cover_alt[cover.test_frunk-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.test_frunk',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.DOOR: 'door'>,
+    'original_icon': None,
+    'original_name': 'Frunk',
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': <CoverEntityFeature: 1>,
+    'translation_key': 'vehicle_state_ft',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_ft',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover_alt[cover.test_frunk-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Test Frunk',
+      'supported_features': <CoverEntityFeature: 1>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_frunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'open',
+  })
+# ---
+# name: test_cover_alt[cover.test_none-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.test_none',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.WINDOW: 'window'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': <CoverEntityFeature: 3>,
+    'translation_key': 'windows',
+    'unique_id': 'LRWXF7EK4KC700000-windows',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover_alt[cover.test_none-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Test None',
+      'supported_features': <CoverEntityFeature: 3>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_none',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'open',
+  })
+# ---
+# name: test_cover_alt[cover.test_none_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.test_none_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.DOOR: 'door'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': <CoverEntityFeature: 3>,
+    'translation_key': 'charge_state_charge_port_door_open',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_charge_port_door_open',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover_alt[cover.test_none_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Test None',
+      'supported_features': <CoverEntityFeature: 3>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_none_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'open',
+  })
+# ---
+# name: test_cover_alt[cover.test_none_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.test_none_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.DOOR: 'door'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': <CoverEntityFeature: 1>,
+    'translation_key': 'vehicle_state_ft',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_ft',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover_alt[cover.test_none_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Test None',
+      'supported_features': <CoverEntityFeature: 1>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_none_3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'open',
+  })
+# ---
+# name: test_cover_alt[cover.test_none_4-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.test_none_4',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.DOOR: 'door'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': <CoverEntityFeature: 3>,
+    'translation_key': 'vehicle_state_rt',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_rt',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover_alt[cover.test_none_4-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Test None',
+      'supported_features': <CoverEntityFeature: 3>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_none_4',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'open',
+  })
+# ---
+# name: test_cover_alt[cover.test_none_5-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.test_none_5',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.WINDOW: 'window'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': <CoverEntityFeature: 11>,
+    'translation_key': 'vehicle_state_sun_roof_state',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_sun_roof_state',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover_alt[cover.test_none_5-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Test None',
+      'supported_features': <CoverEntityFeature: 11>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_none_5',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_cover_alt[cover.test_sunroof-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.test_sunroof',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.WINDOW: 'window'>,
+    'original_icon': None,
+    'original_name': 'Sunroof',
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': <CoverEntityFeature: 11>,
+    'translation_key': 'vehicle_state_sun_roof_state',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_sun_roof_state',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover_alt[cover.test_sunroof-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Test Sunroof',
+      'supported_features': <CoverEntityFeature: 11>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_sunroof',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_cover_alt[cover.test_trunk-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.test_trunk',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.DOOR: 'door'>,
+    'original_icon': None,
+    'original_name': 'Trunk',
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': <CoverEntityFeature: 3>,
+    'translation_key': 'vehicle_state_rt',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_rt',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover_alt[cover.test_trunk-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Test Trunk',
+      'supported_features': <CoverEntityFeature: 3>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'open',
+  })
+# ---
+# name: test_cover_alt[cover.test_windows-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.test_windows',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.WINDOW: 'window'>,
+    'original_icon': None,
+    'original_name': 'Windows',
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': <CoverEntityFeature: 3>,
+    'translation_key': 'windows',
+    'unique_id': 'LRWXF7EK4KC700000-windows',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover_alt[cover.test_windows-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Test Windows',
+      'supported_features': <CoverEntityFeature: 3>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_windows',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'open',
+  })
+# ---
+# name: test_cover_readonly[cover.test_charge_port_door-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.test_charge_port_door',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.DOOR: 'door'>,
+    'original_icon': None,
+    'original_name': 'Charge port door',
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'charge_state_charge_port_door_open',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_charge_port_door_open',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover_readonly[cover.test_charge_port_door-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Test Charge port door',
+      'supported_features': <CoverEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_charge_port_door',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'open',
+  })
+# ---
+# name: test_cover_readonly[cover.test_frunk-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.test_frunk',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.DOOR: 'door'>,
+    'original_icon': None,
+    'original_name': 'Frunk',
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'vehicle_state_ft',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_ft',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover_readonly[cover.test_frunk-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Test Frunk',
+      'supported_features': <CoverEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_frunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'closed',
+  })
+# ---
+# name: test_cover_readonly[cover.test_sunroof-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.test_sunroof',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.WINDOW: 'window'>,
+    'original_icon': None,
+    'original_name': 'Sunroof',
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'vehicle_state_sun_roof_state',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_sun_roof_state',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover_readonly[cover.test_sunroof-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Test Sunroof',
+      'supported_features': <CoverEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_sunroof',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'open',
+  })
+# ---
+# name: test_cover_readonly[cover.test_trunk-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.test_trunk',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.DOOR: 'door'>,
+    'original_icon': None,
+    'original_name': 'Trunk',
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'vehicle_state_rt',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_rt',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover_readonly[cover.test_trunk-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Test Trunk',
+      'supported_features': <CoverEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'closed',
+  })
+# ---
+# name: test_cover_readonly[cover.test_windows-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.test_windows',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.WINDOW: 'window'>,
+    'original_icon': None,
+    'original_name': 'Windows',
+    'platform': 'tesla_fleet',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'windows',
+    'unique_id': 'LRWXF7EK4KC700000-windows',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover_readonly[cover.test_windows-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Test Windows',
+      'supported_features': <CoverEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_windows',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'closed',
+  })
+# ---

--- a/tests/components/tesla_fleet/test_cover.py
+++ b/tests/components/tesla_fleet/test_cover.py
@@ -1,0 +1,240 @@
+"""Test the Teslemetry cover platform."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from syrupy import SnapshotAssertion
+from tesla_fleet_api.exceptions import VehicleOffline
+
+from homeassistant.components.cover import (
+    DOMAIN as COVER_DOMAIN,
+    SERVICE_CLOSE_COVER,
+    SERVICE_OPEN_COVER,
+    SERVICE_STOP_COVER,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    STATE_CLOSED,
+    STATE_OPEN,
+    STATE_UNKNOWN,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import assert_entities, setup_platform
+from .const import COMMAND_OK, VEHICLE_DATA_ALT
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_cover(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    normal_config_entry: MockConfigEntry,
+) -> None:
+    """Tests that the cover entities are correct."""
+
+    await setup_platform(hass, normal_config_entry, [Platform.COVER])
+    assert_entities(hass, normal_config_entry.entry_id, entity_registry, snapshot)
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_cover_alt(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    mock_vehicle_data: AsyncMock,
+    normal_config_entry: MockConfigEntry,
+) -> None:
+    """Tests that the cover entities are correct with alternate values."""
+
+    mock_vehicle_data.return_value = VEHICLE_DATA_ALT
+    await setup_platform(hass, normal_config_entry, [Platform.COVER])
+    assert_entities(hass, normal_config_entry.entry_id, entity_registry, snapshot)
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_cover_readonly(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    readonly_config_entry: MockConfigEntry,
+) -> None:
+    """Tests that the cover entities are correct without scopes."""
+
+    await setup_platform(hass, readonly_config_entry, [Platform.COVER])
+    assert_entities(hass, readonly_config_entry.entry_id, entity_registry, snapshot)
+
+
+async def test_cover_offline(
+    hass: HomeAssistant,
+    mock_vehicle_data: AsyncMock,
+    normal_config_entry: MockConfigEntry,
+) -> None:
+    """Tests that the cover entities are correct when offline."""
+
+    mock_vehicle_data.side_effect = VehicleOffline
+    await setup_platform(hass, normal_config_entry, [Platform.COVER])
+    state = hass.states.get("cover.test_windows")
+    assert state.state == STATE_UNKNOWN
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_cover_services(
+    hass: HomeAssistant,
+    normal_config_entry: MockConfigEntry,
+) -> None:
+    """Tests that the cover entities are correct."""
+
+    await setup_platform(hass, normal_config_entry, [Platform.COVER])
+
+    # Vent Windows
+    entity_id = "cover.test_windows"
+    with patch(
+        "homeassistant.components.teslemetry.VehicleSpecific.window_control",
+        return_value=COMMAND_OK,
+    ) as call:
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_OPEN_COVER,
+            {ATTR_ENTITY_ID: [entity_id]},
+            blocking=True,
+        )
+        call.assert_called_once()
+        state = hass.states.get(entity_id)
+        assert state
+        assert state.state is STATE_OPEN
+
+        call.reset_mock()
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_CLOSE_COVER,
+            {ATTR_ENTITY_ID: ["cover.test_windows"]},
+            blocking=True,
+        )
+        call.assert_called_once()
+        state = hass.states.get(entity_id)
+        assert state
+        assert state.state is STATE_CLOSED
+
+    # Charge Port Door
+    entity_id = "cover.test_charge_port_door"
+    with patch(
+        "homeassistant.components.teslemetry.VehicleSpecific.charge_port_door_open",
+        return_value=COMMAND_OK,
+    ) as call:
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_OPEN_COVER,
+            {ATTR_ENTITY_ID: [entity_id]},
+            blocking=True,
+        )
+        call.assert_called_once()
+        state = hass.states.get(entity_id)
+        assert state
+        assert state.state is STATE_OPEN
+
+    with patch(
+        "homeassistant.components.teslemetry.VehicleSpecific.charge_port_door_close",
+        return_value=COMMAND_OK,
+    ) as call:
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_CLOSE_COVER,
+            {ATTR_ENTITY_ID: [entity_id]},
+            blocking=True,
+        )
+        call.assert_called_once()
+        state = hass.states.get(entity_id)
+        assert state
+        assert state.state is STATE_CLOSED
+
+    # Frunk
+    entity_id = "cover.test_frunk"
+    with patch(
+        "homeassistant.components.teslemetry.VehicleSpecific.actuate_trunk",
+        return_value=COMMAND_OK,
+    ) as call:
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_OPEN_COVER,
+            {ATTR_ENTITY_ID: [entity_id]},
+            blocking=True,
+        )
+        call.assert_called_once()
+        state = hass.states.get(entity_id)
+        assert state
+        assert state.state is STATE_OPEN
+
+    # Trunk
+    entity_id = "cover.test_trunk"
+    with patch(
+        "homeassistant.components.teslemetry.VehicleSpecific.actuate_trunk",
+        return_value=COMMAND_OK,
+    ) as call:
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_OPEN_COVER,
+            {ATTR_ENTITY_ID: [entity_id]},
+            blocking=True,
+        )
+        call.assert_called_once()
+        state = hass.states.get(entity_id)
+        assert state
+        assert state.state is STATE_OPEN
+
+        call.reset_mock()
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_CLOSE_COVER,
+            {ATTR_ENTITY_ID: [entity_id]},
+            blocking=True,
+        )
+        call.assert_called_once()
+        state = hass.states.get(entity_id)
+        assert state
+        assert state.state is STATE_CLOSED
+
+    # Sunroof
+    entity_id = "cover.test_sunroof"
+    with patch(
+        "homeassistant.components.teslemetry.VehicleSpecific.sun_roof_control",
+        return_value=COMMAND_OK,
+    ) as call:
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_OPEN_COVER,
+            {ATTR_ENTITY_ID: [entity_id]},
+            blocking=True,
+        )
+        call.assert_called_once()
+        state = hass.states.get(entity_id)
+        assert state
+        assert state.state is STATE_OPEN
+
+        call.reset_mock()
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_STOP_COVER,
+            {ATTR_ENTITY_ID: [entity_id]},
+            blocking=True,
+        )
+        call.assert_called_once()
+        state = hass.states.get(entity_id)
+        assert state
+        assert state.state is STATE_OPEN
+
+        call.reset_mock()
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_CLOSE_COVER,
+            {ATTR_ENTITY_ID: [entity_id]},
+            blocking=True,
+        )
+        call.assert_called_once()
+        state = hass.states.get(entity_id)
+        assert state
+        assert state.state is STATE_CLOSED


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add cover platform to Tesla Fleet

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/34859

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
