### PR TITLE
Prevent leading and trailing spaces in translation values

### DIFF
--- a/homeassistant/components/fronius/strings.json
+++ b/homeassistant/components/fronius/strings.json
@@ -275,7 +275,7 @@
         "name": "Relative self consumption"
       },
       "capacity_maximum": {
-        "name": "Maximum capacity "
+        "name": "Maximum capacity"
       },
       "capacity_designed": {
         "name": "Designed capacity"

--- a/homeassistant/components/hive/strings.json
+++ b/homeassistant/components/hive/strings.json
@@ -21,7 +21,7 @@
         "data": {
           "device_name": "Device Name"
         },
-        "description": "Enter your Hive configuration ",
+        "description": "Enter your Hive configuration",
         "title": "Hive Configuration."
       },
       "reauth": {

--- a/homeassistant/components/husqvarna_automower/strings.json
+++ b/homeassistant/components/husqvarna_automower/strings.json
@@ -55,7 +55,7 @@
         "name": "Cutting height"
       },
       "my_lawn_cutting_height": {
-        "name": "My lawn cutting height "
+        "name": "My lawn cutting height"
       },
       "work_area_cutting_height": {
         "name": "{work_area} cutting height"

--- a/homeassistant/components/madvr/strings.json
+++ b/homeassistant/components/madvr/strings.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Setup madVR Envy",
-        "description": "Your device needs to be on in order to add the integation. ",
+        "description": "Your device needs to be on in order to add the integation.",
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "port": "[%key:common::config_flow::data::port%]"
@@ -15,7 +15,7 @@
       },
       "reconfigure": {
         "title": "Reconfigure madVR Envy",
-        "description": "Your device needs to be on in order to reconfigure the integation. ",
+        "description": "Your device needs to be on in order to reconfigure the integation.",
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "port": "[%key:common::config_flow::data::port%]"

--- a/homeassistant/components/waze_travel_time/strings.json
+++ b/homeassistant/components/waze_travel_time/strings.json
@@ -100,7 +100,7 @@
         },
         "avoid_subscription_roads": {
           "name": "[%key:component::waze_travel_time::options::step::init::data::avoid_subscription_roads%]",
-          "description": "Whether to avoid subscription roads. "
+          "description": "Whether to avoid subscription roads."
         }
       }
     }

--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -131,14 +131,13 @@ def translation_value_validator(value: Any) -> str:
     - prevents strings with single quoted placeholders
     - prevents combined translations
     """
-    value = cv.string_with_no_html(value)
-    value = string_no_single_quoted_placeholders(value)
-    if RE_COMBINED_REFERENCE.search(value):
+    string_value = cv.string_with_no_html(value)
+    string_value = string_no_single_quoted_placeholders(string_value)
+    if RE_COMBINED_REFERENCE.search(string_value):
         raise vol.Invalid("the string should not contain combined translations")
-    value = str(value)
-    if value != value.strip(" "):
+    if string_value != string_value.strip(" "):
         raise vol.Invalid("the string should not contain leading or trailing spaces")
-    return str(value)
+    return string_value
 
 
 def string_no_single_quoted_placeholders(value: str) -> str:

--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -135,6 +135,9 @@ def translation_value_validator(value: Any) -> str:
     value = string_no_single_quoted_placeholders(value)
     if RE_COMBINED_REFERENCE.search(value):
         raise vol.Invalid("the string should not contain combined translations")
+    value = str(value)
+    if value != value.strip(" "):
+        raise vol.Invalid("the string should not contain leading or trailing spaces")
     return str(value)
 
 

--- a/tests/components/husqvarna_automower/snapshots/test_number.ambr
+++ b/tests/components/husqvarna_automower/snapshots/test_number.ambr
@@ -195,7 +195,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'My lawn cutting height ',
+    'original_name': 'My lawn cutting height',
     'platform': 'husqvarna_automower',
     'previous_unique_id': None,
     'supported_features': 0,
@@ -207,7 +207,7 @@
 # name: test_number_snapshot[number.test_mower_1_my_lawn_cutting_height-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Test Mower 1 My lawn cutting height ',
+      'friendly_name': 'Test Mower 1 My lawn cutting height',
       'max': 100.0,
       'min': 0.0,
       'mode': <NumberMode.AUTO: 'auto'>,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, as spotted in #126377

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
