### PR TITLE
Move gardena_bluetooth base entity to separate module

### DIFF
--- a/homeassistant/components/gardena_bluetooth/__init__.py
+++ b/homeassistant/components/gardena_bluetooth/__init__.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 import homeassistant.util.dt as dt_util
 
 from .const import DOMAIN
-from .coordinator import Coordinator, DeviceUnavailable
+from .coordinator import DeviceUnavailable, GardenaBluetoothCoordinator
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
@@ -75,7 +75,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         model=model,
     )
 
-    coordinator = Coordinator(hass, LOGGER, client, uuids, device, address)
+    coordinator = GardenaBluetoothCoordinator(
+        hass, LOGGER, client, uuids, device, address
+    )
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -87,7 +89,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        coordinator: Coordinator = hass.data[DOMAIN].pop(entry.entry_id)
+        coordinator: GardenaBluetoothCoordinator = hass.data[DOMAIN].pop(entry.entry_id)
         await coordinator.async_shutdown()
 
     return unload_ok

--- a/homeassistant/components/gardena_bluetooth/binary_sensor.py
+++ b/homeassistant/components/gardena_bluetooth/binary_sensor.py
@@ -18,7 +18,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .coordinator import Coordinator, GardenaBluetoothDescriptorEntity
+from .coordinator import GardenaBluetoothCoordinator
+from .entity import GardenaBluetoothDescriptorEntity
 
 
 @dataclass(frozen=True)
@@ -55,7 +56,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up binary sensor based on a config entry."""
-    coordinator: Coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: GardenaBluetoothCoordinator = hass.data[DOMAIN][entry.entry_id]
     entities = [
         GardenaBluetoothBinarySensor(coordinator, description, description.context)
         for description in DESCRIPTIONS

--- a/homeassistant/components/gardena_bluetooth/button.py
+++ b/homeassistant/components/gardena_bluetooth/button.py
@@ -14,7 +14,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .coordinator import Coordinator, GardenaBluetoothDescriptorEntity
+from .coordinator import GardenaBluetoothCoordinator
+from .entity import GardenaBluetoothDescriptorEntity
 
 
 @dataclass(frozen=True)
@@ -44,7 +45,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up button based on a config entry."""
-    coordinator: Coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: GardenaBluetoothCoordinator = hass.data[DOMAIN][entry.entry_id]
     entities = [
         GardenaBluetoothButton(coordinator, description, description.context)
         for description in DESCRIPTIONS

--- a/homeassistant/components/gardena_bluetooth/coordinator.py
+++ b/homeassistant/components/gardena_bluetooth/coordinator.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from datetime import timedelta
 import logging
-from typing import Any
 
 from gardena_bluetooth.client import Client
 from gardena_bluetooth.exceptions import (
@@ -16,12 +15,7 @@ from gardena_bluetooth.parse import Characteristic, CharacteristicType
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.entity import EntityDescription
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-    UpdateFailed,
-)
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 SCAN_INTERVAL = timedelta(seconds=60)
 LOGGER = logging.getLogger(__name__)
@@ -31,7 +25,7 @@ class DeviceUnavailable(HomeAssistantError):
     """Raised if device can't be found."""
 
 
-class Coordinator(DataUpdateCoordinator[dict[str, bytes]]):
+class GardenaBluetoothCoordinator(DataUpdateCoordinator[dict[str, bytes]]):
     """Class to manage fetching data."""
 
     def __init__(
@@ -102,34 +96,3 @@ class Coordinator(DataUpdateCoordinator[dict[str, bytes]]):
 
         self.data[char.uuid] = char.encode(value)
         await self.async_refresh()
-
-
-class GardenaBluetoothEntity(CoordinatorEntity[Coordinator]):
-    """Coordinator entity for Gardena Bluetooth."""
-
-    _attr_has_entity_name = True
-
-    def __init__(self, coordinator: Coordinator, context: Any = None) -> None:
-        """Initialize coordinator entity."""
-        super().__init__(coordinator, context)
-        self._attr_device_info = coordinator.device_info
-
-    @property
-    def available(self) -> bool:
-        """Return if entity is available."""
-        return self.coordinator.last_update_success and self._attr_available
-
-
-class GardenaBluetoothDescriptorEntity(GardenaBluetoothEntity):
-    """Coordinator entity for entities with entity description."""
-
-    def __init__(
-        self,
-        coordinator: Coordinator,
-        description: EntityDescription,
-        context: set[str],
-    ) -> None:
-        """Initialize description entity."""
-        super().__init__(coordinator, context)
-        self._attr_unique_id = f"{coordinator.address}-{description.key}"
-        self.entity_description = description

--- a/homeassistant/components/gardena_bluetooth/entity.py
+++ b/homeassistant/components/gardena_bluetooth/entity.py
@@ -1,0 +1,43 @@
+"""Provides the DataUpdateCoordinator."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.helpers.entity import EntityDescription
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .coordinator import GardenaBluetoothCoordinator
+
+
+class GardenaBluetoothEntity(CoordinatorEntity[GardenaBluetoothCoordinator]):
+    """Coordinator entity for Gardena Bluetooth."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self, coordinator: GardenaBluetoothCoordinator, context: Any = None
+    ) -> None:
+        """Initialize coordinator entity."""
+        super().__init__(coordinator, context)
+        self._attr_device_info = coordinator.device_info
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self.coordinator.last_update_success and self._attr_available
+
+
+class GardenaBluetoothDescriptorEntity(GardenaBluetoothEntity):
+    """Coordinator entity for entities with entity description."""
+
+    def __init__(
+        self,
+        coordinator: GardenaBluetoothCoordinator,
+        description: EntityDescription,
+        context: set[str],
+    ) -> None:
+        """Initialize description entity."""
+        super().__init__(coordinator, context)
+        self._attr_unique_id = f"{coordinator.address}-{description.key}"
+        self.entity_description = description

--- a/homeassistant/components/gardena_bluetooth/number.py
+++ b/homeassistant/components/gardena_bluetooth/number.py
@@ -23,11 +23,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .coordinator import (
-    Coordinator,
-    GardenaBluetoothDescriptorEntity,
-    GardenaBluetoothEntity,
-)
+from .coordinator import GardenaBluetoothCoordinator
+from .entity import GardenaBluetoothDescriptorEntity, GardenaBluetoothEntity
 
 
 @dataclass(frozen=True)
@@ -111,7 +108,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up entity based on a config entry."""
-    coordinator: Coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: GardenaBluetoothCoordinator = hass.data[DOMAIN][entry.entry_id]
     entities: list[NumberEntity] = [
         GardenaBluetoothNumber(coordinator, description, description.context)
         for description in DESCRIPTIONS
@@ -159,7 +156,7 @@ class GardenaBluetoothRemainingOpenSetNumber(GardenaBluetoothEntity, NumberEntit
 
     def __init__(
         self,
-        coordinator: Coordinator,
+        coordinator: GardenaBluetoothCoordinator,
     ) -> None:
         """Initialize the remaining time entity."""
         super().__init__(coordinator, {Valve.remaining_open_time.uuid})

--- a/homeassistant/components/gardena_bluetooth/sensor.py
+++ b/homeassistant/components/gardena_bluetooth/sensor.py
@@ -21,11 +21,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.dt as dt_util
 
 from .const import DOMAIN
-from .coordinator import (
-    Coordinator,
-    GardenaBluetoothDescriptorEntity,
-    GardenaBluetoothEntity,
-)
+from .coordinator import GardenaBluetoothCoordinator
+from .entity import GardenaBluetoothDescriptorEntity, GardenaBluetoothEntity
 
 
 @dataclass(frozen=True)
@@ -101,7 +98,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up Gardena Bluetooth sensor based on a config entry."""
-    coordinator: Coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: GardenaBluetoothCoordinator = hass.data[DOMAIN][entry.entry_id]
     entities: list[GardenaBluetoothEntity] = [
         GardenaBluetoothSensor(coordinator, description, description.context)
         for description in DESCRIPTIONS
@@ -140,7 +137,7 @@ class GardenaBluetoothRemainSensor(GardenaBluetoothEntity, SensorEntity):
 
     def __init__(
         self,
-        coordinator: Coordinator,
+        coordinator: GardenaBluetoothCoordinator,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator, {Valve.remaining_open_time.uuid})

--- a/homeassistant/components/gardena_bluetooth/switch.py
+++ b/homeassistant/components/gardena_bluetooth/switch.py
@@ -13,14 +13,15 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .coordinator import Coordinator, GardenaBluetoothEntity
+from .coordinator import GardenaBluetoothCoordinator
+from .entity import GardenaBluetoothEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up switch based on a config entry."""
-    coordinator: Coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: GardenaBluetoothCoordinator = hass.data[DOMAIN][entry.entry_id]
     entities = []
     if GardenaBluetoothValveSwitch.characteristics.issubset(
         coordinator.characteristics
@@ -41,7 +42,7 @@ class GardenaBluetoothValveSwitch(GardenaBluetoothEntity, SwitchEntity):
 
     def __init__(
         self,
-        coordinator: Coordinator,
+        coordinator: GardenaBluetoothCoordinator,
     ) -> None:
         """Initialize the switch."""
         super().__init__(

--- a/homeassistant/components/gardena_bluetooth/valve.py
+++ b/homeassistant/components/gardena_bluetooth/valve.py
@@ -12,7 +12,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .coordinator import Coordinator, GardenaBluetoothEntity
+from .coordinator import GardenaBluetoothCoordinator
+from .entity import GardenaBluetoothEntity
 
 FALLBACK_WATERING_TIME_IN_SECONDS = 60 * 60
 
@@ -21,7 +22,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up switch based on a config entry."""
-    coordinator: Coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: GardenaBluetoothCoordinator = hass.data[DOMAIN][entry.entry_id]
     entities = []
     if GardenaBluetoothValve.characteristics.issubset(coordinator.characteristics):
         entities.append(GardenaBluetoothValve(coordinator))
@@ -45,7 +46,7 @@ class GardenaBluetoothValve(GardenaBluetoothEntity, ValveEntity):
 
     def __init__(
         self,
-        coordinator: Coordinator,
+        coordinator: GardenaBluetoothCoordinator,
     ) -> None:
         """Initialize the switch."""
         super().__init__(

--- a/tests/components/gardena_bluetooth/conftest.py
+++ b/tests/components/gardena_bluetooth/conftest.py
@@ -112,10 +112,5 @@ def mock_client(
 
 
 @pytest.fixture(autouse=True)
-def enable_all_entities():
+def enable_all_entities(entity_registry_enabled_by_default: None) -> None:
     """Make sure all entities are enabled."""
-    with patch(
-        "homeassistant.components.gardena_bluetooth.coordinator.GardenaBluetoothEntity.entity_registry_enabled_default",
-        new=Mock(return_value=True),
-    ):
-        yield


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #126473

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
