### PR TITLE
Add authentication support to MotionMount integration

### DIFF
--- a/homeassistant/components/motionmount/__init__.py
+++ b/homeassistant/components/motionmount/__init__.py
@@ -51,11 +51,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Check we're properly authenticated or be able to become so
     if not mm.is_authenticated:
         if CONF_PIN not in entry.data:
-            raise ConfigEntryAuthFailed("No pin provided")
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="no_pin_provided",
+            )
+
         pin = entry.data[CONF_PIN]
         await mm.authenticate(pin)
         if not mm.is_authenticated:
-            raise ConfigEntryAuthFailed("Incorrect pin")
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="incorrect_pin",
+            )
 
     # Store an API object for your platforms to access
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = mm

--- a/homeassistant/components/motionmount/config_flow.py
+++ b/homeassistant/components/motionmount/config_flow.py
@@ -208,21 +208,18 @@ class MotionMountFlowHandler(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle backoff progress."""
-        if self.backoff_task is not None:
-            if self.backoff_task.done():
-                self.backoff_task = None
-                return self.async_show_progress_done(next_step_id="auth")
+        if not self.backoff_task or self.backoff_task.done():
+            self.backoff_task = None
+            return self.async_show_progress_done(next_step_id="auth")
 
-            return self.async_show_progress(
-                step_id="backoff",
-                description_placeholders={
-                    "timeout": str(self.backoff_time),
-                },
-                progress_action="progress_action",
-                progress_task=self.backoff_task,
-            )
-
-        return await self.async_step_auth()
+        return self.async_show_progress(
+            step_id="backoff",
+            description_placeholders={
+                "timeout": str(self.backoff_time),
+            },
+            progress_action="progress_action",
+            progress_task=self.backoff_task,
+        )
 
     def _create_or_update_entry(self) -> ConfigFlowResult:
         if self.reauth_entry:

--- a/homeassistant/components/motionmount/config_flow.py
+++ b/homeassistant/components/motionmount/config_flow.py
@@ -285,6 +285,6 @@ class MotionMountFlowHandler(ConfigFlow, domain=DOMAIN):
 
     async def _backoff(self, time: int) -> None:
         while time > 0:
-            await asyncio.sleep(1)
             time -= 1
             self.backoff_time = time
+            await asyncio.sleep(1)

--- a/homeassistant/components/motionmount/config_flow.py
+++ b/homeassistant/components/motionmount/config_flow.py
@@ -177,9 +177,6 @@ class MotionMountFlowHandler(ConfigFlow, domain=DOMAIN):
         """Handle authentication form."""
         errors = {}
 
-        if self.backoff_task:
-            return await self.async_step_backoff()
-
         if user_input is not None:
             self.connection_data[CONF_PIN] = user_input[CONF_PIN]
 

--- a/homeassistant/components/motionmount/config_flow.py
+++ b/homeassistant/components/motionmount/config_flow.py
@@ -193,7 +193,7 @@ class MotionMountFlowHandler(ConfigFlow, domain=DOMAIN):
                 self.backoff_task = self.hass.async_create_task(self._backoff(valid))
                 return await self.async_step_backoff()
 
-            errors[CONF_PIN] = "Pin is not correct"
+            errors[CONF_PIN] = CONF_PIN
 
         return self.async_show_form(
             step_id="auth",

--- a/homeassistant/components/motionmount/config_flow.py
+++ b/homeassistant/components/motionmount/config_flow.py
@@ -181,13 +181,15 @@ class MotionMountFlowHandler(ConfigFlow, domain=DOMAIN):
             self.connection_data[CONF_PIN] = user_input[CONF_PIN]
 
             # Validate pin code
-            valid = await self._validate_input_pin(self.connection_data)
-            if valid is True:
+            valid_or_wait_time = await self._validate_input_pin(self.connection_data)
+            if valid_or_wait_time is True:
                 return self._create_or_update_entry()
 
-            if type(valid) is int:
-                self.backoff_time = valid
-                self.backoff_task = self.hass.async_create_task(self._backoff(valid))
+            if type(valid_or_wait_time) is int:
+                self.backoff_time = valid_or_wait_time
+                self.backoff_task = self.hass.async_create_task(
+                    self._backoff(valid_or_wait_time)
+                )
                 return await self.async_step_backoff()
 
             errors[CONF_PIN] = CONF_PIN

--- a/homeassistant/components/motionmount/config_flow.py
+++ b/homeassistant/components/motionmount/config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.config_entries import (
     ConfigFlow,
     ConfigFlowResult,
 )
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_UUID
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PIN, CONF_PORT, CONF_UUID
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
@@ -34,7 +34,7 @@ class MotionMountFlowHandler(ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         """Set up the instance."""
-        self.discovery_info: dict[str, Any] = {}
+        self.connection_data: dict[str, Any] = {}
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -43,23 +43,16 @@ class MotionMountFlowHandler(ConfigFlow, domain=DOMAIN):
         if user_input is None:
             return self._show_setup_form()
 
+        self.connection_data.update(user_input)
         info = {}
         try:
-            info = await self._validate_input(user_input)
+            info = await self._validate_input_connect(self.connection_data)
         except (ConnectionError, socket.gaierror):
             return self.async_abort(reason="cannot_connect")
         except TimeoutError:
             return self.async_abort(reason="time_out")
         except motionmount.NotConnectedError:
             return self.async_abort(reason="not_connected")
-        except motionmount.MotionMountResponseError:
-            # This is most likely due to missing support for the mac address property
-            # Abort if the handler has config entries already
-            if self._async_current_entries():
-                return self.async_abort(reason="already_configured")
-
-            # Otherwise we try to continue with the generic uid
-            info[CONF_UUID] = DEFAULT_DISCOVERY_UNIQUE_ID
 
         # If the device mac is valid we use it, otherwise we use the default id
         if info.get(CONF_UUID, EMPTY_MAC) != EMPTY_MAC:
@@ -67,17 +60,25 @@ class MotionMountFlowHandler(ConfigFlow, domain=DOMAIN):
         else:
             unique_id = DEFAULT_DISCOVERY_UNIQUE_ID
 
-        name = info.get(CONF_NAME, user_input[CONF_HOST])
+        name = info.get(CONF_NAME, self.connection_data[CONF_HOST])
+        self.connection_data[CONF_NAME] = name
 
         await self.async_set_unique_id(unique_id)
         self._abort_if_unique_id_configured(
             updates={
-                CONF_HOST: user_input[CONF_HOST],
-                CONF_PORT: user_input[CONF_PORT],
+                CONF_HOST: self.connection_data[CONF_HOST],
+                CONF_PORT: self.connection_data[CONF_PORT],
             }
         )
 
-        return self.async_create_entry(title=name, data=user_input)
+        if not info[CONF_PIN]:
+            # We need a pin to authenticate
+            return await self.async_step_auth()
+        # No pin is needed
+        return self.async_create_entry(
+            title=self.connection_data[CONF_NAME],
+            data=self.connection_data,
+        )
 
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
@@ -91,7 +92,7 @@ class MotionMountFlowHandler(ConfigFlow, domain=DOMAIN):
         name = discovery_info.name.removesuffix(f".{zctype}")
         unique_id = discovery_info.properties.get("mac")
 
-        self.discovery_info.update(
+        self.connection_data.update(
             {
                 CONF_HOST: host,
                 CONF_PORT: port,
@@ -114,16 +115,13 @@ class MotionMountFlowHandler(ConfigFlow, domain=DOMAIN):
         self.context.update({"title_placeholders": {"name": name}})
 
         try:
-            info = await self._validate_input(self.discovery_info)
+            info = await self._validate_input_connect(self.connection_data)
         except (ConnectionError, socket.gaierror):
             return self.async_abort(reason="cannot_connect")
         except TimeoutError:
             return self.async_abort(reason="time_out")
         except motionmount.NotConnectedError:
             return self.async_abort(reason="not_connected")
-        except motionmount.MotionMountResponseError:
-            info = {}
-            # We continue as we want to be able to connect with older FW that does not support MAC address
 
         # If the device supplied as with a valid MAC we use that
         if info.get(CONF_UUID, EMPTY_MAC) != EMPTY_MAC:
@@ -137,6 +135,10 @@ class MotionMountFlowHandler(ConfigFlow, domain=DOMAIN):
         else:
             await self._async_handle_discovery_without_unique_id()
 
+        if not info[CONF_PIN]:
+            # We need a pin to authenticate
+            return await self.async_step_auth()
+        # No pin is needed
         return await self.async_step_zeroconf_confirm()
 
     async def async_step_zeroconf_confirm(
@@ -146,16 +148,44 @@ class MotionMountFlowHandler(ConfigFlow, domain=DOMAIN):
         if user_input is None:
             return self.async_show_form(
                 step_id="zeroconf_confirm",
-                description_placeholders={CONF_NAME: self.discovery_info[CONF_NAME]},
+                description_placeholders={CONF_NAME: self.connection_data[CONF_NAME]},
                 errors={},
             )
 
         return self.async_create_entry(
-            title=self.discovery_info[CONF_NAME],
-            data=self.discovery_info,
+            title=self.connection_data[CONF_NAME],
+            data=self.connection_data,
         )
 
-    async def _validate_input(self, data: dict) -> dict[str, Any]:
+    async def async_step_auth(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle authentication form."""
+        errors = {}
+
+        if user_input is not None:
+            self.connection_data[CONF_PIN] = user_input[CONF_PIN]
+
+            # Validate pin code
+            if await self._validate_input_pin(self.connection_data):
+                return self.async_create_entry(
+                    title=self.connection_data[CONF_NAME],
+                    data=self.connection_data,
+                )
+
+            errors[CONF_PIN] = "Pin is not correct"
+
+        return self.async_show_form(
+            step_id="auth",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_PIN): vol.All(int, vol.Range(min=1, max=9999)),
+                }
+            ),
+            errors=errors,
+        )
+
+    async def _validate_input_connect(self, data: dict) -> dict[str, Any]:
         """Validate the user input allows us to connect."""
 
         mm = motionmount.MotionMount(data[CONF_HOST], data[CONF_PORT])
@@ -164,7 +194,23 @@ class MotionMountFlowHandler(ConfigFlow, domain=DOMAIN):
         finally:
             await mm.disconnect()
 
-        return {CONF_UUID: format_mac(mm.mac.hex()), CONF_NAME: mm.name}
+        return {
+            CONF_UUID: format_mac(mm.mac.hex()),
+            CONF_NAME: mm.name,
+            CONF_PIN: mm.is_authenticated,
+        }
+
+    async def _validate_input_pin(self, data: dict) -> bool:
+        """Validate the user input allows us to authenticate."""
+
+        mm = motionmount.MotionMount(data[CONF_HOST], data[CONF_PORT])
+        try:
+            await mm.connect()
+            await mm.authenticate(data[CONF_PIN])
+        finally:
+            await mm.disconnect()
+
+        return mm.is_authenticated
 
     def _show_setup_form(
         self, errors: dict[str, str] | None = None

--- a/homeassistant/components/motionmount/entity.py
+++ b/homeassistant/components/motionmount/entity.py
@@ -111,5 +111,5 @@ class MotionMountEntity(Entity):
                 self.platform.config_entry.async_start_reauth(self.hass)
                 return False
 
-        _LOGGER.warning("Successfully reconnected to MotionMount")
+        _LOGGER.debug("Successfully reconnected to MotionMount")
         return True

--- a/homeassistant/components/motionmount/entity.py
+++ b/homeassistant/components/motionmount/entity.py
@@ -26,6 +26,7 @@ class MotionMountEntity(Entity):
     def __init__(self, mm: motionmount.MotionMount, config_entry: ConfigEntry) -> None:
         """Initialize general MotionMount entity."""
         self.mm = mm
+        self.config_entry = config_entry
 
         # We store the pin, as we might need it during reconnect
         self.pin = config_entry.data[CONF_PIN]
@@ -84,9 +85,6 @@ class MotionMountEntity(Entity):
 
         Returns false if the connection failed to be ensured.
         """
-        if TYPE_CHECKING:
-            assert self.platform.config_entry
-
         if self.mm.is_connected:
             return True
         try:
@@ -102,13 +100,13 @@ class MotionMountEntity(Entity):
         if not self.mm.is_authenticated:
             if self.pin is None:
                 await self.mm.disconnect()
-                self.platform.config_entry.async_start_reauth(self.hass)
+                self.config_entry.async_start_reauth(self.hass)
                 return False
             await self.mm.authenticate(self.pin)
             if not self.mm.is_authenticated:
                 self.pin = None
                 await self.mm.disconnect()
-                self.platform.config_entry.async_start_reauth(self.hass)
+                self.config_entry.async_start_reauth(self.hass)
                 return False
 
         _LOGGER.debug("Successfully reconnected to MotionMount")

--- a/homeassistant/components/motionmount/select.py
+++ b/homeassistant/components/motionmount/select.py
@@ -51,6 +51,38 @@ class MotionMountPresets(MotionMountEntity, SelectEntity):
 
         self._attr_options = options
 
+    async def _ensure_connected(self) -> bool:
+        """Make sure there is a connection with the MotionMount.
+
+        Returns false if the connection failed to be ensured.
+        """
+        if self.mm.is_connected:
+            return True
+        try:
+            await self.mm.connect()
+        except (ConnectionError, TimeoutError, socket.gaierror):
+            # We're not interested in exceptions here. In case of a failed connection
+            # the try/except from the caller will report it.
+            # The purpose of `_ensure_connected()` is only to make sure we try to
+            # reconnect, where failures should not be logged each time
+            return False
+
+        # Check we're properly authenticated or be able to become so
+        if not self.mm.is_authenticated:
+            if self.pin is None:
+                await self.mm.disconnect()
+                self.config_entry.async_start_reauth(self.hass)
+                return False
+            await self.mm.authenticate(self.pin)
+            if not self.mm.is_authenticated:
+                self.pin = None
+                await self.mm.disconnect()
+                self.config_entry.async_start_reauth(self.hass)
+                return False
+
+        _LOGGER.debug("Successfully reconnected to MotionMount")
+        return True
+
     async def async_update(self) -> None:
         """Get latest state from MotionMount."""
         if not await self._ensure_connected():

--- a/homeassistant/components/motionmount/strings.json
+++ b/homeassistant/components/motionmount/strings.json
@@ -26,6 +26,9 @@
         "description": "Too many incorrect pin attempts."
       }
     },
+    "error": {
+      "pin": "Pin is not correct"
+    },
     "progress": {
       "progress_action": "Too many incorrect pin attempts. Please wait {timeout} s..."
     },

--- a/homeassistant/components/motionmount/strings.json
+++ b/homeassistant/components/motionmount/strings.json
@@ -1,4 +1,7 @@
 {
+  "common": {
+    "incorrect_pin": "Pin is not correct"
+  },
   "config": {
     "flow_title": "{name}",
     "step": {
@@ -27,7 +30,7 @@
       }
     },
     "error": {
-      "pin": "Pin is not correct"
+      "pin": "[%key:component::motionmount::common::incorrect_pin%]"
     },
     "progress": {
       "progress_action": "Too many incorrect pin attempts. Please wait {timeout} s..."
@@ -78,6 +81,12 @@
   "exceptions": {
     "failed_communication": {
       "message": "Failed to communicate with MotionMount"
+    },
+    "no_pin_provided": {
+      "message": "No pin provided"
+    },
+    "incorrect_pin": {
+      "message": "[%key:component::motionmount::common::incorrect_pin%]"
     }
   }
 }

--- a/homeassistant/components/motionmount/strings.json
+++ b/homeassistant/components/motionmount/strings.json
@@ -20,7 +20,14 @@
         "data": {
           "pin": "[%key:common::config_flow::data::pin%]"
         }
+      },
+      "backoff": {
+        "title": "Authenticate to your MotionMount",
+        "description": "Too many incorrect pin attempts."
       }
+    },
+    "progress": {
+      "progress_action": "Too many incorrect pin attempts. Please wait {timeout} s..."
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",

--- a/homeassistant/components/motionmount/strings.json
+++ b/homeassistant/components/motionmount/strings.json
@@ -13,13 +13,20 @@
       "zeroconf_confirm": {
         "description": "Do you want to set up {name}?",
         "title": "Discovered MotionMount"
+      },
+      "auth": {
+        "title": "Authenticate to your MotionMount",
+        "description": "Your MotionMount requires a pin to operate.",
+        "data": {
+          "pin": "[%key:common::config_flow::data::pin%]"
+        }
       }
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "time_out": "Failed to connect due to a time out.",
+      "time_out": "[%key:common::config_flow::error::timeout_connect%]",
       "not_connected": "Failed to connect.",
       "invalid_response": "Failed to connect due to an invalid response from the MotionMount."
     }

--- a/homeassistant/components/motionmount/strings.json
+++ b/homeassistant/components/motionmount/strings.json
@@ -28,7 +28,8 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "time_out": "[%key:common::config_flow::error::timeout_connect%]",
       "not_connected": "Failed to connect.",
-      "invalid_response": "Failed to connect due to an invalid response from the MotionMount."
+      "invalid_response": "Failed to connect due to an invalid response from the MotionMount.",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },
   "entity": {

--- a/tests/components/motionmount/__init__.py
+++ b/tests/components/motionmount/__init__.py
@@ -2,7 +2,7 @@
 
 from ipaddress import ip_address
 
-from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.const import CONF_HOST, CONF_PIN, CONF_PORT
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 HOST = "192.168.1.31"
@@ -20,6 +20,8 @@ MOCK_USER_INPUT = {
     CONF_HOST: HOST,
     CONF_PORT: PORT,
 }
+
+MOCK_PIN_INPUT = {CONF_PIN: 1234}
 
 MOCK_ZEROCONF_TVM_SERVICE_INFO_V1 = ZeroconfServiceInfo(
     type=TVM_ZEROCONF_SERVICE_TYPE,

--- a/tests/components/motionmount/test_config_flow.py
+++ b/tests/components/motionmount/test_config_flow.py
@@ -117,33 +117,6 @@ async def test_user_not_connected_error(
     assert result["reason"] == "not_connected"
 
 
-async def test_user_response_error_single_device_old_ce_old_new_pro(
-    hass: HomeAssistant,
-    mock_motionmount_config_flow: MagicMock,
-) -> None:
-    """Test that the flow creates an entry when there is a response error."""
-    mock_motionmount_config_flow.connect.side_effect = (
-        motionmount.MotionMountResponseError(motionmount.MotionMountResponse.NotFound)
-    )
-
-    user_input = MOCK_USER_INPUT.copy()
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-        data=user_input,
-    )
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == HOST
-
-    assert result["data"]
-    assert result["data"][CONF_HOST] == HOST
-    assert result["data"][CONF_PORT] == PORT
-
-    assert result["result"]
-
-
 async def test_user_response_error_single_device_new_ce_old_pro(
     hass: HomeAssistant,
     mock_motionmount_config_flow: MagicMock,
@@ -197,30 +170,6 @@ async def test_user_response_error_single_device_new_ce_new_pro(
 
     assert result["result"]
     assert result["result"].unique_id == ZEROCONF_MAC
-
-
-async def test_user_response_error_multi_device_old_ce_old_new_pro(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_motionmount_config_flow: MagicMock,
-) -> None:
-    """Test that the flow is aborted when there are multiple devices."""
-    mock_config_entry.add_to_hass(hass)
-
-    mock_motionmount_config_flow.connect.side_effect = (
-        motionmount.MotionMountResponseError(motionmount.MotionMountResponse.NotFound)
-    )
-
-    user_input = MOCK_USER_INPUT.copy()
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-        data=user_input,
-    )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
 
 
 async def test_user_response_error_multi_device_new_ce_new_pro(
@@ -320,48 +269,6 @@ async def test_zeroconf_not_connected_error(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "not_connected"
-
-
-async def test_show_zeroconf_form_old_ce_old_pro(
-    hass: HomeAssistant,
-    mock_motionmount_config_flow: MagicMock,
-) -> None:
-    """Test that the zeroconf confirmation form is served."""
-    mock_motionmount_config_flow.connect.side_effect = (
-        motionmount.MotionMountResponseError(motionmount.MotionMountResponse.NotFound)
-    )
-
-    discovery_info = dataclasses.replace(MOCK_ZEROCONF_TVM_SERVICE_INFO_V1)
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_ZEROCONF},
-        data=discovery_info,
-    )
-
-    assert result["step_id"] == "zeroconf_confirm"
-    assert result["type"] is FlowResultType.FORM
-    assert result["description_placeholders"] == {CONF_NAME: "My MotionMount"}
-
-
-async def test_show_zeroconf_form_old_ce_new_pro(
-    hass: HomeAssistant,
-    mock_motionmount_config_flow: MagicMock,
-) -> None:
-    """Test that the zeroconf confirmation form is served."""
-    mock_motionmount_config_flow.connect.side_effect = (
-        motionmount.MotionMountResponseError(motionmount.MotionMountResponse.NotFound)
-    )
-
-    discovery_info = dataclasses.replace(MOCK_ZEROCONF_TVM_SERVICE_INFO_V2)
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_ZEROCONF},
-        data=discovery_info,
-    )
-
-    assert result["step_id"] == "zeroconf_confirm"
-    assert result["type"] is FlowResultType.FORM
-    assert result["description_placeholders"] == {CONF_NAME: "My MotionMount"}
 
 
 async def test_show_zeroconf_form_new_ce_old_pro(

--- a/tests/components/motionmount/test_config_flow.py
+++ b/tests/components/motionmount/test_config_flow.py
@@ -423,6 +423,9 @@ async def test_authentication_correct_pin(
     type(mock_motionmount_config_flow).is_authenticated = PropertyMock(
         return_value=False
     )
+    type(mock_motionmount_config_flow).can_authenticate = PropertyMock(
+        return_value=True
+    )
 
     user_input = MOCK_USER_INPUT.copy()
 

--- a/tests/components/motionmount/test_config_flow.py
+++ b/tests/components/motionmount/test_config_flow.py
@@ -409,7 +409,7 @@ async def test_authentication_incorrect_pin(
     assert result["step_id"] == "auth"
 
     assert result["errors"]
-    assert result["errors"][CONF_PIN] == "Pin is not correct"
+    assert result["errors"][CONF_PIN] == CONF_PIN
 
 
 async def test_authentication_correct_pin(

--- a/tests/components/motionmount/test_config_flow.py
+++ b/tests/components/motionmount/test_config_flow.py
@@ -1,10 +1,11 @@
 """Tests for the Vogel's MotionMount config flow."""
 
-import asyncio
 import dataclasses
+from datetime import timedelta
 import socket
 from unittest.mock import MagicMock, PropertyMock
 
+from freezegun.api import FrozenDateTimeFactory
 import motionmount
 import pytest
 
@@ -26,7 +27,7 @@ from . import (
     ZEROCONF_NAME,
 )
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 MAC = bytes.fromhex("c4dd57f8a55f")
 pytestmark = pytest.mark.usefixtures("mock_setup_entry")
@@ -505,6 +506,7 @@ async def test_authentication_first_incorrect_pin_to_backoff(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_motionmount_config_flow: MagicMock,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test that authentication is requested when needed."""
     type(mock_motionmount_config_flow).name = PropertyMock(return_value=ZEROCONF_NAME)
@@ -534,7 +536,9 @@ async def test_authentication_first_incorrect_pin_to_backoff(
     assert result["type"] is FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "backoff"
 
-    await asyncio.sleep(2)
+    freezer.tick(timedelta(seconds=2))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
     # Now simulate the user entered the correct pin to finalize the test
     type(mock_motionmount_config_flow).is_authenticated = PropertyMock(
@@ -564,6 +568,7 @@ async def test_authentication_multiple_incorrect_pins(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_motionmount_config_flow: MagicMock,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test that authentication is requested when needed."""
     type(mock_motionmount_config_flow).name = PropertyMock(return_value=ZEROCONF_NAME)
@@ -592,7 +597,9 @@ async def test_authentication_multiple_incorrect_pins(
     assert result["type"] is FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "backoff"
 
-    await asyncio.sleep(2)
+    freezer.tick(timedelta(seconds=2))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
     # Now simulate the user entered the correct pin to finalize the test
     type(mock_motionmount_config_flow).is_authenticated = PropertyMock(
@@ -622,6 +629,7 @@ async def test_authentication_show_backoff_when_still_running(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_motionmount_config_flow: MagicMock,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test that authentication is requested when needed."""
     type(mock_motionmount_config_flow).name = PropertyMock(return_value=ZEROCONF_NAME)
@@ -658,7 +666,9 @@ async def test_authentication_show_backoff_when_still_running(
     assert result["type"] is FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "backoff"
 
-    await asyncio.sleep(2)
+    freezer.tick(timedelta(seconds=2))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
     # Now simulate the user entered the correct pin to finalize the test
     type(mock_motionmount_config_flow).is_authenticated = PropertyMock(


### PR DESCRIPTION
## Proposed change
This PR adds authentication support to the MotionMount integration.
The MotionMount supports a pin-based authentication scheme to prevent users from either using or configuring the MotionMount. When too many incorrect pin entries are attempted the MotionMount enforces a delay timer. This is also handled using a progress step.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
