### PR TITLE
Don't crash entire Matter integration setup when one node is failing

### DIFF
--- a/homeassistant/components/matter/adapter.py
+++ b/homeassistant/components/matter/adapter.py
@@ -55,10 +55,6 @@ class MatterAdapter:
         """Set up all existing nodes and subscribe to new nodes."""
         initialized_nodes: set[int] = set()
         for node in self.matter_client.get_nodes():
-            if not node.available:
-                # ignore un-initialized nodes at startup
-                # catch them later when they become available.
-                continue
             initialized_nodes.add(node.node_id)
             self._setup_node(node)
 
@@ -142,10 +138,18 @@ class MatterAdapter:
     def _setup_node(self, node: MatterNode) -> None:
         """Set up an node."""
         LOGGER.debug("Setting up entities for node %s", node.node_id)
-
-        for endpoint in node.endpoints.values():
-            # Node endpoints are translated into HA devices
-            self._setup_endpoint(endpoint)
+        try:
+            for endpoint in node.endpoints.values():
+                # Node endpoints are translated into HA devices
+                self._setup_endpoint(endpoint)
+        except Exception as err:  # noqa: BLE001
+            # We don't want to crash the whole setup when a single node fails to setup
+            # for whatever reason, so we catch all exceptions here.
+            LOGGER.exception(
+                "Error setting up node %s: %s",
+                node.node_id,
+                err,
+            )
 
     def _create_device_registry(
         self,

--- a/tests/components/matter/common.py
+++ b/tests/components/matter/common.py
@@ -34,15 +34,7 @@ async def setup_integration_with_node_fixture(
     override_attributes: dict[str, Any] | None = None,
 ) -> MatterNode:
     """Set up Matter integration with fixture as node."""
-    node_data = load_and_parse_node_fixture(node_fixture)
-    if override_attributes:
-        node_data["attributes"].update(override_attributes)
-    node = MatterNode(
-        dataclass_from_dict(
-            MatterNodeData,
-            node_data,
-        )
-    )
+    node = create_node_from_fixture(node_fixture, override_attributes)
     client.get_nodes.return_value = [node]
     client.get_node.return_value = node
     config_entry = MockConfigEntry(
@@ -54,6 +46,21 @@ async def setup_integration_with_node_fixture(
     await hass.async_block_till_done()
 
     return node
+
+
+def create_node_from_fixture(
+    node_fixture: str, override_attributes: dict[str, Any] | None = None
+) -> MatterNode:
+    """Create a node from a fixture."""
+    node_data = load_and_parse_node_fixture(node_fixture)
+    if override_attributes:
+        node_data["attributes"].update(override_attributes)
+    return MatterNode(
+        dataclass_from_dict(
+            MatterNodeData,
+            node_data,
+        )
+    )
 
 
 def set_node_attribute(

--- a/tests/components/matter/test_init.py
+++ b/tests/components/matter/test_init.py
@@ -11,10 +11,7 @@ from matter_server.client.exceptions import (
     ServerVersionTooNew,
     ServerVersionTooOld,
 )
-from matter_server.client.models.node import MatterNode
 from matter_server.common.errors import MatterError
-from matter_server.common.helpers.util import dataclass_from_dict
-from matter_server.common.models import MatterNodeData
 import pytest
 
 from homeassistant.components.hassio import HassioAPIError
@@ -29,7 +26,7 @@ from homeassistant.helpers import (
 )
 from homeassistant.setup import async_setup_component
 
-from .common import load_and_parse_node_fixture, setup_integration_with_node_fixture
+from .common import create_node_from_fixture, setup_integration_with_node_fixture
 
 from tests.common import MockConfigEntry
 from tests.typing import WebSocketGenerator
@@ -56,13 +53,7 @@ async def test_entry_setup_unload(
     matter_client: MagicMock,
 ) -> None:
     """Test the integration set up and unload."""
-    node_data = load_and_parse_node_fixture("onoff-light")
-    node = MatterNode(
-        dataclass_from_dict(
-            MatterNodeData,
-            node_data,
-        )
-    )
+    node = create_node_from_fixture("onoff-light")
     matter_client.get_nodes.return_value = [node]
     matter_client.get_node.return_value = node
     entry = MockConfigEntry(domain="matter", data={"url": "ws://localhost:5580/ws"})


### PR DESCRIPTION
## Proposed change

While working on #126059 I realized that whenever something unexpected happens to one of our nodes, we crash the entire integration set-up which is a bad UX in my opinion. I'm not a fan of swallowing exceptions but on the other hand making all devices unusable if something bad happens to e.g. parsing one attribute doesn't feel right either. Especially now that Matter is still so young and people commission devices we have never ever seen in the wild before, let alone wrote tests for them.

So this basically guards node_setup with a try..except block that logs the exception instead of bailing out completely.
At least this makes sure that other nodes still can get setup.

One other small change in this PR is to not ignore unavailable nodes in setup as that prevents them from getting added.
All nodes should be setup, if they are unavailable, they will get marked as such with the entity state.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
