### PR TITLE
Move modern_forms base entity to separate module

### DIFF
--- a/homeassistant/components/modern_forms/__init__.py
+++ b/homeassistant/components/modern_forms/__init__.py
@@ -11,11 +11,10 @@ from aiomodernforms import ModernFormsConnectionError, ModernFormsError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import ModernFormsDataUpdateCoordinator
+from .entity import ModernFormsDeviceEntity
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
@@ -84,35 +83,3 @@ def modernforms_exception_handler[
             _LOGGER.error("Invalid response from API: %s", error)
 
     return handler
-
-
-class ModernFormsDeviceEntity(CoordinatorEntity[ModernFormsDataUpdateCoordinator]):
-    """Defines a Modern Forms device entity."""
-
-    _attr_has_entity_name = True
-
-    def __init__(
-        self,
-        *,
-        entry_id: str,
-        coordinator: ModernFormsDataUpdateCoordinator,
-        enabled_default: bool = True,
-    ) -> None:
-        """Initialize the Modern Forms entity."""
-        super().__init__(coordinator)
-        self._attr_enabled_default = enabled_default
-        self._entry_id = entry_id
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device information about this Modern Forms device."""
-        return DeviceInfo(
-            identifiers={(DOMAIN, self.coordinator.data.info.mac_address)},
-            name=self.coordinator.data.info.device_name,
-            manufacturer="Modern Forms",
-            model=self.coordinator.data.info.fan_type,
-            sw_version=(
-                f"{self.coordinator.data.info.firmware_version} /"
-                f" {self.coordinator.data.info.main_mcu_firmware_version}"
-            ),
-        )

--- a/homeassistant/components/modern_forms/binary_sensor.py
+++ b/homeassistant/components/modern_forms/binary_sensor.py
@@ -8,9 +8,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import dt as dt_util
 
-from . import ModernFormsDeviceEntity
 from .const import CLEAR_TIMER, DOMAIN
 from .coordinator import ModernFormsDataUpdateCoordinator
+from .entity import ModernFormsDeviceEntity
 
 
 async def async_setup_entry(

--- a/homeassistant/components/modern_forms/entity.py
+++ b/homeassistant/components/modern_forms/entity.py
@@ -1,0 +1,41 @@
+"""The Modern Forms integration."""
+
+from __future__ import annotations
+
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import ModernFormsDataUpdateCoordinator
+
+
+class ModernFormsDeviceEntity(CoordinatorEntity[ModernFormsDataUpdateCoordinator]):
+    """Defines a Modern Forms device entity."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        *,
+        entry_id: str,
+        coordinator: ModernFormsDataUpdateCoordinator,
+        enabled_default: bool = True,
+    ) -> None:
+        """Initialize the Modern Forms entity."""
+        super().__init__(coordinator)
+        self._attr_enabled_default = enabled_default
+        self._entry_id = entry_id
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information about this Modern Forms device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.coordinator.data.info.mac_address)},
+            name=self.coordinator.data.info.device_name,
+            manufacturer="Modern Forms",
+            model=self.coordinator.data.info.fan_type,
+            sw_version=(
+                f"{self.coordinator.data.info.firmware_version} /"
+                f" {self.coordinator.data.info.main_mcu_firmware_version}"
+            ),
+        )

--- a/homeassistant/components/modern_forms/fan.py
+++ b/homeassistant/components/modern_forms/fan.py
@@ -18,7 +18,7 @@ from homeassistant.util.percentage import (
 )
 from homeassistant.util.scaling import int_states_in_range
 
-from . import ModernFormsDeviceEntity, modernforms_exception_handler
+from . import modernforms_exception_handler
 from .const import (
     ATTR_SLEEP_TIME,
     CLEAR_TIMER,
@@ -29,6 +29,7 @@ from .const import (
     SERVICE_SET_FAN_SLEEP_TIMER,
 )
 from .coordinator import ModernFormsDataUpdateCoordinator
+from .entity import ModernFormsDeviceEntity
 
 
 async def async_setup_entry(

--- a/homeassistant/components/modern_forms/light.py
+++ b/homeassistant/components/modern_forms/light.py
@@ -17,7 +17,7 @@ from homeassistant.util.percentage import (
     ranged_value_to_percentage,
 )
 
-from . import ModernFormsDeviceEntity, modernforms_exception_handler
+from . import modernforms_exception_handler
 from .const import (
     ATTR_SLEEP_TIME,
     CLEAR_TIMER,
@@ -28,6 +28,7 @@ from .const import (
     SERVICE_SET_LIGHT_SLEEP_TIMER,
 )
 from .coordinator import ModernFormsDataUpdateCoordinator
+from .entity import ModernFormsDeviceEntity
 
 BRIGHTNESS_RANGE = (1, 255)
 

--- a/homeassistant/components/modern_forms/sensor.py
+++ b/homeassistant/components/modern_forms/sensor.py
@@ -11,9 +11,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.util import dt as dt_util
 
-from . import ModernFormsDeviceEntity
 from .const import CLEAR_TIMER, DOMAIN
 from .coordinator import ModernFormsDataUpdateCoordinator
+from .entity import ModernFormsDeviceEntity
 
 
 async def async_setup_entry(

--- a/homeassistant/components/modern_forms/switch.py
+++ b/homeassistant/components/modern_forms/switch.py
@@ -9,9 +9,10 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import ModernFormsDeviceEntity, modernforms_exception_handler
+from . import modernforms_exception_handler
 from .const import DOMAIN
 from .coordinator import ModernFormsDataUpdateCoordinator
+from .entity import ModernFormsDeviceEntity
 
 
 async def async_setup_entry(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #126473

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
