### PR TITLE
Update Google Photos to have a DataUpdateCoordinator for loading albums

### DIFF
--- a/homeassistant/components/google_photos/__init__.py
+++ b/homeassistant/components/google_photos/__init__.py
@@ -44,8 +44,7 @@ async def async_setup_entry(
     except ClientError as err:
         raise ConfigEntryNotReady from err
     coordinator = GooglePhotosUpdateCoordinator(hass, GooglePhotosLibraryApi(auth))
-    # Start a refresh but don't block startup
-    await coordinator.async_request_refresh()
+    await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
 
     async_register_services(hass)

--- a/homeassistant/components/google_photos/__init__.py
+++ b/homeassistant/components/google_photos/__init__.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from . import api
 from .const import DOMAIN
+from .coordinator import GooglePhotosUpdateCoordinator
 from .services import async_register_services
 from .types import GooglePhotosConfigEntry
 
@@ -42,7 +43,10 @@ async def async_setup_entry(
         raise ConfigEntryNotReady from err
     except ClientError as err:
         raise ConfigEntryNotReady from err
-    entry.runtime_data = GooglePhotosLibraryApi(auth)
+    coordinator = GooglePhotosUpdateCoordinator(hass, GooglePhotosLibraryApi(auth))
+    # Start a refresh but don't block startup
+    await coordinator.async_request_refresh()
+    entry.runtime_data = coordinator
 
     async_register_services(hass)
 

--- a/homeassistant/components/google_photos/coordinator.py
+++ b/homeassistant/components/google_photos/coordinator.py
@@ -16,10 +16,7 @@ from google_photos_library_api.exceptions import GooglePhotosApiError
 from google_photos_library_api.model import Album
 
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-
-from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,7 +24,7 @@ UPDATE_INTERVAL: Final = datetime.timedelta(hours=24)
 ALBUM_PAGE_SIZE = 50
 
 
-class GooglePhotosUpdateCoordinator(DataUpdateCoordinator[dict[str, str] | None]):
+class GooglePhotosUpdateCoordinator(DataUpdateCoordinator[dict[str, str]]):
     """Coordinator for fetching Google Photos albums.
 
     The `data` object is a dict from Album ID to Album title.
@@ -42,6 +39,7 @@ class GooglePhotosUpdateCoordinator(DataUpdateCoordinator[dict[str, str] | None]
             update_interval=UPDATE_INTERVAL,
         )
         self.client = client
+        self.data = {}
 
     async def _async_update_data(self) -> dict[str, str]:
         """Fetch albums from API endpoint."""
@@ -59,12 +57,6 @@ class GooglePhotosUpdateCoordinator(DataUpdateCoordinator[dict[str, str] | None]
 
     async def list_albums(self) -> list[Album]:
         """Return Albums with refreshed URLs based on the cached list of album ids."""
-        if self.data is None:
-            key = "albums_not_loaded" if self.last_update_success else "albums_failed"
-            raise HomeAssistantError(
-                translation_domain=DOMAIN,
-                translation_key=key,
-            )
         return await asyncio.gather(
             *(self.client.get_album(album_id) for album_id in self.data)
         )

--- a/homeassistant/components/google_photos/coordinator.py
+++ b/homeassistant/components/google_photos/coordinator.py
@@ -39,7 +39,6 @@ class GooglePhotosUpdateCoordinator(DataUpdateCoordinator[dict[str, str]]):
             update_interval=UPDATE_INTERVAL,
         )
         self.client = client
-        self.data = {}
 
     async def _async_update_data(self) -> dict[str, str]:
         """Fetch albums from API endpoint."""

--- a/homeassistant/components/google_photos/coordinator.py
+++ b/homeassistant/components/google_photos/coordinator.py
@@ -1,0 +1,70 @@
+"""Coordinator for fetching data from Google Photos API.
+
+This coordinator fetches the list of Google Photos albums that were created by
+Home Assistant, which for large libraries may take some time. The list of album
+ids and titles is cached and this provides a method to refresh urls since they
+are short lived.
+"""
+
+import asyncio
+import datetime
+import logging
+from typing import Final
+
+from google_photos_library_api.api import GooglePhotosLibraryApi
+from google_photos_library_api.exceptions import GooglePhotosApiError
+from google_photos_library_api.model import Album
+
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+UPDATE_INTERVAL: Final = datetime.timedelta(hours=24)
+ALBUM_PAGE_SIZE = 50
+
+
+class GooglePhotosUpdateCoordinator(DataUpdateCoordinator[dict[str, str] | None]):
+    """Coordinator for fetching Google Photos albums.
+
+    The `data` object is a dict from Album ID to Album title.
+    """
+
+    def __init__(self, hass: HomeAssistant, client: GooglePhotosLibraryApi) -> None:
+        """Initialize TaskUpdateCoordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="Google Photos",
+            update_interval=UPDATE_INTERVAL,
+        )
+        self.client = client
+
+    async def _async_update_data(self) -> dict[str, str]:
+        """Fetch albums from API endpoint."""
+        albums: dict[str, str] = {}
+        try:
+            async for album_result in await self.client.list_albums(
+                page_size=ALBUM_PAGE_SIZE
+            ):
+                for album in album_result.albums:
+                    albums[album.id] = album.title
+        except GooglePhotosApiError as err:
+            _LOGGER.debug("Error listing albums: %s", err)
+            raise UpdateFailed(f"Error listing albums: {err}") from err
+        return albums
+
+    async def list_albums(self) -> list[Album]:
+        """Return Albums with refreshed URLs based on the cached list of album ids."""
+        if self.data is None:
+            key = "albums_not_loaded" if self.last_update_success else "albums_failed"
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key=key,
+            )
+        return await asyncio.gather(
+            *(self.client.get_album(album_id) for album_id in self.data)
+        )

--- a/homeassistant/components/google_photos/media_source.py
+++ b/homeassistant/components/google_photos/media_source.py
@@ -17,7 +17,6 @@ from homeassistant.components.media_source import (
     PlayMedia,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 
 from . import GooglePhotosConfigEntry
 from .const import DOMAIN, READ_SCOPE
@@ -205,11 +204,7 @@ class GooglePhotosMediaSource(MediaSource):
                 for special_album in SpecialAlbum
             ]
 
-            try:
-                albums: list[Album] = await coordinator.list_albums()
-            except (GooglePhotosApiError, HomeAssistantError) as err:
-                raise BrowseError(f"Error listing albums: {err}") from err
-
+            albums = await coordinator.list_albums()
             source.children.extend(
                 _build_album(
                     album.title,

--- a/homeassistant/components/google_photos/media_source.py
+++ b/homeassistant/components/google_photos/media_source.py
@@ -17,6 +17,7 @@ from homeassistant.components.media_source import (
     PlayMedia,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 
 from . import GooglePhotosConfigEntry
 from .const import DOMAIN, READ_SCOPE
@@ -149,7 +150,7 @@ class GooglePhotosMediaSource(MediaSource):
                 f"Could not resolve identiifer that is not a Photo: {identifier}"
             )
         entry = self._async_config_entry(identifier.config_entry_id)
-        client = entry.runtime_data
+        client = entry.runtime_data.client
         media_item = await client.get_media_item(media_item_id=identifier.media_id)
         if not media_item.mime_type:
             raise BrowseError("Could not determine mime type of media item")
@@ -189,7 +190,8 @@ class GooglePhotosMediaSource(MediaSource):
         # Determine the configuration entry for this item
         identifier = PhotosIdentifier.of(item.identifier)
         entry = self._async_config_entry(identifier.config_entry_id)
-        client = entry.runtime_data
+        coordinator = entry.runtime_data
+        client = coordinator.client
 
         source = _build_account(entry, identifier)
         if identifier.id_type is None:
@@ -202,13 +204,10 @@ class GooglePhotosMediaSource(MediaSource):
                 )
                 for special_album in SpecialAlbum
             ]
-            albums: list[Album] = []
+
             try:
-                async for album_result in await client.list_albums(
-                    page_size=ALBUM_PAGE_SIZE
-                ):
-                    albums.extend(album_result.albums)
-            except GooglePhotosApiError as err:
+                albums: list[Album] = await coordinator.list_albums()
+            except (GooglePhotosApiError, HomeAssistantError) as err:
                 raise BrowseError(f"Error listing albums: {err}") from err
 
             source.children.extend(

--- a/homeassistant/components/google_photos/services.py
+++ b/homeassistant/components/google_photos/services.py
@@ -97,7 +97,7 @@ def async_register_services(hass: HomeAssistant) -> None:
                 translation_placeholders={"target": DOMAIN},
             )
 
-        client_api = config_entry.runtime_data
+        client_api = config_entry.runtime_data.client
         upload_tasks = []
         file_results = await hass.async_add_executor_job(
             _read_file_contents, hass, call.data[CONF_FILENAME]

--- a/homeassistant/components/google_photos/services.yaml
+++ b/homeassistant/components/google_photos/services.yaml
@@ -9,7 +9,3 @@ upload:
       required: true
       selector:
         object:
-    album:
-      required: true
-      selector:
-        text:

--- a/homeassistant/components/google_photos/services.yaml
+++ b/homeassistant/components/google_photos/services.yaml
@@ -6,6 +6,10 @@ upload:
         config_entry:
           integration: google_photos
     filename:
-      required: false
+      required: true
       selector:
         object:
+    album:
+      required: true
+      selector:
+        text:

--- a/homeassistant/components/google_photos/services.yaml
+++ b/homeassistant/components/google_photos/services.yaml
@@ -6,6 +6,6 @@ upload:
         config_entry:
           integration: google_photos
     filename:
-      required: true
+      required: false
       selector:
         object:

--- a/homeassistant/components/google_photos/strings.json
+++ b/homeassistant/components/google_photos/strings.json
@@ -57,9 +57,6 @@
     },
     "albums_failed": {
       "message": "Cannot fetch albums from the Google Photos API"
-    },
-    "albums_not_loaded": {
-      "message": "Albums have not yet been loaded from Google Photos API"
     }
   },
   "services": {

--- a/homeassistant/components/google_photos/strings.json
+++ b/homeassistant/components/google_photos/strings.json
@@ -65,7 +65,7 @@
   "services": {
     "upload": {
       "name": "Upload media",
-      "description": "Upload photos to Google Photos.",
+      "description": "Upload images or videos to Google Photos.",
       "fields": {
         "config_entry_id": {
           "name": "Integration Id",
@@ -75,11 +75,6 @@
           "name": "Filename",
           "description": "Path to the image or video to upload.",
           "example": "/config/www/image.jpg"
-        },
-        "album": {
-          "name": "Album",
-          "description": "Album name that is the destination for the uploaded content.",
-          "example": "Family Photos"
         }
       }
     }

--- a/homeassistant/components/google_photos/strings.json
+++ b/homeassistant/components/google_photos/strings.json
@@ -54,12 +54,18 @@
     },
     "api_error": {
       "message": "Google Photos API responded with error: {message}"
+    },
+    "albums_failed": {
+      "message": "Cannot fetch albums from the Google Photos API"
+    },
+    "albums_not_loaded": {
+      "message": "Albums have not yet been loaded from Google Photos API"
     }
   },
   "services": {
     "upload": {
       "name": "Upload media",
-      "description": "Upload images or videos to Google Photos.",
+      "description": "Upload photos to Google Photos.",
       "fields": {
         "config_entry_id": {
           "name": "Integration Id",
@@ -69,6 +75,11 @@
           "name": "Filename",
           "description": "Path to the image or video to upload.",
           "example": "/config/www/image.jpg"
+        },
+        "album": {
+          "name": "Album",
+          "description": "Album name that is the destination for the uploaded content.",
+          "example": "Family Photos"
         }
       }
     }

--- a/homeassistant/components/google_photos/types.py
+++ b/homeassistant/components/google_photos/types.py
@@ -1,7 +1,7 @@
 """Google Photos types."""
 
-from google_photos_library_api.api import GooglePhotosLibraryApi
-
 from homeassistant.config_entries import ConfigEntry
 
-type GooglePhotosConfigEntry = ConfigEntry[GooglePhotosLibraryApi]
+from .coordinator import GooglePhotosUpdateCoordinator
+
+type GooglePhotosConfigEntry = ConfigEntry[GooglePhotosUpdateCoordinator]

--- a/tests/components/google_photos/conftest.py
+++ b/tests/components/google_photos/conftest.py
@@ -171,6 +171,17 @@ def mock_client_api(
     mock_api.list_albums.return_value.__aiter__ = list_albums
     mock_api.list_albums.return_value.__anext__ = list_albums
     mock_api.list_albums.side_effect = api_error
+
+    # Mock a point lookup by reading contents of the album fixture above
+    async def get_album(album_id: str, **kwargs: Any) -> Mock:
+        for album in load_json_object_fixture("list_albums.json", DOMAIN)["albums"]:
+            if album["id"] == album_id:
+                return Album.from_dict(album)
+        return None
+
+    mock_api.get_album = get_album
+    mock_api.get_album.side_effect = api_error
+
     return mock_api
 
 

--- a/tests/components/google_photos/test_media_source.py
+++ b/tests/components/google_photos/test_media_source.py
@@ -157,24 +157,6 @@ async def test_browse_invalid_path(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("setup_integration")
-@pytest.mark.parametrize("api_error", [GooglePhotosApiError("some error")])
-async def test_invalid_album_id(hass: HomeAssistant, mock_api: Mock) -> None:
-    """Test browsing to an album id that does not exist."""
-    browse = await async_browse_media(hass, f"{URI_SCHEME}{DOMAIN}")
-    assert browse.domain == DOMAIN
-    assert browse.identifier is None
-    assert browse.title == "Google Photos"
-    assert [(child.identifier, child.title) for child in browse.children] == [
-        (CONFIG_ENTRY_ID, "Account Name")
-    ]
-
-    with pytest.raises(BrowseError, match="Error listing media items"):
-        await async_browse_media(
-            hass, f"{URI_SCHEME}{DOMAIN}/{CONFIG_ENTRY_ID}/a/invalid-album-id"
-        )
-
-
-@pytest.mark.usefixtures("setup_integration")
 @pytest.mark.parametrize(
     ("identifier", "expected_error"),
     [
@@ -193,24 +175,7 @@ async def test_missing_photo_id(
 
 
 @pytest.mark.usefixtures("setup_integration", "mock_api")
-@pytest.mark.parametrize("api_error", [GooglePhotosApiError("some error")])
-async def test_list_albums_failure(hass: HomeAssistant) -> None:
-    """Test an error while browsing albums."""
-    browse = await async_browse_media(hass, f"{URI_SCHEME}{DOMAIN}")
-    assert browse.domain == DOMAIN
-    assert browse.identifier is None
-    assert browse.title == "Google Photos"
-    assert [(child.identifier, child.title) for child in browse.children] == [
-        (CONFIG_ENTRY_ID, "Account Name")
-    ]
-
-    with pytest.raises(BrowseError, match="Error listing albums"):
-        await async_browse_media(hass, f"{URI_SCHEME}{DOMAIN}/{CONFIG_ENTRY_ID}")
-
-
-@pytest.mark.usefixtures("setup_integration", "mock_api")
-@pytest.mark.parametrize("api_error", [GooglePhotosApiError("some error")])
-async def test_list_media_items_failure(hass: HomeAssistant) -> None:
+async def test_list_media_items_failure(hass: HomeAssistant, mock_api: Mock) -> None:
     """Test browsing to an album id that does not exist."""
     browse = await async_browse_media(hass, f"{URI_SCHEME}{DOMAIN}")
     assert browse.domain == DOMAIN
@@ -219,6 +184,8 @@ async def test_list_media_items_failure(hass: HomeAssistant) -> None:
     assert [(child.identifier, child.title) for child in browse.children] == [
         (CONFIG_ENTRY_ID, "Account Name")
     ]
+
+    mock_api.list_media_items.side_effect = GooglePhotosApiError("some error")
 
     with pytest.raises(BrowseError, match="Error listing media items"):
         await async_browse_media(

--- a/tests/components/google_photos/test_media_source.py
+++ b/tests/components/google_photos/test_media_source.py
@@ -195,7 +195,7 @@ async def test_missing_photo_id(
 @pytest.mark.usefixtures("setup_integration", "mock_api")
 @pytest.mark.parametrize("api_error", [GooglePhotosApiError("some error")])
 async def test_list_albums_failure(hass: HomeAssistant) -> None:
-    """Test browsing to an album id that does not exist."""
+    """Test an error while browsing albums."""
     browse = await async_browse_media(hass, f"{URI_SCHEME}{DOMAIN}")
     assert browse.domain == DOMAIN
     assert browse.identifier is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update Google Photos to have a DataUpdateCoordinator for loading albums. This is needed to avoid blocking the media player UI on loading albums which may take multiple round trips on larger accounts with many pages of albums. In particular, now that this is limited to just content created by Home Assistant, there are may be many empty pages for a large account. When loading the media player, it now will fetch albums directly to get a refreshed album cover url.

This is part of a sequence of changes to improve performance/effectiveness:
- Add an album data update coordinator (this PR)
- Require an album title when creating a new media item (uses the data update coordinator to find the album id for a specific album title to avoid scanning albums again)
- Only render content uploaded to albums in the media player

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
