### PR TITLE
Meteoswiss

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -309,6 +309,7 @@ homeassistant.components.media_extractor.*
 homeassistant.components.media_player.*
 homeassistant.components.media_source.*
 homeassistant.components.met_eireann.*
+homeassistant.components.meteoswiss.*
 homeassistant.components.metoffice.*
 homeassistant.components.mikrotik.*
 homeassistant.components.min_max.*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -903,6 +903,8 @@ build.json @home-assistant/supervisor
 /homeassistant/components/meteoalarm/ @rolfberkenbosch
 /homeassistant/components/meteoclimatic/ @adrianmo
 /tests/components/meteoclimatic/ @adrianmo
+/homeassistant/components/meteoswiss/ @albertomontesg
+/tests/components/meteoswiss/ @albertomontesg
 /homeassistant/components/metoffice/ @MrHarcombe @avee87
 /tests/components/metoffice/ @MrHarcombe @avee87
 /homeassistant/components/microbees/ @microBeesTech

--- a/homeassistant/components/meteoswiss/__init__.py
+++ b/homeassistant/components/meteoswiss/__init__.py
@@ -1,0 +1,35 @@
+"""The meteoswiss integration."""
+
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+# TODO List the platforms that you want to support.
+# For your initial PR, limit it to 1 platform.
+PLATFORMS: list[Platform] = [Platform.LIGHT]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up meteoswiss from a config entry."""
+
+    hass.data.setdefault(DOMAIN, {})
+    # TODO 1. Create API instance
+    # TODO 2. Validate the API connection (and authentication)
+    # TODO 3. Store an API object for your platforms to access
+    # hass.data[DOMAIN][entry.entry_id] = MyApi(...)
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/homeassistant/components/meteoswiss/config_flow.py
+++ b/homeassistant/components/meteoswiss/config_flow.py
@@ -1,104 +1,94 @@
 """Config flow for meteoswiss integration."""
 
-from __future__ import annotations
-
-import logging
+import functools
 from typing import Any
 
+import pandas as pd
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
-
-from .const import DOMAIN
-
-_LOGGER = logging.getLogger(__name__)
-
-# TODO adjust the data schema to the data that you need
-STEP_USER_DATA_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_HOST): str,
-        vol.Required(CONF_USERNAME): str,
-        vol.Required(CONF_PASSWORD): str,
-    }
+from homeassistant.helpers.selector import (
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
 )
 
-
-class PlaceholderHub:
-    """Placeholder class to make tests pass.
-
-    TODO Remove this placeholder class and replace with things from your PyPI package.
-    """
-
-    def __init__(self, host: str) -> None:
-        """Initialize."""
-        self.host = host
-
-    async def authenticate(self, username: str, password: str) -> bool:
-        """Test if we can authenticate with the host."""
-        return True
+from .const import DOMAIN, LOCATION_NAME, POSTAL_CODE, POSTAL_CODE_ADDITIONAL_NUMBER
 
 
-async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
-    """Validate the user input allows us to connect.
-
-    Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
-    """
-    # TODO validate the data can be used to set up a connection.
-
-    # If your PyPI package is not built with async, pass your methods
-    # to the executor:
-    # await hass.async_add_executor_job(
-    #     your_validate_func, data[CONF_USERNAME], data[CONF_PASSWORD]
-    # )
-
-    hub = PlaceholderHub(data[CONF_HOST])
-
-    if not await hub.authenticate(data[CONF_USERNAME], data[CONF_PASSWORD]):
-        raise InvalidAuth
-
-    # If you cannot connect:
-    # throw CannotConnect
-    # If the authentication is wrong:
-    # InvalidAuth
-
-    # Return info that you want to store in the config entry.
-    return {"title": "Name of the device"}
-
-
-class ConfigFlow(ConfigFlow, domain=DOMAIN):
+class MeteoSwissConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for meteoswiss."""
 
     VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize ConfigFlow."""
+        super().__init__()
+        self._postal_code_mapping: dict[str, tuple[int, int]] = None
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step."""
-        errors: dict[str, str] = {}
-        if user_input is not None:
-            try:
-                info = await validate_input(self.hass, user_input)
-            except CannotConnect:
-                errors["base"] = "cannot_connect"
-            except InvalidAuth:
-                errors["base"] = "invalid_auth"
-            except Exception:  # pylint: disable=broad-except
-                _LOGGER.exception("Unexpected exception")
-                errors["base"] = "unknown"
-            else:
-                return self.async_create_entry(title=info["title"], data=user_input)
 
-        return self.async_show_form(
-            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        return self.async_show_menu(
+            step_id="user",
+            menu_options={
+                "weather_forecast": "Weather Forecast",
+            },
         )
 
+    async def async_step_weather_forecast(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the setup of a weather forecast device."""
+        errors: dict[str, str] = {}
 
-class CannotConnect(HomeAssistantError):
-    """Error to indicate we cannot connect."""
+        if self._postal_code_mapping is None:
+            df = await self.hass.async_add_executor_job(
+                functools.partial(
+                    pd.read_csv,
+                    "https://data.geo.admin.ch/ch.swisstopo-vd.ortschaftenverzeichnis_plz/ortschaftenverzeichnis_plz/ortschaftenverzeichnis_plz_2056.csv.zip",
+                    header=0,
+                    sep=";",
+                )
+            )
+            df = df[["Ortschaftsname", "PLZ", "Zusatzziffer"]].drop_duplicates()
+            # TODO: split the post code and location number: also on the Meteoswiss client.
+            self._postal_code_mapping = {
+                f'{r["PLZ"]}, {r["Ortschaftsname"]}': (r["PLZ"], r["Zusatzziffer"])
+                for _, r in df.iterrows()
+            }
 
+        if user_input is not None:
+            postal_code, additional_number = self._postal_code_mapping.get(
+                user_input[POSTAL_CODE]
+            )
+            if postal_code is None:
+                errors["base"] = "postal_code_not_found"
+            else:
+                return self.async_create_entry(
+                    title=user_input[LOCATION_NAME],
+                    data={
+                        LOCATION_NAME: user_input[LOCATION_NAME],
+                        POSTAL_CODE: postal_code,
+                        POSTAL_CODE_ADDITIONAL_NUMBER: additional_number,
+                    },
+                )
 
-class InvalidAuth(HomeAssistantError):
-    """Error to indicate there is invalid auth."""
+        data_schema = vol.Schema(
+            {
+                vol.Required(LOCATION_NAME, default="Home"): str,
+                vol.Required(POSTAL_CODE): SelectSelector(
+                    SelectSelectorConfig(
+                        options=list(self._postal_code_mapping.keys()),
+                        mode=SelectSelectorMode.DROPDOWN,
+                        sort=True,
+                    )
+                ),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="weather_forecast", data_schema=data_schema, errors=errors
+        )

--- a/homeassistant/components/meteoswiss/config_flow.py
+++ b/homeassistant/components/meteoswiss/config_flow.py
@@ -1,0 +1,104 @@
+"""Config flow for meteoswiss integration."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+# TODO adjust the data schema to the data that you need
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+    }
+)
+
+
+class PlaceholderHub:
+    """Placeholder class to make tests pass.
+
+    TODO Remove this placeholder class and replace with things from your PyPI package.
+    """
+
+    def __init__(self, host: str) -> None:
+        """Initialize."""
+        self.host = host
+
+    async def authenticate(self, username: str, password: str) -> bool:
+        """Test if we can authenticate with the host."""
+        return True
+
+
+async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
+    """Validate the user input allows us to connect.
+
+    Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
+    """
+    # TODO validate the data can be used to set up a connection.
+
+    # If your PyPI package is not built with async, pass your methods
+    # to the executor:
+    # await hass.async_add_executor_job(
+    #     your_validate_func, data[CONF_USERNAME], data[CONF_PASSWORD]
+    # )
+
+    hub = PlaceholderHub(data[CONF_HOST])
+
+    if not await hub.authenticate(data[CONF_USERNAME], data[CONF_PASSWORD]):
+        raise InvalidAuth
+
+    # If you cannot connect:
+    # throw CannotConnect
+    # If the authentication is wrong:
+    # InvalidAuth
+
+    # Return info that you want to store in the config entry.
+    return {"title": "Name of the device"}
+
+
+class ConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for meteoswiss."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            try:
+                info = await validate_input(self.hass, user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                return self.async_create_entry(title=info["title"], data=user_input)
+
+        return self.async_show_form(
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+
+class CannotConnect(HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class InvalidAuth(HomeAssistantError):
+    """Error to indicate there is invalid auth."""

--- a/homeassistant/components/meteoswiss/const.py
+++ b/homeassistant/components/meteoswiss/const.py
@@ -1,3 +1,12 @@
 """Constants for the meteoswiss integration."""
 
-DOMAIN = "meteoswiss"
+from typing import Final
+
+DOMAIN: Final[str] = "meteoswiss"
+
+
+# Config flow field names.
+LOCATION_NAME: Final[str] = "location_name"
+POSTAL_CODE: Final[str] = "postal_code"
+POSTAL_CODE_ADDITIONAL_NUMBER: Final[str] = "additional_number"
+STATION_CODE: Final[str] = "station_code"

--- a/homeassistant/components/meteoswiss/const.py
+++ b/homeassistant/components/meteoswiss/const.py
@@ -1,0 +1,3 @@
+"""Constants for the meteoswiss integration."""
+
+DOMAIN = "meteoswiss"

--- a/homeassistant/components/meteoswiss/coordinator.py
+++ b/homeassistant/components/meteoswiss/coordinator.py
@@ -1,0 +1,55 @@
+"""DataUpdateCoordinator for MeteoSwiss integration."""
+
+import dataclasses
+import datetime
+import logging
+
+import meteoswiss_async
+import requests
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN, POSTAL_CODE, POSTAL_CODE_ADDITIONAL_NUMBER
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(kw_only=True, frozen=True)
+class MeteoSwissData:
+    """Data that gets updated by the coordinator."""
+
+    weather: meteoswiss_async.Weather
+
+
+class MeteoSwissDataUpdateCoordinator(DataUpdateCoordinator[MeteoSwissData]):
+    """Class to manage fetching Met data."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        api_client: meteoswiss_async.MeteoSwissClient,
+    ) -> None:
+        """Initialize global Met data updater."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=datetime.timedelta(minutes=5),
+        )
+        self._api_client = api_client
+        self._postal_code: str = str(self.config_entry.data[POSTAL_CODE])
+        self._additional_number: int = self.config_entry.data[
+            POSTAL_CODE_ADDITIONAL_NUMBER
+        ]
+
+    async def _async_update_data(self) -> MeteoSwissData:
+        """Fetch data from Meteoswiss API."""
+        try:
+            weather = await self._api_client.get_weather(
+                postal_code=self._postal_code, additional_number=self._additional_number
+            )
+            return MeteoSwissData(weather=weather)
+        except requests.exceptions.HTTPError as err:
+            _LOGGER.error("Meteoswiss coordinator update failed", exc_info=err)
+            raise UpdateFailed(f"Update failed: {err}") from err

--- a/homeassistant/components/meteoswiss/manifest.json
+++ b/homeassistant/components/meteoswiss/manifest.json
@@ -3,11 +3,11 @@
   "name": "MeteoSwiss",
   "codeowners": ["@albertomontesg"],
   "config_flow": true,
-  "dependencies": [],
   "documentation": "https://www.home-assistant.io/integrations/meteoswiss",
-  "homekit": {},
   "iot_class": "cloud_polling",
-  "requirements": ["meteoswiss-async==0.1.0"],
+  "requirements": [
+    "meteoswiss-async @ git+https://github.com/albertomontesg/meteoswiss-async.git@main"
+  ],
   "ssdp": [],
   "zeroconf": []
 }

--- a/homeassistant/components/meteoswiss/manifest.json
+++ b/homeassistant/components/meteoswiss/manifest.json
@@ -1,0 +1,13 @@
+{
+  "domain": "meteoswiss",
+  "name": "MeteoSwiss",
+  "codeowners": ["@albertomontesg"],
+  "config_flow": true,
+  "dependencies": [],
+  "documentation": "https://www.home-assistant.io/integrations/meteoswiss",
+  "homekit": {},
+  "iot_class": "cloud_polling",
+  "requirements": ["meteoswiss-async==0.1.0"],
+  "ssdp": [],
+  "zeroconf": []
+}

--- a/homeassistant/components/meteoswiss/strings.json
+++ b/homeassistant/components/meteoswiss/strings.json
@@ -1,0 +1,21 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/homeassistant/components/meteoswiss/strings.json
+++ b/homeassistant/components/meteoswiss/strings.json
@@ -1,18 +1,15 @@
 {
   "config": {
     "step": {
-      "user": {
+      "weather_forecast": {
         "data": {
-          "host": "[%key:common::config_flow::data::host%]",
-          "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]"
+          "location_name": "Location Name",
+          "postal_code": "Postal Code"
         }
       }
     },
     "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "postal_code_not_found": "Postal code not found."
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"

--- a/homeassistant/components/meteoswiss/weather.py
+++ b/homeassistant/components/meteoswiss/weather.py
@@ -1,0 +1,124 @@
+"""Support for MeteoSwiss weather service."""
+
+import datetime
+
+import meteoswiss_async
+
+from homeassistant.components.weather import (
+    Forecast,
+    SingleCoordinatorWeatherEntity,
+    WeatherEntityFeature,
+)
+from homeassistant.const import (
+    UnitOfPrecipitationDepth,
+    UnitOfPressure,
+    UnitOfSpeed,
+    UnitOfTemperature,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import MeteoSwissConfigEntry
+from .const import DOMAIN, LOCATION_NAME, POSTAL_CODE, POSTAL_CODE_ADDITIONAL_NUMBER
+from .coordinator import MeteoSwissDataUpdateCoordinator
+
+DEFAULT_NAME = "MeteoSwiss"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: MeteoSwissConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Add a weather entity from a config_entry."""
+    coordinator = config_entry.runtime_data
+
+    entities = [MeteoSwissWeather(coordinator, config_entry)]
+
+    async_add_entities(entities)
+
+
+class MeteoSwissWeather(
+    SingleCoordinatorWeatherEntity[MeteoSwissDataUpdateCoordinator]
+):
+    """Implementation of a MeteoSwiss weather condition."""
+
+    _attr_attribution = (
+        "Weather forecast from MeteoSwiss, delivered by the Swiss "
+        "Meteorological Institute."
+    )
+    _attr_has_entity_name = True
+    _attr_native_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_native_precipitation_unit = UnitOfPrecipitationDepth.MILLIMETERS
+    _attr_native_pressure_unit = UnitOfPressure.HPA
+    _attr_native_wind_speed_unit = UnitOfSpeed.KILOMETERS_PER_HOUR
+    _attr_supported_features = (
+        WeatherEntityFeature.FORECAST_DAILY | WeatherEntityFeature.FORECAST_HOURLY
+    )
+
+    def __init__(
+        self,
+        coordinator: MeteoSwissDataUpdateCoordinator,
+        config_entry: MeteoSwissConfigEntry,
+    ) -> None:
+        """Initialise the platform with a data instance and site."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{config_entry.data[POSTAL_CODE]}{config_entry.data[POSTAL_CODE_ADDITIONAL_NUMBER]:02d}"
+        self._config = config_entry.data
+        self._attr_device_info = DeviceInfo(
+            name="Forecast",
+            entry_type=DeviceEntryType.SERVICE,
+            identifiers={(DOMAIN, config_entry.entry_id)},
+            manufacturer="MeteoSwiss",
+            model="Location Forecast",
+            configuration_url="https://www.meteoswiss.admin.ch/",
+        )
+        self._attr_name = self._config[LOCATION_NAME]
+
+    @property
+    def condition(self) -> str | None:
+        """Return the current condition."""
+        return meteoswiss_async.Condition.from_icon(
+            self.coordinator.data.weather.current_weather.icon
+        )
+
+    @property
+    def native_temperature(self) -> float | None:
+        """Return the temperature."""
+        return float(self.coordinator.data.weather.current_weather.temperature)
+
+    @callback
+    def _async_forecast_daily(self) -> list[Forecast] | None:
+        """Return the daily forecast in native units."""
+        return [
+            Forecast(
+                datetime=day.day_date,
+                condition=day.condition,
+                native_temperature=day.temperature_max,
+                native_templow=day.temperature_min,
+                native_precipitation=day.precipitation,
+            )
+            for day in self.coordinator.data.weather.forecast
+        ]
+
+    @callback
+    def _async_forecast_hourly(self) -> list[Forecast] | None:
+        """Return the hourly forecast in native units."""
+        forecast: list[Forecast] = []
+        graph: meteoswiss_async.Graph = self.coordinator.data.weather.graph
+        start_time = graph.start.to_datetime()
+        for i in range(graph.num_entry_hours):
+            forecast.append(
+                Forecast(
+                    datetime=str(start_time),
+                    condition=graph.weather_condition_3h[i // 3],
+                    native_temperature=graph.temperature_max_1h[i],
+                    native_templow=graph.temperature_min_1h[i],
+                    native_precipitation=graph.precipitation_mean_1h,
+                    native_wind_speed=graph.wind_speed_3h[i // 3],
+                    wind_bearing=graph.wind_direction_3h[i // 3],
+                )
+            )
+            start_time += datetime.timedelta(hours=1)
+        return forecast

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -359,6 +359,7 @@ FLOWS = {
         "met_eireann",
         "meteo_france",
         "meteoclimatic",
+        "meteoswiss",
         "metoffice",
         "microbees",
         "mikrotik",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -3650,6 +3650,12 @@
       "config_flow": true,
       "iot_class": "cloud_polling"
     },
+    "meteoswiss": {
+      "name": "MeteoSwiss",
+      "integration_type": "hub",
+      "config_flow": true,
+      "iot_class": "cloud_polling"
+    },
     "metoffice": {
       "name": "Met Office",
       "integration_type": "hub",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1350,6 +1350,9 @@ meteoalertapi==0.3.1
 # homeassistant.components.meteo_france
 meteofrance-api==1.3.0
 
+# homeassistant.components.meteoswiss
+meteoswiss-async==0.1.0
+
 # homeassistant.components.mfi
 mficlient==0.5.0
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1119,6 +1119,9 @@ melnor-bluetooth==0.0.25
 # homeassistant.components.meteo_france
 meteofrance-api==1.3.0
 
+# homeassistant.components.meteoswiss
+meteoswiss-async==0.1.0
+
 # homeassistant.components.mfi
 mficlient==0.5.0
 

--- a/tests/components/meteoswiss/__init__.py
+++ b/tests/components/meteoswiss/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the meteoswiss integration."""

--- a/tests/components/meteoswiss/conftest.py
+++ b/tests/components/meteoswiss/conftest.py
@@ -1,0 +1,15 @@
+"""Common fixtures for the meteoswiss tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.meteoswiss.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry

--- a/tests/components/meteoswiss/test_config_flow.py
+++ b/tests/components/meteoswiss/test_config_flow.py
@@ -1,0 +1,145 @@
+"""Test the meteoswiss config flow."""
+
+from unittest.mock import AsyncMock, patch
+
+from homeassistant import config_entries
+from homeassistant.components.meteoswiss.config_flow import CannotConnect, InvalidAuth
+from homeassistant.components.meteoswiss.const import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+
+async def test_form(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
+    """Test we get the form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.meteoswiss.config_flow.PlaceholderHub.authenticate",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "1.1.1.1",
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "test-password",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Name of the device"
+    assert result["data"] == {
+        CONF_HOST: "1.1.1.1",
+        CONF_USERNAME: "test-username",
+        CONF_PASSWORD: "test-password",
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_invalid_auth(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.meteoswiss.config_flow.PlaceholderHub.authenticate",
+        side_effect=InvalidAuth,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "1.1.1.1",
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "test-password",
+            },
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}
+
+    # Make sure the config flow tests finish with either an
+    # FlowResultType.CREATE_ENTRY or FlowResultType.ABORT so
+    # we can show the config flow is able to recover from an error.
+    with patch(
+        "homeassistant.components.meteoswiss.config_flow.PlaceholderHub.authenticate",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "1.1.1.1",
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "test-password",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Name of the device"
+    assert result["data"] == {
+        CONF_HOST: "1.1.1.1",
+        CONF_USERNAME: "test-username",
+        CONF_PASSWORD: "test-password",
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_cannot_connect(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.meteoswiss.config_flow.PlaceholderHub.authenticate",
+        side_effect=CannotConnect,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "1.1.1.1",
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "test-password",
+            },
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+    # Make sure the config flow tests finish with either an
+    # FlowResultType.CREATE_ENTRY or FlowResultType.ABORT so
+    # we can show the config flow is able to recover from an error.
+
+    with patch(
+        "homeassistant.components.meteoswiss.config_flow.PlaceholderHub.authenticate",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "1.1.1.1",
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "test-password",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Name of the device"
+    assert result["data"] == {
+        CONF_HOST: "1.1.1.1",
+        CONF_USERNAME: "test-username",
+        CONF_PASSWORD: "test-password",
+    }
+    assert len(mock_setup_entry.mock_calls) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Todo:
- [ ] Add tests
- [ ] Add entities related to warnings

Open questions:
* The metoeSwiss API provides 2 types of information: 
  1. given a Post Code it provides a forecast which is done as a Weather entity.
  2. Information about a weather station which will be translated into multiple Sensors, and even an image entity with the pictures provided by the station.
  In this case, should it be bundled into a single component (with a menu option during the config flow), or should it be split into 2 different components?
* During the config flow there is the need to fetch some data in advance in order to fill a Selector schema + validate the user input. 
  1. The ConfigFlow does not provide a good endpoint to do some initial data fetching. Is the current implementation a good approach?
  2. The data is being fetched using the Pandas library, but seeing all components dependencies, I have not seen any existing dependency on Pandas? Is this something that would be allowed, or is it discouraged which would require to implement the fetching from the compressed CSV by hand on the component? Looking for guidance here as any option would do the job.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
