### PR TITLE
Fix error if light status is missing in Nice G.O.

### DIFF
--- a/homeassistant/components/nice_go/coordinator.py
+++ b/homeassistant/components/nice_go/coordinator.py
@@ -47,7 +47,7 @@ class NiceGODevice:
     id: str
     name: str
     barrier_status: str
-    light_status: bool
+    light_status: bool | None
     fw_version: str
     connected: bool
     vacation_mode: bool
@@ -113,7 +113,11 @@ class NiceGOUpdateCoordinator(DataUpdateCoordinator[dict[str, NiceGODevice]]):
         else:
             barrier_status = BARRIER_STATUS[int(barrier_status_raw[2])].lower()
 
-        light_status = barrier_state.reported["lightStatus"].split(",")[0] == "1"
+        light_status = (
+            barrier_state.reported["lightStatus"].split(",")[0] == "1"
+            if barrier_state.reported.get("lightStatus")
+            else None
+        )
         fw_version = barrier_state.reported["deviceFwVersion"]
         if barrier_state.connectionState:
             connected = barrier_state.connectionState.connected

--- a/homeassistant/components/nice_go/light.py
+++ b/homeassistant/components/nice_go/light.py
@@ -1,6 +1,6 @@
 """Nice G.O. light."""
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.light import ColorMode, LightEntity
 from homeassistant.core import HomeAssistant
@@ -22,6 +22,7 @@ async def async_setup_entry(
     async_add_entities(
         NiceGOLightEntity(coordinator, device_id, device_data.name)
         for device_id, device_data in coordinator.data.items()
+        if device_data.light_status is not None
     )
 
 
@@ -35,6 +36,8 @@ class NiceGOLightEntity(NiceGOEntity, LightEntity):
     @property
     def is_on(self) -> bool:
         """Return if the light is on or not."""
+        if TYPE_CHECKING:
+            assert self.data.light_status is not None
         return self.data.light_status
 
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/tests/components/nice_go/fixtures/get_all_barriers.json
+++ b/tests/components/nice_go/fixtures/get_all_barriers.json
@@ -60,5 +60,35 @@
       "connected": true,
       "updatedTimestamp": "123"
     }
+  },
+  {
+    "id": "3",
+    "type": "WallStation",
+    "controlLevel": "Owner",
+    "attr": [
+      {
+        "key": "organization",
+        "value": "test_organization"
+      }
+    ],
+    "state": {
+      "deviceId": "3",
+      "desired": { "key": "value" },
+      "reported": {
+        "displayName": "Test Garage 3",
+        "autoDisabled": false,
+        "migrationStatus": "DONE",
+        "deviceId": "3",
+        "vcnMode": false,
+        "deviceFwVersion": "1.2.3.4.5.6",
+        "barrierStatus": "2,100,0,0,-1,0,3,0"
+      },
+      "timestamp": null,
+      "version": null
+    },
+    "connectionState": {
+      "connected": true,
+      "updatedTimestamp": "123"
+    }
   }
 ]

--- a/tests/components/nice_go/snapshots/test_cover.ambr
+++ b/tests/components/nice_go/snapshots/test_cover.ambr
@@ -120,11 +120,11 @@
     'original_device_class': <CoverDeviceClass.GARAGE: 'garage'>,
     'original_icon': None,
     'original_name': None,
-    'platform': 'linear_garage_door',
+    'platform': 'nice_go',
     'previous_unique_id': None,
     'supported_features': <CoverEntityFeature: 3>,
     'translation_key': None,
-    'unique_id': 'test3-GDO',
+    'unique_id': '3',
     'unit_of_measurement': None,
   })
 # ---
@@ -140,7 +140,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'opening',
+    'state': 'closed',
   })
 # ---
 # name: test_covers[cover.test_garage_4-entry]

--- a/tests/components/nice_go/snapshots/test_diagnostics.ambr
+++ b/tests/components/nice_go/snapshots/test_diagnostics.ambr
@@ -20,6 +20,15 @@
         'name': 'Test Garage 2',
         'vacation_mode': True,
       }),
+      '3': dict({
+        'barrier_status': 'closed',
+        'connected': True,
+        'fw_version': '1.2.3.4.5.6',
+        'id': '3',
+        'light_status': None,
+        'name': 'Test Garage 3',
+        'vacation_mode': False,
+      }),
     }),
     'entry': dict({
       'data': dict({

--- a/tests/components/nice_go/test_light.py
+++ b/tests/components/nice_go/test_light.py
@@ -78,6 +78,7 @@ async def test_update_light_state(
 
     assert hass.states.get("light.test_garage_1_light").state == STATE_ON
     assert hass.states.get("light.test_garage_2_light").state == STATE_OFF
+    assert hass.states.get("light.test_garage_3_light") is None
 
     device_update = load_json_object_fixture("device_state_update.json", DOMAIN)
     await mock_config_entry.runtime_data.on_data(device_update)
@@ -86,3 +87,4 @@ async def test_update_light_state(
 
     assert hass.states.get("light.test_garage_1_light").state == STATE_OFF
     assert hass.states.get("light.test_garage_2_light").state == STATE_ON
+    assert hass.states.get("light.test_garage_3_light") is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Mighty Mule openers do not have lights, so I have fixed this by not adding lights if it's not returned by the API

I consider this a sort of a "band-aid" fix while I wait for debug logs to release in 2024.10

Once I get debug logs from the affected user I hope to convert to entity descriptions using the type returned by the API

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #126238
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
