### PR TITLE
Move purpleair base entity to separate module

### DIFF
--- a/homeassistant/components/purpleair/__init__.py
+++ b/homeassistant/components/purpleair/__init__.py
@@ -2,21 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from typing import Any
-
-from aiopurpleair.models.sensors import SensorModel
-
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    ATTR_LATITUDE,
-    ATTR_LONGITUDE,
-    CONF_SHOW_ON_MAP,
-    Platform,
-)
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import PurpleAirDataUpdateCoordinator
@@ -48,53 +36,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
-
-
-class PurpleAirEntity(CoordinatorEntity[PurpleAirDataUpdateCoordinator]):
-    """Define a base PurpleAir entity."""
-
-    _attr_has_entity_name = True
-
-    def __init__(
-        self,
-        coordinator: PurpleAirDataUpdateCoordinator,
-        entry: ConfigEntry,
-        sensor_index: int,
-    ) -> None:
-        """Initialize."""
-        super().__init__(coordinator)
-
-        self._sensor_index = sensor_index
-
-        self._attr_device_info = DeviceInfo(
-            configuration_url=self.coordinator.async_get_map_url(sensor_index),
-            hw_version=self.sensor_data.hardware,
-            identifiers={(DOMAIN, str(sensor_index))},
-            manufacturer="PurpleAir, Inc.",
-            model=self.sensor_data.model,
-            name=self.sensor_data.name,
-            sw_version=self.sensor_data.firmware_version,
-        )
-        self._entry = entry
-
-    @property
-    def extra_state_attributes(self) -> Mapping[str, Any]:
-        """Return entity specific state attributes."""
-        attrs = {}
-
-        # Displaying the geography on the map relies upon putting the latitude/longitude
-        # in the entity attributes with "latitude" and "longitude" as the keys.
-        # Conversely, we can hide the location on the map by using other keys, like
-        # "lati" and "long":
-        if self._entry.options.get(CONF_SHOW_ON_MAP):
-            attrs[ATTR_LATITUDE] = self.sensor_data.latitude
-            attrs[ATTR_LONGITUDE] = self.sensor_data.longitude
-        else:
-            attrs["lati"] = self.sensor_data.latitude
-            attrs["long"] = self.sensor_data.longitude
-        return attrs
-
-    @property
-    def sensor_data(self) -> SensorModel:
-        """Define a property to get this entity's SensorModel object."""
-        return self.coordinator.data.data[self._sensor_index]

--- a/homeassistant/components/purpleair/entity.py
+++ b/homeassistant/components/purpleair/entity.py
@@ -1,0 +1,66 @@
+"""The PurpleAir integration."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from aiopurpleair.models.sensors import SensorModel
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE, CONF_SHOW_ON_MAP
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import PurpleAirDataUpdateCoordinator
+
+
+class PurpleAirEntity(CoordinatorEntity[PurpleAirDataUpdateCoordinator]):
+    """Define a base PurpleAir entity."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: PurpleAirDataUpdateCoordinator,
+        entry: ConfigEntry,
+        sensor_index: int,
+    ) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+
+        self._sensor_index = sensor_index
+
+        self._attr_device_info = DeviceInfo(
+            configuration_url=self.coordinator.async_get_map_url(sensor_index),
+            hw_version=self.sensor_data.hardware,
+            identifiers={(DOMAIN, str(sensor_index))},
+            manufacturer="PurpleAir, Inc.",
+            model=self.sensor_data.model,
+            name=self.sensor_data.name,
+            sw_version=self.sensor_data.firmware_version,
+        )
+        self._entry = entry
+
+    @property
+    def extra_state_attributes(self) -> Mapping[str, Any]:
+        """Return entity specific state attributes."""
+        attrs = {}
+
+        # Displaying the geography on the map relies upon putting the latitude/longitude
+        # in the entity attributes with "latitude" and "longitude" as the keys.
+        # Conversely, we can hide the location on the map by using other keys, like
+        # "lati" and "long":
+        if self._entry.options.get(CONF_SHOW_ON_MAP):
+            attrs[ATTR_LATITUDE] = self.sensor_data.latitude
+            attrs[ATTR_LONGITUDE] = self.sensor_data.longitude
+        else:
+            attrs["lati"] = self.sensor_data.latitude
+            attrs["long"] = self.sensor_data.longitude
+        return attrs
+
+    @property
+    def sensor_data(self) -> SensorModel:
+        """Define a property to get this entity's SensorModel object."""
+        return self.coordinator.data.data[self._sensor_index]

--- a/homeassistant/components/purpleair/sensor.py
+++ b/homeassistant/components/purpleair/sensor.py
@@ -27,9 +27,9 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import PurpleAirEntity
 from .const import CONF_SENSOR_INDICES, DOMAIN
 from .coordinator import PurpleAirDataUpdateCoordinator
+from .entity import PurpleAirEntity
 
 CONCENTRATION_PARTICLES_PER_100_MILLILITERS = f"particles/100{UnitOfVolume.MILLILITERS}"
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #126473

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
